### PR TITLE
spdlog: reformat expression arguments, and comment about fmt_9

### DIFF
--- a/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
+++ b/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
@@ -41,7 +41,7 @@ let
   # no stable hal release yet with recent spdlog/fmt support, remove
   # once 4.0.0 is released - see https://github.com/emsec/hal/issues/452
   spdlog' = spdlog.override {
-    fmt = fmt_8.overrideAttrs (_: rec {
+    fmt_9 = fmt_8.overrideAttrs (_: rec {
       version = "8.0.1";
       src = fetchFromGitHub {
         owner = "fmtlib";

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, fmt
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+# Although we include upstream patches that fix compilation with fmt_10, we
+# still use fmt_9 because this dependency is propagated, and many of spdlog's
+# reverse dependencies don't support fmt_9 yet.
+, fmt_9
 , staticBuild ? stdenv.hostPlatform.isStatic
 
 # tests
@@ -29,7 +37,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ fmt ];
+  propagatedBuildInputs = [ fmt_9 ];
 
   cmakeFlags = [
     "-DSPDLOG_BUILD_SHARED=${if staticBuild then "OFF" else "ON"}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40672,9 +40672,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };
 
-  spdlog = callPackage ../development/libraries/spdlog {
-    fmt = fmt_9;
-  };
+  spdlog = callPackage ../development/libraries/spdlog { };
 
   dart = callPackage ../development/compilers/dart { };
 


### PR DESCRIPTION
###### Motivation for this change

Explain in a comment why we use fmt_9, and make that visible in the expression, and not in `all-packages.nix`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
