### PR TITLE
buildFHSEnv: disable multiArch by default

### DIFF
--- a/doc/builders/special/fhs-environments.section.md
+++ b/doc/builders/special/fhs-environments.section.md
@@ -11,6 +11,8 @@ Accepted arguments are:
         Packages to be installed for the main host's architecture (i.e. x86_64 on x86_64 installations). Along with libraries binaries are also installed.
 - `multiPkgs`
         Packages to be installed for all architectures supported by a host (i.e. i686 and x86_64 on x86_64 installations). Only libraries are installed by default.
+- `multiArch`
+        Whether to install 32bit multiPkgs into the FHSEnv in 64bit environments
 - `extraBuildCommands`
         Additional commands to be executed for finalizing the directory structure.
 - `extraBuildCommandsMulti`

--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -16,7 +16,7 @@ let
 in appimageTools.wrapType2 {
   inherit pname version src;
 
-  multiPkgs = null; # no 32bit needed
+  multiArch = false; # no 32bit needed
   extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
 
   extraInstallCommands = ''

--- a/pkgs/applications/blockchains/mycrypto/default.nix
+++ b/pkgs/applications/blockchains/mycrypto/default.nix
@@ -28,7 +28,7 @@ let
 in appimageTools.wrapType2 rec {
   inherit name src;
 
-  multiPkgs = null; # no p32bit needed
+  multiArch = false; # no p32bit needed
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
 
   extraInstallCommands = ''

--- a/pkgs/applications/misc/bottles/fhsenv.nix
+++ b/pkgs/applications/misc/bottles/fhsenv.nix
@@ -7,6 +7,9 @@
 }:
 
 let fhsEnv = {
+  # Many WINE games need 32bit
+  multiArch = true;
+
   targetPkgs = pkgs: with pkgs; [
     bottles-unwrapped
     # This only allows to enable the toggle, vkBasalt won't work if not installed with environment.systemPackages (or nix-env)

--- a/pkgs/applications/misc/chrysalis/default.nix
+++ b/pkgs/applications/misc/chrysalis/default.nix
@@ -14,7 +14,7 @@ in appimageTools.wrapAppImage rec {
     };
   };
 
-  multiPkgs = null;
+  multiArch = false;
   extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [
     p.glib
   ];

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -47,7 +47,7 @@ let
       export LC_ALL=C.UTF-8
     '';
 
-    multiPkgs = null; # no 32bit needed
+    multiArch = false; # no 32bit needed
     extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
     extraInstallCommands = ''
       mv $out/bin/{${name},${pname}}

--- a/pkgs/applications/misc/lutris/fhsenv.nix
+++ b/pkgs/applications/misc/lutris/fhsenv.nix
@@ -18,6 +18,9 @@ in buildFHSEnv {
 
   runScript = "lutris";
 
+  # Many native and WINE games need 32bit
+  multiArch = true;
+
   targetPkgs = pkgs: with pkgs; [
     lutris-unwrapped
 

--- a/pkgs/applications/misc/marktext/default.nix
+++ b/pkgs/applications/misc/marktext/default.nix
@@ -20,7 +20,7 @@ appimageTools.wrapType2 rec {
     export LC_ALL=C.UTF-8
   '';
 
-  multiPkgs = null; # no 32bit needed
+  multiArch = false; # no 32bit needed
   extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [
     p.libsecret
     p.xorg.libxkbfile

--- a/pkgs/applications/misc/notable/default.nix
+++ b/pkgs/applications/misc/notable/default.nix
@@ -26,7 +26,7 @@ appimageTools.wrapType2 rec {
     export LC_ALL=C.UTF-8
   '';
 
-  multiPkgs = null; # no 32bit needed
+  multiArch = false; # no 32bit needed
   extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [ p.at-spi2-atk p.at-spi2-core ];
   extraInstallCommands = ''
     mv $out/bin/{${name},${pname}}

--- a/pkgs/applications/misc/zettlr/default.nix
+++ b/pkgs/applications/misc/zettlr/default.nix
@@ -21,7 +21,7 @@ in
 appimageTools.wrapType2 rec {
   inherit name src;
 
-  multiPkgs = null; # no 32bit needed
+  multiArch = false; # no 32bit needed
   extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ texlive pandoc ];
   extraInstallCommands = ''
     mv $out/bin/{${name},${pname}}

--- a/pkgs/applications/networking/Sylk/default.nix
+++ b/pkgs/applications/networking/Sylk/default.nix
@@ -17,7 +17,7 @@ appimageTools.wrapType2 rec {
     export LC_ALL=C.UTF-8
   '';
 
-  multiPkgs = null; # no 32bit needed
+  multiArch = false; # no 32bit needed
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
   extraInstallCommands = "mv $out/bin/{${name},${pname}}";
 

--- a/pkgs/applications/networking/browsers/polypane/default.nix
+++ b/pkgs/applications/networking/browsers/polypane/default.nix
@@ -16,7 +16,7 @@ let
 in appimageTools.wrapType2 {
   inherit pname src version;
 
-  multiPkgs = null;
+  multiArch = false;
   extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
 
   extraInstallCommands = ''

--- a/pkgs/applications/networking/cluster/octant/desktop.nix
+++ b/pkgs/applications/networking/cluster/octant/desktop.nix
@@ -27,7 +27,7 @@ let
       export LC_ALL=C.UTF-8
     '';
 
-    multiPkgs = null; # no 32bit needed
+    multiArch = false; # no 32bit needed
     extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
     extraInstallCommands =
       let appimageContents = appimageTools.extractType2 { inherit name src; }; in

--- a/pkgs/applications/networking/station/default.nix
+++ b/pkgs/applications/networking/station/default.nix
@@ -20,7 +20,7 @@ in appimageTools.wrapType2 rec {
     export LC_ALL=C.UTF-8
   '';
 
-  multiPkgs = null;
+  multiArch = false;
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
   extraInstallCommands = ''
     mv $out/bin/{${name},${pname}}

--- a/pkgs/applications/office/tusk/default.nix
+++ b/pkgs/applications/office/tusk/default.nix
@@ -31,7 +31,7 @@ in appimageTools.wrapType2 rec {
     export LC_ALL=C.UTF-8
   '';
 
-  multiPkgs = null; # no 32bit needed
+  multiArch = false; # no 32bit needed
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
   extraInstallCommands = ''
     mv $out/bin/{${pname}-${version},${pname}}

--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -36,7 +36,7 @@ let
   inherit (stdenv) is64bit;
 
   # use of glibc_multi is only supported on x86_64-linux
-  isMultiBuild  = multiPkgs != null && stdenv.isx86_64 && stdenv.isLinux;
+  isMultiBuild = stdenv.system == "x86_64-linux";
   isTargetBuild = !isMultiBuild;
 
   # list of packages (usually programs) which are only be installed for the
@@ -51,21 +51,34 @@ let
   # these match the host's architecture, glibc_multi is used for multilib
   # builds. glibcLocales must be before glibc or glibc_multi as otherwiese
   # the wrong LOCALE_ARCHIVE will be used where only C.UTF-8 is available.
-  basePkgs = with pkgs;
-    [ glibcLocales
-      (if isMultiBuild then glibc_multi else glibc)
-      (toString gcc.cc.lib) bashInteractiveFHS coreutils less shadow su
-      gawk diffutils findutils gnused gnugrep
-      gnutar gzip bzip2 xz
-    ];
-  baseMultiPkgs = with pkgsi686Linux;
-    [ (toString gcc.cc.lib)
-    ];
+  basePkgs = with pkgs; [
+    glibcLocales
+    (if isMultiBuild then glibc_multi else glibc)
+    (toString gcc.cc.lib)
+    bashInteractiveFHS
+    coreutils
+    less
+    shadow
+    su
+    gawk
+    diffutils
+    findutils
+    gnused
+    gnugrep
+    gnutar
+    gzip
+    bzip2
+    xz
+  ];
+  baseMultiPkgs = with pkgsi686Linux; [
+    (toString gcc.cc.lib)
+  ];
 
   ldconfig = writeShellScriptBin "ldconfig" ''
     # due to a glibc bug, 64-bit ldconfig complains about patchelf'd 32-bit libraries, so we're using 32-bit ldconfig
-    exec ${if stdenv.isx86_64 && stdenv.isLinux then pkgsi686Linux.glibc.bin else pkgs.glibc.bin}/bin/ldconfig -f /etc/ld.so.conf -C /etc/ld.so.cache "$@"
+    exec ${if stdenv.system == "x86_64-linux" then pkgsi686Linux.glibc.bin else pkgs.glibc.bin}/bin/ldconfig -f /etc/ld.so.conf -C /etc/ld.so.cache "$@"
   '';
+
   etcProfile = writeText "profile" ''
     export PS1='${name}-chrootenv:\u@\h:\w\$ '
     export LOCALE_ARCHIVE='/usr/lib/locale/locale-archive'
@@ -104,7 +117,7 @@ let
   # Compose /etc for the chroot environment
   etcPkg = runCommandLocal "${name}-chrootenv-etc" { } ''
     mkdir -p $out/etc
-    cd $out/etc
+    pushd $out/etc
 
     # environment variables
     ln -s ${etcProfile} profile
@@ -172,13 +185,18 @@ let
     ln -s lib64 lib
 
     # copy glibc stuff
-    cp -rsHf ${staticUsrProfileTarget}/lib/32/* lib32/ && chmod u+w -R lib32/
+    cp -rsHf ${staticUsrProfileTarget}/lib/32/* lib32/
+    chmod u+w -R lib32/
 
     # copy content of multiPaths (32bit libs)
-    [ -d ${staticUsrProfileMulti}/lib ] && cp -rsHf ${staticUsrProfileMulti}/lib/* lib32/ && chmod u+w -R lib32/
+    if [ -d ${staticUsrProfileMulti}/lib ]; then
+      cp -rsHf ${staticUsrProfileMulti}/lib/* lib32/
+      chmod u+w -R lib32/
+    fi
 
     # copy content of targetPaths (64bit libs)
-    cp -rsHf ${staticUsrProfileTarget}/lib/* lib64/ && chmod u+w -R lib64/
+    cp -rsHf ${staticUsrProfileTarget}/lib/* lib64/
+    chmod u+w -R lib64/
 
     # symlink 32-bit ld-linux.so
     ln -Ls ${staticUsrProfileTarget}/lib/32/ld-linux.so.2 lib/
@@ -191,13 +209,15 @@ let
   # the target profile is the actual profile that will be used for the chroot
   setupTargetProfile = ''
     mkdir -m0755 usr
-    cd usr
+    pushd usr
+
     ${setupLibDirs}
-    ${lib.optionalString isMultiBuild ''
+
+    '' + lib.optionalString isMultiBuild ''
     if [ -d "${staticUsrProfileMulti}/share" ]; then
       cp -rLf ${staticUsrProfileMulti}/share share
     fi
-    ''}
+    '' + ''
     if [ -d "${staticUsrProfileTarget}/share" ]; then
       if [ -d share ]; then
         chmod -R 755 share
@@ -223,18 +243,19 @@ let
         ln -s "$i"
       fi
     done
+
+    popd
   '';
 
 in runCommandLocal "${name}-fhs" {
   passthru = {
-    inherit args multiPaths targetPaths;
+    inherit args multiPaths targetPaths ldconfig;
   };
 } ''
   mkdir -p $out
-  cd $out
+  pushd $out
+
   ${setupTargetProfile}
-  cd $out
   ${extraBuildCommands}
-  cd $out
   ${lib.optionalString isMultiBuild extraBuildCommandsMulti}
 ''

--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -12,6 +12,7 @@
 , profile ? ""
 , targetPkgs ? pkgs: []
 , multiPkgs ? pkgs: []
+, multiArch ? true # Whether to include 32bit packages
 , extraBuildCommands ? ""
 , extraBuildCommandsMulti ? ""
 , extraOutputsToInstall ? []
@@ -35,8 +36,8 @@
 let
   inherit (stdenv) is64bit;
 
-  # use of glibc_multi is only supported on x86_64-linux
-  isMultiBuild = stdenv.system == "x86_64-linux";
+  # "use of glibc_multi is only supported on x86_64-linux"
+  isMultiBuild = multiArch && stdenv.system == "x86_64-linux";
   isTargetBuild = !isMultiBuild;
 
   # list of packages (usually programs) which are only be installed for the

--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -12,7 +12,7 @@
 , profile ? ""
 , targetPkgs ? pkgs: []
 , multiPkgs ? pkgs: []
-, multiArch ? true # Whether to include 32bit packages
+, multiArch ? false # Whether to include 32bit packages
 , extraBuildCommands ? ""
 , extraBuildCommandsMulti ? ""
 , extraOutputsToInstall ? []

--- a/pkgs/development/embedded/arduino/arduino-core/chrootenv.nix
+++ b/pkgs/development/embedded/arduino/arduino-core/chrootenv.nix
@@ -14,7 +14,7 @@ buildFHSEnv {
         pyserial
       ]))
     ]);
-  multiPkgs = null;
+  multiArch = false;
 
   extraInstallCommands = ''
     ${lib.optionalString withGui ''

--- a/pkgs/development/tools/database/beekeeper-studio/default.nix
+++ b/pkgs/development/tools/database/beekeeper-studio/default.nix
@@ -18,7 +18,7 @@ in
 appimageTools.wrapType2 {
   inherit name src;
 
-  multiPkgs = null; # no 32bit needed
+  multiArch = false; # no 32bit needed
   extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
 
   extraInstallCommands = ''

--- a/pkgs/development/web/bloomrpc/default.nix
+++ b/pkgs/development/web/bloomrpc/default.nix
@@ -21,7 +21,7 @@ appimageTools.wrapType2 {
     export LC_ALL=C.UTF-8
   '';
 
-  multiPkgs = null; # no 32bit needed
+  multiArch = false; # no 32bit needed
   extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
 
   extraInstallCommands = ''

--- a/pkgs/games/heroic/fhsenv.nix
+++ b/pkgs/games/heroic/fhsenv.nix
@@ -9,6 +9,9 @@ buildFHSEnv {
 
   runScript = "heroic";
 
+  # Many Wine and native games need 32-bit libraries.
+  multiArch = true;
+
   targetPkgs = pkgs: with pkgs; [
     heroic-unwrapped
     gamemode

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -61,6 +61,9 @@ let
 in buildFHSEnv rec {
   name = "steam";
 
+  # Steam still needs 32bit and various native games do too
+  multiArch = true;
+
   targetPkgs = pkgs: with pkgs; [
     steam
     # License agreement

--- a/pkgs/tools/misc/flexoptix-app/default.nix
+++ b/pkgs/tools/misc/flexoptix-app/default.nix
@@ -28,7 +28,7 @@ in appimageTools.wrapAppImage {
   inherit pname version;
   src = appimageContents;
 
-  multiPkgs = null; # no 32bit needed
+  multiArch = false; # no 32bit needed
   extraPkgs = { pkgs, ... }@args: [
     pkgs.hidapi
   ] ++ appimageTools.defaultFhsEnvArgs.multiPkgs args;


### PR DESCRIPTION
###### Description of changes

Most FHSEnv-wrapped packages in Nixpkgs wrap a x86_64-linux binary; making
multiArch unnecessary bloat closure size. Saves about 1G in anki-bin.

This makes multiArch FHSEnvs the exception rather than the rule.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
