### PR TITLE
doc/module-system: Introduce concepts

### DIFF
--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -1,14 +1,207 @@
 # Module System {#module-system}
 
+::: {.note}
+This chapter is new and not complete yet. For a gentle introduction to the module system, in the context of NixOS, see [Writing NixOS Modules](https://nixos.org/manual/nixos/unstable/index.html#sec-writing-modules) in the NixOS manual.
+:::
+
 ## Introduction {#module-system-introduction}
 
 The module system is a language for handling configuration, implemented as a Nix library.
 
-Compared to plain Nix, it adds documentation, type checking and composition or extensibility.
+It was historically known as the NixOS module system.
 
-::: {.note}
-This chapter is new and not complete yet. For a gentle introduction to the module system, in the context of NixOS, see [Writing NixOS Modules](https://nixos.org/manual/nixos/unstable/index.html#sec-writing-modules) in the NixOS manual.
-:::
+Its purpose is to "extend" the Nix language with
+
+- **dynamic type checking** to find mistakes early on, improving error messages;
+- **documentation**, so that each option has a description, conveniently located in the file that declares it
+- **modularity** or **aspect oriented programming**: separate files can all contribute to the same option.
+
+The following sections are dense introductory reference material.
+
+<!-- TODO: link the tutorial
+   If you're learning to work with the module system, consider following the introductory tutorial to get a feel for the module system. -->
+
+## Concepts {#module-system-concepts}
+
+The following sections briefly define the concepts that make up the module system.
+
+<!-- keep them short -->
+
+### Module Evaluation {#module-system-concept-evaluation}
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+Module evaluation is the process of turning a set of modules into option values.
+
+The module system can be seen as an embedded domain specific language (eDSL) for configuration. The defining feature of an eDSL is that they are evaluated by a host language, which in this case is the Nix expression language. So _module evaluation_ is implemented using Nix evaluation, by means of the [`evalModules`] function.
+
+### Configuration {#module-system-concept-configuration}
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+A configuration is the result of [module evaluation](#module-system-concept-evaluation).
+
+It consists of a set of options. Each option is identified by an [attribute path], and may produce a single value (which may in turn be a composite value such as an attribute set).
+
+The module system provides its caller with _all_ the options and their values. It is up to the [application] to assign meaning to the options and to pick options (typically one option) that represents the value of the entire configuration.
+
+### Module {#module-system-concept-module}
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+A module is a function that produces part of the configuration.
+
+A module can be written using multiple, similar [syntaxes](#module-syntax), which are converted internally to the most general syntax, which is a function that returns an attribute set with specific attribute names.
+
+These attributes, the [module attributes] are then processed in order to produce the [module arguments], which are passed to the modules.
+
+As you can see, module system evaluation is a cyclic process. This works thanks to Nix's lazy evaluation.
+
+### Data flow {#module-system-data-flow}
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+The following diagram shows the data flows that occur within a module system evaluation.
+
+Multiplicity is not modeled. For example `.options -> options` is a many-to-many transformation where any option declaration can affect any option.
+
+```mermaid
+flowchart TD
+
+allModules["all modules"]
+dotimports[".imports"]
+dotoptions[".options"]
+dotconfig[".config"]
+
+subgraph evalModules["evalModules arguments"]
+modules
+prefix
+more["..."]
+end
+
+modules --> allModules
+
+allModules -->|has| dotimports
+allModules -->|has| dotoptions
+allModules -->|has| dotconfig
+
+dotimports -->|closure| allModules
+
+dotoptions -->|merge| options
+
+options -->|default| definitions
+options -->|type.merge| config
+
+dotconfig --> definitions
+
+definitions -->|merge| config
+
+options -->|argument| allModules
+config -->|argument| allModules
+
+subgraph configuration["returned configuration"]
+retOptions["options"]
+retConfig["config"]
+retModule["_module"]
+retMore["..."]
+end
+
+options --> retOptions
+config -->|remove ._module| retConfig
+config -->|_module| retModule
+```
+
+### Module syntax {#module-syntax}
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+A module can be specified as an attribute set or a function.
+The attribute set may be in canonical or shorthand form.
+
+<!-- TODO elaboration, examples -->
+
+<!-- TODO refer to complete reference doc -->
+
+### Option declaration
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+For a [configuration] to be useful, its modules must declare options, a [freeformType] or both.
+
+Options are declared by adding the return value of [mkOption] to attribute paths in the [options](#module-attr-options).
+
+Advanced: like the value of an option, the option itself will be merged when multiple declarations are present at the same option path.
+
+<!-- TODO refer to complete reference doc -->
+
+### Config definitions
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+Each module can define values for the options it chooses to. This means that multiple definitions may exist simultaneously. The definitions are merged together according to the option declaration attributes, and notably the [option type].
+
+TBD:
+- laziness and `mkIf` / `pushDownProperties`
+
+<!-- TODO refer to complete reference doc -->
+
+### Option type
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+An option type defines the condition under which a definition is valid, and it specifies how to merge definitions, if at all possible.
+
+TBD:
+- `.check` method is shallow
+- `.merge` is responsible for extra checking
+- link to the standard types
+- option types can be composed from option types.
+  - they're still called option types even if they're not a the root of an option
+
+<!-- TODO refer to complete reference doc -->
+
+### Submodules
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+A submodule is a [configuration] inside a [configuration].
+
+While options are already contained within a hierarchy of composition, by virtue of option declarations having an attribute path rather than a single attribute, this type of composition is limited to attributes with a fixed name.
+
+`types.attrsOf` on the other hand does allow definitions with arbitrary attribute names, but does not - by itself - declare an option structure with such arbitrary attributes. This is the role of the submodule [option type].
+
+Furthermore, a submodule can be used without `attrsOf` or `listOf` to add a [freeformType] at and below a certain option path.
+
+<!-- TODO refer to complete reference doc -->
+
+### freeformType
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+No need to declare all possible options
+
+TBD
+- attributes
+- mention RFC 42, as people still throw that around
+
+### Option path
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+The attribute path that leads to an option declaration.
+This is only defined within the context of a single [configuration] and does not extend through [submodules] or `types.attrsOf`. See [location].
+
+### Location
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+The path to a declaration or definition. Unlike an option path, this traverses type boundaries, resulting in a descriptive path that includes the initial option path, [attrsOf] names, and option paths within [submodules].
+
+### Definition modifiers(?)
+
+<!-- NOTE: this is an introductory section. It is not meant to be a complete reference -->
+
+`mkIf`, `mkAfter`, `mkForce`, etc.
 
 
 ## `lib.evalModules` {#module-system-lib-evalModules}


### PR DESCRIPTION

###### Description of changes

A rough draft for adding an overview of concepts to the module system reference. Early PR for presentation to docs team.

Written from memory to focus on high level structure of the library, so a bunch of work to do
 - [ ] compare* with existing docs in `evalModules` here
 - [ ] compare* with existing docs in NixOS manual

*: Compare means: make consistent, add links, deduplicate info if possible

##### Diataxis

This is reference material in a form that is meant to provide somewhat of an overview.

It defers to other sections to provide the full depth, which is uncharacteristic of typical reference material.
It is however not an explanation, as it is does not cover the why; only the what. (Except for the eDSL part I guess)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
