### PR TITLE
python310Packages.requests-toolbelt: 0.10.1 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/requests-toolbelt/default.nix
+++ b/pkgs/development/python-modules/requests-toolbelt/default.nix
@@ -1,22 +1,21 @@
 { lib
 , betamax
 , buildPythonPackage
-, fetchpatch
 , fetchPypi
-, mock
 , pyopenssl
 , pytestCheckHook
 , requests
+, trustme
 }:
 
 buildPythonPackage rec {
   pname = "requests-toolbelt";
-  version = "0.10.1";
+  version = "1.0.0";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-YuCff/XMvakncqKfOUpJw61ssYHVaLEzdiayq7Yopj0=";
+    hash = "sha256-doGgo9BHAStb3A7jfX+PB+vnarCMrsz8OSHOI8iNW8Y=";
   };
 
   propagatedBuildInputs = [
@@ -25,17 +24,9 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     betamax
-    mock
+    pyopenssl
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # https://github.com/requests/toolbelt/issues/306
-    "test_no_content_length_header"
-    "test_read_file"
-    "test_reads_file_from_url_wrapper"
-    "test_x509_der"
-    "test_x509_pem"
+    trustme
   ];
 
   pythonImportsCheck = [
@@ -45,6 +36,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Toolbelt of useful classes and functions to be used with requests";
     homepage = "http://toolbelt.rtfd.org";
+    changelog = "https://github.com/requests/toolbelt/blob/${version}/HISTORY.rst";
     license = licenses.asl20;
     maintainers = with maintainers; [ matthiasbeyer ];
   };


### PR DESCRIPTION
###### Description of changes

From the release notes:

>**Breaking Changes**
Removed Google App Engine support to allow using urllib3 2.0
>
>**Fixed Bugs**
Ensured the test suite no longer reaches the Internet
>
>**Miscellaneous**
Added explicit support for Python 3.11

I think that the tests can be reenabled because the certificate expiration issue that was reported in https://github.com/NixOS/nixpkgs/issues/147776 should be fixed now that upstream uses `trustme`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
