### PR TITLE
treewide: Remove fetchurl of SourceForge snapshots

### DIFF
--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -1,7 +1,7 @@
 { config
 , lib
 , stdenv
-, fetchzip
+, fetchgit
 , autoreconfHook
 , autoconf-archive
 , pkg-config
@@ -39,8 +39,9 @@ stdenv.mkDerivation rec {
   pname = "sox";
   version = "unstable-2021-05-09";
 
-  src = fetchzip {
-    url = "https://sourceforge.net/code-snapshots/git/s/so/sox/code.git/sox-code-42b3557e13e0fe01a83465b672d89faddbe65f49.zip";
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/sox/code";
+    rev = "42b3557e13e0fe01a83465b672d89faddbe65f49";
     hash = "sha256-9cpOwio69GvzVeDq79BSmJgds9WU5kA/KUlAkHcpN5c=";
   };
 

--- a/pkgs/tools/graphics/enblend-enfuse/default.nix
+++ b/pkgs/tools/graphics/enblend-enfuse/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip
+{ lib, stdenv, fetchhg
 , autoreconfHook
 , boost
 , freeglut
@@ -20,10 +20,10 @@ stdenv.mkDerivation rec {
   pname = "enblend-enfuse";
   version = "unstable-2022-03-06";
 
-  src = fetchzip {
-    url = "https://sourceforge.net/code-snapshots/hg/e/en/enblend/code/enblend-code-0f423c72e51872698fe2985ca3bd453961ffe4e0.zip";
-    sha256 = "sha256-0gCUSdg3HR3YeIbOByEBCZh2zGlYur6DeCOzUM53fdc=";
-    stripRoot = true;
+  src = fetchhg {
+    url = "http://hg.code.sf.net/p/enblend/code";
+    rev = "0f423c72e51872698fe2985ca3bd453961ffe4e0";
+    hash = "sha256-0gCUSdg3HR3YeIbOByEBCZh2zGlYur6DeCOzUM53fdc=";
   };
 
   buildInputs = [ boost freeglut glew gsl lcms2 libpng libtiff libGLU libGL vigra ];


### PR DESCRIPTION
###### Description of changes

I have a machine which builds everything without substituters, to test that `nixpkgs` actually works. I discovered that `sox` failed to build because snapshots from https://sourceforge.net/code-snapshots are generated by interaction with the web UI and they go away after a while. This PR changes every `fetchzip` against `https://sourceforge.net/code-snapshots/...` to fetch from the upstream source repo. I have confirmed that the source hashes did not change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
- [X] Confirmed that source hashes did not change.