### PR TITLE
pulsarctl: init at 2.10.3.3

### DIFF
--- a/pkgs/tools/admin/pulsarctl/default.nix
+++ b/pkgs/tools/admin/pulsarctl/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, nix-update-script
+, testers
+, pulsarctl
+}:
+
+buildGoModule rec {
+  pname = "pulsarctl";
+  version = "2.10.3.3";
+
+  src = fetchFromGitHub {
+    owner = "streamnative";
+    repo = "pulsarctl";
+    rev = "v${version}";
+    hash = "sha256-BOVFBIG+XKBOmLOx/IzseEArcPeriJWzn30FOERBy9s=";
+  };
+
+  vendorHash = "sha256-ao8Bxaq9LHvC6Zdd1isyMKxoTJ0MGelSPPxwgqVJcK8=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  preBuild = let
+    buildVars = {
+      ReleaseVersion = version;
+      BuildTS = "None";
+      GitHash = src.rev;
+      GitBranch = "None";
+      GoVersion = "$(go version | egrep -o 'go[0-9]+[.][^ ]*')";
+    };
+    buildVarsFlags = lib.concatStringsSep " " (lib.mapAttrsToList (k: v: "-X github.com/streamnative/pulsarctl/pkg/cmdutils.${k}=${v}") buildVars);
+  in
+  ''
+    buildFlagsArray+=("-ldflags=${buildVarsFlags}")
+  '';
+
+  excludedPackages = [
+    "./pkg/test"
+    "./pkg/test/bookkeeper"
+    "./pkg/test/bookkeeper/containers"
+    "./pkg/test/pulsar"
+    "./pkg/test/pulsar/containers"
+    "./site/gen-pulsarctldocs"
+    "./site/gen-pulsarctldocs/generators"
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    installShellCompletion --cmd pulsarctl \
+      --bash <($out/bin/pulsarctl completion bash) \
+      --fish <($out/bin/pulsarctl completion fish) \
+      --zsh <($out/bin/pulsarctl completion zsh)
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = pulsarctl;
+      command = "pulsarctl --version";
+      version = "v${version}";
+    };
+  };
+
+  meta = with lib; {
+    description = " a CLI for Apache Pulsar written in Go";
+    homepage = "https://github.com/streamnative/pulsarctl";
+    license = with licenses; [ asl20 ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ gaelreyrol ];
+    mainProgram = "pulsarctl";
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5869,6 +5869,8 @@ with pkgs;
 
   pscale = callPackage ../development/tools/pscale { };
 
+  pulsarctl = callPackage ../tools/admin/pulsarctl { };
+
   psstop = callPackage ../tools/system/psstop { };
 
   precice = callPackage ../development/libraries/precice { };


### PR DESCRIPTION
###### Description of changes

This PR adds a [pulsarctl](https://github.com/streamnative/pulsarctl) tool to manage Apache Pulsar platform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
