### PR TITLE
build-support: Add fetchpijul function.

### DIFF
--- a/pkgs/build-support/fetchpijul/default.nix
+++ b/pkgs/build-support/fetchpijul/default.nix
@@ -1,0 +1,56 @@
+{ lib, stdenvNoCC, pijul }:
+
+lib.makeOverridable (
+{ url
+, hash ? ""
+, change ? null
+, state ? null
+, channel ? "main"
+, name ? "fetchpijul"
+, # TODO: Changes in pijul are unordered so there's many ways to end up with the same repository state.
+  # This makes leaveDotPijul unfeasible to implement until pijul CLI implements
+  # a way of reordering changes to sort them in a consistent and deterministic manner.
+  # leaveDotPijul ? false
+}:
+if change != null && state != null then
+  throw "Only one of 'change' or 'state' can be set"
+else
+  stdenvNoCC.mkDerivation {
+    inherit name;
+    nativeBuildInputs = [ pijul ];
+
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      pijul clone \
+        ''${change:+--change "$change"} \
+        ''${state:+--state "$state"} \
+        --channel "$channel" \
+        "$url" \
+        "$out"
+
+      runHook postInstall
+    '';
+
+    fixupPhase = ''
+      runHook preFixup
+
+      rm -rf "$out/.pijul"
+
+      runHook postFixup
+    '';
+
+    outputHashAlgo = if hash != "" then null else "sha256";
+    outputHashMode = "recursive";
+    outputHash = if hash != "" then
+      hash
+    else
+      lib.fakeSha256;
+
+    inherit url change state channel;
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -899,6 +899,8 @@ with pkgs;
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  fetchpijul = callPackage ../build-support/fetchpijul { };
+
   inherit (callPackage ../build-support/node/fetch-yarn-deps { })
     prefetch-yarn-deps
     fetchYarnDeps;


### PR DESCRIPTION
###### Description of changes

Adds a super simple fetcher which clones a pijul repository.
Closes #121526

Potential next steps:
- Add ability to specify what paths to clone
- Add `fetchFromNest` for similar convenience to `fetchFromGitHub` etc.

Note that pijul does not have a notion of "revisions" and likewise changes in pijul are unordered. The `change` attribute will fetch only the specific change and all of its dependencies (usually not what you want, though could be more useful, especially with the added ability to specify which paths to clone). The `state` attribute however identifies the state of the repository with all the patches up to this point applied.
This is the closest to git's revision and should be what deterministically identifies the state of a repository at a specific moment in time.

EDIT: One additional argument that could be helpful would be `channel`. Channels are not quite like branches in git because they simply point to a specific set of changes. For example channel `main` could be an alias for patches `A B D` and channel `foo` could be an alias for patches `A C D`. More info here: https://pijul.org/manual/workflows/channels.html
EDIT2: Added as it seems like `state` depends on what channel we specify

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
