### PR TITLE
minimal-bootstrap: use recursive FOD to make nix unpack bootstrap sources

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix
@@ -29,7 +29,7 @@ rec {
 
   Run the following command:
   ```
-  nix hash file $(nix build --print-out-paths -f '<nixpkgs>' make-minimal-bootstrap-sources)
+  nix hash path $(nix build --print-out-paths -f '<nixpkgs>' make-minimal-bootstrap-sources)
   ```
 
   # Why do we need this `.nar` archive?
@@ -71,11 +71,11 @@ rec {
   requirements above apply to `minimal-bootstrap-sources`.
   */
   minimal-bootstrap-sources = derivation {
-    name = "${name}.nar.xz";
+    inherit name;
     system = builtins.currentSystem;
-    outputHashMode = "flat";
+    outputHashMode = "recursive";
     inherit outputHashAlgo;
-    outputHash = "sha256-ig988BiRTz92hhZZgKQW1tVPoV4aQ2D69Cq3wHvVgHg=";
+    outputHash = "sha256-FpMp7z+B3cR3LkQ+PooH/b1/NlxH8NHVJNWifaPWt4U=";
 
     # This builder always fails, but fortunately Nix will print the
     # "builder", which is really the error message that we want the
@@ -85,21 +85,12 @@ rec {
       #
       # Neither your store nor your substituters seems to have:
       #
-      #  ${name}.nar.xz
+      #  /nix/store/________________________________-${name}
       #
-      # Please obtain or create this file, give it exactly the name
-      # shown above, and then run the following command:
-      #
-      #   nix-store --add-fixed ${outputHashAlgo} ${name}.nar.xz
-      #
-      # You can create this file from an already-bootstrapped nixpkgs
+      # You can create this path from an already-bootstrapped nixpkgs
       # using the following command:
       #
       #   nix-build '<nixpkgs>' -A make-minimal-bootstrap-sources
-      #
-      # Or, if you prefer, you can create this file using only `git`,
-      # `nix`, and `xz`.  For the commands needed in order to do this,
-      # see `make-bootstrap-sources.nix`.
       #
     '';
   };

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix
@@ -7,6 +7,7 @@ rec {
   version = "unstable-2023-05-02";
   rev = "3189b5f325b7ef8b88e3edec7c1cde4fce73c76c";
   outputHashAlgo = "sha256";
+  outputHash = "sha256-FpMp7z+B3cR3LkQ+PooH/b1/NlxH8NHVJNWifaPWt4U=";
 
   # This 256 byte seed is the only pre-compiled binary in the bootstrap chain.
   hex0-seed = import <nix/fetchurl.nix> {
@@ -74,8 +75,7 @@ rec {
     inherit name;
     system = builtins.currentSystem;
     outputHashMode = "recursive";
-    inherit outputHashAlgo;
-    outputHash = "sha256-FpMp7z+B3cR3LkQ+PooH/b1/NlxH8NHVJNWifaPWt4U=";
+    inherit outputHashAlgo outputHash;
 
     # This builder always fails, but fortunately Nix will print the
     # "builder", which is really the error message that we want the
@@ -85,13 +85,21 @@ rec {
       #
       # Neither your store nor your substituters seems to have:
       #
-      #  /nix/store/________________________________-${name}
+      #  ${builtins.placeholder "out"}
       #
       # You can create this path from an already-bootstrapped nixpkgs
       # using the following command:
       #
       #   nix-build '<nixpkgs>' -A make-minimal-bootstrap-sources
       #
+      # Or, if you prefer, you can create this file using only `git`,
+      # `nix`, and `xz`.  For the commands needed in order to do this,
+      # see `make-bootstrap-sources.nix`.  Once you have the manual
+      # result, do:
+      #
+      #   nix-store --add-fixed --recursive ${outputHashAlgo} ./${name}
+      #
+      # to add it to your store.
     '';
   };
 }

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/make-bootstrap-sources.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/make-bootstrap-sources.nix
@@ -8,44 +8,31 @@
 #
 # To build:
 #
-#   nix-build '<nixpkgs>' -o sources.nar.xz -A make-minimal-bootstrap-sources
+#   nix-build '<nixpkgs>' -A make-minimal-bootstrap-sources
 #
 
 { lib
 , fetchFromGitHub
-, runCommand
-, nix
-, xz
 }:
-let
+fetchFromGitHub {
   inherit (import ./bootstrap-sources.nix { }) name rev;
+  owner = "oriansj";
+  repo = "stage0-posix";
+  sha256 = "sha256-FpMp7z+B3cR3LkQ+PooH/b1/NlxH8NHVJNWifaPWt4U=";
+  fetchSubmodules = true;
+  postFetch = ''
+    # Seed binaries will be fetched separately
+    echo "Removing seed binaries"
+    rm -rf $out/bootstrap-seeds/*
 
-  src = fetchFromGitHub {
-    owner = "oriansj";
-    repo = "stage0-posix";
-    inherit rev;
-    sha256 = "sha256-FpMp7z+B3cR3LkQ+PooH/b1/NlxH8NHVJNWifaPWt4U=";
-    fetchSubmodules = true;
-    postFetch = ''
-      # Seed binaries will be fetched separately
-      echo "Removing seed binaries"
-      rm -rf $out/bootstrap-seeds/*
-
-      # Remove vendored/duplicate M2libc's
-      echo "Removing duplicate M2libc"
-      rm -rf \
-        $out/M2-Mesoplanet/M2libc \
-        $out/M2-Planet/M2libc \
-        $out/mescc-tools/M2libc \
-        $out/mescc-tools-extra/M2libc
-    '';
-  };
-
-in
-runCommand "${name}.nar.xz" {
-  nativeBuildInputs = [ nix xz ];
-
-  passthru = { inherit src; };
+    # Remove vendored/duplicate M2libc's
+    echo "Removing duplicate M2libc"
+    rm -rf \
+      $out/M2-Mesoplanet/M2libc \
+      $out/M2-Planet/M2libc \
+      $out/mescc-tools/M2libc \
+      $out/mescc-tools-extra/M2libc
+  '';
 
   meta = with lib; {
     description = "Packaged sources for the first bootstrapping stage";
@@ -54,6 +41,4 @@ runCommand "${name}.nar.xz" {
     maintainers = teams.minimal-bootstrap.members;
     platforms = platforms.all;
   };
-} ''
-  nix-store --dump ${src} | xz -c > $out
-''
+}

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/make-bootstrap-sources.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/make-bootstrap-sources.nix
@@ -14,11 +14,16 @@
 { lib
 , fetchFromGitHub
 }:
+
+let
+  expected = import ./bootstrap-sources.nix { };
+in
+
 fetchFromGitHub {
-  inherit (import ./bootstrap-sources.nix { }) name rev;
+  inherit (expected) name rev;
   owner = "oriansj";
   repo = "stage0-posix";
-  sha256 = "sha256-FpMp7z+B3cR3LkQ+PooH/b1/NlxH8NHVJNWifaPWt4U=";
+  sha256 = expected.outputHash;
   fetchSubmodules = true;
   postFetch = ''
     # Seed binaries will be fetched separately


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is an addendum to work done in #238357. Investigating it seems like the contents of the narball wasn't being unpacked, causing hex0 to not find sources for hex1 and hang. Switching to a recursive FOD seems like a solution?

Related #227914

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
