### PR TITLE
flutter: Separate cache and unwrapped derivations #2

### DIFF
--- a/pkgs/development/compilers/flutter/patches/flutter3/move-cache.patch
+++ b/pkgs/development/compilers/flutter/patches/flutter3/move-cache.patch
@@ -35,3 +35,19 @@ index dd80b1e46e..8e54517765 100644
        if (!devToolsDir.existsSync()) {
          throw Exception('Could not find directory at ${devToolsDir.path}');
        }
+diff --git a/packages/flutter_tools/lib/src/cache.dart b/packages/flutter_tools/lib/src/cache.dart
+index 1c31c1b5db..76c7210d3b 100644
+--- a/packages/flutter_tools/lib/src/cache.dart
++++ b/packages/flutter_tools/lib/src/cache.dart
+@@ -529,6 +529,11 @@ class Cache {
+ 
+   /// Return the top-level directory in the cache; this is `bin/cache`.
+   Directory getRoot() {
++    const Platform platform = LocalPlatform();
++    if (platform.environment.containsKey('FLUTTER_CACHE_DIR')) {
++      return _fileSystem.directory(platform.environment['FLUTTER_CACHE_DIR']);
++    }
++
+     if (_rootOverride != null) {
+       return _fileSystem.directory(_fileSystem.path.join(_rootOverride!.path, 'bin', 'cache'));
+     } else {

--- a/pkgs/development/compilers/flutter/wrapper.nix
+++ b/pkgs/development/compilers/flutter/wrapper.nix
@@ -4,7 +4,19 @@
 , flutter
 , supportsLinuxDesktop ? stdenv.hostPlatform.isLinux
 , supportsAndroid ? stdenv.hostPlatform.isx86_64
-, includedEngineArtifacts ? null
+, includedEngineArtifacts ? {
+    common = [
+      "flutter_patched_sdk"
+      "flutter_patched_sdk_product"
+    ];
+    platform = {
+      android = lib.optionalAttrs supportsAndroid
+        ((lib.genAttrs [ "arm" "arm64" "x64" ] (architecture: [ "profile" "release" ])) // { x86 = [ "jit-release" ]; });
+      linux = lib.optionalAttrs supportsLinuxDesktop
+        (lib.genAttrs ((lib.optional stdenv.hostPlatform.isx86_64 "x64") ++ (lib.optional stdenv.hostPlatform.isAarch64 "arm64"))
+          (architecture: [ "debug" "profile" "release" ]));
+    };
+  }
 , extraPkgConfigPackages ? [ ]
 , extraLibraries ? [ ]
 , extraIncludes ? [ ]
@@ -32,30 +44,73 @@
 , cmake
 , ninja
 , clang
+, lndir
+, symlinkJoin
 }:
 
 let
-  flutterWithArtifacts = flutter.override {
-    includedEngineArtifacts = if includedEngineArtifacts != null then includedEngineArtifacts else {
-      common = [
-        "flutter_patched_sdk"
-        "flutter_patched_sdk_product"
-      ];
-      platform = {
-        android = lib.optionalAttrs supportsAndroid
-          ((lib.genAttrs [ "arm" "arm64" "x64" ] (architecture: [ "profile" "release" ])) // { x86 = [ "jit-release" ]; });
-        linux = lib.optionalAttrs supportsLinuxDesktop
-          (lib.genAttrs ((lib.optional stdenv.hostPlatform.isx86_64 "x64") ++ (lib.optional stdenv.hostPlatform.isAarch64 "arm64"))
-            (architecture: [ "debug" "profile" "release" ]));
-      };
-    };
+  engineArtifacts = callPackage ./engine-artifacts { inherit (flutter) engineVersion; };
+  mkCommonArtifactLinkCommand = { artifact }:
+    ''
+      mkdir -p $out/artifacts/engine/common
+      lndir -silent ${artifact} $out/artifacts/engine/common
+    '';
+  mkPlatformArtifactLinkCommand = { artifact, os, architecture, variant ? null }:
+    let
+      artifactDirectory = "${os}-${architecture}${lib.optionalString (variant != null) "-${variant}"}";
+    in
+    ''
+      mkdir -p $out/artifacts/engine/${artifactDirectory}
+      lndir -silent ${artifact} $out/artifacts/engine/${artifactDirectory}
+    '';
+  engineArtifactDirectory =
+    runCommandLocal "flutter-engine-artifacts-${flutter.version}" { nativeBuildInputs = [ lndir ]; }
+      (
+        builtins.concatStringsSep "\n"
+          ((map
+            (name: mkCommonArtifactLinkCommand {
+              artifact = engineArtifacts.common.${name};
+            })
+            (includedEngineArtifacts.common or [ ])) ++
+          (builtins.foldl'
+            (commands: os: commands ++
+              (builtins.foldl'
+                (commands: architecture: commands ++
+                  (builtins.foldl'
+                    (commands: variant: commands ++
+                      (map
+                        (artifact: mkPlatformArtifactLinkCommand {
+                          inherit artifact os architecture variant;
+                        })
+                        engineArtifacts.platform.${os}.${architecture}.variants.${variant}))
+                    (map
+                      (artifact: mkPlatformArtifactLinkCommand {
+                        inherit artifact os architecture;
+                      })
+                      engineArtifacts.platform.${os}.${architecture}.base)
+                    includedEngineArtifacts.platform.${os}.${architecture}))
+                [ ]
+                (builtins.attrNames includedEngineArtifacts.platform.${os})))
+            [ ]
+            (builtins.attrNames (includedEngineArtifacts.platform or { }))))
+      );
+
+  cacheDir = symlinkJoin {
+    name = "flutter-cache-dir";
+    paths = [
+      engineArtifactDirectory
+      "${flutter}/bin/cache"
+    ];
   };
 
   # By default, Flutter stores downloaded files (such as the Pub cache) in the SDK directory.
   # Wrap it to ensure that it does not do that, preferring home directories instead.
+  # The sh file `$out/bin/internal/shared.sh` runs when launching Flutter and calls `"$FLUTTER_ROOT/bin/cache/` instead of our environment variable `FLUTTER_CACHE_DIR`.
+  # We do not patch it since the script doesn't require engine artifacts(which are the only thing not added by the unwrapped derivation), so it shouldn't fail, and patching it will just be harder to maintain.
   immutableFlutter = writeShellScript "flutter_immutable" ''
     export PUB_CACHE=''${PUB_CACHE:-"$HOME/.pub-cache"}
-    ${flutterWithArtifacts}/bin/flutter "$@"
+    export FLUTTER_CACHE_DIR=${cacheDir}
+    ${flutter}/bin/flutter "$@"
   '';
 
   # Tools that the Flutter tool depends on.
@@ -105,12 +160,12 @@ in
 {
   nativeBuildInputs = [ makeWrapper ];
 
-  passthru = flutterWithArtifacts.passthru // {
-    inherit (flutterWithArtifacts) version;
-    unwrapped = flutterWithArtifacts;
+  passthru = flutter.passthru // {
+    inherit (flutter) version;
+    unwrapped = flutter;
   };
 
-  inherit (flutterWithArtifacts) meta;
+  inherit (flutter) meta;
 } ''
   for path in ${builtins.concatStringsSep " " (builtins.foldl' (paths: pkg: paths ++ (map (directory: "'${pkg}/${directory}/pkgconfig'") ["lib" "share"])) [ ] pkgConfigPackages)}; do
     addToSearchPath FLUTTER_PKG_CONFIG_PATH "$path"


### PR DESCRIPTION
This PR is a continuation of 238177 (Sorry for the trouble)

flutter-unwrapped will now not come with engine artifacts in its cache directory.
To specify a different cache directory, set FLUTTER_CACHE_DIR

Before this PR, changing which artifacts Flutter will have required rebuilding Flutter. This is because Flutter's unwrapped derivation required symlinking the engine artifacts to the cache directory(`$out/bin/cache`).

So this:

```dart
pkgs.flutter.override {
  supportsAndroid = false;
  supportsLinuxDesktop = true;
}
```

And this:

```dart
pkgs.flutter.override {
  supportsAndroid = true;
  supportsLinuxDesktop = true;
}
```

Would build Flutter twice, even though it's not necessary.

To fix this, this PR moved the cache directory to an environment variable(when specified). This allows changing which artifacts
Flutter sees at runtime, so no need to rebuild.

Additionally, the wrapper has been adjusted to this change and will now provide the engine artifacts through `FLUTTER_CACHE_DIR`.
### Note

The sh file `$out/bin/internal/shared.sh` runs when launching Flutter and calls `$FLUTTER_ROOT/bin/cache/` instead of our environment variable `FLUTTER_CACHE_DIR`.
I decided not to patch it since the script doesn't require engine artifacts(which are the only thing not added by the unwrapped derivation), so it shouldn't fail, and patching it will just be harder to maintain.
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
