### PR TITLE
nixos/{sway,river,hyprland}: improve common wayland-session module

### DIFF
--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -2,23 +2,14 @@
 
 let
   cfg = config.programs.hyprland;
-
-  finalPortalPackage = cfg.portalPackage.override {
-    hyprland = cfg.finalPackage;
-  };
 in
 {
   options.programs.hyprland = {
-    enable = lib.mkEnableOption null // {
-      description = ''
-        Whether to enable Hyprland, the dynamic tiling Wayland compositor that doesn't sacrifice on its looks.
-
-        You can manually launch Hyprland by executing {command}`Hyprland` on a TTY.
-
-        A configuration file will be generated in {file}`~/.config/hypr/hyprland.conf`.
-        See <https://wiki.hyprland.org> for more information.
-      '';
-    };
+    enable = lib.mkEnableOption ''
+      Hyprland, the dynamic tiling Wayland compositor that doesn't sacrifice on its looks.
+      You can manually launch Hyprland by executing {command}`Hyprland` on a TTY.
+      A configuration file will be generated in {file}`~/.config/hypr/hyprland.conf`.
+      See <https://wiki.hyprland.org> for more information'';
 
     package = lib.mkPackageOption pkgs "hyprland" { };
 
@@ -28,8 +19,9 @@ in
       default = cfg.package.override {
         enableXWayland = cfg.xwayland.enable;
       };
-      defaultText = lib.literalExpression
-        "`programs.hyprland.package` with applied configuration";
+      defaultText = lib.literalMD ''
+        `programs.hyprland.package` with applied configuration
+      '';
       description = ''
         The Hyprland package after applying configuration.
       '';
@@ -37,7 +29,21 @@ in
 
     portalPackage = lib.mkPackageOption pkgs "xdg-desktop-portal-hyprland" { };
 
-    xwayland.enable = lib.mkEnableOption ("XWayland") // { default = true; };
+    finalPortalPackage = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      default = cfg.portalPackage.override {
+        hyprland = cfg.finalPackage;
+      };
+      defaultText = lib.literalMD ''
+        `programs.hyprland.portalPackage` with applied configuration
+      '';
+      description = ''
+        The Hyprland Portal package after applying configuration.
+      '';
+    };
+
+    xwayland.enable = lib.mkEnableOption "XWayland" // { default = true; };
 
     systemd.setPath.enable = lib.mkEnableOption null // {
       default = true;
@@ -54,10 +60,11 @@ in
     {
       environment.systemPackages = [ cfg.finalPackage ];
 
+      # To make a Hyprland session available if a display manager like SDDM is enabled:
       services.displayManager.sessionPackages = [ cfg.finalPackage ];
 
       xdg.portal = {
-        extraPortals = [ finalPortalPackage ];
+        extraPortals = [ cfg.finalPortalPackage ];
         configPackages = lib.mkDefault [ cfg.finalPackage ];
       };
 

--- a/nixos/modules/programs/wayland/lib.nix
+++ b/nixos/modules/programs/wayland/lib.nix
@@ -1,0 +1,12 @@
+{ lib }:
+
+{
+  genFinalPackage = pkg: args:
+    let
+      expectedArgs = with lib;
+        lib.naturalSort (lib.attrNames args);
+      existingArgs = with lib;
+        naturalSort (intersectLists expectedArgs (attrNames (functionArgs pkg.override)));
+    in
+      if existingArgs != expectedArgs then pkg else pkg.override args;
+}

--- a/nixos/modules/programs/wayland/river.nix
+++ b/nixos/modules/programs/wayland/river.nix
@@ -22,18 +22,12 @@ in
 
     extraPackages = lib.mkOption {
       type = with lib.types; listOf package;
-      default = with pkgs; [
-        swaylock
-        foot
-        dmenu
-      ];
+      default = with pkgs; [ swaylock foot dmenu ];
       defaultText = lib.literalExpression ''
         with pkgs; [ swaylock foot dmenu ];
       '';
       example = lib.literalExpression ''
-        with pkgs; [
-          termite rofi light
-        ]
+        with pkgs; [ termite rofi light ]
       '';
       description = ''
         Extra packages to be installed system wide. See
@@ -48,7 +42,7 @@ in
       environment.systemPackages = lib.optional (cfg.package != null) cfg.package ++ cfg.extraPackages;
 
       # To make a river session available if a display manager like SDDM is enabled:
-      services.displayManager.sessionPackages = lib.optionals (cfg.package != null) [ cfg.package ];
+      services.displayManager.sessionPackages = lib.optional (cfg.package != null) cfg.package;
 
       # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050913
       xdg.portal.config.river.default = lib.mkDefault [ "wlr" "gtk" ];

--- a/nixos/modules/programs/wayland/river.nix
+++ b/nixos/modules/programs/wayland/river.nix
@@ -2,6 +2,8 @@
 
 let
   cfg = config.programs.river;
+
+  wayland-lib = import ./lib.nix { inherit lib; };
 in
 {
   options.programs.river = {
@@ -9,13 +11,18 @@ in
 
     package = lib.mkPackageOption pkgs "river" {
       nullable = true;
-      default = pkgs.river.override {
-        xwaylandSupport = cfg.xwayland.enable;
-      };
       extraDescription = ''
+        If the package is not overridable with `xwaylandSupport`, then the module option
+        {option}`xwayland` will have no effect.
+
         Set to `null` to not add any River package to your path.
         This should be done if you want to use the Home Manager River module to install River.
       '';
+    } // {
+      apply = p: if p == null then null else
+        wayland-lib.genFinalPackage p {
+          xwaylandSupport = cfg.xwayland.enable;
+        };
     };
 
     xwayland.enable = lib.mkEnableOption "XWayland" // { default = true; };

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -3,44 +3,9 @@
 let
   cfg = config.programs.sway;
 
-  wrapperOptions = lib.types.submodule {
-    options =
-      let
-        mkWrapperFeature  = default: description: lib.mkOption {
-          type = lib.types.bool;
-          inherit default;
-          example = !default;
-          description = "Whether to make use of the ${description}";
-        };
-      in {
-        base = mkWrapperFeature true ''
-          base wrapper to execute extra session commands and prepend a
-          dbus-run-session to the sway command.
-        '';
-        gtk = mkWrapperFeature false ''
-          wrapGAppsHook wrapper to execute sway with required environment
-          variables for GTK applications.
-        '';
-    };
-  };
-
   genFinalPackage = pkg:
     let
-      expectedArgs = lib.naturalSort [
-        "extraSessionCommands"
-        "extraOptions"
-        "withBaseWrapper"
-        "withGtkWrapper"
-        "enableXWayland"
-        "isNixOS"
-      ];
-      existedArgs = with lib;
-        naturalSort
-        (intersectLists expectedArgs (attrNames (functionArgs pkg.override)));
-    in if existedArgs != expectedArgs then
-      pkg
-    else
-      pkg.override {
+      args = {
         extraSessionCommands = cfg.extraSessionCommands;
         extraOptions = cfg.extraOptions;
         withBaseWrapper = cfg.wrapperFeatures.base;
@@ -48,6 +13,13 @@ let
         enableXWayland = cfg.xwayland.enable;
         isNixOS = true;
       };
+
+      expectedArgs = with lib;
+        lib.naturalSort (lib.attrNames args);
+      existingArgs = with lib;
+        naturalSort (intersectLists expectedArgs (attrNames (functionArgs pkg.override)));
+    in
+      if existingArgs != expectedArgs then pkg else pkg.override args;
 in
 {
   options.programs.sway = {
@@ -58,30 +30,28 @@ in
       <https://github.com/swaywm/sway/wiki> and
       "man 5 sway" for more information'';
 
-    package = lib.mkOption {
-      type = with lib.types; nullOr package;
-      default = pkgs.sway;
-      apply = p: if p == null then null else genFinalPackage p;
-      defaultText = lib.literalExpression "pkgs.sway";
-      description = ''
-        Sway package to use. If the package does not contain the override arguments
-        `extraSessionCommands`, `extraOptions`, `withBaseWrapper`, `withGtkWrapper`,
-        `enableXWayland` and `isNixOS`, then the module options {option}`wrapperFeatures`,
-        {option}`extraSessionCommands`, {option}`extraOptions` and {option}`wayland`
-        will have no effect.
+    package = lib.mkPackageOption pkgs "sway" {
+      nullable = true;
+      extraDescription = ''
+        If the package is not overridable with `extraSessionCommands`, `extraOptions`,
+        `withBaseWrapper`, `withGtkWrapper`, `enableXWayland` and `isNixOS`,
+        then the module options {option}`wrapperFeatures`, {option}`extraSessionCommands`,
+        {option}`extraOptions` and {option}`xwayland` will have no effect.
 
-        Set to `null` to not add any Sway package to your path. This should be done if
-        you want to use the Home Manager Sway module to install Sway.
+        Set to `null` to not add any Sway package to your path.
+        This should be done if you want to use the Home Manager Sway module to install Sway.
       '';
+    } // {
+      apply = p: if p == null then null else genFinalPackage p;
     };
 
-    wrapperFeatures = lib.mkOption {
-      type = wrapperOptions;
-      default = { };
-      example = { gtk = true; };
-      description = ''
-        Attribute set of features to enable in the wrapper.
-      '';
+    wrapperFeatures = {
+      base = lib.mkEnableOption ''
+        the base wrapper to execute extra session commands and prepend a
+        dbus-run-session to the sway command'' // { default = true; };
+      gtk = lib.mkEnableOption ''
+        the wrapGAppsHook wrapper to execute sway with required environment
+        variables for GTK applications'';
     };
 
     extraSessionCommands = lib.mkOption {
@@ -123,17 +93,12 @@ in
 
     extraPackages = lib.mkOption {
       type = with lib.types; listOf package;
-      default = with pkgs; [
-        swaylock swayidle foot dmenu wmenu
-      ];
+      default = with pkgs; [ swaylock swayidle foot dmenu wmenu ];
       defaultText = lib.literalExpression ''
         with pkgs; [ swaylock swayidle foot dmenu wmenu ];
       '';
       example = lib.literalExpression ''
-        with pkgs; [
-          i3status i3status-rust
-          termite rofi light
-        ]
+        with pkgs; [ i3status i3status-rust termite rofi light ]
       '';
       description = ''
         Extra packages to be installed system wide. See
@@ -150,8 +115,7 @@ in
         {
           assertion = cfg.extraSessionCommands != "" -> cfg.wrapperFeatures.base;
           message = ''
-            The extraSessionCommands for Sway will not be run if
-            wrapperFeatures.base is disabled.
+            The extraSessionCommands for Sway will not be run if wrapperFeatures.base is disabled.
           '';
         }
       ];
@@ -160,7 +124,7 @@ in
         systemPackages = lib.optional (cfg.package != null) cfg.package ++ cfg.extraPackages;
 
         # Needed for the default wallpaper:
-        pathsToLink = lib.optionals (cfg.package != null) [ "/share/backgrounds/sway" ];
+        pathsToLink = lib.optional (cfg.package != null) "/share/backgrounds/sway";
 
         etc = {
           "sway/config.d/nixos.conf".source = pkgs.writeText "nixos.conf" ''
@@ -176,7 +140,7 @@ in
       programs.gnupg.agent.pinentryPackage = lib.mkDefault pkgs.pinentry-gnome3;
 
       # To make a Sway session available if a display manager like SDDM is enabled:
-      services.displayManager.sessionPackages = lib.optionals (cfg.package != null) [ cfg.package ];
+      services.displayManager.sessionPackages = lib.optional (cfg.package != null) cfg.package;
 
       # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050913
       xdg.portal.config.sway.default = lib.mkDefault [ "wlr" "gtk" ];

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -3,23 +3,7 @@
 let
   cfg = config.programs.sway;
 
-  genFinalPackage = pkg:
-    let
-      args = {
-        extraSessionCommands = cfg.extraSessionCommands;
-        extraOptions = cfg.extraOptions;
-        withBaseWrapper = cfg.wrapperFeatures.base;
-        withGtkWrapper = cfg.wrapperFeatures.gtk;
-        enableXWayland = cfg.xwayland.enable;
-        isNixOS = true;
-      };
-
-      expectedArgs = with lib;
-        lib.naturalSort (lib.attrNames args);
-      existingArgs = with lib;
-        naturalSort (intersectLists expectedArgs (attrNames (functionArgs pkg.override)));
-    in
-      if existingArgs != expectedArgs then pkg else pkg.override args;
+  wayland-lib = import ./lib.nix { inherit lib; };
 in
 {
   options.programs.sway = {
@@ -42,7 +26,15 @@ in
         This should be done if you want to use the Home Manager Sway module to install Sway.
       '';
     } // {
-      apply = p: if p == null then null else genFinalPackage p;
+      apply = p: if p == null then null else
+        wayland-lib.genFinalPackage p {
+          extraSessionCommands = cfg.extraSessionCommands;
+          extraOptions = cfg.extraOptions;
+          withBaseWrapper = cfg.wrapperFeatures.base;
+          withGtkWrapper = cfg.wrapperFeatures.gtk;
+          enableXWayland = cfg.xwayland.enable;
+          isNixOS = true;
+        };
     };
 
     wrapperFeatures = {

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.programs.sway;
@@ -31,6 +31,7 @@ let
         "extraOptions"
         "withBaseWrapper"
         "withGtkWrapper"
+        "enableXWayland"
         "isNixOS"
       ];
       existedArgs = with lib;
@@ -44,9 +45,11 @@ let
         extraOptions = cfg.extraOptions;
         withBaseWrapper = cfg.wrapperFeatures.base;
         withGtkWrapper = cfg.wrapperFeatures.gtk;
+        enableXWayland = cfg.xwayland.enable;
         isNixOS = true;
       };
-in {
+in
+{
   options.programs.sway = {
     enable = lib.mkEnableOption ''
       Sway, the i3-compatible tiling Wayland compositor. You can manually launch
@@ -63,8 +66,10 @@ in {
       description = ''
         Sway package to use. If the package does not contain the override arguments
         `extraSessionCommands`, `extraOptions`, `withBaseWrapper`, `withGtkWrapper`,
-        `isNixOS`, then the module options {option}`wrapperFeatures`,
-        {option}`wrapperFeatures` and {option}`wrapperFeatures` will have no effect.
+        `enableXWayland` and `isNixOS`, then the module options {option}`wrapperFeatures`,
+        {option}`extraSessionCommands`, {option}`extraOptions` and {option}`wayland`
+        will have no effect.
+
         Set to `null` to not add any Sway package to your path. This should be done if
         you want to use the Home Manager Sway module to install Sway.
       '';
@@ -114,6 +119,8 @@ in {
       '';
     };
 
+    xwayland.enable = lib.mkEnableOption "XWayland" // { default = true; };
+
     extraPackages = lib.mkOption {
       type = with lib.types; listOf package;
       default = with pkgs; [
@@ -135,46 +142,51 @@ in {
         for a list of useful software.
       '';
     };
-
   };
 
-  config = lib.mkIf cfg.enable
-    (lib.mkMerge [
-      {
-        assertions = [
-          {
-            assertion = cfg.extraSessionCommands != "" -> cfg.wrapperFeatures.base;
-            message = ''
-              The extraSessionCommands for Sway will not be run if
-              wrapperFeatures.base is disabled.
-            '';
-          }
-        ];
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = cfg.extraSessionCommands != "" -> cfg.wrapperFeatures.base;
+          message = ''
+            The extraSessionCommands for Sway will not be run if
+            wrapperFeatures.base is disabled.
+          '';
+        }
+      ];
 
-        environment = {
-          systemPackages = lib.optional (cfg.package != null) cfg.package ++ cfg.extraPackages;
-          # Needed for the default wallpaper:
-          pathsToLink = lib.optionals (cfg.package != null) [ "/share/backgrounds/sway" ];
-          etc = {
-            "sway/config.d/nixos.conf".source = pkgs.writeText "nixos.conf" ''
-              # Import the most important environment variables into the D-Bus and systemd
-              # user environments (e.g. required for screen sharing and Pinentry prompts):
-              exec dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP
-            '';
-          } // lib.optionalAttrs (cfg.package != null) {
-            "sway/config".source = lib.mkOptionDefault "${cfg.package}/etc/sway/config";
-          };
+      environment = {
+        systemPackages = lib.optional (cfg.package != null) cfg.package ++ cfg.extraPackages;
+
+        # Needed for the default wallpaper:
+        pathsToLink = lib.optionals (cfg.package != null) [ "/share/backgrounds/sway" ];
+
+        etc = {
+          "sway/config.d/nixos.conf".source = pkgs.writeText "nixos.conf" ''
+            # Import the most important environment variables into the D-Bus and systemd
+            # user environments (e.g. required for screen sharing and Pinentry prompts):
+            exec dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP
+          '';
+        } // lib.optionalAttrs (cfg.package != null) {
+          "sway/config".source = lib.mkOptionDefault "${cfg.package}/etc/sway/config";
         };
+      };
 
-        programs.gnupg.agent.pinentryPackage = lib.mkDefault pkgs.pinentry-gnome3;
+      programs.gnupg.agent.pinentryPackage = lib.mkDefault pkgs.pinentry-gnome3;
 
-        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050913
-        xdg.portal.config.sway.default = lib.mkDefault [ "wlr" "gtk" ];
+      # To make a Sway session available if a display manager like SDDM is enabled:
+      services.displayManager.sessionPackages = lib.optionals (cfg.package != null) [ cfg.package ];
 
-        # To make a Sway session available if a display manager like SDDM is enabled:
-        services.displayManager.sessionPackages = lib.optionals (cfg.package != null) [ cfg.package ]; }
-      (import ./wayland-session.nix { inherit lib pkgs; })
-    ]);
+      # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050913
+      xdg.portal.config.sway.default = lib.mkDefault [ "wlr" "gtk" ];
+    }
+
+    (import ./wayland-session.nix {
+      inherit lib pkgs;
+      xwayland = cfg.xwayland.enable;
+    })
+  ]);
 
   meta.maintainers = with lib.maintainers; [ primeos colemickens ];
 }

--- a/nixos/modules/programs/wayland/wayland-session.nix
+++ b/nixos/modules/programs/wayland/wayland-session.nix
@@ -14,12 +14,5 @@
     xwayland.enable = lib.mkDefault xwayland;
   };
 
-  xdg.portal = {
-    enable = lib.mkDefault true;
-
-    extraPortals = [
-      # For screen sharing
-      pkgs.xdg-desktop-portal-wlr
-    ];
-  };
+  xdg.portal.wlr.enable = lib.mkDefault true;
 }

--- a/nixos/modules/programs/wayland/wayland-session.nix
+++ b/nixos/modules/programs/wayland/wayland-session.nix
@@ -1,23 +1,25 @@
-{ lib, pkgs, ... }: {
-    security = {
-      polkit.enable = true;
-      pam.services.swaylock = {};
-    };
+{ lib, pkgs, xwayland ? true }:
 
-    hardware.opengl.enable = lib.mkDefault true;
-    fonts.enableDefaultPackages = lib.mkDefault true;
+{
+  security = {
+    polkit.enable = true;
+    pam.services.swaylock = {};
+  };
 
-    programs = {
-      dconf.enable = lib.mkDefault true;
-      xwayland.enable = lib.mkDefault true;
-    };
+  hardware.opengl.enable = lib.mkDefault true;
+  fonts.enableDefaultPackages = lib.mkDefault true;
 
-    xdg.portal = {
-      enable = lib.mkDefault true;
+  programs = {
+    dconf.enable = lib.mkDefault true;
+    xwayland.enable = lib.mkDefault xwayland;
+  };
 
-      extraPortals = [
-        # For screen sharing
-        pkgs.xdg-desktop-portal-wlr
-      ];
-    };
+  xdg.portal = {
+    enable = lib.mkDefault true;
+
+    extraPortals = [
+      # For screen sharing
+      pkgs.xdg-desktop-portal-wlr
+    ];
+  };
 }


### PR DESCRIPTION
###### Description of changes

- Introduce an `xwayland` option to the Sway and River modules, similar to the one in the Hyprland module (see #228858)

- Make the Hyprland module use the generic `wayland-session` module, already used by the Sway and River modules (introduced by #232011)

- Factor out the `genFinalPackage` function (introduced in #267261) from the Sway module into a new `lib` file

- Use it as an `apply` function of the `package` option in the River and Hyprland modules, as a cleaner alternative to the `finalPackage` option introduced in #244919


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).