### PR TITLE
dwmblocks-async: init at 2773129

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13079,6 +13079,12 @@
     githubId = 4201956;
     name = "pongo1231";
   };
+  poptart = {
+    email = "poptart@hosakacorp.net";
+    github = "terrorbyte";
+    githubId = 1601039;
+    name = "Cale Black";
+  };
   portothree = {
     name = "Gustavo Porto";
     email = "gus@p8s.co";

--- a/pkgs/applications/misc/dwmblocks-async/default.nix
+++ b/pkgs/applications/misc/dwmblocks-async/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, libX11, patches ? [ ] }:
+
+stdenv.mkDerivation {
+  pname = "dwmblocks-async";
+  version = "unstable-2023-04-05";
+
+  src = fetchFromGitHub {
+    owner = "UtkarshVerma";
+    repo = "dwmblocks-async";
+    rev = "27731295335d31966491f55f54912c3b9dd1a7a7";
+    sha256 = "sha256-9VHalp9NM26yQ3A9NgbPFiukxfaKnv/VcKJpQh1lhu4=";
+  };
+
+  inherit patches;
+
+  buildInputs = [ libX11 ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description =
+      "A dwm status bar that utilizes a modular and async design to keep it responsive";
+    homepage = "https://github.com/UtkarshVerma/dwmblocks-async";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ poptart ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30521,6 +30521,8 @@ with pkgs;
 
   dwmblocks = callPackage ../applications/misc/dwmblocks { };
 
+  dwmblocks-async = callPackage ../applications/misc/dwmblocks-async { };
+
   dwmbar = callPackage ../applications/misc/dwmbar { };
 
   dwm-status = callPackage ../applications/window-managers/dwm/dwm-status.nix { };


### PR DESCRIPTION
###### Description of changes

This package adds the `dwmblocks-async` dwm status bar management program that utilizes a async signaling design for responsive interaction and updating. It additionally can handle mouse clicks with dwm patches and [the upstream developer has a set of example usage scripts here.](https://github.com/UtkarshVerma/dotfiles/tree/main/.local/bin/statusbar).

A couple of things of note, this project doesn't utilize the `config.def.h` style structure that is common in suckless-esque repositories and instead opts for having users directly patch the `config.h` and `config.c`, so this PR needs to be patch compatible (which I did test). If this isn't seen as acceptable I will happily add function arguments for `configFile` and `configHeaderFile` to inline replace vs patch.

For actual use with dwm click actions and colors the upstream dev [provided a list of required patches for dwm](https://github.com/UtkarshVerma/dwmblocks-async#clickable-blocks).

Project Repo: [https://github.com/UtkarshVerma/dwmblocks-async](https://github.com/UtkarshVerma/dwmblocks-async)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
