### PR TITLE
grub2: 2.06 -> unstable-2023-07-03

### DIFF
--- a/pkgs/tools/misc/grub/add-hidden-menu-entries.patch
+++ b/pkgs/tools/misc/grub/add-hidden-menu-entries.patch
@@ -1,0 +1,204 @@
+diff --git a/grub-core/commands/legacycfg.c b/grub-core/commands/legacycfg.c
+index e9e9d94ef..54e08a1b4 100644
+--- a/grub-core/commands/legacycfg.c
++++ b/grub-core/commands/legacycfg.c
+@@ -143,7 +143,7 @@ legacy_file (const char *filename)
+ 	    args[0] = oldname;
+ 	    grub_normal_add_menu_entry (1, args, NULL, NULL, "legacy",
+ 					NULL, NULL,
+-					entrysrc, 0);
++					entrysrc, 0, 0);
+ 	    grub_free (args);
+ 	    entrysrc[0] = 0;
+ 	    grub_free (oldname);
+@@ -205,7 +205,7 @@ legacy_file (const char *filename)
+ 	}
+       args[0] = entryname;
+       grub_normal_add_menu_entry (1, args, NULL, NULL, NULL,
+-				  NULL, NULL, entrysrc, 0);
++				  NULL, NULL, entrysrc, 0, 0);
+       grub_free (args);
+     }
+ 
+diff --git a/grub-core/commands/menuentry.c b/grub-core/commands/menuentry.c
+index 720e6d8ea..50632ccce 100644
+--- a/grub-core/commands/menuentry.c
++++ b/grub-core/commands/menuentry.c
+@@ -78,7 +78,7 @@ grub_normal_add_menu_entry (int argc, const char **args,
+ 			    char **classes, const char *id,
+ 			    const char *users, const char *hotkey,
+ 			    const char *prefix, const char *sourcecode,
+-			    int submenu)
++			    int submenu, int hidden)
+ {
+   int menu_hotkey = 0;
+   char **menu_args = NULL;
+@@ -188,8 +188,11 @@ grub_normal_add_menu_entry (int argc, const char **args,
+   (*last)->args = menu_args;
+   (*last)->sourcecode = menu_sourcecode;
+   (*last)->submenu = submenu;
++  (*last)->hidden = hidden;
++
++  if (!hidden)
++    menu->size++;
+ 
+-  menu->size++;
+   return GRUB_ERR_NONE;
+ 
+  fail:
+@@ -286,7 +289,8 @@ grub_cmd_menuentry (grub_extcmd_context_t ctxt, int argc, char **args)
+ 				       users,
+ 				       ctxt->state[2].arg, 0,
+ 				       ctxt->state[3].arg,
+-				       ctxt->extcmd->cmd->name[0] == 's');
++				       ctxt->extcmd->cmd->name[0] == 's',
++               ctxt->extcmd->cmd->name[0] == 'h');
+ 
+   src = args[argc - 1];
+   args[argc - 1] = NULL;
+@@ -303,7 +307,8 @@ grub_cmd_menuentry (grub_extcmd_context_t ctxt, int argc, char **args)
+ 				  ctxt->state[0].args, ctxt->state[4].arg,
+ 				  users,
+ 				  ctxt->state[2].arg, prefix, src + 1,
+-				  ctxt->extcmd->cmd->name[0] == 's');
++				  ctxt->extcmd->cmd->name[0] == 's',
++          ctxt->extcmd->cmd->name[0] == 'h');
+ 
+   src[len - 1] = ch;
+   args[argc - 1] = src;
+@@ -311,7 +316,7 @@ grub_cmd_menuentry (grub_extcmd_context_t ctxt, int argc, char **args)
+   return r;
+ }
+ 
+-static grub_extcmd_t cmd, cmd_sub;
++static grub_extcmd_t cmd, cmd_sub, cmd_hidden;
+ 
+ void
+ grub_menu_init (void)
+@@ -327,6 +332,12 @@ grub_menu_init (void)
+ 				  | GRUB_COMMAND_FLAG_EXTRACTOR,
+ 				  N_("BLOCK"), N_("Define a submenu."),
+ 				  options);
++  cmd_hidden = grub_register_extcmd ("hiddenentry", grub_cmd_menuentry,
++                  GRUB_COMMAND_FLAG_BLOCKS
++                  | GRUB_COMMAND_ACCEPT_DASH
++                  | GRUB_COMMAND_FLAG_EXTRACTOR,
++                  N_("BLOCK"), N_("Define a hidden menu entry."),
++                  options);
+ }
+ 
+ void
+diff --git a/grub-core/normal/menu.c b/grub-core/normal/menu.c
+index 6a90e091f..4236f55bc 100644
+--- a/grub-core/normal/menu.c
++++ b/grub-core/normal/menu.c
+@@ -37,6 +37,8 @@
+    entry failing to boot.  */
+ #define DEFAULT_ENTRY_ERROR_DELAY_MS  2500
+ 
++#define MENU_INCLUDE_HIDDEN 0x10000
++
+ grub_err_t (*grub_gfxmenu_try_hook) (int entry, grub_menu_t menu,
+ 				     int nested) = NULL;
+ 
+@@ -80,8 +82,20 @@ grub_menu_get_entry (grub_menu_t menu, int no)
+ {
+   grub_menu_entry_t e;
+ 
+-  for (e = menu->entry_list; e && no > 0; e = e->next, no--)
+-    ;
++  if (no & MENU_INCLUDE_HIDDEN) {
++    no &= ~MENU_INCLUDE_HIDDEN;
++
++    for (e = menu->entry_list; e && no > 0; e = e->next, no--)
++      ;
++  } else {
++    for (e = menu->entry_list; e && no > 0; e = e->next, no--) {
++      /* Skip hidden entries */
++      while (e && e->hidden)
++        e = e->next;
++    }
++    while (e && e->hidden)
++      e = e->next;
++  }
+ 
+   return e;
+ }
+@@ -93,10 +107,10 @@ get_entry_index_by_hotkey (grub_menu_t menu, int hotkey)
+   grub_menu_entry_t entry;
+   int i;
+ 
+-  for (i = 0, entry = menu->entry_list; i < menu->size;
++  for (i = 0, entry = menu->entry_list; entry;
+        i++, entry = entry->next)
+     if (entry->hotkey == hotkey)
+-      return i;
++      return i | MENU_INCLUDE_HIDDEN;
+ 
+   return -1;
+ }
+@@ -509,6 +523,10 @@ get_entry_number (grub_menu_t menu, const char *name)
+       grub_menu_entry_t e = menu->entry_list;
+       int i;
+ 
++       /* Skip hidden entries */
++      while (e && e->hidden)
++        e = e->next;
++
+       grub_errno = GRUB_ERR_NONE;
+ 
+       for (i = 0; e; i++)
+@@ -520,6 +538,10 @@ get_entry_number (grub_menu_t menu, const char *name)
+ 	      break;
+ 	    }
+ 	  e = e->next;
++
++    /* Skip hidden entries */
++    while (e && e->hidden)
++      e = e->next;
+ 	}
+ 
+       if (! e)
+diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
+index b1321eb26..d2e46cac8 100644
+--- a/grub-core/normal/menu_text.c
++++ b/grub-core/normal/menu_text.c
+@@ -289,7 +289,11 @@ print_entries (grub_menu_t menu, const struct menu_viewer_data *data)
+       print_entry (data->geo.first_entry_y + i, data->offset == i,
+ 		   e, data);
+       if (e)
+-	e = e->next;
++	      e = e->next;
++
++      /* Skip hidden entries */
++      while (e && e->hidden)
++        e = e->next;
+     }
+ 
+   grub_term_gotoxy (data->term,
+diff --git a/include/grub/menu.h b/include/grub/menu.h
+index ee2b5e910..eb8a86ba9 100644
+--- a/include/grub/menu.h
++++ b/include/grub/menu.h
+@@ -58,6 +58,8 @@ struct grub_menu_entry
+ 
+   int submenu;
+ 
++  int hidden;
++
+   /* The next element.  */
+   struct grub_menu_entry *next;
+ };
+diff --git a/include/grub/normal.h b/include/grub/normal.h
+index 218cbabcc..bcb412466 100644
+--- a/include/grub/normal.h
++++ b/include/grub/normal.h
+@@ -145,7 +145,7 @@ grub_normal_add_menu_entry (int argc, const char **args, char **classes,
+ 			    const char *id,
+ 			    const char *users, const char *hotkey,
+ 			    const char *prefix, const char *sourcecode,
+-			    int submenu);
++			    int submenu, int hidden);
+ 
+ grub_err_t
+ grub_normal_set_password (const char *user, const char *password);

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -1,8 +1,6 @@
-{ lib, stdenv, fetchurl, flex, bison, python3, autoreconfHook, gnulib, libtool, bash
-, gettext, ncurses, libusb-compat-0_1, freetype, qemu, lvm2, unifont, pkg-config
+{ lib, stdenv, runCommand, fetchFromSavannah, flex, bison, python3, autoconf, automake, libtool, bash
+, rsync, gettext, ncurses, libusb-compat-0_1, freetype, qemu, lvm2, unifont, pkg-config
 , buildPackages
-, fetchpatch
-, pkgsBuildBuild
 , nixosTests
 , fuse # only needed for grub-mount
 , runtimeShell
@@ -42,8 +40,35 @@ let
   canEfi = lib.any (system: stdenv.hostPlatform.system == system) (lib.mapAttrsToList (name: _: name) efiSystemsBuild);
   inPCSystems = lib.any (system: stdenv.hostPlatform.system == system) (lib.mapAttrsToList (name: _: name) pcSystems);
 
-  version = "2.06";
+  gnulib = fetchFromSavannah {
+    repo = "gnulib";
+    # NOTE: keep in sync with bootstrap.conf!
+    rev = "9f48fb992a3d7e96610c4ce8be969cff2d61a01b";
+    hash = "sha256-mzbF66SNqcSlI+xmjpKpNMwzi13yEWoc1Fl7p4snTto=";
+  };
 
+  src = fetchFromSavannah {
+    repo = "grub";
+    rev = "6425c12cd77ad51ad24be84c092aefacf0875089";
+    hash = "sha256-PSCa993Reph6w9+leE4a/9E6vIALdOqU3FZEPwasFyk=";
+  };
+
+  # HACK: the translations are stored on a different server,
+  # not versioned and not included in the git repo, so fetch them
+  # and hope they don't change often
+  locales = runCommand "grub-locales" {
+    nativeBuildInputs = [rsync];
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-bQPQ65gAcuUQ8ELB2hKywuXZ0kdC2bBCsUII/b4FkvQ=";
+  }
+  ''
+    mkdir -p po
+    ${src}/linguas.sh
+
+    mv po $out
+  '';
 in (
 
 assert efiSupport -> canEfi;
@@ -52,301 +77,12 @@ assert !(efiSupport && xenSupport);
 
 stdenv.mkDerivation rec {
   pname = "grub";
-  inherit version;
-
-  src = fetchurl {
-    url = "mirror://gnu/grub/grub-${version}.tar.xz";
-    sha256 = "sha256-t56kSvkbk9F80/6Ava5u1DdwZ4qaWuGSzOqAPrtlfuE=";
-  };
+  version = "unstable-2023-07-03";
+  inherit src;
 
   patches = [
     ./fix-bash-completion.patch
-    (fetchpatch {
-      name = "Add-hidden-menu-entries.patch";
-      # https://lists.gnu.org/archive/html/grub-devel/2016-04/msg00089.html
-      url = "https://marc.info/?l=grub-devel&m=146193404929072&q=mbox";
-      sha256 = "00wa1q5adiass6i0x7p98vynj9vsz1w0gn1g4dgz89v35mpyw2bi";
-    })
-
-    # Pull upstream patch to fix linkage against binutils-2.36.
-    (fetchpatch {
-      name = "binutils-2.36.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=b98275138bf4fc250a1c362dfd2c8b1cf2421701";
-      sha256 = "001m058bsl2pcb0ii84jfm5ias8zgzabrfy6k2cc9w6w1y51ii82";
-    })
-    # Properly handle multiple initrd paths in 30_os-prober
-    # Remove this patch once a new release is cut
-    (fetchpatch {
-      name = "Properly-handle-multiple-initrd-paths-in-os-prober.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=000b5cd04fd228f9741f5dca0491636bc0b89eb8";
-      sha256 = "sha256-Mex3qQ0lW7ZCv7ZI7MSSqbylJXZ5RTbR4Pv1+CJ0ciM=";
-    })
-
-    # Upstreamed patches for flicker-free boot
-    # Remove these patches once a new release is cut
-    (fetchpatch {
-      # term/efi/console: Do not set colorstate until the first text output
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=9381dbe045b39bd9395c9ab4276d95b4041ec9fb";
-      sha256 = "sha256-ZFq/PdCYo6aRySZRAfZARO8BmXwGgqeXz+9uNgNJEO8=";
-    })
-    (fetchpatch {
-      # term/efi/console: Do not set cursor until the first text output
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=7c316e18301e101e4dcd8abe88c0bed0b1b78857";
-      sha256 = "sha256-WJiK7MqmdStzq77vIDsO60Fu7i9LE/jDYzF4E9FXb7c=";
-    })
-    (fetchpatch {
-      # normal/menu: Don't show "Booting `%s'" msg when auto-booting with TIMEOUT_STYLE_HIDDEN
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=5bb4f2b7d665c84bde402d1a528b652a61753380";
-      sha256 = "sha256-lwJPPyq6yj7X1C2RuHfxnwKKstFkWGxcMXuSQqd9Z4I=";
-    })
-    (fetchpatch {
-      # kern/main: Suppress the "Welcome to GRUB!" message in EFI builds
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=3e4cbbeca0ef35097301a1086f85fd0d119e64aa";
-      sha256 = "sha256-cQX4x9V5Y7SU9WACn5FzDjukL2/StAUMMoHY/DRHq+g=";
-    })
-
-    (fetchpatch {
-      name = "CVE-2021-3981.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=0adec29674561034771c13e446069b41ef41e4d4";
-      sha256 = "sha256-3vkvWjcSv0hyY2EX3ig2EXEe+XLiRsXYlcd5kpY4wXw=";
-    })
-    # June 2022 security patches
-    # https://lists.gnu.org/archive/html/grub-devel/2022-06/msg00035.html
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.1.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=1469983ebb9674753ad333d37087fb8cb20e1dce";
-      sha256 = "sha256-oB4S0jvIXsDPcjIz1E2LKm7gwdvZjywuI1j0P6JQdJg=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.2.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=14ceb3b3ff6db664649138442b6562c114dcf56e";
-      sha256 = "sha256-mKe8gzd0U4PbV8z3TWCdvv7UugEgYaVIkB4dyMrSGEE=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.3.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=04c86e0bb7b58fc2f913f798cdb18934933e532d";
-      sha256 = "sha256-sA+PTlk4hwYOVKRZBHkEskabzmsf47Hi4h3mzWOFjwM=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.4.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=6fe755c5c07bb386fda58306bfd19e4a1c974c53";
-      sha256 = "sha256-8zmFocUfnjSyhYitUFDHoilHDnm1NJmhcKwO9dueV3k=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.5.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=f1ce0e15e70ea1aafcfa26ad93e7585f65783c6f";
-      sha256 = "sha256-Wrlam6CRPUAHbKqe/X1YLcRxJ2LQTtmQ/Y66gxUlqK4=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.6.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=5bff31cdb6b93d738f850834e6291df1d0b136fa";
-      sha256 = "sha256-ReLWSePXjRweymsVAL/uoBgYMWt9vRDcY3iXlDNZT0w=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.7.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=347880a13c239b4c2811c94c9a7cf78b607332e3";
-      sha256 = "sha256-07hpHuJFw95xGoJ/6ej7i6HlCFb2QRxP3arvRjKW4uU=";
-    })
-    ## Needed to apply patch 8
-    (fetchpatch {
-      name = "video-remove-trailing-whitespaces.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=1f48917d8ddb490dcdc70176e0f58136b7f7811a";
-      sha256 = "sha256-/yf/LGpwYcQ36KITzmiFfg4BvhcApKbrlFzjKK8V2kI=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.8.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=e623866d9286410156e8b9d2c82d6253a1b22d08";
-      sha256 = "sha256-zFxP6JY5Q9s3yJHdkbZ2w+dXFKeOCXjFnQKadB5HLCg=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.9.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=210245129c932dc9e1c2748d9d35524fb95b5042";
-      sha256 = "sha256-FyZhdTlcRVmn7X2hv93RhWP7NOoEMb7ib/DWveyz3Ew=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.10.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=690bee69fae6b4bd911293d6b7e56774e29fdf64";
-      sha256 = "sha256-nOAXxebCW/s5M6sjPKdSdx47/PcH1lc0yYT0flVwoC8=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.11.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=d5caac8ab79d068ad9a41030c772d03a4d4fbd7b";
-      sha256 = "sha256-9fGJJkgZ6+E01MJqVTR1qFITx9EAx41Hv9QNfdqBgu0=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.12.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=768ef2199e0265cf455b154f1a80a612f02274c8";
-      sha256 = "sha256-2/JJJux5vqXUc77bi3aXRy8NclbvyD/0e6UN8/6Ui3c=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.13.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=166a4d61448f74745afe1dac2f2cfb85d04909bf";
-      sha256 = "sha256-XxTZ8P8qr4qEXELdHwaRACPeIZ/iixlATLB5RvVQsC8=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.14.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=22a3f97d39f6a10b08ad7fd1cc47c4dcd10413f6";
-      sha256 = "sha256-bzB2gmGvWR2ylvMw779KQ/VHBBMsDNbG96eg9qQlljA=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.15.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=830a9628b2c9e1b6388af624aaf4a80818ed6be0";
-      sha256 = "sha256-8fna2VbbUw8zBx77osaOOHlZFgRrHqwQK87RoUtCF6w=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.16.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=3e4817538de828319ba6d59ced2fbb9b5ca13287";
-      sha256 = "sha256-iCZAyRS/a15x5aJCJBYl9nw6Hc3WRCUG7zF5V+OwDKg=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.17.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=f407e34f3871a4c402bbd516e7c28ea193cef1b7";
-      sha256 = "sha256-S45cLZNTWapAodKudUz2fMjnPsW6vbtNz0bIvIBGmu4=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.18.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=c1b7eef9fa4aaefbf7d0507505c3bb2914e1ad6b";
-      sha256 = "sha256-TWPfEAOePwC77yiVdsTSZIjfsMp7+0XabCz9K3FlV7w=";
-    })
-    ## Needed to apply patch 19
-    (fetchpatch {
-      name = "net-remove-trailing-whitespaces.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=e453a4a64392a41bc7b37f890aceb358112d1687";
-      sha256 = "sha256-JCbUB77Y6js5u99uJ9StDxNjjahNy4nO3crK8/GvmPY=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.19.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=96abf4fb9d829f4a405d5df39bc74bbccbd0e322";
-      sha256 = "sha256-6E2MKO5kauFA1TA8YkUgIUusniwHS2Sr44A/a7ZqDCo=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.20.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=ee9652031491326736714a988fbbaeab8ef9255c";
-      sha256 = "sha256-E21q+Mj+JBQlUW0pe4zbaoL3ErXmCanyizwAsRYYZHk=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.21.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=8f287c3e13da2bf82049e2e464eca7ca4fef0a85";
-      sha256 = "sha256-dZ24RwYsHeUrMuiU7PDgPcw+iK9cOd6q+E0xWXbtTkE=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.22.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=dad94fffe14be476df5f34a8e5a90ea62a41fe12";
-      sha256 = "sha256-06TyTEvSy19dsnXZZoKBGx7ymJVWogr0NorzLflEwY4=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.23.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=ec6bfd3237394c1c7dbf2fd73417173318d22f4b";
-      sha256 = "sha256-NryxSekO8oSxsnv5G9mFZExm4Pwfc778mslyUDuDhlM=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.24.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=b26b4c08e7119281ff30d0fb4a6169bd2afa8fe4";
-      sha256 = "sha256-fSH3cxl/76DwkE8dHSR9uao9Vf1sJrhz7SmUSgDNodI=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.25.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=4bd9877f62166b7e369773ab92fe24a39f6515f8";
-      sha256 = "sha256-VMtR/sF8F1BMKmJ06ZZEPNH/+l0RySy/E6lVWdCyFKE=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.26.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=deae293f399dde3773cf37dfa9b77ca7e04ef772";
-      sha256 = "sha256-sCC3KE9adavw7jHMTVlxtyuwDFCPRDqT24H3AKUYf68=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.27.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=e40b83335bb33d9a2d1c06cc269875b3b3d6c539";
-      sha256 = "sha256-cviCfBkzacAtnHGW87RLshhduE4Ym/v2Vq4h/sZDmZg=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.28.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=11e1cffb7e2492ddac4ab8d19ce466783adbb957";
-      sha256 = "sha256-I1feoneVeU3XkscKfVprWWJfLUnrc5oauMXYDyDxo5M=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.29.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=13dce204cf6f3f0f49c9949971052a4c9657c0c0";
-      sha256 = "sha256-DzFHxgR9A8FNZ/y9OMeBvTp1K6J5ePyL06dhHQmk7Ik=";
-    })
-    (fetchpatch {
-      name = "CVE-2021-3695.CVE-2021-3696.CVE-2021-3697.CVE-2022-28733.CVE-2022-28734.CVE-2022-28735.CVE-2022-28736.CVE-2022-28737.30.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=2f4430cc0a44fd8c8aa7aee5c51887667ad3d6c3";
-      sha256 = "sha256-AufP/10/auO4NMjYQ7yPDDbYShwGaktyQtqJx2Jasz8=";
-    })
-    # October 2022 security patches
-    # https://lists.gnu.org/archive/html/grub-devel/2022-11/msg00059.html
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.1.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=f6b6236077f059e64ee315f2d7acb8fa4eda87c5";
-      sha256 = "sha256-pk02iVf/u6CdsVjl8HaFBh0Bt473ZQzz5zBp9SoBLtE=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.2.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=9c76ec09ae08155df27cd237eaea150b4f02f532";
-      sha256 = "sha256-axbEOH5WFkUroGna2XY1f2kq7+B1Cs6LiubIA2EBdiM=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.3.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=768e1ef2fc159f6e14e7246e4be09363708ac39e";
-      sha256 = "sha256-aKDUVS/Yx1c87NCrt4EG8BlSpkHijUyAJIwbmtzNjD8=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.4.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=c51292274ded3259eb04c2f1c8d253ffbdb5216a";
-      sha256 = "sha256-OLNOKuAJuHy2MBMnU2xcYM7AaxmDk9fchXhggoDrxJU=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.5.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=23843fe8947e4da955a05ad3d1858725bfcb56c8";
-      sha256 = "sha256-ptn00nqVJlEb1c6HhoMy9nrBuctH077LM4yXKsK47gc=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.6.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=b9396daf1c2e3cdc0a1e69b056852e0769fb24de";
-      sha256 = "sha256-K7XNneDZjLpZh/C908+5uYsB/0oIdgQqmk0yJrdQLG4=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.7.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=1d2015598cc7a9fca4b39186273e3519a88e80c7";
-      sha256 = "sha256-s4pZtszH4b/0u85rpzVapZmNQdYEq/wW06SQ3PW/1aU=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.8.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=93a786a00163e50c29f0394df198518617e1c9a5";
-      sha256 = "sha256-R8x557RMAxJ0ZV2jb6zDmwOPVlk6875q37fNpqKsPT0=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.9.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=1eac01c147b4d85d2ec4a7e5671fa4345f2e8549";
-      sha256 = "sha256-eOnhmU3pT5cCVnNHcY/BzDjldfs7yh/OGsxa15tGv94=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.10.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=992c06191babc1e109caf40d6a07ec6fdef427af";
-      sha256 = "sha256-kezNKPcLmFXwyZbXtJbaPTIbE8tijmHIzdC2jsKwrNk=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.11.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=9d81f71c6b8f55cf20cd56f5fe29c759df9b48cc";
-      sha256 = "sha256-jnniVGy4KvFGFmcOP2YLA46k3cK8vwoByo19ismVUzE=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.12.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=22b77b87e10a3a6c9bb9885415bc9a9c678378e6";
-      sha256 = "sha256-iYTEqN5997I7MVIg82jt/bbEAYhcgq8fNRCNPpY9ze0=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-2601.CVE-2022-3775.13.patch";
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=1514678888595ef41a968a0c69b7ff769edd1e9c";
-      sha256 = "sha256-tgAEoAtaNKJjscjMFkXXiVn59Pa4c+NiQ3iVW6CMrpo=";
-    })
-
-    # fix incompatibility with e2fsprogs 1.47+
-    (fetchpatch {
-      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=7fd5feff97c4b1f446f8fcf6d37aca0c64e7c763";
-      sha256 = "sha256-pejn1bJkC7XnT2ODaxeERHUrMOONoBV6w0wF2Z2ZKWI=";
-    })
+    ./add-hidden-menu-entries.patch
   ];
 
   postPatch = if kbdcompSupport then ''
@@ -357,7 +93,7 @@ stdenv.mkDerivation rec {
   '';
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ bison flex python3 pkg-config gettext freetype autoreconfHook ];
+  nativeBuildInputs = [ bison flex python3 pkg-config gettext freetype autoconf automake ];
   buildInputs = [ ncurses libusb-compat-0_1 freetype lvm2 fuse libtool bash ]
     ++ lib.optional doCheck qemu
     ++ lib.optional zfsSupport zfs;
@@ -367,9 +103,6 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "all" ];
 
   separateDebugInfo = !xenSupport;
-
-  # Work around a bug in the generated flex lexer (upstream flex bug?)
-  env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
   preConfigure =
     '' for i in "tests/util/"*.in
@@ -392,6 +125,18 @@ stdenv.mkDerivation rec {
       unset CPP # setting CPP intereferes with dependency calculation
 
       patchShebangs .
+
+      GNULIB_REVISION=$(. bootstrap.conf; echo $GNULIB_REVISION)
+      if [ "$GNULIB_REVISION" != ${gnulib.rev} ]; then
+        echo "This version of GRUB requires a different gnulib revision!"
+        echo "We have: ${gnulib.rev}"
+        echo "GRUB needs: $GNULIB_REVISION"
+        exit 1
+      fi
+
+      cp -f --no-preserve=mode ${locales}/* po
+
+      ./bootstrap --no-git --gnulib-srcdir=${gnulib}
 
       substituteInPlace ./configure --replace '/usr/share/fonts/unifont' '${unifont}/share/fonts'
     '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8471,17 +8471,7 @@ with pkgs;
 
   grpc-client-cli = callPackage ../development/tools/misc/grpc-client-cli { };
 
-  grub2 = callPackage ../tools/misc/grub/default.nix {
-    # update breaks grub2
-    gnulib = pkgs.gnulib.overrideAttrs {
-      version = "20200223";
-      src = fetchgit {
-        url = "https://git.savannah.gnu.org/r/gnulib.git";
-        rev = "292fd5d6ff5ecce81ec3c648f353732a9ece83c0";
-        sha256 = "0hkg3nql8nsll0vrqk4ifda0v4kpi67xz42r8daqsql6c4rciqnw";
-      };
-    };
-  };
+  grub2 = callPackage ../tools/misc/grub/default.nix { };
 
   grub2_efi = grub2.override {
     efiSupport = true;


### PR DESCRIPTION
- build from latest git
- remove all the backports
- manually forward-port + vendor the hiddenentry patch (original link was dead btw)
- vendor the exact gnulib version grub wants

###### Description of changes

Our GRUB is very very broken. One could argue that that's just GRUB in general, but at least the version from master seems _less_ broken, and Arch is shipping it, and the giant pile of backports has become unmaintainable a long time ago.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
