### PR TITLE
libe57format: 2.2.0 -> 3.0.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -40,6 +40,8 @@
 
 - `himalaya` has been updated to `0.8.0`, which drops the native TLS support (in favor of Rustls) and add OAuth 2.0 support. See the [release note](https://github.com/soywod/himalaya/releases/tag/v0.8.0) for more details.
 
+- `libe57format` has been updated to `3.0.0`, which which some backward-incompatible API changes. See the [release note](https://github.com/asmaloney/libE57Format/releases/tag/v3.0.0) for more details.
+
 - The [services.caddy.acmeCA](#opt-services.caddy.acmeCA) option now defaults to `null` instead of `"https://acme-v02.api.letsencrypt.org/directory"`, to use all of Caddy's default ACME CAs and enable Caddy's automatic issuer fallback feature by default, as recommended by upstream.
 
 - `php80` is no longer supported due to upstream not supporting this version anymore.

--- a/pkgs/development/libraries/libe57format/default.nix
+++ b/pkgs/development/libraries/libe57format/default.nix
@@ -1,46 +1,51 @@
 {
   lib, stdenv,
   cmake,
-  fetchpatch,
   fetchFromGitHub,
-  boost,
   xercesc,
-  icu,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libe57format";
-  version = "2.2.0";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "asmaloney";
     repo = "libE57Format";
-    rev = "v${version}";
-    sha256 = "15l23spjvak5h3n7aj3ggy0c3cwcg8mvnc9jlbd9yc2ra43bx7bp";
+    rev = "v${finalAttrs.version}";
+    sha256 = "1kiinxwhnwp60zmivmsf3ai2yqjf09jn2ga8xn6nvaz7vdaz3rbz";
+    fetchSubmodules = true; # for submodule-vendored libraries such as `gtest`
   };
 
-  patches = [
-    # gcc11 header fix
-    (fetchpatch {
-      url = "https://github.com/asmaloney/libE57Format/commit/13f6a16394ce3eb50ea4cd21f31f77f53294e8d0.patch";
-      sha256 = "sha256-4vVhKrCxnWO106DSAk+xxo4uk6zC89m9VQAPaDJ8Ed4=";
-    })
-  ];
+  # Repository of E57 files used for testing.
+  libE57Format-test-data_src = fetchFromGitHub {
+    owner = "asmaloney";
+    repo = "libE57Format-test-data";
+    rev = "1e6edb0f6e261a6d37599440b8f5f3bba59ecd4b";
+    sha256 = "1cah10ifi0l2lq1afzkvbrxal18prq24v2r0ka8qg248nz5xvnjk";
+  };
 
   nativeBuildInputs = [
     cmake
   ];
 
   buildInputs = [
-    boost
-    icu
-  ];
-
-  propagatedBuildInputs = [
-    # Necessary for projects that try to find libE57Format via CMake
-    # due to the way that libe57format's CMake config is written.
     xercesc
   ];
+
+  cmakeFlags = [
+    # See https://github.com/asmaloney/libE57Format/blob/9372bdea8db2cc0c032a08f6d655a53833d484b8/test/README.md
+    (if finalAttrs.doCheck
+      then "-DE57_TEST_DATA_PATH=${finalAttrs.libE57Format-test-data_src}"
+      else "-DE57_BUILD_TEST=OFF"
+    )
+  ];
+
+  doCheck = true;
+
+  postCheck = ''
+    ./testE57
+  '';
 
   # The build system by default builds ONLY static libraries, and with
   # `-DE57_BUILD_SHARED=ON` builds ONLY shared libraries, see:
@@ -66,4 +71,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ chpatrick nh2 ];
     platforms = platforms.linux; # because of the .so buiding in `postInstall` above
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

New version: https://github.com/asmaloney/libE57Format/releases/tag/v3.0.0

* Tests now run during the build by default.
* The dependency on `boost` was removed: https://github.com/asmaloney/libE57Format/commit/cf46a9d3c82fa218507712f5de925887876542ba
* `xercesc` is now an official dependency: https://github.com/asmaloney/libE57Format/commit/7569757cacfbf744be809a2c47df454adaf3bbfd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Further:

* Tested that `pdal` builds.