### PR TITLE
nixos/jool-nat64: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -911,6 +911,7 @@
   ./services/networking/jibri/default.nix
   ./services/networking/jicofo.nix
   ./services/networking/jitsi-videobridge.nix
+  ./services/networking/jool-nat64.nix
   ./services/networking/kea.nix
   ./services/networking/keepalived/default.nix
   ./services/networking/keybase.nix

--- a/nixos/modules/services/networking/jool-nat64.nix
+++ b/nixos/modules/services/networking/jool-nat64.nix
@@ -1,0 +1,94 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.jool-nat64;
+  settingsFormat = pkgs.formats.json { };
+in {
+  options.services.jool-nat64 = {
+    enable = mkEnableOption (lib.mdDoc "NAT64 translation using jool");
+
+    instances = mkOption {
+      type = types.attrsOf (types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          # explicitly list this option to have the default value
+          framework = mkOption {
+            type = types.enum [ "iptables" "netfilter" ];
+            description = "the framework used to configure the instance";
+            default = "netfilter";
+          };
+        };
+      });
+      default = {
+        default = {
+          framework = "netfilter";
+          global.pool6 = "64:ff9b::/96";
+        };
+      };
+      description = lib.mdDoc ''
+        Attribute set of jool instance configurations. The attribute names are the instance names.
+        See <https://nicmx.github.io/Jool/en/config-atomic.html#nat64> for possible configuration options.
+      '';
+      example = literalExpression ''
+        {
+          example = {
+            global = {
+              pool6 = "64:ff9b::/96";
+              pool4 = "192.0.2.1/32";
+              icmp-timeout = "0:01:00";
+            };
+          };
+          secondary = {
+            global.pool6 = "2001:db8:6464::/96";
+            denylist =  [ "192.168.0.0/16" ];
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    boot.extraModulePackages = with config.boot.kernelPackages; [ jool ];
+
+    systemd.services = lib.mapAttrs' (name: value:
+      let
+        configFile = pkgs.writeText "config"
+          # ensure that the instance name is set and matches the attribute name
+          (builtins.toJSON (value // { instance = name; }));
+      in lib.nameValuePair "jool-nat64-${name}" {
+        description = "jool stateful NAT64";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        serviceConfig = {
+          ExecStartPre = "${pkgs.kmod}/bin/modprobe jool";
+          ExecStart = "${pkgs.jool-cli}/bin/jool file handle ${configFile}";
+          ExecStop = "${pkgs.jool-cli}/bin/jool instance remove ${name}";
+          Type = "oneshot";
+          RemainAfterExit = true;
+
+          DynamicUser = true;
+          AmbientCapabilities = [ "CAP_NET_ADMIN" "CAP_SYS_MODULE" ];
+          CapabilityBoundingSet = [ "CAP_NET_ADMIN" "CAP_SYS_MODULE" ];
+          RestrictAddressFamilies = [ "AF_NETLINK" ];
+          ProtectSystem = true;
+          ProtectHome = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = [ "native" ];
+          UMask = "0077";
+        };
+      }) cfg.instances;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -380,6 +380,7 @@ in {
   jibri = handleTest ./jibri.nix {};
   jirafeau = handleTest ./jirafeau.nix {};
   jitsi-meet = handleTest ./jitsi-meet.nix {};
+  jool = handleTest ./jool.nix {};
   k3s = handleTest ./k3s {};
   kafka = handleTest ./kafka.nix {};
   kanidm = handleTest ./kanidm.nix {};

--- a/nixos/tests/jool.nix
+++ b/nixos/tests/jool.nix
@@ -1,0 +1,64 @@
+import ./make-test-python.nix ({lib, pkgs, ... }: {
+  name = "jool";
+
+  meta.maintainers = with lib.maintainers; [ apfelkuchen6 ];
+
+  nodes = {
+    plat = { self, config, pkgs, ... }: {
+      virtualisation.vlans = [ 1 2 ];
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+        firewall.enable = false;
+      };
+      systemd.network.networks = {
+        "01-eth1" = {
+          name = "eth1";
+          address = [ "2001:db8::64/64" ];
+        };
+        "02-legacynet" = {
+          name = "eth2";
+          address = [ "172.16.0.64/24" ];
+        };
+      };
+      services.jool-nat64.enable = true;
+    };
+    client = {
+      virtualisation.vlans = [ 1 ];
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+      };
+      systemd.network.networks."01-lan" = {
+        name = "eth1";
+        address = [ "2001:db8::1/64" ];
+        routes = [{
+          routeConfig = {
+            Gateway = "2001:db8::64";
+            Destination = "64:ff9b::/96";
+          };
+        }];
+      };
+    };
+    legacy = {
+      virtualisation.vlans = [ 2 ];
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+      };
+      systemd.network.networks."02-legacynet" = {
+        name = "eth1";
+        address = [ "172.16.0.2/24" ];
+      };
+    };
+  };
+  testScript = ''
+    start_all()
+    plat.wait_for_unit("systemd-networkd-wait-online.service")
+    legacy.wait_for_unit("systemd-networkd-wait-online.service")
+    client.wait_for_unit("systemd-networkd-wait-online.service")
+    plat.wait_for_unit("jool-nat64-default.service");
+
+    client.succeed("ping -c 1 64:ff9b::172.16.0.2")
+  '';
+})

--- a/pkgs/os-specific/linux/jool/cli.nix
+++ b/pkgs/os-specific/linux/jool/cli.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config, libnl, iptables }:
+{ nixosTests, lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config, libnl, iptables }:
 
 let
   sourceAttrs = (import ./source.nix) { inherit fetchFromGitHub; };
@@ -23,6 +23,11 @@ stdenv.mkDerivation {
   prePatch = ''
     sed -e 's%^XTABLES_SO_DIR = .*%XTABLES_SO_DIR = '"$out"'/lib/xtables%g' -i src/usr/iptables/Makefile
   '';
+
+
+  passthru.tests = {
+    inherit (nixosTests) jool;
+  };
 
   meta = with lib; {
     homepage = "https://www.jool.mx/";


### PR DESCRIPTION
###### Description of changes

This adds a simple nixos-module for jool-nat64 with support for multiple instances. jool-siit is not covered.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
