### PR TITLE
cctools-port: fix build with clang 16 on x86_64-darwin

### DIFF
--- a/pkgs/os-specific/darwin/cctools/darwin-memstream.patch
+++ b/pkgs/os-specific/darwin/cctools/darwin-memstream.patch
@@ -1,7 +1,3 @@
-MacOS SDKs before 10.13 don't support open_memstream. This is already replaced
-by a runtime check in cctools-port, but because we build with SDK 10.12 by
-default, linking still fails for us. Disable it entirely here.
-
 --- a/cctools/include/stuff/diagnostics.h
 +++ b/cctools/include/stuff/diagnostics.h
 @@ -60,13 +60,6 @@ void diagnostics_log_msg(enum diagnostic_level level, const char* message);
@@ -16,6 +12,6 @@ default, linking still fails for us. Disable it entirely here.
 -#ifndef HAVE_OPENMEMSTREAM_RUNTIME
 -#  define HAVE_OPENMEMSTREAM_RUNTIME 1
 -#endif
-+#define HAVE_OPENMEMSTREAM_RUNTIME 0
++#define HAVE_OPENMEMSTREAM_RUNTIME 1
  
  #endif /* diagnostics_h */

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, autoreconfHook
+{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, autoreconfHook, memstreamHook
 , installShellFiles
 , libuuid
 , libobjc ? null, maloader ? null
@@ -35,7 +35,8 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" "man" ];
 
-  nativeBuildInputs = [ autoconf automake libtool autoreconfHook installShellFiles ];
+  nativeBuildInputs = [ autoconf automake libtool autoreconfHook installShellFiles ]
+    ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [ memstreamHook ];
   buildInputs = [ libuuid ]
     ++ lib.optionals stdenv.isDarwin [ libobjc ]
     ++ lib.optional enableTapiSupport libtapi;
@@ -51,8 +52,9 @@ stdenv.mkDerivation {
       url = "https://github.com/MercuryTechnologies/cctools-port/commit/025899b7b3593dedb0c681e689e57c0e7bbd9b80.patch";
       hash = "sha256-SWVUzFaJHH2fu9y8RcU3Nx/QKx60hPE5zFx0odYDeQs=";
     })
-  ]
-    ++ lib.optional stdenv.isDarwin ./darwin-no-memstream.patch;
+    # Always use `open_memstream`. This is provided by memstream via hook on x86_64-darwin.
+    ./darwin-memstream.patch
+  ];
 
   __propagatedImpureHostDeps = [
     # As far as I can tell, otool from cctools is the only thing that depends on these two, and we should fix them


### PR DESCRIPTION
###### Description of changes

Clang 16 fails to build even with `open_memstream` disabled. Just use the memstream package to provide an implementation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
