### PR TITLE
nixos/atop: Fix regression in enabling atop units

### DIFF
--- a/nixos/modules/programs/atop.nix
+++ b/nixos/modules/programs/atop.nix
@@ -123,8 +123,8 @@ in
       boot.extraModulePackages = [ (lib.mkIf cfg.netatop.enable cfg.netatop.package) ];
       systemd =
         let
-          mkSystemd = type: cond: name: restartTriggers: {
-            ${name} = lib.mkIf cond {
+          mkSystemd = type: name: restartTriggers: {
+            ${name} = {
               inherit restartTriggers;
               wantedBy = [ (if type == "services" then "multi-user.target" else if type == "timers" then "timers.target" else null) ];
             };
@@ -134,42 +134,44 @@ in
         in
         {
           packages = [ atop (lib.mkIf cfg.netatop.enable cfg.netatop.package) ];
-          services =
-            mkService cfg.atopService.enable "atop" [ atop ]
-            // lib.mkIf cfg.atopService.enable {
-              # always convert logs to newer version first
-              # XXX might trigger TimeoutStart but restarting atop.service will
-              # convert remainings logs and start eventually
-              atop.serviceConfig.ExecStartPre = pkgs.writeShellScript "atop-update-log-format" ''
-                set -e -u
-                shopt -s nullglob
-                for logfile in "$LOGPATH"/atop_*
-                do
-                  ${atop}/bin/atopconvert "$logfile" "$logfile".new
-                  # only replace old file if version was upgraded to avoid
-                  # false positives for atop-rotate.service
-                  if ! ${pkgs.diffutils}/bin/cmp -s "$logfile" "$logfile".new
-                  then
-                    ${pkgs.coreutils}/bin/mv -v -f "$logfile".new "$logfile"
-                  else
-                    ${pkgs.coreutils}/bin/rm -f "$logfile".new
-                  fi
-                done
-              '';
-            }
-            // mkService cfg.atopacctService.enable "atopacct" [ atop ]
-            // mkService cfg.netatop.enable "netatop" [ cfg.netatop.package ]
-            // mkService cfg.atopgpu.enable "atopgpu" [ atop ];
-          timers = mkTimer cfg.atopRotateTimer.enable "atop-rotate" [ atop ];
+          services = lib.mkMerge [
+            (lib.mkIf cfg.atopService.enable (lib.recursiveUpdate
+              (mkService "atop" [ atop ])
+              {
+                # always convert logs to newer version first
+                # XXX might trigger TimeoutStart but restarting atop.service will
+                # convert remainings logs and start eventually
+                atop.preStart = ''
+                  set -e -u
+                  shopt -s nullglob
+                  for logfile in "$LOGPATH"/atop_*
+                  do
+                    ${atop}/bin/atopconvert "$logfile" "$logfile".new
+                    # only replace old file if version was upgraded to avoid
+                    # false positives for atop-rotate.service
+                    if ! ${pkgs.diffutils}/bin/cmp -s "$logfile" "$logfile".new
+                    then
+                      ${pkgs.coreutils}/bin/mv -v -f "$logfile".new "$logfile"
+                    else
+                      ${pkgs.coreutils}/bin/rm -f "$logfile".new
+                    fi
+                  done
+                '';
+              }))
+            (lib.mkIf cfg.atopacctService.enable (mkService "atopacct" [ atop ]))
+            (lib.mkIf cfg.netatop.enable (mkService "netatop" [ cfg.netatop.package ]))
+            (lib.mkIf cfg.atopgpu.enable (mkService "atopgpu" [ atop ]))
+          ];
+          timers = lib.mkIf cfg.atopRotateTimer.enable (mkTimer "atop-rotate" [ atop ]);
         };
 
       security.wrappers = lib.mkIf cfg.setuidWrapper.enable {
-        atop =
-          { setuid = true;
-            owner = "root";
-            group = "root";
-            source = "${atop}/bin/atop";
-          };
+        atop = {
+          setuid = true;
+          owner = "root";
+          group = "root";
+          source = "${atop}/bin/atop";
+        };
       };
     }
   );


### PR DESCRIPTION
Fix regression where the systemd units for atop are no longer automatically started at boot when programs.atop.enable = true.

Regression was introduced in commit: 09350ff7d424
  nixos/atop: Convert log format to fix service start

This commit restructures the atop systemd service config so that the code to convert the log format gets configured as a preStart script along with the addition of the wantedBy rule.

**Additional notes on the regression:**
The atop unit files get created correctly, but are not linked from
/etc/systemd/system/multi-user.target.wants.

With the module's default settings, the two units that are not started
are: atop.service and atopacct.service.  As a result, atop logs do not
get created under /var/log/atop, unless the units are started manually.

The associated PR: #175558

The problem with the units not starting is noted in a comment, along
with a workaround, on PR:  https://github.com/NixOS/nixpkgs/pull/175558#issuecomment-1213085331


**Additional notes on testing:**
To test, I ran the atop.defaults test (which had been failing on master):
```
$ nix-build '<nixpkgs>' -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/c7e4b0832c92b56db5916811083d2c6963e0bb2d.tar.gz -A nixosTests.atop.defaults
```
20230708 -- updated test URL for latest commit:
```
$ nix-build '<nixpkgs>' -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/8f4f1ce005ceba182805d5a8866e39269b9a23a5.tar.gz -A nixosTests.atop.defaults
```
I also successfully built nixosTests.atop.netatop, which had also been failing.

I also built nixosTests.atop.justThePackage and nixosTests.atop.minimal, which had not been failing.

I skipped testing of nixosTests.atop.atopgpu and nixosTests.atop.everything.

NOTE: I believe the update can be backported to NixOS 23.05.

@pschyska @7c6f434c @klemensn 
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
