### PR TITLE
nixos/tailscale: add client options

### DIFF
--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -5,7 +5,8 @@ with lib;
 let
   cfg = config.services.tailscale;
   isNetworkd = config.networking.useNetworkd;
-in {
+in
+{
   meta.maintainers = with maintainers; [ danderson mbaillie twitchyliquid64 ];
 
   options.services.tailscale = {
@@ -49,56 +50,166 @@ in {
         When set to `server` or `both`, IP forwarding will be enabled.
       '';
     };
-  };
 
-  config = mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ]; # for the CLI
-    systemd.packages = [ cfg.package ];
-    systemd.services.tailscaled = {
-      wantedBy = [ "multi-user.target" ];
-      path = [
-        config.networking.resolvconf.package # for configuring DNS in some configs
-        pkgs.procps     # for collecting running services (opt-in feature)
-        pkgs.glibc      # for `getent` to look up user shells
-        pkgs.kmod       # required to pass tailscale's v6nat check
-      ];
-      serviceConfig.Environment = [
-        "PORT=${toString cfg.port}"
-        ''"FLAGS=--tun ${lib.escapeShellArg cfg.interfaceName}"''
-      ] ++ (lib.optionals (cfg.permitCertUid != null) [
-        "TS_PERMIT_CERT_UID=${cfg.permitCertUid}"
-      ]);
-      # Restart tailscaled with a single `systemctl restart` at the
-      # end of activation, rather than a `stop` followed by a later
-      # `start`. Activation over Tailscale can hang for tens of
-      # seconds in the stop+start setup, if the activation script has
-      # a significant delay between the stop and start phases
-      # (e.g. script blocked on another unit with a slow shutdown).
-      #
-      # Tailscale is aware of the correctness tradeoff involved, and
-      # already makes its upstream systemd unit robust against unit
-      # version mismatches on restart for compatibility with other
-      # linux distros.
-      stopIfChanged = false;
-    };
+    client = {
+      enable = mkEnableOption (lib.mdDoc "Enable Tailscale autoconnect");
 
-    boot.kernel.sysctl = mkIf (cfg.useRoutingFeatures == "server" || cfg.useRoutingFeatures == "both") {
-      "net.ipv4.conf.all.forwarding" = mkOverride 97 true;
-      "net.ipv6.conf.all.forwarding" = mkOverride 97 true;
-    };
-
-    networking.firewall.checkReversePath = mkIf (cfg.useRoutingFeatures == "client" || cfg.useRoutingFeatures == "both") "loose";
-
-    networking.dhcpcd.denyInterfaces = [ cfg.interfaceName ];
-
-    systemd.network.networks."50-tailscale" = mkIf isNetworkd {
-      matchConfig = {
-        Name = cfg.interfaceName;
+      authkeyFile = mkOption {
+        type = types.str;
+        description = lib.mdDoc "The authkey to use for authentication with Tailscale";
+        example = "/var/lib/secrets/tailscale/authkey";
       };
-      linkConfig = {
-        Unmanaged = true;
-        ActivationPolicy = "manual";
+
+      loginServer = mkOption {
+        type = types.str;
+        default = "";
+        description = lib.mdDoc "The login server to use for authentication with Tailscale";
+        example = "https://login.tailscale.com";
+      };
+
+      advertiseExitNode = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc "Whether to advertise this node as an exit node";
+      };
+
+      exitNode = mkOption {
+        type = types.str;
+        default = "";
+        description = lib.mdDoc "The exit node to use for this node";
+        example = "my-exit-node";
+      };
+
+      exitNodeAllowLanAccess = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc "Whether to allow LAN access to this node";
+      };
+
+      otherFlags = mkOption {
+        type = types.listOf types.str;
+        default = [""];
+        description = lib.mdDoc "Other flags to pass to `tailscale up`";
+        example = ["--shields-up" "--ssh"];
       };
     };
   };
-}
+
+  config =
+    let
+      daemon = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ]; # for the CLI
+        systemd.packages = [ cfg.package ];
+        systemd.services.tailscaled = {
+          wantedBy = [ "multi-user.target" ];
+          path = [
+            config.networking.resolvconf.package # for configuring DNS in some configs
+            pkgs.procps # for collecting running services (opt-in feature)
+            pkgs.glibc # for `getent` to look up user shells
+            pkgs.kmod # required to pass tailscale's v6nat check
+          ];
+          serviceConfig.Environment = [
+            "PORT=${toString cfg.port}"
+            ''"FLAGS=--tun ${lib.escapeShellArg cfg.interfaceName}"''
+          ] ++ (lib.optionals (cfg.permitCertUid != null) [
+            "TS_PERMIT_CERT_UID=${cfg.permitCertUid}"
+          ]);
+          # Restart tailscaled with a single `systemctl restart` at the
+          # end of activation, rather than a `stop` followed by a later
+          # `start`. Activation over Tailscale can hang for tens of
+          # seconds in the stop+start setup, if the activation script has
+          # a significant delay between the stop and start phases
+          # (e.g. script blocked on another unit with a slow shutdown).
+          #
+          # Tailscale is aware of the correctness tradeoff involved, and
+          # already makes its upstream systemd unit robust against unit
+          # version mismatches on restart for compatibility with other
+          # linux distros.
+          stopIfChanged = false;
+        };
+
+        boot.kernel.sysctl = mkIf (cfg.useRoutingFeatures == "server" || cfg.useRoutingFeatures == "both") {
+          "net.ipv4.conf.all.forwarding" = mkOverride 97 true;
+          "net.ipv6.conf.all.forwarding" = mkOverride 97 true;
+        };
+
+        networking.firewall.checkReversePath = mkIf (cfg.useRoutingFeatures == "client" || cfg.useRoutingFeatures == "both") "loose";
+
+        networking.dhcpcd.denyInterfaces = [ cfg.interfaceName ];
+
+        systemd.network.networks."50-tailscale" = mkIf isNetworkd {
+          matchConfig = {
+            Name = cfg.interfaceName;
+          };
+          linkConfig = {
+            Unmanaged = true;
+            ActivationPolicy = "manual";
+          };
+        };
+      };
+
+      client = lib.mkIf cfg.client.enable {
+        assertions = [
+          {
+            assertion = cfg.client.enable -> cfg.enable;
+            message = "client.enable must be false if enable is false";
+          }
+          {
+            assertion = cfg.client.authkeyFile != "";
+            message = "authkeyFile must be set";
+          }
+          {
+            assertion = cfg.client.exitNodeAllowLanAccess -> cfg.client.exitNode != "";
+            message = "exitNodeAllowLanAccess must be false if exitNode is not set";
+          }
+          {
+            assertion = cfg.client.advertiseExitNode -> cfg.client.exitNode == "";
+            message = "advertiseExitNode must be false if exitNode is set";
+          }
+          {
+            assertion = cfg.client.advertiseExitNode -> cfg.useRoutingFeatures == "server" || cfg.useRoutingFeatures == "both";
+            message = "advertiseExitNode must be false if useRoutingFeatures is not server or both";
+          }
+        ];
+
+        systemd.services.tailscale-autoconnect = {
+          description = "Automatic connection to Tailscale";
+
+          # make sure tailscale is running before trying to connect to tailscale
+          after = [ "network-pre.target" "tailscale.service" ];
+          wants = [ "network-pre.target" "tailscale.service" ];
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig.Type = "oneshot";
+
+          script = with pkgs; ''
+            # wait for tailscaled to settle
+            sleep 2
+
+            # check if we are already authenticated to tailscale
+            status="$(${tailscale}/bin/tailscale status -json | ${jq}/bin/jq -r .BackendState)"
+            echo "tailscale status: $status"
+            if [ "$status" != "NeedsLogin" ]; then
+                exit 0
+            fi
+
+            # otherwise authenticate with tailscale
+            # timeout after 10 seconds to avoid hanging the boot process
+            ${coreutils}/bin/timeout 10 ${tailscale}/bin/tailscale up \
+              ${lib.optionalString (cfg.client.loginServer != "") "--login-server=${cfg.client.loginServer}"} \
+              --authkey=$(cat "${cfg.client.authkeyFile}")
+
+            # we have to proceed in two steps because some options are only available
+            # after authentication
+            ${coreutils}/bin/timeout 10 ${tailscale}/bin/tailscale up \
+              ${lib.optionalString (cfg.client.loginServer != "") "--login-server=${cfg.client.loginServer}"} \
+              ${lib.optionalString (cfg.client.advertiseExitNode) "--advertise-exit-node"} \
+              ${lib.optionalString (cfg.client.exitNode != "") "--exit-node=${cfg.client.exitNode}"} \
+              ${lib.optionalString (cfg.client.exitNodeAllowLanAccess) "--exit-node-allow-lan-access"} \
+              ${escapeShellArgs cfg.client.otherFlags}
+          '';
+        };
+      };
+    in
+      lib.mkMerge [ daemon client ];
+    }


### PR DESCRIPTION
###### Description of changes

This PR adds new options to the tailscale module. It allows declarative connection to tailscale networks, provided a pre-auth key.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).