### PR TITLE
vcpkg: init at 2023-08-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6414,6 +6414,11 @@
     githubId = 21156405;
     name = "GuangTao Zhang";
   };
+  guekka = {
+    github = "Guekka";
+    githubId = 39066502;
+    name = "Guekka";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6315,6 +6315,11 @@
     githubId = 6893840;
     name = "Yacine Hmito";
   };
+  gracicot = {
+    github = "gracicot";
+    githubId = 2906673;
+    name = "Guillaume Racicot";
+  };
   graham33 = {
     email = "graham@grahambennett.org";
     github = "graham33";

--- a/pkgs/development/libraries/cmakerc/default.nix
+++ b/pkgs/development/libraries/cmakerc/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+,
+}:
+stdenv.mkDerivation rec {
+  pname = "cmrc";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "vector-of-bool";
+    repo = "cmrc";
+    rev = version;
+    hash = "sha256-++16WAs2K9BKk8384yaSI/YD1CdtdyXVBIjGhqi4JIk=";
+  };
+
+  installPhase = ''
+    dir=$out/share/cmakerc
+    mkdir -p $dir
+    mv CMakeRC.cmake $dir/cmakerc-config.cmake
+  '';
+
+  meta = with lib; {
+    description = "A Resource Compiler in a Single CMake Script";
+    homepage = "https://github.com/vector-of-bool/cmrc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ guekka ];
+  };
+}

--- a/pkgs/development/tools/vcpkg-tool/default.nix
+++ b/pkgs/development/tools/vcpkg-tool/default.nix
@@ -1,0 +1,86 @@
+{ autoconf
+, automake
+, bash
+, cacert
+, cmake
+, cmakerc
+, coreutils
+, curl
+, fetchFromGitHub
+, fmt
+, gcc
+, git
+, gnumake
+, gzip
+, lib
+, makeWrapper
+, meson
+, ninja
+, perl
+, pkg-config
+, python3
+, stdenv
+, zip
+, zstd
+}:
+let
+  # These are the most common binaries used by vcpkg
+  # If a port requires a binary that is not in this list,
+  # it can be added by an overlay
+  runtimeDeps = [
+    autoconf
+    automake
+    bash
+    cacert
+    coreutils
+    curl
+    cmake
+    gcc
+    git
+    gnumake
+    gzip
+    meson
+    ninja
+    perl
+    pkg-config
+    python3
+    zip
+    zstd
+  ];
+in
+stdenv.mkDerivation {
+  pname = "vcpkg-tool";
+  version = "2023-08-02";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vcpkg-tool";
+    rev = "2023-08-02";
+    hash = "sha256-HlmqJ/rRlfRR6tJNJVaCcwdQmNboMNsXbuJ1LepfdOQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    cmakerc
+    fmt
+    ninja
+    makeWrapper
+  ];
+
+  cmakeFlags = [
+    "-DVCPKG_DEPENDENCY_EXTERNAL_FMT=ON"
+    "-DVCPKG_DEPENDENCY_CMAKERC=ON"
+  ];
+
+  postFixup = ''
+    # add the runtime dependencies to the PATH
+    wrapProgram $out/bin/vcpkg --set PATH ${lib.makeBinPath runtimeDeps}
+  '';
+
+  meta = with lib; {
+    description = "Components of microsoft/vcpkg's binary.";
+    homepage = "https://github.com/microsoft/vcpkg-tool";
+    license = licenses.mit;
+    maintainers = with maintainers; [ guekka gracicot ];
+  };
+}

--- a/pkgs/development/tools/vcpkg/default.nix
+++ b/pkgs/development/tools/vcpkg/default.nix
@@ -1,0 +1,119 @@
+{ fetchFromGitHub
+, makeWrapper
+, stdenv
+, jq
+, runtimeShell
+, lib
+, vcpkg-tool
+}:
+stdenv.mkDerivation rec {
+  pname = "vcpkg";
+  version = "2023.07.21";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vcpkg";
+    rev = "2023.07.21";
+    hash = "sha256-GxBzP8Exupvr7Zt6Txq5wQGzL3N8VwlGYPaRbF291sI=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  # vcpkg needs to be able to write to VCPKG_ROOT, and requires the executable to be in VCPKG_ROOT
+  # One way to achieve that would be to write a nixos module, but it would be better to be able to
+  # use vcpkg in a nix-shell
+  # So here's a wrapper script that will use the current user's home directory to store vcpgk's data
+  # Note: we cannot use writeShellScript, because the placeholder would refer to the script itself
+  vcpkgScript =
+    let
+      out = placeholder "out";
+    in
+    ''
+    #!${runtimeShell}
+    vcpkg_root_path="$HOME/.local/share/vcpkg/root/"
+
+    if [[ ! -d "$vcpkg_root_path" ]]; then
+      mkdir -p "$vcpkg_root_path"
+      touch "$vcpkg_root_path/.vcpkg-root"
+      touch "$vcpkg_root_path/vcpkg.disable-metrics"
+    fi
+
+    # Always take control of the root by linking current triplets
+    # We should sent a MR to vcpkg-tool to add an argument to set the builtin-triplets
+    rm -f "$vcpkg_root_path/triplets"
+    ln -s ${out}/share/vcpkg/triplets "$vcpkg_root_path"
+
+    # vcpkg needs to copy its own licence file for some reason.
+    # If vcpkg can understand that we can set the root in a immutable filesystem,
+    # we'll be able to drop this one
+    rm -f "$vcpkg_root_path/LICENSE.txt"
+    ln -s ${out}/share/vcpkg/LICENSE.txt "$vcpkg_root_path"
+
+    # vcpkg cmake script tries to bootstrap if exe is not found
+    touch "$vcpkg_root_path/vcpkg"
+
+    # this is not strictly needed, but it makes it easier for the user to find the cmake toolchain file
+    rm -f "$vcpkg_root_path/scripts"
+    ln -s ${out}/share/vcpkg/scripts "$vcpkg_root_path/"
+
+    # TODO: Make it change the root only if the vcpkg-root is either unset or set to the share dir
+    # If we do that, we'll be able to drop the patch
+    ${vcpkg-tool}/bin/vcpkg \
+      --vcpkg-root="$vcpkg_root_path" \
+      --x-scripts-root="${out}/share/vcpkg/scripts" \
+      --x-builtin-ports-root="${out}/share/vcpkg/ports" \
+      --x-builtin-registry-versions-dir="${out}/share/vcpkg/versions" "$@"
+  '';
+
+  vcpkgPatchRemoveRootArgument = builtins.readFile ./patches/remove-root-argument.diff;
+
+  passAsFile = [ "vcpkgScript" "vcpkgPatchRemoveRootArgument" ];
+
+  # This list contains the ports that fail to build
+  # They are replaced by a dummy port that will tell the user to install them with Nix
+  # It is not exhaustive, but can be extended with an overlay
+  nativePackages = [
+    "gettext"
+    "qt"
+    "qt5"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/bin $out/share/vcpkg/scripts/buildsystems
+    cp --preserve=mode -r ${src}/{docs,ports,triplets,scripts,.vcpkg-root,versions,LICENSE.txt} $out/share/vcpkg/
+    cp $vcpkgScriptPath $out/bin/vcpkg
+    chmod +x $out/bin/vcpkg
+    ln -s $out/bin/vcpkg $out/share/vcpkg/vcpkg
+    touch $out/share/vcpkg/vcpkg.disable-metrics
+  '';
+
+  postFixup = ''
+    # instead of fixing all the ports manually, we prompt the user to install them using Nix
+    # in the future, a better solution would be to generate a nix derivation from
+    # the vcpkg manifest
+    for port in ${lib.concatStringsSep " " nativePackages}
+    do
+      portfile=$out/share/vcpkg/ports/$port/portfile.cmake
+      echo 'set(VCPKG_POLICY_EMPTY_PACKAGE enabled)' > $portfile
+      echo "message(WARNING Please install $port with Nix)" >> $portfile
+
+      # We're going to manipulate the vcpkg.json here
+      # We want to preserve the structure, but remove all dependencies
+      manifest=$out/share/vcpkg/ports/$port/vcpkg.json
+      ${jq}/bin/jq 'walk(if type == "object" and has("dependencies") then .dependencies = [] else . end)' \
+        $manifest > result.json
+      mv result.json $manifest
+    done
+
+    patch -i $vcpkgPatchRemoveRootArgumentPath $out/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+  '';
+
+  meta = with lib; {
+    description = "C++ Library Manager";
+    homepage = "https://vcpkg.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ guekka gracicot ];
+  };
+}

--- a/pkgs/development/tools/vcpkg/patches/remove-root-argument.diff
+++ b/pkgs/development/tools/vcpkg/patches/remove-root-argument.diff
@@ -1,0 +1,12 @@
+index 4ee6740a2..c5a79d191 100644
+--- a/scripts/buildsystems/vcpkg.cmake
++++ b/scripts/buildsystems/vcpkg.cmake
+@@ -506,7 +506,6 @@ if(VCPKG_MANIFEST_MODE AND VCPKG_MANIFEST_INSTALL AND NOT Z_VCPKG_CMAKE_IN_TRY_C
+         execute_process(
+-            COMMAND "${Z_VCPKG_EXECUTABLE}" install
++            COMMAND vcpkg install
+                 --triplet "${VCPKG_TARGET_TRIPLET}"
+-                --vcpkg-root "${Z_VCPKG_ROOT_DIR}"
+                 "--x-wait-for-lock"
+                 "--x-manifest-root=${VCPKG_MANIFEST_DIR}"
+                 "--x-install-root=${_VCPKG_INSTALLED_DIR}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -771,6 +771,8 @@ with pkgs;
 
   vcpkg-tool = callPackage ../development/tools/vcpkg-tool { fmt = fmt_10; };
 
+  vcpkg = callPackage ../development/tools/vcpkg {  };
+
   r3ctl = qt5.callPackage ../tools/misc/r3ctl { };
 
   ptouch-print = callPackage ../misc/ptouch-print { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -477,6 +477,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };
 
+  cmakerc = callPackage ../development/libraries/cmakerc { };
+
   cmark = callPackage ../development/libraries/cmark { };
 
   cmark-gfm = callPackage ../development/libraries/cmark-gfm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -769,6 +769,8 @@ with pkgs;
 
   sea-orm-cli = callPackage ../development/tools/sea-orm-cli { };
 
+  vcpkg-tool = callPackage ../development/tools/vcpkg-tool { fmt = fmt_10; };
+
   r3ctl = qt5.callPackage ../tools/misc/r3ctl { };
 
   ptouch-print = callPackage ../misc/ptouch-print { };


### PR DESCRIPTION
###### Description of changes

This PR packages vcpkg, [the C++ package manager](vcpkg.io/).
Because a lot of ports assume a FHS environment, it provides a way to replace vcpkg ports with manually installed Nix packages.
I also tried to write a NixOS test, but got stuck because of the lack of internet access.

It is based on [the work of](https://discourse.nixos.org/t/installing-vcpkg-on-macos-using-nix/16852/8) @gracicot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
