### PR TITLE
tpm2-tss: fix CVE-2023-22745

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/CVE-2023-22745.patch
+++ b/pkgs/development/libraries/tpm2-tss/CVE-2023-22745.patch
@@ -1,0 +1,113 @@
+diff --git a/src/tss2-rc/tss2_rc.c b/src/tss2-rc/tss2_rc.c
+index 15ced567..4e146593 100644
+--- a/src/tss2-rc/tss2_rc.c
++++ b/src/tss2-rc/tss2_rc.c
+@@ -1,5 +1,8 @@
+ /* SPDX-License-Identifier: BSD-2-Clause */
+-
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++#include <assert.h>
+ #include <stdarg.h>
+ #include <stdbool.h>
+ #include <stdio.h>
+@@ -834,7 +837,7 @@ tss_err_handler (TSS2_RC rc)
+ static struct {
+     char name[TSS2_ERR_LAYER_NAME_MAX];
+     TSS2_RC_HANDLER handler;
+-} layer_handler[TPM2_ERROR_TSS2_RC_LAYER_COUNT] = {
++} layer_handler[TPM2_ERROR_TSS2_RC_LAYER_COUNT + 1] = {
+     ADD_HANDLER("tpm" , tpm2_ehandler),
+     ADD_NULL_HANDLER,                       /* layer 1  is unused */
+     ADD_NULL_HANDLER,                       /* layer 2  is unused */
+@@ -869,7 +872,7 @@ unknown_layer_handler(TSS2_RC rc)
+     static __thread char buf[32];
+ 
+     clearbuf(buf);
+-    catbuf(buf, "0x%X", tpm2_error_get(rc));
++    catbuf(buf, "0x%X", rc);
+ 
+     return buf;
+ }
+@@ -966,19 +969,27 @@ Tss2_RC_Decode(TSS2_RC rc)
+         catbuf(buf, "%u:", layer);
+     }
+ 
+-    handler = !handler ? unknown_layer_handler : handler;
+-
+     /*
+      * Handlers only need the error bits. This way they don't
+      * need to concern themselves with masking off the layer
+      * bits or anything else.
+      */
+-    UINT16 err_bits = tpm2_error_get(rc);
+-    const char *e = err_bits ? handler(err_bits) : "success";
+-    if (e) {
+-        catbuf(buf, "%s", e);
++    if (handler) {
++        UINT16 err_bits = tpm2_error_get(rc);
++        const char *e = err_bits ? handler(err_bits) : "success";
++        if (e) {
++            catbuf(buf, "%s", e);
++        } else {
++            catbuf(buf, "0x%X", err_bits);
++        }
+     } else {
+-        catbuf(buf, "0x%X", err_bits);
++        /*
++         * we don't want to drop any bits if we don't know what to do with it
++         * so drop the layer byte since we we already have that.
++         */
++        const char *e = unknown_layer_handler(rc >> 8);
++        assert(e);
++        catbuf(buf, "%s", e);
+     }
+ 
+     return buf;
+diff --git a/test/unit/test_tss2_rc.c b/test/unit/test_tss2_rc.c
+index f4249b7b..c297298d 100644
+--- a/test/unit/test_tss2_rc.c
++++ b/test/unit/test_tss2_rc.c
+@@ -199,7 +199,7 @@ test_custom_handler(void **state)
+      * Test an unknown layer
+      */
+     e = Tss2_RC_Decode(rc);
+-    assert_string_equal(e, "1:0x2A");
++    assert_string_equal(e, "1:0x100");
+ }
+ 
+ static void
+@@ -282,6 +282,23 @@ test_tcti(void **state)
+     assert_string_equal(e, "tcti:Fails to connect to next lower layer");
+ }
+ 
++static void
++test_all_FFs(void **state)
++{
++    (void) state;
++
++    const char *e = Tss2_RC_Decode(0xFFFFFFFF);
++    assert_string_equal(e, "255:0xFFFFFF");
++}
++
++static void
++test_all_FFs_set_handler(void **state)
++{
++    (void) state;
++    Tss2_RC_SetHandler(0xFF, "garbage", custom_err_handler);
++    Tss2_RC_SetHandler(0xFF, NULL, NULL);
++}
++
+ /* link required symbol, but tpm2_tool.c declares it AND main, which
+  * we have a main below for cmocka tests.
+  */
+@@ -313,6 +330,8 @@ main(int argc, char* argv[])
+             cmocka_unit_test(test_esys),
+             cmocka_unit_test(test_mu),
+             cmocka_unit_test(test_tcti),
++            cmocka_unit_test(test_all_FFs),
++            cmocka_unit_test(test_all_FFs_set_handler),
+     };
+ 
+     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -53,6 +53,9 @@ stdenv.mkDerivation rec {
     # Do not rely on dynamic loader path
     # TCTI loader relies on dlopen(), this patch prefixes all calls with the output directory
     ./no-dynamic-loader-path.patch
+    # Backport of https://github.com/tpm2-software/tpm2-tss/commit/306490c8d848c367faa2d9df81f5e69dab46ffb5
+    # Does not apply cleanly because of tests
+    ./CVE-2023-22745.patch
   ];
 
   postPatch = ''
@@ -91,6 +94,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tpm2-software/tpm2-tss";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ baloo ];
   };
 }


### PR DESCRIPTION
###### Description of changes

This brings a fix for CVE-2023-22745.

I also volunteered to [maintain the derivation](https://github.com/NixOS/nixpkgs/pull/240627) and bringing the change here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

