### PR TITLE
mswatch: Remove rec and . from end of meta.description

### DIFF
--- a/pkgs/applications/networking/mailreaders/mswatch/default.nix
+++ b/pkgs/applications/networking/mailreaders/mswatch/default.nix
@@ -8,7 +8,7 @@
 , glib
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "mswatch";
   # Stable release won't compile successfully
   version = "unstable-2018-11-21";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A command-line Linux utility that efficiently directs mail synchronization between a pair of mailboxes.";
+    description = "A command-line Linux utility that efficiently directs mail synchronization between a pair of mailboxes";
     homepage = "https://mswatch.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/networking/mailreaders/mswatch/default.nix
+++ b/pkgs/applications/networking/mailreaders/mswatch/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchzip
+, fetchsvn
 , pkg-config
 , autoreconfHook
 , bison
@@ -13,9 +13,10 @@ stdenv.mkDerivation {
   # Stable release won't compile successfully
   version = "unstable-2018-11-21";
 
-  src = fetchzip {
-    url = "https://sourceforge.net/code-snapshots/svn/m/ms/mswatch/code/mswatch-code-r369-trunk.zip";
-    hash = "sha256-czwwhchTizfgVmeknQGLijYgaFSP/45pD2yhDKj5BKw=";
+  src = fetchsvn {
+    url = "svn://svn.code.sf.net/p/mswatch/code/trunk";
+    rev = "369";
+    sha256 = "sha256-czwwhchTizfgVmeknQGLijYgaFSP/45pD2yhDKj5BKw=";
   };
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
###### Motivation for this change

Use `fetchgit` instead of sourceforge snapshots, see discussion at https://github.com/NixOS/nixpkgs/pull/239140#discussion_r1248079360 .

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
