### PR TITLE
git-blame-ignore-revs: add large docs migrations

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -39,3 +39,60 @@ d1c1a0c656ccd8bd3b25d3c4287f2d075faf3cf3
 
 # fix indentation in meteor default.nix
 a37a6de881ec4c6708e6b88fd16256bbc7f26bbd
+
+# treewide: automatically md-convert option descriptions
+2e751c0772b9d48ff6923569adfa661b030ab6a2
+
+# nixos/*: automatically convert option docs
+087472b1e5230ffc8ba642b1e4f9218adf4634a2
+
+# nixos/*: automatically convert option descriptions
+ef176dcf7e76c3639571d7c6051246c8fbadf12a
+
+# nixos/*: automatically convert option docs to MD
+61e93df1891972bae3e0c97a477bd44e8a477aa0
+
+# nixos/*: convert options with admonitions to MD
+722b99bc0eb57711c0498a86a3f55e6c69cdb05f
+
+# nixos/*: automatically convert option docs
+6039648c50c7c0858b5e506c6298773a98e0f066
+
+# nixos/*: md-convert options with unordered lists
+c915b915b5e466a0b0b2af2906cd4d2380b8a1de
+
+# nixos/*: convert options with listings
+f2ea09ecbe1fa1da32eaa6e036d64ac324a2986f
+
+# nixos/*: convert straggler options to MD
+1d41cff3dc4c8f37bb5841f51fcbff705e169178
+
+# nixos/*: normalize manpage references to single-line form
+423545fe4865d126e86721ba30da116e29c65004
+
+# nixos/documentation: split options doc build
+fc614c37c653637e5475a0b0a987489b4d1f351d
+
+# nixos/*: convert options with admonitions to MD
+722b99bc0eb57711c0498a86a3f55e6c69cdb05f
+
+# nixos/*: convert internal option descriptions to MD
+9547123258f69efd92b54763051d6dc7f3bfcaca
+
+# nixos/*: replace </para><para> with double linebreaks
+694d5b19d30bf66687b42fb77f43ea7cd1002a62
+
+# treewide: add defaultText for options with simple interpolation defaults
+fb0e5be84331188a69b3edd31679ca6576edb75a
+
+# nixos/*: mark pre-existing markdown descriptions as mdDoc
+7e7d68a250f75678451cd44f8c3d585bf750461e
+
+# nixos/*: normalize link format
+3aebb4a2be8821a6d8a695f0908d8567dc00de31
+
+# nixos/*: replace <code> in option docs with <literal>
+16102dce2fbad670bd47dd75c860a8daa5fe47ad
+
+# nixos/*: add trivial defaultText for options with simple defaults
+25124556397ba17bfd70297000270de1e6523b0a


### PR DESCRIPTION
###### Description of changes

these are by far not all commits of the docs migrations, but they are the largest ones by number of lines changed and number of files edited. hopefully this will reduce the number of misdirected module maintainer pings ...

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
