### PR TITLE
hypre: init at 2.28.0, add as a dependency to petsc

### DIFF
--- a/pkgs/development/libraries/science/math/hypre/default.nix
+++ b/pkgs/development/libraries/science/math/hypre/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, mpi
+, blas
+, lapack
+, openssh
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hypre";
+  version = "2.28.0";
+  # For version info for PETSc, see petsc/config/BuildSystem/config/packages/hypre.py
+
+  src = fetchFromGitHub {
+    owner = "hypre-space";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-/k2ijrre1xYT5cYrW4QbH3spgifWErXE7CnQFH01cnI=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ mpi blas lapack ];
+  checkInputs = lib.optionals (mpi.pname == "openmpi") [ openssh ];
+
+  cmakeDir = "../src";
+  cmakeFlags = [
+    "-DHYPRE_BUILD_TESTS=ON"
+    "-DHYPRE_ENABLE_HYPRE_BLAS=OFF"
+    "-DHYPRE_ENABLE_HYPRE_LAPACK=OFF"
+  ];
+
+  doCheck = true;
+  # Checks taken from the global Makefile, target `check`
+  checkPhase = ''
+    runHook preCheck
+
+    TESTS="ij struct sstruct"
+    cp $src/src/test/TEST_sstruct/sstruct.in.default .
+    for test_name in $TESTS; do
+      [ -n "$($PWD/test/$test_name > /dev/null)" ] && exit 1
+    done
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Parallel solvers for sparse linear systems featuring multigrid methods";
+    homepage = "https://www.llnl.gov/casc/hypre/";
+    downloadPage = "https://github.com/hypre-space/hypre/releases";
+    license = with lib.licenses; [ mit asl20 ];
+    maintainers = with lib.maintainers; [ yl3dy ];
+  };
+}

--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -11,6 +11,7 @@
 , petsc-withp4est ? true
 , p4est
 , zlib                  # propagated by p4est but required by petsc
+, withHypre ? true, hypre
 }:
 
 # This version of PETSc does not support a non-MPI p4est build
@@ -68,6 +69,10 @@ stdenv.mkDerivation rec {
       ''}
       "--with-blas=1"
       "--with-lapack=1"
+      ${lib.optionalString withHypre ''
+        "--with-hypre=1"
+        "--with-hypre-dir=${hypre}"
+      ''}
     )
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38195,6 +38195,8 @@ with pkgs;
 
   gurobi = callPackage ../applications/science/math/gurobi { };
 
+  hypre = callPackage ../development/libraries/science/math/hypre { };
+
   jags = callPackage ../applications/science/math/jags { };
 
   labplot = libsForQt5.callPackage ../applications/science/math/labplot { };


### PR DESCRIPTION
###### Description of changes

hypre is a collection of high performance preconditioners for iterative linear solvers, mainly used by PETSc.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).