### PR TITLE
bcc: 0.26.0 -> 0.28.0

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -1,13 +1,26 @@
-{ lib, stdenv, fetchFromGitHub
-, makeWrapper, cmake, llvmPackages
-, flex, bison, elfutils, python, luajit, netperf, iperf, libelf
-, bash, libbpf, nixosTests
-, audit
+{ audit
+, bash
+, bison
+, cmake
+, elfutils
+, fetchFromGitHub
+, flex
+, iperf
+, lib
+, libbpf
+, llvmPackages
+, luajit
+, makeWrapper
+, netperf
+, nixosTests
+, python3
+, stdenv
+, zip
 }:
 
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "bcc";
-  version = "0.26.0";
+  version = "0.28.0";
 
   disabled = !stdenv.isLinux;
 
@@ -15,7 +28,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "iovisor";
     repo = "bcc";
     rev = "v${version}";
-    sha256 = "sha256-zx38tPwuuGU6px9pRNN5JtvBysK9fStOvoqe7cLo7LM=";
+    sha256 = "sha256-+ecSaVroDC2bWbio4JsuwEvHQdCMpxLt7hIkeREMJs8=";
   };
   format = "other";
 
@@ -31,8 +44,16 @@ python.pkgs.buildPythonApplication rec {
     ./fix-deadlock-detector-import.patch
   ];
 
-  propagatedBuildInputs = [ python.pkgs.netaddr ];
-  nativeBuildInputs = [ makeWrapper cmake flex bison llvmPackages.llvm.dev ];
+  propagatedBuildInputs = [ python3.pkgs.netaddr ];
+  nativeBuildInputs = [
+    bison
+    cmake
+    flex
+    llvmPackages.llvm.dev
+    makeWrapper
+    python3.pkgs.setuptools
+    zip
+  ];
 
   cmakeFlags = [
     "-DBCC_KERNEL_MODULES_DIR=/run/booted-system/kernel-modules/lib/modules"
@@ -59,6 +80,10 @@ python.pkgs.buildPythonApplication rec {
       --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
   '';
 
+  preInstall = ''
+    # required for setuptool during install
+    export PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+  '';
   postInstall = ''
     mkdir -p $out/bin $out/share
     rm -r $out/share/bcc/tools/old

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18360,7 +18360,6 @@ with pkgs;
   bpftools = callPackage ../os-specific/linux/bpftools { };
 
   bcc = callPackage ../os-specific/linux/bcc {
-    python = python3;
     llvmPackages = llvmPackages_14;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18360,11 +18360,11 @@ with pkgs;
   bpftools = callPackage ../os-specific/linux/bpftools { };
 
   bcc = callPackage ../os-specific/linux/bcc {
-    llvmPackages = llvmPackages_14;
+    llvmPackages = llvmPackages_16;
   };
 
   bpftrace = callPackage ../os-specific/linux/bpftrace {
-    llvmPackages = llvmPackages_14;
+    llvmPackages = llvmPackages_16;
   };
 
   bpm-tools = callPackage ../tools/audio/bpm-tools { };


### PR DESCRIPTION
###### Description of changes

- upgrade bcc from 0.26 to 0.28. The python packaging changed a bit but it apparently just requires pulling in setuptools and fixing up PYTHONPATH like some other services did. I've renamed python to python3 just because I don't see the point of keeping it as a variable now python = python2 is dead.
- while here upgrade the LLVM toolchain used by bcc/bpftrace to the latest llvm 16; happy to split that out if appropriate I've tested the build with both the previous llvm14 and this.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
