### PR TITLE
pcsc-cyberjack: 3.99.5_SP13 -> 3.99.5_SP15

### DIFF
--- a/pkgs/tools/security/pcsc-cyberjack/default.nix
+++ b/pkgs/tools/security/pcsc-cyberjack/default.nix
@@ -2,17 +2,18 @@
 
 let
   version = "3.99.5";
-  suffix = "SP13";
+  suffix = "SP15";
   tarBall = "${version}final.${suffix}";
 
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "pcsc-cyberjack";
   inherit version;
 
   src = fetchurl {
     url =
-      "http://support.reiner-sct.de/downloads/LINUX/V${version}_${suffix}/${pname}_${tarBall}.tar.gz";
-    sha256 = "1lx4bfz4riz7j77sl65akyxzww0ygm63w0c1b75knr1pijlv8d3b";
+      "https://support.reiner-sct.de/downloads/LINUX/V${version}_${suffix}/${pname}_${tarBall}.tar.bz2";
+    sha256 = "sha256-rLfCgyRQcYdWcTdnxLPvUAgy1lLtUbNRELkQsR69Rno=";
   };
 
   outputs = [ "out" "tools" ];

--- a/pkgs/tools/security/pcsc-cyberjack/default.nix
+++ b/pkgs/tools/security/pcsc-cyberjack/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     description = "REINER SCT cyberJack USB chipcard reader user space driver";
     homepage = "https://www.reiner-sct.com/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ aszlig ];
+    maintainers = with maintainers; [ aszlig flokli ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
pcsc-cyberjack (3.99.5final.sp15) unstable; urgency=low
  * add REINER SCT cyberJack wave HUN
  * add REINER SCT cyberJack RFID komfort FON

 -- Frank Neuber <sct@kernelport.com>  Fri, 01 Oct 2021 08:11:04 +0000

pcsc-cyberjack (3.99.5final.sp14) unstable; urgency=low
  * Update to the Reiner-SCT repository rev cyberJack@1454

 -- Frank Neuber <sct@kernelport.com>  Mon, 02 Dec 2019 16:57:46 +0100


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
