### PR TITLE
r8152-udev-rules: init at 2.16.3.20221209

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -359,6 +359,12 @@
     githubId = 1517066;
     name = "Aiken Cairncross";
   };
+  accelbread = {
+    name = "Archit Gupta";
+    email = "archit@accelbread.com";
+    github = "accelbread";
+    githubId = 9895679;
+  };
   aciceri = {
     name = "Andrea Ciceri";
     email = "andrea.ciceri@autistici.org";

--- a/pkgs/os-specific/linux/r8152-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/r8152-udev-rules/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+}:
+stdenv.mkDerivation rec {
+  pname = "r8152-udev-rules";
+  version = "2.16.3.20221209";
+
+  src = fetchFromGitHub {
+    owner = "wget";
+    repo = "realtek-r8152-linux";
+    rev = "v${version}";
+    sha256 = "sha256-RaYuprQFbWAy8CtSZOau0Qlo3jtZnE1AhHBgzASopSA=";
+  };
+
+  # We don't want to build the kernel module
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/udev/rules.d
+    cp 50-usb-realtek-net.rules $out/lib/udev/rules.d/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Udev rules for Realtek RTL8152/RTL8153 USB Ethernet adapters.";
+    license = lib.licenses.gpl2Only;
+    homepage = "https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-usb-3-0-software";
+    maintainers = with lib.maintainers; [ accelbread ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28884,6 +28884,8 @@ with pkgs;
 
   rtw88-firmware = callPackage ../os-specific/linux/firmware/rtw88-firmware { };
 
+  r8152-udev-rules = callPackage ../os-specific/linux/r8152-udev-rules { };
+
   rvvm = callPackage ../applications/virtualization/rvvm { };
 
   s3ql = callPackage ../tools/backup/s3ql { };


### PR DESCRIPTION
###### Description of changes

Adds a package with the udev rules for r8152 ethernet usb adapters. The kernel module is upstreamed, but the generic module gets used by default instead of the realtek one. These udev rules result in the correct module being used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
