### PR TITLE
openfpgaloader: Remove udev dependency if not available (e.g. on Darwin)

### DIFF
--- a/pkgs/development/embedded/fpga/openfpgaloader/default.nix
+++ b/pkgs/development/embedded/fpga/openfpgaloader/default.nix
@@ -26,10 +26,9 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libftdi1
     libusb1
-    udev
     hidapi
     zlib
-  ];
+  ] ++ lib.optionals (!stdenv.isDarwin) [ udev ];
 
   meta = with lib; {
     description = "Universal utility for programming FPGAs";

--- a/pkgs/development/embedded/fpga/openfpgaloader/default.nix
+++ b/pkgs/development/embedded/fpga/openfpgaloader/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     libusb1
     hidapi
     zlib
-  ] ++ lib.optionals (!stdenv.isDarwin) [ udev ];
+  ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform udev) [ udev ];
 
   meta = with lib; {
     description = "Universal utility for programming FPGAs";


### PR DESCRIPTION
###### Description of changes

openfpgaloader: Remove udev dependency if not available (e.g. on Darwin).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

