### PR TITLE
kodi: fix build with fmt10

### DIFF
--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -1,4 +1,5 @@
 { stdenv, lib, fetchFromGitHub, autoconf, automake, libtool, makeWrapper
+, fetchpatch
 , pkg-config, cmake, yasm, python3Packages
 , libxcrypt, libgcrypt, libgpg-error, libunistring
 , boost, avahi, lame
@@ -110,7 +111,15 @@ in stdenv.mkDerivation {
     version = kodiVersion;
 
     src = kodi_src;
-
+    patches = [
+      # Fix compatiblity with fmt 10.0 (from spdlog).
+      # Remove with the next release: https://github.com/xbmc/xbmc/pull/23453
+      (fetchpatch {
+        name = "Fix fmt10 compat";
+        url = "https://github.com/xbmc/xbmc/pull/23453.patch";
+        hash = "sha256-zMUparbQ8gfgeXj8W3MDmPi5OgLNz/zGCJINU7H6Rx0=";
+      })
+    ];
     buildInputs = [
       gnutls libidn2 libtasn1 nasm p11-kit
       libxml2 python3Packages.python


### PR DESCRIPTION
###### Description of changes

kodi doesn't build with libfmt_10, which it pulls indirectly from spdlog

We could make a spdlog variant with libfmt_9 but that compilation problem is already fixed upstream (PR still open), so just backport that PR until we get a new release

Link: https://github.com/xbmc/xbmc/pull/23453

###### Things done

Note: local computer is mighty slow, build still in progress -- will confim it all worked tomorrow but it got further than when it fails without patch so it's probably ok.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
