### PR TITLE
jhide: init at 0.1.0-unstable-2021-05-01

### DIFF
--- a/pkgs/by-name/jh/jhide/package.nix
+++ b/pkgs/by-name/jh/jhide/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  fetchFromGitLab,
+  writeText,
+  sbcl,
+  asdf,
+}:
+sbcl.buildASDFSystem {
+  pname = "jhide";
+  version = "0.1.0-unstable-2021-05-01";
+
+  src = fetchFromGitLab {
+    owner = "jgkamat";
+    repo = "jhide";
+    rev = "93f364a39c326620d5a2c7a598af0f6967c47ae5";
+    hash = "sha256-iuuuXUSz9rhv1kYCQ+FewegWUaVdjvO8S4uo4R5pV1Y=";
+  };
+
+  lispLibs = with sbcl.pkgs; [
+    parenscript
+    str
+    unix-opts
+    alexandria
+    arrow-macros
+    cl-json
+  ];
+
+  buildScript = writeText "build-jhide.lisp" ''
+    (load "${asdf}/lib/common-lisp/asdf/build/asdf.lisp")
+
+    (asdf:load-system 'jhide)
+
+    ;; Prevents "cannot create /homeless-shelter" error
+    (asdf:disable-output-translations)
+
+    (sb-ext:save-lisp-and-die
+      "jhide"
+      :purify t
+      #+sb-core-compression :compression
+      #+sb-core-compression t
+      :executable t
+
+      ;; Prevent --help from being intercepted by sbcl
+      :save-runtime-options t
+
+      :toplevel #'jhide:main)
+  '';
+
+  flags = [
+    "--noinform"
+    "--non-interactive"
+    "--end-toplevel-options"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp jhide $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Tool for creating Greasemonkey scripts from AdBlock Plus element filtering lists";
+    homepage = "https://gitlab.com/jgkamat/jhide";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ somasis ];
+    mainProgram = "jhide";
+  };
+}


### PR DESCRIPTION
###### Description of changes

jhide is a tool for generating Greasemonkey scripts from AdBlockPlus lists that contain element hiding filters.

Useful for adding element-hiding functionality to some alternative browsers such as `qutebrowser`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
