### PR TITLE
cargo-toml-lint: init at 0.1.1

### DIFF
--- a/pkgs/development/tools/rust/cargo-toml-lint/default.nix
+++ b/pkgs/development/tools/rust/cargo-toml-lint/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, rustPlatform
+, fetchCrate
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-toml-lint";
+  version = "0.1.1";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-U3y9gnFvkqJmyFqRAUQorJQY0iRzAE9UUXzFmgZIyaM=";
+  };
+
+  cargoHash = "sha256-ujdekIucqes2Wya4jwTMLstb8JMptbAlqYhgMxfp2gg=";
+
+  meta = with lib; {
+    description = "A simple linter for Cargo.toml manifests";
+    homepage = "https://github.com/fuellabs/cargo-toml-lint";
+    changelog = "https://github.com/fuellabs/cargo-toml-lint/releases/tag/v${version}";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ mitchmindtree ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16792,6 +16792,7 @@ with pkgs;
   cargo-sync-readme = callPackage ../development/tools/rust/cargo-sync-readme { };
   cargo-tally = callPackage ../development/tools/rust/cargo-tally { };
   cargo-temp = callPackage ../development/tools/rust/cargo-temp { };
+  cargo-toml-lint = callPackage ../development/tools/rust/cargo-toml-lint { };
   cargo-udeps = callPackage ../development/tools/rust/cargo-udeps {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
   };


### PR DESCRIPTION
###### Description of changes

Adds `cargo-toml-lint`, a simple crate/tool for linting cargo manifest files. It checks for things like manifest validity, ordering of dependencies and contiguous listing of array entries.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).