### PR TITLE
python310Packages.skia-pathops: 0.7.4 -> 0.8.0, mark broken for PyPy

### DIFF
--- a/pkgs/development/python-modules/skia-pathops/default.nix
+++ b/pkgs/development/python-modules/skia-pathops/default.nix
@@ -1,27 +1,30 @@
 { lib
-, stdenv
-, buildPythonPackage
-, cython
-, ninja
-, setuptools-scm
-, setuptools
-, fetchPypi
-, gn
-, pytestCheckHook
-, xcodebuild
 , ApplicationServices
 , OpenGL
+, buildPythonPackage
+, cython
+, fetchPypi
+, gn
+, isPyPy
+, ninja
+, pytestCheckHook
+, pythonOlder
+, setuptools
+, setuptools-scm
+, stdenv
+, xcodebuild
 }:
 
 buildPythonPackage rec {
   pname = "skia-pathops";
-  version = "0.7.4";
+  version = "0.8.0";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "skia-pathops";
     inherit version;
     extension = "zip";
-    hash = "sha256-Ci/e6Ht62wGMv6bpXvnkKZ7WOwCAvidnejD/77ypE1A=";
+    hash = "sha256-0SrxzvKL5KbzNgZdBtMeO006bCKFB6gdOgxZbXignO4=";
   };
 
   postPatch = ''
@@ -50,8 +53,10 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python access to operations on paths using the Skia library";
-    homepage = "https://skia.org/dev/present/pathops";
+    homepage = "https://github.com/fonttools/skia-pathops";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.BarinovMaxim ];
+    # ERROR at //gn/BUILDCONFIG.gn:87:14: Script returned non-zero exit code.
+    broken = isPyPy;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
