### PR TITLE
cockroachdb-bin: init at 23.1.7

### DIFF
--- a/pkgs/servers/sql/cockroachdb/cockroachdb-bin.nix
+++ b/pkgs/servers/sql/cockroachdb/cockroachdb-bin.nix
@@ -6,21 +6,25 @@
 
 let
   version = "23.1.7";
-  name = "cockroachdb-${version}";
+  name = "cockroachdb";
 
   # For several reasons building cockroach from source has become
-  # nearly imposible. See https://github.com/NixOS/nixpkgs/pull/152626
+  # nearly impossible. See https://github.com/NixOS/nixpkgs/pull/152626
   # Therefore we use the pre-build release binary and wrap it with buildFHSUserEnv to
   # work on nix.
   # You can generate the hashes with
   # nix flake prefetch <url>
-  src = fetchzip (lib.getAttr stdenv.system {
-    x86_64-linux = {
-      name = "cockroachdb-release-${version}";
-      url = "https://binaries.cockroachdb.com/cockroach-v${version}.linux-amd64.tgz";
-      sha256 = "sha256-FL/zDrl+QstBp54LE9/SbIfSPorneGZSef6dcOQJbSo=";
+  srcs = {
+    aarch64-linux = fetchzip {
+      url = "https://binaries.cockroachdb.com/cockroach-v${version}.linux-arm64.tgz";
+      hash = "sha256-73qJL3o328NckH6POXv+AUvlAJextb31Vs8NGdc8dwE=";
     };
-  });
+    x86_64-linux = fetchzip {
+      url = "https://binaries.cockroachdb.com/cockroach-v${version}.linux-amd64.tgz";
+      hash = "sha256-FL/zDrl+QstBp54LE9/SbIfSPorneGZSef6dcOQJbSo=";
+    };
+  };
+  src = srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
 in
 buildFHSEnv {
@@ -32,7 +36,7 @@ buildFHSEnv {
     homepage = "https://www.cockroachlabs.com";
     description = "A scalable, survivable, strongly-consistent SQL database";
     license = licenses.bsl11;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "aarch64-linux" "x86_64-linux" ];
     maintainers = with maintainers; [ rushmorem thoughtpolice neosimsim ];
   };
 }

--- a/pkgs/servers/sql/cockroachdb/cockroachdb-bin.nix
+++ b/pkgs/servers/sql/cockroachdb/cockroachdb-bin.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchzip
+, buildFHSEnv
+}:
+
+let
+  version = "23.1.7";
+  name = "cockroachdb-${version}";
+
+  # For several reasons building cockroach from source has become
+  # nearly imposible. See https://github.com/NixOS/nixpkgs/pull/152626
+  # Therefore we use the pre-build release binary and wrap it with buildFHSUserEnv to
+  # work on nix.
+  # You can generate the hashes with
+  # nix flake prefetch <url>
+  src = fetchzip (lib.getAttr stdenv.system {
+    x86_64-linux = {
+      name = "cockroachdb-release-${version}";
+      url = "https://binaries.cockroachdb.com/cockroach-v${version}.linux-amd64.tgz";
+      sha256 = "sha256-FL/zDrl+QstBp54LE9/SbIfSPorneGZSef6dcOQJbSo=";
+    };
+  });
+
+in
+buildFHSEnv {
+  inherit name;
+
+  runScript = "${src}/cockroach";
+
+  meta = with lib; {
+    homepage = "https://www.cockroachlabs.com";
+    description = "A scalable, survivable, strongly-consistent SQL database";
+    license = licenses.bsl11;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ rushmorem thoughtpolice neosimsim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27384,6 +27384,8 @@ with pkgs;
 
   cockroachdb = callPackage ../servers/sql/cockroachdb { };
 
+  cockroachdb-bin = callPackage ../servers/sql/cockroachdb/cockroachdb-bin.nix { };
+
   coconutbattery = callPackage ../os-specific/darwin/coconutbattery { };
 
   conky = callPackage ../os-specific/linux/conky ({


### PR DESCRIPTION
As part of #152626 we figured that recent versions of cockroach became nearly impossible to build.
As solution I suggest we use the pre-build releases in FHS.

Unfortunately version 20.1.8 has not been released for `aarch` so we have to drop these supported platforms, for now.

However I tested the derivation with a few newer release and they all worked, so updating cockroach should become a lot easier in the future.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module

