### PR TITLE
cudaPackages: multiple outputs for redistributables

### DIFF
--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -54,3 +54,65 @@ for your specific card(s).
 
 Library maintainers should consult [NVCC Docs](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/)
 and release notes for their software package.
+
+## Adding a new CUDA release {#adding-a-new-cuda-release}
+
+> **WARNING**
+>
+> This section of the docs is still very much in progress. Feedback is welcome in GitHub Issues tagging @NixOS/cuda-maintainers or on [Matrix](https://matrix.to/#/#cuda:nixos.org).
+
+The CUDA Toolkit is a suite of CUDA libraries and software meant to provide a development environment for CUDA-accelerated applications. Until the release of CUDA 11.4, NVIDIA had only made the CUDA Toolkit available as a multi-gigabyte runfile installer, which we provide through the [`cudaPackages.cudatoolkit`](https://search.nixos.org/packages?channel=unstable&type=packages&query=cudaPackages.cudatoolkit) attribute. From CUDA 11.4 and onwards, NVIDIA has also provided CUDA redistributables (“CUDA-redist”): individually packaged CUDA Toolkit components meant to facilitate redistribution and inclusion in downstream projects. These packages are available in the [`cudaPackages`](https://search.nixos.org/packages?channel=unstable&type=packages&query=cudaPackages) package set.
+
+All new projects should use the CUDA redistributables available in [`cudaPackages`](https://search.nixos.org/packages?channel=unstable&type=packages&query=cudaPackages) in place of [`cudaPackages.cudatoolkit`](https://search.nixos.org/packages?channel=unstable&type=packages&query=cudaPackages.cudatoolkit), as they are much easier to maintain and update.
+
+### Updating CUDA redistributables {#updating-cuda-redistributables}
+
+1. Go to NVIDIA's index of CUDA redistributables: <https://developer.download.nvidia.com/compute/cuda/redist/>
+2. Copy the `redistrib_*.json` corresponding to the release to `pkgs/development/compilers/cudatoolkit/redist/manifests`.
+3. Generate the `redistrib_features_*.json` file by running:
+
+    ```bash
+    nix run github:ConnorBaker/cuda-redist-find-features -- <path to manifest>
+    ```
+
+    That command will generate the `redistrib_features_*.json` file in the same directory as the manifest.
+
+4. Include the path to the new manifest in `pkgs/development/compilers/cudatoolkit/redist/extension.nix`.
+
+### Updating the CUDA Toolkit runfile installer {#updating-the-cuda-toolkit}
+
+> **WARNING**
+>
+> While the CUDA Toolkit runfile installer is still available in Nixpkgs as the [`cudaPackages.cudatoolkit`](https://search.nixos.org/packages?channel=unstable&type=packages&query=cudaPackages.cudatoolkit) attribute, its use is not recommended and should it be considered deprecated. Please migrate to the CUDA redistributables provided by the [`cudaPackages`](https://search.nixos.org/packages?channel=unstable&type=packages&query=cudaPackages) package set.
+>
+> To ensure packages relying on the CUDA Toolkit runfile installer continue to build, it will continue to be updated until a migration path is available.
+
+1. Go to NVIDIA's CUDA Toolkit runfile installer download page: <https://developer.nvidia.com/cuda-downloads>
+2. Select the appropriate OS, architecture, distribution, and version, and installer type.
+
+   - For example: Linux, x86_64, Ubuntu, 22.04, runfile (local)
+   - NOTE: Typically, we use the Ubuntu runfile. It is unclear if the runfile for other distributions will work.
+
+3. Take the link provided by the installer instructions on the webpage after selecting the installer type and get its hash by running:
+
+   ```bash
+   nix store prefetch-file --hash-type sha256 <link>
+   ```
+
+4. Update `pkgs/development/compilers/cudatoolkit/versions.toml` to include the release.
+
+### Updating the CUDA package set {#updating-the-cuda-package-set}
+
+1. Include a new `cudaPackages_<major>_<minor>` package set in `pkgs/top-level/all-packages.nix`.
+
+   - NOTE: Changing the default CUDA package set should occur in a separate PR, allowing time for additional testing.
+
+2. Successfully build the closure of the new package set, updating `pkgs/development/compilers/cudatoolkit/redist/overrides.nix` as needed. Below are some common failures:
+
+| Unable to ... | During ... | Reason | Solution | Note |
+| --- | --- | --- | --- | --- |
+| Find headers | `configurePhase` or `buildPhase` | Missing dependency on a `dev` output | Add the missing dependency | The `dev` output typically contain the headers |
+| Find libraries | `configurePhase` | Missing dependency on a `dev` output | Add the missing dependency | The `dev` output typically contain CMake configuration files |
+| Find libraries | `buildPhase` or `patchelf` | Missing dependency on a `lib` or `static` output | Add the missing dependency | The `lib` or `static` output typically contain the libraries |
+
+In the scenario you are unable to run the resulting binary: this is arguably the most complicated as it could be any combination of the previous reasons. This type of failure typically occurs when a library attempts to load or open a library it depends on that it does not declare in its `DT_NEEDED` section. As a first step, ensure that dependencies are patched with [`cudaPackages.autoAddOpenGLRunpath`](https://search.nixos.org/packages?channel=unstable&type=packages&query=cudaPackages.autoAddOpenGLRunpath). Failing that, try running the application with [`nixGL`](https://github.com/guibou/nixGL) or a similar wrapper tool. If that works, it likely means that the application is attempting to load a library that is not in the `RPATH` or `RUNPATH` of the binary.

--- a/pkgs/development/compilers/cudatoolkit/hooks/nvcc-setup-hook.sh
+++ b/pkgs/development/compilers/cudatoolkit/hooks/nvcc-setup-hook.sh
@@ -2,4 +2,4 @@
 
 # CMake's enable_language(CUDA) runs a compiler test and it doesn't account for
 # CUDAToolkit_ROOT. We have to help it locate libcudart
-export NVCC_APPEND_FLAGS+=" -L@cudartRoot@/lib -I@cudartRoot@/include"
+export NVCC_APPEND_FLAGS+=" -L@cudartLib@/lib -L@cudartStatic@/lib -I@cudartInclude@/include"

--- a/pkgs/development/compilers/cudatoolkit/hooks/setup-cuda-hook.sh
+++ b/pkgs/development/compilers/cudatoolkit/hooks/setup-cuda-hook.sh
@@ -56,7 +56,7 @@ setupCUDAToolkitCompilers() {
     # CMake's enable_language(CUDA) runs a compiler test and it doesn't account for
     # CUDAToolkit_ROOT. We have to help it locate libcudart
     if [[ -z "${nvccDontPrependCudartFlags-}" ]] ; then
-        export NVCC_APPEND_FLAGS+=" -L@cudartRoot@/lib -I@cudartRoot@/include"
+        export NVCC_APPEND_FLAGS+=" -L@cudartLib@/lib -L@cudartStatic@/lib -I@cudartInclude@/include"
     fi
 }
 

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -1,3 +1,10 @@
+# Type Aliases
+#
+# See ./extension.nix:
+# - ReleaseAttrs
+# - ReleaseFeaturesAttrs
+#
+# General callPackage-supplied arguments
 { lib
 , stdenv
 , backendStdenv
@@ -5,22 +12,57 @@
 , autoPatchelfHook
 , autoAddOpenGLRunpathHook
 , markForCudatoolkitRootHook
+, lndir
+, symlinkJoin
 }:
-
-pname:
-attrs:
-
+# Function arguments
+{
+  # Short package name (e.g., "cuda_cccl")
+  # pname : String
+  pname
+, # Long package name (e.g., "CXX Core Compute Libraries")
+  # description : String
+  description
+, # platforms : List System
+  platforms
+, # version : Version
+  version
+, # releaseAttrs : ReleaseAttrs
+  releaseAttrs
+, # releaseFeaturesAttrs : ReleaseFeaturesAttrs
+  releaseFeaturesAttrs
+,
+}:
 let
-  arch = "linux-x86_64";
+  # Useful imports
+  inherit (lib.lists) optionals;
+  inherit (lib.meta) getExe;
+  inherit (lib.strings) optionalString;
 in
 backendStdenv.mkDerivation {
-  inherit pname;
-  inherit (attrs) version;
+  # NOTE: Even though there's no actual buildPhase going on here, the derivations of the
+  # redistributables are sensitive to the compiler flags provided to stdenv. The patchelf package
+  # is sensitive to the compiler flags provided to stdenv, and we depend on it. As such, we are
+  # also sensitive to the compiler flags provided to stdenv.
+  inherit pname version;
+  strictDeps = true;
 
-  src = assert (lib.hasAttr arch attrs); fetchurl {
-    url = "https://developer.download.nvidia.com/compute/cuda/redist/${attrs.${arch}.relative_path}";
-    inherit (attrs.${arch}) sha256;
+  outputs = with releaseFeaturesAttrs;
+    [ "out" ]
+    ++ optionals hasBin [ "bin" ]
+    ++ optionals hasLib [ "lib" ]
+    ++ optionals hasStatic [ "static" ]
+    ++ optionals hasDev [ "dev" ]
+    ++ optionals hasDoc [ "doc" ]
+    ++ optionals hasSample [ "sample" ];
+
+  src = fetchurl {
+    url = "https://developer.download.nvidia.com/compute/cuda/redist/${releaseAttrs.relative_path}";
+    inherit (releaseAttrs) sha256;
   };
+
+  # We do need some other phases, like configurePhase, so the multiple-output setup hook works.
+  dontBuild = true;
 
   nativeBuildInputs = [
     autoPatchelfHook
@@ -46,23 +88,87 @@ backendStdenv.mkDerivation {
     "$ORIGIN"
   ];
 
-  dontBuild = true;
+  installPhase = with releaseFeaturesAttrs;
+    # Pre-install hook
+    ''
+      runHook preInstall
+    ''
+    # doc and dev have special output handling. Other outputs need to be moved to their own
+    # output.
+    # Note that moveToOutput operates on all outputs:
+    # https://github.com/NixOS/nixpkgs/blob/2920b6fc16a9ed5d51429e94238b28306ceda79e/pkgs/build-support/setup-hooks/multiple-outputs.sh#L105-L107
+    + ''
+      mkdir -p "$out"
+      rm LICENSE
+      mv * "$out"
+    ''
+    # Handle bin, which defaults to out
+    + optionalString hasBin ''
+      moveToOutput "bin" "$bin"
+    ''
+    # Handle lib, which defaults to out
+    + optionalString hasLib ''
+      moveToOutput "lib" "$lib"
+    ''
+    # Handle static libs, which isn't handled by the setup hook
+    + optionalString hasStatic ''
+      moveToOutput "**/*.a" "$static"
+    ''
+    # Handle samples, which isn't handled by the setup hook
+    + optionalString hasSample ''
+      moveToOutput "samples" "$sample"
+    ''
+    # Post-install hook
+    + ''
+      runHook postInstall
+    '';
 
-  # TODO: choose whether to install static/dynamic libs
-  installPhase = ''
-    runHook preInstall
-    rm LICENSE
-    mkdir -p $out
-    mv * $out
-    runHook postInstall
+  # The out output leverages the same functionality which backs the `symlinkJoin` function in
+  # Nixpkgs:
+  # https://github.com/NixOS/nixpkgs/blob/d8b2a92df48f9b08d68b0132ce7adfbdbc1fbfac/pkgs/build-support/trivial-builders/default.nix#L510
+  #
+  # That should allow us to emulate "fat" default outputs without having to actually create them.
+  #
+  # It is important that this run after the autoPatchelfHook, otherwise the symlinks in out will reference libraries in lib, creating a circular dependency.
+  postPhases = [ "postPatchelf" ];
+  # For each output, create a symlink to it in the out output.
+  # NOTE: We must recreate the out output here, because the setup hook will have deleted it
+  # if it was empty.
+  # NOTE: Do not use optionalString based on whether `outputs` contains only `out` -- phases
+  # which are empty strings are skipped/unset and result in errors of the form "command not
+  # found: <customPhaseName>".
+  postPatchelf = ''
+    mkdir -p "$out"
+    for output in $outputs; do
+      if [ "$output" = "out" ]; then
+        continue
+      fi
+      ${getExe lndir} "''${!output}" "$out"
+    done
   '';
 
+  # Make the CUDA-patched stdenv available
   passthru.stdenv = backendStdenv;
 
+  # Setting propagatedBuildInputs to false will prevent outputs known to the multiple-outputs
+  # from depending on `out` by default.
+  # https://github.com/NixOS/nixpkgs/blob/2920b6fc16a9ed5d51429e94238b28306ceda79e/pkgs/build-support/setup-hooks/multiple-outputs.sh#L196
+  # Indeed, we want to do the opposite -- fat "out" outputs that contain all the other outputs.
+  propagatedBuildOutputs = false;
+
+  # By default, if the dev output exists it just uses that.
+  # However, because we disabled propagatedBuildOutputs, dev doesn't contain libraries or
+  # anything of the sort. To remedy this, we set outputSpecified to true, and use
+  # outputsToInstall, which tells Nix which outputs to use when the package name is used
+  # unqualified (that is, without an explicit output).
+  outputSpecified = true;
+
   meta = {
-    description = attrs.name;
+    inherit description platforms;
     license = lib.licenses.unfree;
     maintainers = lib.teams.cuda.members;
-    platforms = lib.optionals (lib.hasAttr arch attrs) [ "x86_64-linux" ];
+    # Force the use of the default, fat output by default (even though `dev` exists, which
+    # causes Nix to prefer that output over the others if outputSpecified isn't set).
+    outputsToInstall = [ "out" ];
   };
 }

--- a/pkgs/development/compilers/cudatoolkit/redist/extension.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/extension.nix
@@ -1,33 +1,139 @@
-final: prev: let
-
+# Type Aliases
+#
+# ReleaseAttrs : {
+#   "relative_path" : String,
+#   "sha256" : String,
+#   "md5" : String,
+#   "size" : String,
+# }
+#
+# NOTE: PackageAttrs must have at least one of the arches.
+# PackageAttrs : {
+#   "name" : String,
+#   "license" : String,
+#   "version" : String,
+#   "license_path" : None | String,
+#   "linux-aarch64" : None | ReleaseAttrs,
+#   "linux-ppc64le" : None | ReleaseAttrs,
+#   "linux-sbsa" : None | ReleaseAttrs,
+#   "linux-x86_64" : None | ReleaseAttrs,
+#   "windows-x86_64" : None | ReleaseAttrs,
+# }
+#
+# ReleaseFeaturesAttrs : {
+#   "hasBin" : Boolean,
+#   "hasDev" : Boolean,
+#   "hasDoc" : Boolean,
+#   "hasLib" : Boolean,
+#   "hasOut" : Boolean,
+#   "hasSample" : Boolean,
+#   "hasStatic" : Boolean,
+#   "rootDirs" : List String,
+# }
+#
+# NOTE: PackageFeatureAttrs must have at least one of the arches.
+# PackageFeatureAttrs : {
+#   "linux-aarch64" : None | ReleaseFeaturesAttrs,
+#   "linux-ppc64le" : None | ReleaseFeaturesAttrs,
+#   "linux-sbsa" : None | ReleaseFeaturesAttrs,
+#   "linux-x86_64" : None | ReleaseFeaturesAttrs,
+#   "windows-x86_64" : None | ReleaseFeaturesAttrs,
+# }
+#
+final: prev:
+let
+  # NOTE: We use hasAttr throughout instead of the (?) operator because hasAttr does not require
+  # us to interpolate our variables into strings (like ${attrName}).
+  inherit (builtins) attrNames concatMap hasAttr listToAttrs removeAttrs;
   inherit (final) callPackage;
-  inherit (prev) cudaVersion lib;
+  inherit (prev) cudaVersion;
+  inherit (prev.lib.attrsets) nameValuePair optionalAttrs;
+  inherit (prev.lib.lists) optionals;
+  inherit (prev.lib.trivial) flip importJSON pipe;
 
-  ### Cuda Toolkit Redist
-
-  # Manifest files for redist cudatoolkit. These can be found at
+  # Manifest files for CUDA redistributables (aka redist). These can be found at
   # https://developer.download.nvidia.com/compute/cuda/redist/
-  cudaToolkitRedistManifests = {
-    "11.4" = ./manifests/redistrib_11.4.4.json;
-    "11.5" = ./manifests/redistrib_11.5.2.json;
-    "11.6" = ./manifests/redistrib_11.6.2.json;
-    "11.7" = ./manifests/redistrib_11.7.0.json;
-    "11.8" = ./manifests/redistrib_11.8.0.json;
-    "12.0" = ./manifests/redistrib_12.0.1.json;
-    "12.1" = ./manifests/redistrib_12.1.1.json;
-    "12.2" = ./manifests/redistrib_12.2.0.json;
+  # Maps a cuda version to the specific version of the manifest.
+  cudaVersionMap = {
+    "11.4" = "11.4.4";
+    "11.5" = "11.5.2";
+    "11.6" = "11.6.2";
+    "11.7" = "11.7.0";
+    "11.8" = "11.8.0";
+    "12.0" = "12.0.1";
+    "12.1" = "12.1.1";
+    "12.2" = "12.2.0";
   };
 
-  # Function to build a single cudatoolkit redist package
-  buildCudaToolkitRedistPackage = callPackage ./build-cuda-redist-package.nix { };
+  # Check if the current CUDA version is supported.
+  cudaVersionMappingExists = hasAttr cudaVersion cudaVersionMap;
 
-  # Function that builds all cudatoolkit redist packages given a cuda version and manifest file
-  buildCudaToolkitRedistPackages = { version, manifest }: let
-    attrs = lib.filterAttrs (key: value: key != "release_date") (lib.importJSON manifest);
-  in lib.mapAttrs buildCudaToolkitRedistPackage attrs;
+  # Maps a cuda version to its manifest files.
+  # The manifest itself is from NVIDIA, but the features manifest is generated
+  # by us ahead of time and allows us to split pacakges into multiple outputs.
+  # Package names (e.g., "cuda_cccl") are mapped to their attributes or features.
+  # Since we map each attribute to a package name, we need to make sure to get rid of meta
+  # attributes included in the manifest. Currently, these are any of the following:
+  # - release_date
+  # - release_label
+  # - release_product
+  redistManifests =
+    let
+      # Remove meta attributes from the manifest
+      # removeAttrs : AttrSet String b -> Attr String b
+      removeMetaAttrs = flip removeAttrs [ "release_date" "release_label" "release_product" ];
+      # processManifest : Path -> Attr Set (String PackageAttrs)
+      processManifest = flip pipe [ importJSON removeMetaAttrs ];
+      # fullCudaVersion : String
+      fullCudaVersion = cudaVersionMap.${cudaVersion};
+    in
+    {
+      # features : Attr Set (String PackageFeatureAttrs)
+      features = processManifest ./manifests/redistrib_features_${fullCudaVersion}.json;
+      # manifest : Attr Set (String PackageAttrs)
+      manifest = processManifest ./manifests/redistrib_${fullCudaVersion}.json;
+    };
 
-  # All cudatoolkit redist packages for the current cuda version
-  cudaToolkitRedistPackages = lib.optionalAttrs (lib.hasAttr cudaVersion cudaToolkitRedistManifests)
-    (buildCudaToolkitRedistPackages { version = cudaVersion; manifest = cudaToolkitRedistManifests.${cudaVersion}; });
+  # Function to build a single redist package
+  buildRedistPackage = callPackage ./build-cuda-redist-package.nix { };
 
-in cudaToolkitRedistPackages
+  # Function that builds all redist packages given manifests
+  buildRedistPackages = { features, manifest }:
+    let
+      wrapper = pname:
+        let
+          # Get the redist architectures the package provides distributables for
+          packageAttrs = manifest.${pname};
+
+          # Check if supported
+          # TODO(@connorbaker): Currently hardcoding x86_64-linux as the only supported platform.
+          isSupported = packageAttrs ? linux-x86_64;
+
+          # Build the derivation
+          drv = buildRedistPackage {
+            inherit pname;
+            # TODO(@connorbaker): We currently discard the license attribute.
+            inherit (manifest.${pname}) version;
+            description = manifest.${pname}.name;
+            platforms = [ "x86_64-linux" ];
+            releaseAttrs = manifest.${pname}.linux-x86_64;
+            releaseFeaturesAttrs = features.${pname}.linux-x86_64;
+          };
+
+          # Wrap in an optional so we can filter out the empty lists created by unsupported
+          # packages with concatMap.
+          wrapped = optionals isSupported [ (nameValuePair pname drv) ];
+        in
+        wrapped;
+
+      # concatMap provides us an easy way to filter out packages for unsupported platforms.
+      # We wrap the buildRedistPackage call in a list to prevent errors when the package is not
+      # supported (by returning an empty list).
+      redistPackages = listToAttrs (concatMap wrapper (attrNames manifest));
+    in
+    redistPackages;
+
+  # All redistributable packages for the current CUDA version
+  redistPackages = optionalAttrs cudaVersionMappingExists (buildRedistPackages redistManifests);
+in
+redistPackages

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.4.4.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.4.4.json
@@ -1,0 +1,1518 @@
+{
+  "cuda_cccl": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_cudart": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "lib32"
+      ]
+    }
+  },
+  "cuda_cuobjdump": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_cupti": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    }
+  },
+  "cuda_cuxxfilt": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_demo_suite": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    }
+  },
+  "cuda_documentation": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    }
+  },
+  "cuda_gdb": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    }
+  },
+  "cuda_memcheck": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nsight": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    }
+  },
+  "cuda_nvcc": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    }
+  },
+  "cuda_nvdisasm": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvml_dev": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml"
+      ]
+    }
+  },
+  "cuda_nvprof": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvprune": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvrtc": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvtx": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_nvvp": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    }
+  },
+  "cuda_sanitizer_api": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compute-sanitizer"
+      ]
+    }
+  },
+  "fabricmanager": {
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    }
+  },
+  "libcublas": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libcufft": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcufile": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    }
+  },
+  "libcurand": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusolver": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusparse": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libnpp": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvjpeg": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "nsight_compute": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-compute"
+      ]
+    }
+  },
+  "nsight_nvtx": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "NvToolsExt"
+      ]
+    }
+  },
+  "nsight_systems": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-systems"
+      ]
+    }
+  },
+  "nsight_vse": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "NvToolsExt",
+        "nsight_vse"
+      ]
+    }
+  },
+  "nvidia_driver": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "lib",
+        "lib32",
+        "man",
+        "sbin",
+        "share",
+        "supported-gpus",
+        "systemd",
+        "tests",
+        "wine"
+      ]
+    }
+  },
+  "nvidia_fs": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    }
+  },
+  "visual_studio_integration": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "visual_studio_integration"
+      ]
+    }
+  }
+}

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.5.2.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.5.2.json
@@ -1,0 +1,1536 @@
+{
+  "cuda_cccl": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_cudart": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "lib32"
+      ]
+    }
+  },
+  "cuda_cuobjdump": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_cupti": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    }
+  },
+  "cuda_cuxxfilt": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_demo_suite": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    }
+  },
+  "cuda_documentation": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    }
+  },
+  "cuda_gdb": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    }
+  },
+  "cuda_memcheck": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nsight": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    }
+  },
+  "cuda_nvcc": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    }
+  },
+  "cuda_nvdisasm": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvml_dev": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml"
+      ]
+    }
+  },
+  "cuda_nvprof": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvprune": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvrtc": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvtx": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_nvvp": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    }
+  },
+  "cuda_sanitizer_api": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compute-sanitizer"
+      ]
+    }
+  },
+  "fabricmanager": {
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    }
+  },
+  "libcublas": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libcufft": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcufile": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    }
+  },
+  "libcurand": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusolver": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusparse": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libnpp": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvidia_nscq": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "lib"
+      ]
+    }
+  },
+  "libnvjpeg": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "nsight_compute": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-compute"
+      ]
+    }
+  },
+  "nsight_nvtx": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "NvToolsExt"
+      ]
+    }
+  },
+  "nsight_systems": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-systems"
+      ]
+    }
+  },
+  "nsight_vse": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "NvToolsExt",
+        "nsight_vse"
+      ]
+    }
+  },
+  "nvidia_driver": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "lib",
+        "lib32",
+        "man",
+        "sbin",
+        "share",
+        "supported-gpus",
+        "systemd",
+        "tests",
+        "wine"
+      ]
+    }
+  },
+  "nvidia_fs": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    }
+  },
+  "visual_studio_integration": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "visual_studio_integration"
+      ]
+    }
+  }
+}

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.6.2.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.6.2.json
@@ -1,0 +1,1546 @@
+{
+  "cuda_cccl": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_cudart": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "lib32"
+      ]
+    }
+  },
+  "cuda_cuobjdump": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_cupti": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    }
+  },
+  "cuda_cuxxfilt": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_demo_suite": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    }
+  },
+  "cuda_documentation": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    }
+  },
+  "cuda_gdb": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    }
+  },
+  "cuda_memcheck": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nsight": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    }
+  },
+  "cuda_nvcc": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    }
+  },
+  "cuda_nvdisasm": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvml_dev": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml"
+      ]
+    }
+  },
+  "cuda_nvprof": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include"
+      ]
+    }
+  },
+  "cuda_nvprune": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvrtc": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvtx": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_nvvp": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    }
+  },
+  "cuda_sanitizer_api": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compute-sanitizer"
+      ]
+    }
+  },
+  "fabricmanager": {
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    }
+  },
+  "libcublas": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libcufft": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcufile": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    }
+  },
+  "libcurand": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusolver": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusparse": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libnpp": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvidia_nscq": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "lib"
+      ]
+    }
+  },
+  "libnvjpeg": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "nsight_compute": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-compute"
+      ]
+    }
+  },
+  "nsight_nvtx": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "NvToolsExt"
+      ]
+    }
+  },
+  "nsight_systems": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-systems"
+      ]
+    }
+  },
+  "nsight_vse": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "NvToolsExt",
+        "nsight_vse"
+      ]
+    }
+  },
+  "nvidia_driver": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "lib",
+        "lib32",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests",
+        "wine"
+      ]
+    }
+  },
+  "nvidia_fs": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    }
+  },
+  "visual_studio_integration": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "visual_studio_integration"
+      ]
+    }
+  }
+}

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.7.0.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.7.0.json
@@ -1,0 +1,1565 @@
+{
+  "cuda_cccl": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_cudart": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_cuobjdump": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_cupti": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    }
+  },
+  "cuda_cuxxfilt": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_demo_suite": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    }
+  },
+  "cuda_documentation": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    }
+  },
+  "cuda_gdb": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    }
+  },
+  "cuda_memcheck": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nsight": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    }
+  },
+  "cuda_nvcc": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    }
+  },
+  "cuda_nvdisasm": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvml_dev": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml"
+      ]
+    }
+  },
+  "cuda_nvprof": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include"
+      ]
+    }
+  },
+  "cuda_nvprune": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvrtc": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvtx": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_nvvp": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    }
+  },
+  "cuda_sanitizer_api": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compute-sanitizer"
+      ]
+    }
+  },
+  "fabricmanager": {
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    }
+  },
+  "libcublas": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libcufft": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcufile": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    }
+  },
+  "libcurand": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusolver": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusparse": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libnpp": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvidia_nscq": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "lib"
+      ]
+    }
+  },
+  "libnvjpeg": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "nsight_compute": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-compute"
+      ]
+    }
+  },
+  "nsight_nvtx": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "NvToolsExt"
+      ]
+    }
+  },
+  "nsight_systems": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-systems"
+      ]
+    }
+  },
+  "nsight_vse": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "NvToolsExt",
+        "nsight_vse"
+      ]
+    }
+  },
+  "nvidia_driver": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "lib32",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests",
+        "wine"
+      ]
+    }
+  },
+  "nvidia_fs": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    }
+  },
+  "visual_studio_integration": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "visual_studio_integration"
+      ]
+    }
+  }
+}

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.8.0.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_11.8.0.json
@@ -1,0 +1,1938 @@
+{
+  "cuda_cccl": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_compat": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compat"
+      ]
+    }
+  },
+  "cuda_cudart": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_cuobjdump": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_cupti": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    }
+  },
+  "cuda_cuxxfilt": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_demo_suite": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    }
+  },
+  "cuda_documentation": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    }
+  },
+  "cuda_gdb": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    }
+  },
+  "cuda_memcheck": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nsight": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    }
+  },
+  "cuda_nvcc": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    }
+  },
+  "cuda_nvdisasm": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvml_dev": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml"
+      ]
+    }
+  },
+  "cuda_nvprof": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvprune": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvrtc": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvtx": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_nvvp": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    }
+  },
+  "cuda_profiler_api": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_sanitizer_api": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compute-sanitizer"
+      ]
+    }
+  },
+  "fabricmanager": {
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    }
+  },
+  "libcublas": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libcudla": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    }
+  },
+  "libcufft": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcufile": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    }
+  },
+  "libcurand": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusolver": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusparse": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libnpp": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvidia_nscq": {
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "lib"
+      ]
+    }
+  },
+  "libnvjpeg": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "nsight_compute": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-compute"
+      ]
+    }
+  },
+  "nsight_nvtx": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "NvToolsExt"
+      ]
+    }
+  },
+  "nsight_systems": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-systems"
+      ]
+    }
+  },
+  "nsight_vse": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight_vse"
+      ]
+    }
+  },
+  "nvidia_driver": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "lib32",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests",
+        "wine"
+      ]
+    }
+  },
+  "nvidia_fs": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    }
+  },
+  "visual_studio_integration": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "visual_studio_integration"
+      ]
+    }
+  }
+}

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_12.0.1.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_12.0.1.json
@@ -1,0 +1,2050 @@
+{
+  "cuda_cccl": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_compat": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compat"
+      ]
+    }
+  },
+  "cuda_cudart": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_cuobjdump": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_cupti": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    }
+  },
+  "cuda_cuxxfilt": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_demo_suite": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    }
+  },
+  "cuda_documentation": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    }
+  },
+  "cuda_gdb": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    }
+  },
+  "cuda_nsight": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    }
+  },
+  "cuda_nvcc": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    }
+  },
+  "cuda_nvdisasm": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvml_dev": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml"
+      ]
+    }
+  },
+  "cuda_nvprof": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvprune": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvrtc": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvtx": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_nvvp": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    }
+  },
+  "cuda_opencl": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_profiler_api": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_sanitizer_api": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compute-sanitizer"
+      ]
+    }
+  },
+  "fabricmanager": {
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    }
+  },
+  "libcublas": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libcudla": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    }
+  },
+  "libcufft": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcufile": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    }
+  },
+  "libcurand": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusolver": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusparse": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libnpp": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvidia_nscq": {
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvjitlink": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "res"
+      ]
+    }
+  },
+  "libnvjpeg": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvvm_samples": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    }
+  },
+  "nsight_compute": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-compute"
+      ]
+    }
+  },
+  "nsight_systems": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-systems"
+      ]
+    }
+  },
+  "nsight_vse": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight_vse"
+      ]
+    }
+  },
+  "nvidia_driver": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "lib32",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests",
+        "wine"
+      ]
+    }
+  },
+  "nvidia_fs": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    }
+  },
+  "visual_studio_integration": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "visual_studio_integration"
+      ]
+    }
+  }
+}

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_12.1.1.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_12.1.1.json
@@ -1,0 +1,2050 @@
+{
+  "cuda_cccl": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_compat": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compat"
+      ]
+    }
+  },
+  "cuda_cudart": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_cuobjdump": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_cupti": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    }
+  },
+  "cuda_cuxxfilt": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_demo_suite": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    }
+  },
+  "cuda_documentation": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    }
+  },
+  "cuda_gdb": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    }
+  },
+  "cuda_nsight": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    }
+  },
+  "cuda_nvcc": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    }
+  },
+  "cuda_nvdisasm": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvml_dev": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml"
+      ]
+    }
+  },
+  "cuda_nvprof": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvprune": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvrtc": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvtx": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_nvvp": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    }
+  },
+  "cuda_opencl": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_profiler_api": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_sanitizer_api": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compute-sanitizer"
+      ]
+    }
+  },
+  "fabricmanager": {
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    }
+  },
+  "libcublas": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libcudla": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    }
+  },
+  "libcufft": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcufile": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    }
+  },
+  "libcurand": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusolver": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusparse": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libnpp": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvidia_nscq": {
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvjitlink": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "res"
+      ]
+    }
+  },
+  "libnvjpeg": {
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvvm_samples": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nvvm"
+      ]
+    }
+  },
+  "nsight_compute": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-compute"
+      ]
+    }
+  },
+  "nsight_systems": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-systems"
+      ]
+    }
+  },
+  "nsight_vse": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight_vse"
+      ]
+    }
+  },
+  "nvidia_driver": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "lib32",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests",
+        "wine"
+      ]
+    }
+  },
+  "nvidia_fs": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    }
+  },
+  "visual_studio_integration": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "visual_studio_integration"
+      ]
+    }
+  }
+}

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_12.2.0.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_features_12.2.0.json
@@ -1,0 +1,2030 @@
+{
+  "cuda_cccl": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_compat": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compat"
+      ]
+    }
+  },
+  "cuda_cudart": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_cuobjdump": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_cupti": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": false,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "doc",
+        "include",
+        "lib",
+        "samples"
+      ]
+    }
+  },
+  "cuda_cuxxfilt": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_demo_suite": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "demo_suite"
+      ]
+    }
+  },
+  "cuda_documentation": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "tools"
+      ]
+    }
+  },
+  "cuda_gdb": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "extras",
+        "share"
+      ]
+    }
+  },
+  "cuda_nsight": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsightee_plugins"
+      ]
+    }
+  },
+  "cuda_nvcc": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "nvvm"
+      ]
+    }
+  },
+  "cuda_nvdisasm": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvml_dev": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "nvml"
+      ]
+    }
+  },
+  "cuda_nvprof": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvprune": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin"
+      ]
+    }
+  },
+  "cuda_nvrtc": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_nvtx": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_nvvp": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "libnvvp"
+      ]
+    }
+  },
+  "cuda_opencl": {
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "cuda_profiler_api": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include"
+      ]
+    }
+  },
+  "cuda_sanitizer_api": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "compute-sanitizer"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "compute-sanitizer"
+      ]
+    }
+  },
+  "fabricmanager": {
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "etc",
+        "include",
+        "lib",
+        "sbin",
+        "share",
+        "systemd"
+      ]
+    }
+  },
+  "libcublas": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libcudla": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    }
+  },
+  "libcufft": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcufile": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": true,
+      "hasStatic": true,
+      "rootDirs": [
+        "etc",
+        "include",
+        "lib",
+        "man",
+        "pkg-config",
+        "samples",
+        "tools"
+      ]
+    }
+  },
+  "libcurand": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusolver": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libcusparse": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "src"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "src"
+      ]
+    }
+  },
+  "libnpp": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "libnvidia_nscq": {
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "lib"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "lib"
+      ]
+    }
+  },
+  "libnvjitlink": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config",
+        "res"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib",
+        "res"
+      ]
+    }
+  },
+  "libnvjpeg": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "include",
+        "lib",
+        "pkg-config"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": true,
+      "hasDev": true,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": true,
+      "rootDirs": [
+        "bin",
+        "include",
+        "lib"
+      ]
+    }
+  },
+  "nsight_compute": {
+    "linux-aarch64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-compute"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-compute"
+      ]
+    }
+  },
+  "nsight_systems": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "nsight-systems"
+      ]
+    },
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight-systems"
+      ]
+    }
+  },
+  "nsight_vse": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "nsight_vse"
+      ]
+    }
+  },
+  "nvidia_driver": {
+    "linux-ppc64le": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "kernel",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": true,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": true,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "bin",
+        "docs",
+        "etc",
+        "firmware",
+        "kernel",
+        "kernel-open",
+        "lib",
+        "lib32",
+        "man",
+        "sbin",
+        "share",
+        "src",
+        "supported-gpus",
+        "systemd",
+        "tests",
+        "wine"
+      ]
+    }
+  },
+  "nvidia_fs": {
+    "linux-aarch64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    },
+    "linux-sbsa": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    },
+    "linux-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "src"
+      ]
+    }
+  },
+  "visual_studio_integration": {
+    "windows-x86_64": {
+      "hasBin": false,
+      "hasDev": false,
+      "hasDoc": false,
+      "hasLib": false,
+      "hasSample": false,
+      "hasStatic": false,
+      "rootDirs": [
+        "visual_studio_integration"
+      ]
+    }
+  }
+}

--- a/pkgs/development/compilers/cudatoolkit/redist/overrides.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/overrides.nix
@@ -1,6 +1,8 @@
 final: prev:
 let
   inherit (prev) lib pkgs;
+  cudaVersionOlder = lib.versionOlder final.cudaVersion;
+  cudaVersionAtLeast = lib.versionAtLeast final.cudaVersion;
 in
 (lib.filterAttrs (attr: _: (prev ? "${attr}")) {
   ### Overrides to fix the components of cudatoolkit-redist
@@ -10,51 +12,83 @@ in
 
   libcufile = prev.libcufile.overrideAttrs (oldAttrs: {
     buildInputs = oldAttrs.buildInputs ++ [
-      prev.libcublas
+      final.libcublas.lib
       pkgs.numactl
       pkgs.rdma-core
     ];
     # libcuda needs to be resolved during runtime
-    autoPatchelfIgnoreMissingDeps = true;
+    autoPatchelfIgnoreMissingDeps =
+      ["libcuda.so.1"]
+      # Before 12.0 libcufile depends on itself for some reason.
+      ++ lib.optionals (cudaVersionOlder "12.0") [
+        "libcufile.so.0"
+      ];
   });
 
-  libcusolver = final.addBuildInputs prev.libcusolver [
-    prev.libcublas
-  ];
+  libcusolver = final.addBuildInputs prev.libcusolver (
+    # Always depends on this
+    [final.libcublas.lib]
+    # Dependency from 12.0 and on
+    ++ lib.optionals (cudaVersionAtLeast "12.0") [
+      final.libnvjitlink.lib
+    ]
+    # Dependency from 12.1 and on
+    ++ lib.optionals (cudaVersionAtLeast "12.1") [
+      final.libcusparse.lib
+    ]
+  );
 
-  cuda_nvcc = prev.cuda_nvcc.overrideAttrs (oldAttrs:
-    let
-      inherit (prev.backendStdenv) cc;
-    in
-    {
-      # Required by cmake's enable_language(CUDA) to build a test program
-      # When implementing cross-compilation support: this is
-      # final.pkgs.targetPackages.cudaPackages.cuda_cudart
-      env.cudartRoot = "${prev.lib.getDev final.cuda_cudart}";
+  libcusparse = final.addBuildInputs prev.libcusparse (
+    lib.optionals (cudaVersionAtLeast "12.0") [
+      final.libnvjitlink.lib
+    ]
+  );
 
-      # Point NVCC at a compatible compiler
+  cuda_gdb = final.addBuildInputs prev.cuda_gdb (
+    # x86_64 only needs gmp from 12.0 and on
+    lib.optionals (cudaVersionAtLeast "12.0") [
+      pkgs.gmp
+    ]
+  );
 
-      # Desiredata: whenever a package (e.g. magma) adds cuda_nvcc to
-      # nativeBuildInputs (offsets `(-1, 0)`), magma should also source the
-      # setupCudaHook, i.e. we want it the hook to be propagated into the
-      # same nativeBuildInputs.
-      #
-      # Logically, cuda_nvcc should include the hook in depsHostHostPropagated,
-      # so that the final offsets for the propagated hook would be `(-1, 0) +
-      # (0, 0) = (-1, 0)`.
-      #
-      # In practice, TargetTarget appears to work:
-      # https://gist.github.com/fd80ff142cd25e64603618a3700e7f82
-      depsTargetTargetPropagated = [
-        final.setupCudaHook
-      ];
-    });
+  cuda_nvcc = prev.cuda_nvcc.overrideAttrs (_: {
+    # Required by cmake's enable_language(CUDA) to build a test program
+    # When implementing cross-compilation support: this is
+    # final.pkgs.targetPackages.cudaPackages.cuda_cudart
+    env = {
+      # Given the multiple-outputs each CUDA redist has, we can specify the exact components we
+      # need from the package. CMake requires:
+      # - the cuda_runtime.h header, which is in the dev output
+      # - the dynamic library, which is in the lib output
+      # - the static library, which is in the static output
+      cudartInclude = "${final.cuda_cudart.dev}";
+      cudartLib = "${final.cuda_cudart.lib}";
+      cudartStatic = "${final.cuda_cudart.static}";
+    };
+
+    # Point NVCC at a compatible compiler
+
+    # Desiredata: whenever a package (e.g. magma) adds cuda_nvcc to
+    # nativeBuildInputs (offsets `(-1, 0)`), magma should also source the
+    # setupCudaHook, i.e. we want it the hook to be propagated into the
+    # same nativeBuildInputs.
+    #
+    # Logically, cuda_nvcc should include the hook in depsHostHostPropagated,
+    # so that the final offsets for the propagated hook would be `(-1, 0) +
+    # (0, 0) = (-1, 0)`.
+    #
+    # In practice, TargetTarget appears to work:
+    # https://gist.github.com/fd80ff142cd25e64603618a3700e7f82
+    depsTargetTargetPropagated = [
+      final.setupCudaHook
+    ];
+  });
 
   cuda_nvprof = prev.cuda_nvprof.overrideAttrs (oldAttrs: {
     nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ pkgs.addOpenGLRunpath ];
-    buildInputs = oldAttrs.buildInputs ++ [ prev.cuda_cupti ];
+    buildInputs = oldAttrs.buildInputs ++ [ final.cuda_cupti.lib ];
     # libcuda needs to be resolved during runtime
-    autoPatchelfIgnoreMissingDeps = true;
+    autoPatchelfIgnoreMissingDeps = ["libcuda.so.1"];
   });
 
   cuda_demo_suite = final.addBuildInputs prev.cuda_demo_suite [
@@ -62,8 +96,8 @@ in
     pkgs.libGLU
     pkgs.libglvnd
     pkgs.mesa
-    prev.libcufft
-    prev.libcurand
+    final.libcufft.lib
+    final.libcurand.lib
   ];
 
   nsight_compute = prev.nsight_compute.overrideAttrs (oldAttrs: {
@@ -100,7 +134,7 @@ in
 
   nvidia_driver = prev.nvidia_driver.overrideAttrs (oldAttrs: {
     # libcuda needs to be resolved during runtime
-    autoPatchelfIgnoreMissingDeps = true;
+    autoPatchelfIgnoreMissingDeps = ["libcuda.so.1"];
     # No need to support this package as we have drivers already
     # in linuxPackages.
     meta.broken = true;

--- a/pkgs/development/libraries/science/math/magma/generic.nix
+++ b/pkgs/development/libraries/science/math/magma/generic.nix
@@ -113,13 +113,17 @@ stdenv.mkDerivation {
     lapack
     blas
   ] ++ lists.optionals cudaSupport (with cudaPackages; [
-    cuda_cudart
-    libcublas # cublas_v2.h
-    libcusparse # cusparse.h
+    cuda_cudart.dev # cuda_runtime.h
+    cuda_cudart.lib # cudart
+    cuda_cudart.static # cudart_static
+    libcublas.dev # cublas_v2.h
+    libcublas.lib # cublas
+    libcusparse.dev # cusparse.h
+    libcusparse.lib # cusparse
   ] ++ lists.optionals (strings.versionOlder cudaVersion "11.8") [
-    cuda_nvprof # <cuda_profiler_api.h>
+    cuda_nvprof.dev # <cuda_profiler_api.h>
   ] ++ lists.optionals (strings.versionAtLeast cudaVersion "11.8") [
-    cuda_profiler_api # <cuda_profiler_api.h>
+    cuda_profiler_api.dev # <cuda_profiler_api.h>
   ]) ++ lists.optionals rocmSupport [
     hip
     hipblas

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -196,7 +196,8 @@ in buildPythonPackage rec {
     export TORCH_CUDA_ARCH_LIST="${gpuTargetString}"
     export CC=${cudatoolkit.cc}/bin/gcc CXX=${cudatoolkit.cc}/bin/g++
   '' + lib.optionalString (cudaSupport && cudnn != null) ''
-    export CUDNN_INCLUDE_DIR=${cudnn}/include
+    export CUDNN_INCLUDE_DIR=${cudnn.dev}/include
+    export CUDNN_LIB_DIR=${cudnn.lib}/lib
   '' + lib.optionalString rocmSupport ''
     export ROCM_PATH=${rocmtoolkit_joined}
     export ROCM_SOURCE_DIR=${rocmtoolkit_joined}
@@ -290,7 +291,7 @@ in buildPythonPackage rec {
 
   buildInputs = [ blas blas.provider pybind11 ]
     ++ lib.optionals stdenv.isLinux [ linuxHeaders_5_19 ] # TMP: avoid "flexible array member" errors for now
-    ++ lib.optionals cudaSupport [ cudnn nccl ]
+    ++ lib.optionals cudaSupport [ cudnn.dev cudnn.lib nccl ]
     ++ lib.optionals rocmSupport [ openmp ]
     ++ lib.optionals (cudaSupport || rocmSupport) [ magma ]
     ++ lib.optionals stdenv.isLinux [ numactl ]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This change which involves creating multiple outputs for CUDA redistributable packages.

We use a script to find out, ahead of time, the outputs each redist package provides. From that, we are able to create multiple outputs for supported redist packages, allowing users to specify exactly which components they require.

Beyond the script which finds outputs ahead of time, there is some custom code involved in making this happen. For example, the way Nixpkgs typically handles multiple outputs involves making `dev` the default output when available, and adding `out` to `dev`'s `propagatedBuildInputs`.

Instead, we make each output independent of the others. If a user wants only to include the headers found in a redist package, they can do so by choosing the `dev` output. If they want to include dynamic libraries, they can do so by specifying the `lib` output, or `static` for static libraries.

To avoid breakages, we continue to provide the `out` output, which becomes the union of all other outputs, effectively making the split outputs opt-in.

Additional changes:

- Overrides for CUDA 12.x packages to ensure `patchelf` succeeds.
- Refactored overrides for CUDA 12.x packages to use only the outputs they require from other CUDA packages.
- `autoPatchelfIgnoreMissingDeps` set to ignore `libcuda.so.1` specifically instead of all libs, removing the possibility of breakages by accidentally ignoring libraries we should be linking.

###### Show us the numbers!

All found by building against `master` and this branch, with `--impure` and a local Nixpkgs configuration of

```nix
{
  allowUnfree = true;
  cudaSupport = true;
  cudaCapabilities = [ "8.9" ];
  cudaForwardCompat = false;
}
```

- cuDNN closure/NAR size went from 2.4G to 1.1G.
  - Comparing `master`'s `cudnn` to this branch's `cudnn.lib`.
- Magma closure size went from 2.9G to 1.6G.
  - Comparing `master` with this branch (same attribute name).
  - Build targeted capability 8.9 (Ada Lovelace) with CUDA 11.8.
  - Mostly as a result of dropping dependencies on static cuBLAS and cuSPARSE.
- PyTorch closure size went from 9.7G to 8.4G.
  - Comparing `master` with this branch (same attribute name).
  - Build targeted capability 8.9 (Ada Lovelace) with CUDA 11.8.
  - Much greater gains to be had in migrating away from CUDA Toolkit.
    - Decrease comes entirely from switch to `cudnn.lib` instead of `cudnn`.
    - Magma does not contribute to the closure size, because we link against it statically.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
