### PR TITLE
searx: fix for flask-babel 3.0

### DIFF
--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -14,6 +14,10 @@ toPythonModule (buildPythonApplication rec {
     sha256 = "sha256-+Wsg1k/h41luk5aVfSn11/lGv8hZYVvpHLbbYHfsExw=";
   };
 
+  patches = [
+   ./fix-flask-babel-3.0.patch
+  ];
+
   postPatch = ''
     sed -i 's/==.*$//' requirements.txt
   '';

--- a/pkgs/servers/web-apps/searx/fix-flask-babel-3.0.patch
+++ b/pkgs/servers/web-apps/searx/fix-flask-babel-3.0.patch
@@ -1,0 +1,27 @@
+commit 38b3a4f70e3226a091c53300659752c595b120f9
+Author: rnhmjoj <rnhmjoj@inventati.org>
+Date:   Fri Jun 30 21:48:35 2023 +0200
+
+    Fix for flask-babel 3.0
+
+diff --git a/searx/webapp.py b/searx/webapp.py
+index 2027e72d..f3174a45 100755
+--- a/searx/webapp.py
++++ b/searx/webapp.py
+@@ -167,7 +167,7 @@ _flask_babel_get_translations = flask_babel.get_translations
+ def _get_translations():
+     if has_request_context() and request.form.get('use-translation') == 'oc':
+         babel_ext = flask_babel.current_app.extensions['babel']
+-        return Translations.load(next(babel_ext.translation_directories), 'oc')
++        return Translations.load(babel_ext.translation_directories[0], 'oc')
+ 
+     return _flask_babel_get_translations()
+ 
+@@ -188,7 +188,6 @@ def _get_browser_or_settings_language(request, lang_list):
+     return settings['search']['default_lang'] or 'en'
+ 
+ 
+-@babel.localeselector
+ def get_locale():
+     if 'locale' in request.form\
+        and request.form['locale'] in settings['locales']:


### PR DESCRIPTION

###### Description of changes

The update to flask-babel 3.0 (48958930) broke searx, despite the program apparently building.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested with `searx.tests`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
