### PR TITLE
tmuxPlugins: wrap with lib.makeScope newScope

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , pkgs
 , stdenv
+, newScope
 }:
 
 let
@@ -47,7 +48,7 @@ let
       '';
     }));
 
-in rec {
+in lib.makeScope newScope (self: with self; {
   inherit mkTmuxPlugin;
 
   mkDerivation = throw "tmuxPlugins.mkDerivation is deprecated, use tmuxPlugins.mkTmuxPlugin instead"; # added 2021-03-14
@@ -644,9 +645,7 @@ in rec {
     };
   };
 
-  tmux-thumbs = pkgs.callPackage ./tmux-thumbs {
-    inherit mkTmuxPlugin;
-  };
+  tmux-thumbs = self.callPackage ./tmux-thumbs { };
 
   urlview = mkTmuxPlugin {
     pluginName = "urlview";
@@ -722,4 +721,4 @@ in rec {
       sha256 = "hRvkBf+YrWycecnDixAsD4CAHg3KsioomfJ/nLl5Zgs=";
     };
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

I wrapped `tmuxPlugins` just like `fishPlugins` with `lib.makeScope newScope` to allow usage of `overrideScope``:

```nix
{
  tmuxPlugins = prev.tmuxPlugins.overrideScope' (tfinal: tprev: {
    new-tmux-plugin = prev.callPackage ./new-tmux-plugin.nix { };
  });
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
