### PR TITLE
sudo: 1.9.13p3 -> 1.9.14p3

### DIFF
--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , buildPackages
 , coreutils
 , pam
@@ -14,12 +15,21 @@
 
 stdenv.mkDerivation rec {
   pname = "sudo";
-  version = "1.9.13p3";
+  version = "1.9.14p3";
 
   src = fetchurl {
     url = "https://www.sudo.ws/dist/${pname}-${version}.tar.gz";
-    hash = "sha256-kjNKEruT4MBWsJ9T4lXMt9b2fGNQ4oE82Vk87sp4Vgs=";
+    hash = "sha256-oIMYscS8hYLABNTNmuKQOrxUnn5GuoFeQf6B0cB4K2I=";
   };
+
+  patches = [
+    # Extra bugfix not included in 1.9.14p3 to address a bug that impacts the
+    # NixOS test suite for sudo.
+    (fetchpatch {
+      url = "https://github.com/sudo-project/sudo/commit/760c9c11074cb921ecc0da9fbb5f0a12afd46233.patch";
+      hash = "sha256-smwyoYEkaqfQYz9C4VVz59YMtKabOPpwhS+RBwXbWuE=";
+    })
+  ];
 
   prePatch = ''
     # do not set sticky bit in nix store


### PR DESCRIPTION
###### Description of changes

Changelog: https://www.sudo.ws/releases/stable/#1.9.14

Draft for now because the switch to use_pty by default seems to break NixOS tests. I suspect it's an issue with the test driver and not sudo itself, but I haven't fully root caused it yet.

```
subtest: test5 user should not be able to run commands under root
machine: must fail: sudo -u test5 sudo -n -u root true
machine # [    7.993051] sudo[856]:     root : TTY=hvc0 ; PWD=/tmp ; USER=test5 ; COMMAND=/run/wrappers/bin/sudo -n -u root true
machine # [    8.011620] sudo[856]: pam_unix(sudo:session): session opened for user test5(uid=1005) by (uid=0)
Test "test5 user should not be able to run commands under root" failed with error: "Incorrect padding"
```

```
Traceback (most recent call last):
  File "/nix/store/q63cjgyqyf82kq8hb2zcbknsnf2jz8wf-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/driver.py", line 93, in subtest
    yield
  File "<string>", line 23, in <module>
  File "/nix/store/q63cjgyqyf82kq8hb2zcbknsnf2jz8wf-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/machine.py", line 618, in fail
    (status, out) = self.execute(command, timeout=timeout)
  File "/nix/store/q63cjgyqyf82kq8hb2zcbknsnf2jz8wf-nixos-test-driver-1.1/lib/python3.10/site-packages/test_driver/machine.py", line 546, in execute
    output = base64.b64decode(self._next_newline_closed_block_from_shell())
  File "/nix/store/1r6n7v2wam7gkr18gxccpg7p5ywgw551-python3-3.10.12/lib/python3.10/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
binascii.Error: Incorrect padding
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
