### PR TITLE
cpython: fix `_PYTHON_SYSCONFIGDATA_NAME` on armv7l with musl

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -184,6 +184,8 @@ let
         if parsed.cpu.significantByte.name == "littleEndian" then "arm" else "armeb"
       else if isx86_32 then "i386"
       else parsed.cpu.name;
+    # Python doesn't distinguish musl and glibc and always prefixes with "gnu"
+    gnuAbiName = replaceStrings [ "musl" ] [ "gnu" ] parsed.abi.name;
     pythonAbiName =
       # python's build doesn't support every gnu<extension>, and doesn't
       # differentiate between musl and glibc, so we list those supported in
@@ -191,7 +193,7 @@ let
       # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L724
       # Note: this is an approximation, as it doesn't take into account the CPU
       # family, or the nixpkgs abi naming conventions.
-      if elem parsed.abi.name [
+      if elem gnuAbiName [
         "gnux32"
         "gnueabihf"
         "gnueabi"
@@ -199,7 +201,7 @@ let
         "gnuabi64"
         "gnuspe"
       ]
-      then parsed.abi.name
+      then gnuAbiName
       else "gnu";
     multiarch =
       if isDarwin then "darwin"


### PR DESCRIPTION
Python always uses "gnu" prefixed ABI names, and this PR handles this by doing a `musl`->`gnu` string replacement.

This was previously done in #110293, and was mistakenly removed in #210035.

With `pkgsCross.armv7l-hf-multiplatform.pkgsStatic`, `parsed.abi.name` is `musleabihf`. Previously, the sysconfigdata name was:
`_sysconfigdata__linux_arm-linux-gnu`

Now, the corrected name is:
`_sysconfigdata__linux_arm-linux-gnueabihf`

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv7l-linux (musl, cross)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @minijackson @pjjw @FRidh 