### PR TITLE
bitwig-studio5: init at 5.0

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
@@ -1,0 +1,126 @@
+{ stdenv
+, fetchurl
+, alsa-lib
+, atk
+, cairo
+, dpkg
+, ffmpeg
+, freetype
+, gdk-pixbuf
+, glib
+, gtk3
+, harfbuzz
+, lib
+, libglvnd
+, libjack2
+, libjpeg
+, libxkbcommon
+, makeWrapper
+, pango
+, pipewire
+, pulseaudio
+, wrapGAppsHook
+, xdg-utils
+, xorg
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bitwig-studio";
+  version = "5.0";
+
+  src = fetchurl {
+    url = "https://downloads.bitwig.com/stable/${version}/${pname}-${version}.deb";
+    sha256 = "sha256-0/S/aNoQA1nAdnr8nUWVLwzrDm+MHqmGIIjPW5YIr7s=";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook ];
+
+  unpackCmd = ''
+    mkdir -p root
+    dpkg-deb -x $curSrc root
+  '';
+
+  dontBuild = true;
+  dontWrapGApps = true; # we only want $gappsWrapperArgs here
+
+  buildInputs = with xorg; [
+    alsa-lib
+    atk
+    cairo
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    harfbuzz
+    libglvnd
+    libjack2
+    # libjpeg8 is required for converting jpeg's to colour palettes
+    libjpeg
+    libxcb
+    libXcursor
+    libX11
+    libXtst
+    libxkbcommon
+    pango
+    pipewire
+    pulseaudio
+    stdenv.cc.cc.lib
+    xcbutil
+    xcbutilwm
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r opt/bitwig-studio $out/libexec
+    ln -s $out/libexec/bitwig-studio $out/bin/bitwig-studio
+    cp -r usr/share $out/share
+    substitute usr/share/applications/com.bitwig.BitwigStudio.desktop \
+      $out/share/applications/com.bitwig.BitwigStudio.desktop \
+      --replace /usr/bin/bitwig-studio $out/bin/bitwig-studio
+
+      runHook postInstall
+  '';
+
+  postFixup = ''
+    # patchelf fails to set rpath on BitwigStudioEngine, so we use
+    # the LD_LIBRARY_PATH way
+
+    find $out -type f -executable \
+      -not -name '*.so.*' \
+      -not -name '*.so' \
+      -not -name '*.jar' \
+      -not -name 'jspawnhelper' \
+      -not -path '*/resources/*' | \
+    while IFS= read -r f ; do
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $f
+      # make xdg-open overrideable at runtime
+      wrapProgram $f \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix PATH : "${lib.makeBinPath [ ffmpeg ]}" \
+        --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
+        --suffix LD_LIBRARY_PATH : "${lib.strings.makeLibraryPath buildInputs}"
+    done
+
+    find $out -type f -executable -name 'jspawnhelper' | \
+    while IFS= read -r f ; do
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $f
+    done
+  '';
+
+  meta = with lib; {
+    description = "A digital audio workstation";
+    longDescription = ''
+      Bitwig Studio is a multi-platform music-creation system for
+      production, performance and DJing, with a focus on flexible
+      editing tools and a super-fast workflow.
+    '';
+    homepage = "https://www.bitwig.com/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ bfortz michalrus mrVanDalo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29943,8 +29943,11 @@ with pkgs;
   bitwig-studio4 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio4.nix {
     libjpeg = libjpeg.override { enableJpeg8 = true; };
   };
+  bitwig-studio5 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio5.nix {
+    libjpeg = libjpeg.override { enableJpeg8 = true; };
+  };
 
-  bitwig-studio = bitwig-studio4;
+  bitwig-studio = bitwig-studio5;
 
   bgpdump = callPackage ../tools/networking/bgpdump { };
 


### PR DESCRIPTION
###### Description of changes

This is basically a copy of the `bitwig-studio4` package, it was enough to just change the version to 5.0 (and correct the hash obviously).

It was a painless upgrade, so far all my projects of `bitwig-studio4` are working with it out of the box.


###### Things done

Copied `bitwig-studio4` to `bitwig-studio5`, changed the version and set it to the default `bitwig-studio` package.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
