### PR TITLE
openexr_2: fix IlmImf test timeout

### DIFF
--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -39,6 +39,10 @@ stdenv.mkDerivation rec {
     # Backport gcc-13 fix:
     #   https://github.com/AcademySoftwareFoundation/openexr/pull/1264
     ./gcc-13.patch
+
+    # Split IlmImfTest to avoid ctest timeout:
+    #   https://github.com/NixOS/nixpkgs/pull/234754#issuecomment-1611387839
+    ./split-IlmImf-tests.patch
   ];
 
   # tests are determined to use /var/tmp on unix

--- a/pkgs/development/libraries/openexr/split-IlmImf-tests.patch
+++ b/pkgs/development/libraries/openexr/split-IlmImf-tests.patch
@@ -1,0 +1,17 @@
+
+# Split IlmImfTest per test SUITE to avoid ctest timeout.
+# For reference:
+# https://github.com/AcademySoftwareFoundation/openexr/blob/983fed9fe11393b8fabea65fa2582af69fb91e63/OpenEXR/IlmImfTest/main.cpp#L287
+diff --git a/OpenEXR/IlmImfTest/CMakeLists.txt b/OpenEXR/IlmImfTest/CMakeLists.txt
+index 60c88afd..192a3f13 100644
+--- a/OpenEXR/IlmImfTest/CMakeLists.txt
++++ b/OpenEXR/IlmImfTest/CMakeLists.txt
+@@ -72,4 +72,7 @@ set_target_properties(IlmImfTest PROPERTIES
+ if(WIN32 AND (BUILD_SHARED_LIBS OR OPENEXR_BUILD_BOTH_STATIC_SHARED))
+   target_compile_definitions(IlmImfTest PRIVATE OPENEXR_DLL)
+ endif()
+-add_test(NAME OpenEXR.IlmImf COMMAND $<TARGET_FILE:IlmImfTest>)
++add_test(NAME OpenEXR.IlmImf_basic COMMAND $<TARGET_FILE:IlmImfTest> basic)
++add_test(NAME OpenEXR.IlmImf_core COMMAND $<TARGET_FILE:IlmImfTest> core)
++add_test(NAME OpenEXR.IlmImf_deep COMMAND $<TARGET_FILE:IlmImfTest> deep)
++add_test(NAME OpenEXR.IlmImf_multi COMMAND $<TARGET_FILE:IlmImfTest> multi)


### PR DESCRIPTION
###### Description of changes

Split openexr_2 IlmImfTest per test suite in an attempt to avoid ctest timeout.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
