### PR TITLE
coeurl: Add upstream commits that fix build

### DIFF
--- a/pkgs/development/libraries/coeurl/default.nix
+++ b/pkgs/development/libraries/coeurl/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , ninja
 , pkg-config
 , meson
@@ -20,6 +21,22 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-sN+YSddUOdnJLcnHyWdjNm1PpxCwnkwiqSvyrwUrg6w=";
   };
+  patches = [
+    # Fix compatibility issues with curl > 7.85, see:
+    # https://nheko.im/nheko-reborn/coeurl/-/commit/d926893007c353fbc149d8538a5762ca8384273a
+    # PATCH CAN BE REMOVED AFTER 0.3.0
+    (fetchpatch {
+      url = "https://nheko.im/nheko-reborn/coeurl/-/commit/d926893007c353fbc149d8538a5762ca8384273a.patch";
+      hash = "sha256-hOBk7riuVI7k7qe/SMq3XJnFzyZ0gB9kVG7dKvWOsPY=";
+    })
+    # Fix error when building with fmt >= 10, see:
+    # https://nheko.im/nheko-reborn/coeurl/-/commit/831e2ee8e9cf08ea1ee9736cde8370f9d0312abc
+    # PATCH CAN BE REMOVED AFTER 0.3.0
+    (fetchpatch {
+      url = "https://nheko.im/nheko-reborn/coeurl/-/commit/831e2ee8e9cf08ea1ee9736cde8370f9d0312abc.patch";
+      hash = "sha256-a52Id7Nm3Mmmwv7eL58j6xovjlkpAO4KahVM/Q3H65w=";
+    })
+  ];
 
   nativeBuildInputs = [ ninja pkg-config meson ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
