### PR TITLE
flat-remix-gnome: update 20230508 -> 20230606.

### DIFF
--- a/pkgs/data/themes/flat-remix-gnome/default.nix
+++ b/pkgs/data/themes/flat-remix-gnome/default.nix
@@ -7,25 +7,25 @@
 let
   # make install will use dconf to find desktop background file uri.
   # consider adding an args to allow specify pictures manually.
-  # https://github.com/daniruiz/flat-remix-gnome/blob/20230508/Makefile#L38
+  # https://github.com/daniruiz/flat-remix-gnome/blob/20230606/Makefile#L38
   fake-dconf = writeScriptBin "dconf" "echo -n";
 in
 stdenv.mkDerivation rec {
   pname = "flat-remix-gnome";
-  version = "20230508";
+  version = "20230606";
 
   src = fetchFromGitHub {
     owner = "daniruiz";
     repo = pname;
     rev = version;
-    hash = "sha256-MMWLSpGMvHFu3gZzU3IlfNxLY6ItMtxGLZltTJZXYaw=";
+    hash = "sha256-NnCRWADyAOR5yyOjB18zSQov+5FfKhhCSkDXBAL80wo=";
   };
 
   nativeBuildInputs = [ glib fake-dconf ];
   makeFlags = [ "PREFIX=$(out)" ];
 
   # make install will back up this file, it will fail if the file doesn't exist.
-  # https://github.com/daniruiz/flat-remix-gnome/blob/20230508/Makefile#L56
+  # https://github.com/daniruiz/flat-remix-gnome/blob/20230606/Makefile#L56
   preInstall = ''
     mkdir -p $out/share/gnome-shell/
     touch $out/share/gnome-shell/gnome-shell-theme.gresource


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
