### PR TITLE
[staging-next-23.05] Revert "cmake: 3.25.3 -> 3.26.4"     

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -35,16 +35,16 @@ in
 assert lib.subtractLists [ "ncurses" "qt5" ] uiToolkits == [];
 # Minimal, bootstrap cmake does not have toolkits
 assert isBootstrap -> (uiToolkits == []);
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "cmake"
     + lib.optionalString isBootstrap "-boot"
     + lib.optionalString cursesUI "-cursesUI"
     + lib.optionalString qt5UI "-qt5UI";
-  version = "3.26.4";
+  version = "3.25.3";
 
   src = fetchurl {
-    url = "https://cmake.org/files/v${lib.versions.majorMinor finalAttrs.version}/cmake-${finalAttrs.version}.tar.gz";
-    hash = "sha256-MTtogMKRvU/jHAqlHW5iZZKCpSHmlfMNXMDSWrvVwgg=";
+    url = "https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
+    sha256 = "sha256-zJlXAdWQym3rxCRemYmTkJnKUoJ91GtdNZLwk6/hkBw=";
   };
 
   patches = [
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  nativeBuildInputs = finalAttrs.setupHooks ++ [
+  nativeBuildInputs = setupHooks ++ [
     pkg-config
   ]
   ++ lib.optionals buildDocs [ texinfo ]
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "CXXFLAGS=-Wno-elaborated-enum-base"
-    "--docdir=share/doc/${finalAttrs.pname}-${finalAttrs.version}"
+    "--docdir=share/doc/${pname}${version}"
   ] ++ (if useSharedLibraries
         then [ "--no-system-jsoncpp" "--system-libs" ]
         else [ "--no-system-libs" ]) # FIXME: cleanup
@@ -154,7 +154,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = false; # fails
 
-  meta = {
+  meta = with lib; {
     homepage = "https://cmake.org/";
     description = "Cross-platform, open-source build system generator";
     longDescription = ''
@@ -164,10 +164,10 @@ stdenv.mkDerivation (finalAttrs: {
       configuration files, and generate native makefiles and workspaces that can
       be used in the compiler environment of your choice.
     '';
-    changelog = "https://cmake.org/cmake/help/v${lib.versions.majorMinor finalAttrs.version}/release/${lib.versions.majorMinor finalAttrs.version}.html";
-    license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ ttuegel lnl7 AndersonTorres ];
-    platforms = lib.platforms.all;
+    changelog = "https://cmake.org/cmake/help/v${lib.versions.majorMinor version}/release/${lib.versions.majorMinor version}.html";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ttuegel lnl7 AndersonTorres ];
+    platforms = platforms.all;
     broken = (qt5UI && stdenv.isDarwin);
   };
-})
+}


### PR DESCRIPTION
Reverts NixOS/nixpkgs#238508

There was no meaningful reason for this backport, and instead it
violated our policy on backportin breaking changes into our stable
release.