### PR TITLE
tlsclient: init at 1.5, pam_dp9ik: init at 1.5

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -548,6 +548,9 @@ let
           (let yubi = config.security.pam.yubico; in optionalString cfg.yubicoAuth ''
             auth ${yubi.control} ${pkgs.yubico-pam}/lib/security/pam_yubico.so mode=${toString yubi.mode} ${optionalString (yubi.challengeResponsePath != null) "chalresp_path=${yubi.challengeResponsePath}"} ${optionalString (yubi.mode == "client") "id=${toString yubi.id}"} ${optionalString yubi.debug "debug"}
           '') +
+          (let dp9ik = config.security.pam.dp9ik; in optionalString dp9ik.enable ''
+            auth ${dp9ik.control} ${pkgs.pam_dp9ik}/lib/security/pam_p9.so ${dp9ik.authserver}
+          '') +
           optionalString cfg.fprintAuth ''
             auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so
           '' +
@@ -912,6 +915,32 @@ in
     };
 
     security.pam.enableOTPW = mkEnableOption (lib.mdDoc "the OTPW (one-time password) PAM module");
+
+    security.pam.dp9ik = {
+      enable = mkEnableOption (
+        lib.mdDoc ''
+          the dp9ik pam module provided by tlsclient.
+
+          If set, users can be authenticated against the 9front
+          authentication server given in {option}`security.pam.dp9ik.authserver`.
+        ''
+      );
+      control = mkOption {
+        default = "sufficient";
+        type = types.str;
+        description = lib.mdDoc ''
+          This option sets the pam "control" used for this module.
+        '';
+      };
+      authserver = mkOption {
+        default = null;
+        type = with types; nullOr string;
+        description = lib.mdDoc ''
+          This controls the hostname for the 9front authentication server
+          that users will be authenticated against.
+        '';
+      };
+    };
 
     security.pam.krb5 = {
       enable = mkOption {

--- a/pkgs/os-specific/linux/pam_dp9ik/default.nix
+++ b/pkgs/os-specific/linux/pam_dp9ik/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, tlsclient
+, stdenv
+, pkg-config
+, pam
+}:
+
+stdenv.mkDerivation {
+  inherit (tlsclient) src version enableParallelBuilding;
+
+  pname = "pam_dp9ik";
+
+  strictDeps = true;
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ pam ];
+
+  makeFlags = [ "pam_p9.so" ];
+  installPhase = ''
+    install -Dm755 -t $out/lib/security/ pam_p9.so
+  '';
+
+  meta = with lib; {
+    description = "dp9ik pam module";
+    longDescription = "Uses tlsclient to authenticate users against a 9front auth server";
+    homepage = "https://git.sr.ht/~moody/tlsclient";
+    license = licenses.mit;
+    maintainers = with maintainers; [ moody ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/admin/tlsclient/default.nix
+++ b/pkgs/tools/admin/tlsclient/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, pkg-config
+, openssl
+, installShellFiles
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tlsclient";
+  version = "1.5";
+
+  src = fetchFromSourcehut {
+    owner = "~moody";
+    repo = "tlsclient";
+    rev = "v${version}";
+    hash = "sha256-9LKx9x5Kx7Mo4EL/b89Mdsdu8NqVYxohn98XnF+IWXs=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ pkg-config installShellFiles ];
+  buildInputs = [ openssl ];
+
+  makeFlags = [ "tlsclient" ];
+  installPhase = ''
+    install -Dm755 -t $out/bin tlsclient
+    installManPage tlsclient.1
+  '';
+
+  meta = with lib; {
+    description = "tlsclient command line utility";
+    longDescription = "unix port of 9front's tlsclient(1) and rcpu(1)";
+    homepage = "https://git.sr.ht/~moody/tlsclient";
+    license = licenses.mit;
+    maintainers = with maintainers; [ moody ];
+    mainProgram = "tlsclient";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13345,6 +13345,8 @@ with pkgs;
 
   tldr-hs = haskellPackages.tldr;
 
+  tlsclient = callPackage ../tools/admin/tlsclient { };
+
   tlsx = callPackage ../tools/security/tlsx { };
 
   tmate = callPackage ../tools/misc/tmate { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27957,6 +27957,8 @@ with pkgs;
 
   pam_ccreds = callPackage ../os-specific/linux/pam_ccreds { };
 
+  pam_dp9ik = callPackage ../os-specific/linux/pam_dp9ik { };
+
   pam_gnupg = callPackage ../os-specific/linux/pam_gnupg { };
 
   pam_krb5 = callPackage ../os-specific/linux/pam_krb5 { };


### PR DESCRIPTION
###### Description of changes

tlsclient is a unix port of the 9front utility by the same name.
This is used for establishing encrypted tls connections to a 9front server using dp9ik authentication.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
