### PR TITLE
vagrant: 2.3.4 -> 2.3.7, vagrant-libvirt-provider: 0.8.2 -> 0.12.2

### DIFF
--- a/pkgs/development/tools/vagrant/0001-Revert-Merge-pull-request-12225-from-chrisroberts-re.patch
+++ b/pkgs/development/tools/vagrant/0001-Revert-Merge-pull-request-12225-from-chrisroberts-re.patch
@@ -214,7 +214,7 @@ index edae9b477..782904f49 100644
          cloud init command '%{cmd}' failed on guest '%{guest_name}'.
        command_deprecated: |-
          The command 'vagrant %{name}' has been deprecated and is no longer functional
-@@ -1238,23 +1238,6 @@ en:
+@@ -1245,30 +1245,6 @@ en:
          following command:
  
            vagrant plugin install --local
@@ -225,12 +225,19 @@ index edae9b477..782904f49 100644
 -        again.
 -      plugin_missing_library: |-
 -        Vagrant failed to install the requested plugin because it depends
--        on a library which is not currently installed on this system. The
--        following library is required by the '%{name}' plugin:
+-        on development files for a library which is not currently installed
+-        on this system. The following library is required by the '%{name}'
+-        plugin:
 -
 -          %{library}
 -
--        Please install the library and then run the command again.
+-        If a package manager is used on this system, please install the development
+-        package for the library. The name of the package will be similar to:
+-
+-          %{library}-dev or %{library}-devel
+-
+-        After the library and development files have been installed, please
+-        run the command again.
 -      plugin_missing_ruby_dev: |-
 -        Vagrant failed to install the requested plugin because the Ruby header
 -        files could not be found. Install the ruby development package for your

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -5,9 +5,9 @@
 let
   # NOTE: bumping the version and updating the hash is insufficient;
   # you must use bundix to generate a new gemset.nix in the Vagrant source.
-  version = "2.3.4";
+  version = "2.3.7";
   url = "https://github.com/hashicorp/vagrant/archive/v${version}.tar.gz";
-  sha256 = "sha256-Q+sUYcbc/SOgw4ZXDmwqh24G0jiLvA8fDJyZ45OqLw8=";
+  hash = "sha256-+oqWMZqnuf9fSpkbd8vzf1SVSdhHN2JLzr76jyAEv0U=";
 
   deps = bundlerEnv rec {
     name = "${pname}-${version}";
@@ -21,7 +21,7 @@ let
       vagrant = {
         source = {
           type = "url";
-          inherit url sha256;
+          inherit url hash;
         };
         inherit version;
       };
@@ -48,7 +48,7 @@ in buildRubyGem rec {
 
   doInstallCheck = true;
   dontBuild = false;
-  src = fetchurl { inherit url sha256; };
+  src = fetchurl { inherit url hash; };
 
   patches = [
     ./unofficial-installation-nowarn.patch
@@ -96,13 +96,6 @@ in buildRubyGem rec {
 
   installCheckPhase = ''
     HOME="$(mktemp -d)" $out/bin/vagrant init --output - > /dev/null
-  '';
-
-  # `patchShebangsAuto` patches this one script which is intended to run
-  # on foreign systems.
-  postFixup = ''
-    sed -i -e '1c#!/bin/sh -' \
-      $out/lib/ruby/gems/*/gems/vagrant-*/plugins/provisioners/salt/bootstrap-salt.sh
   '';
 
   passthru = {

--- a/pkgs/development/tools/vagrant/gemset_libvirt.nix
+++ b/pkgs/development/tools/vagrant/gemset_libvirt.nix
@@ -47,10 +47,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1s8b3bsajwjyrjs53h0nrfrpzzgi8igsrslprhr6fgl80ig3plld";
+      sha256 = "sha256-z0VkRqFk3JU02ULQ+xQbywekzrJgz1YPDul//Ov5ajU=";
       type = "gem";
     };
-    version = "0.9.0";
+    version = "0.11.0";
   };
   fog-xml = {
     dependencies = ["fog-core" "nokogiri"];
@@ -109,10 +109,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0rapl1sfmfi3bfr68da4ca16yhc0pp93vjwkj7y3rdqrzy3b41hy";
+      sha256 = "sha256-RrLSRMxv8BqJv2EnRpDAn9vcpHqErp6sOQOegSMa7nw=";
       type = "gem";
     };
-    version = "2.8.0";
+    version = "2.8.2";
   };
   multi_json = {
     groups = ["default"];
@@ -130,20 +130,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "11w59ga9324yx6339dgsflz3dsqq2mky1qqdwcg6wi5s1bf2yldi";
+      sha256 = "sha256-INyAC4++TE9LWxZOaqOrgqNxvLJ+toXBZpYcNN2KItc=";
       type = "gem";
     };
-    version = "1.13.6";
+    version = "1.15.2";
   };
   racc = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0la56m0z26j3mfn1a9lf2l03qx1xifanndf9p3vx1azf6sqy7v9d";
+      sha256 = "sha256-r2QSSDb908AOgwcD1/hz6l3qvekj83AGo59aXg2hY4c=";
       type = "gem";
     };
-    version = "1.6.0";
+    version = "1.7.1";
   };
   rexml = {
     groups = ["default"];
@@ -154,6 +154,26 @@
       type = "gem";
     };
     version = "3.2.5";
+  };
+  xml-simple = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "sha256-0hEx5RnIbxpbwrbS1X1G5pmOR/GO0kmyXK2GQz29aV0=";
+      type = "gem";
+    };
+    version = "1.1.9";
+  };
+  diffy = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "sha256-NrQv++UTjdxWGCEHwkrY1rBm7P0odoKfOR46SZPYmuE=";
+      type = "gem";
+    };
+    version = "3.4.2";
   };
   ruby-libvirt = {
     groups = ["default"];
@@ -166,14 +186,14 @@
     version = "0.8.0";
   };
   vagrant-libvirt = {
-    dependencies = ["fog-core" "fog-libvirt" "nokogiri" "rexml"];
+    dependencies = ["fog-core" "fog-libvirt" "nokogiri" "rexml" "xml-simple" "diffy"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1j31y6sjhslj5yr0ssvb36ngm7prfsbdfj6131757jl0l0ri8pyv";
+      sha256 = "sha256-NMiRjrVQo2Ui9nOJwpDmNJUk+95gsT85pwFMIiw3bwQ=";
       type = "gem";
     };
-    version = "0.8.2";
+    version = "0.12.2";
   };
 }


### PR DESCRIPTION
###### Description of changes
- File in post fixup phase got deleted by upstream, no longer needed.
https://github.com/hashicorp/vagrant/commit/7db87b9da37e019e0201e0f8c7517da553a8910f

- Patch needed some changes to work with newest version of vagrant.
https://github.com/hashicorp/vagrant/commit/3422582d68e94bb1c4da64512ac9a2c3654237d6

https://github.com/hashicorp/vagrant/releases/tag/v2.3.5
https://github.com/hashicorp/vagrant/releases/tag/v2.3.6
https://github.com/hashicorp/vagrant/releases/tag/v2.3.7

https://github.com/vagrant-libvirt/vagrant-libvirt/compare/0.8.2...0.12.2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
