### PR TITLE
stdenv: fix stagesNative

### DIFF
--- a/pkgs/development/interpreters/perl/intepreter.nix
+++ b/pkgs/development/interpreters/perl/intepreter.nix
@@ -195,9 +195,11 @@ stdenv.mkDerivation (rec {
       substituteInPlace "$out"/lib/perl5/*/*/Config_heavy.pl \
         --replace "${libcInc}" /no-such-path \
         --replace "${
-            if stdenv.hasCC then stdenv.cc.cc else "/no-such-path"
+            if stdenv.hasCC then stdenv.cc else "/no-such-path"
           }" /no-such-path \
-        --replace "${stdenv.cc}" /no-such-path \
+        --replace "${
+            if stdenv.hasCC && stdenv.cc.cc != null then stdenv.cc.cc else "/no-such-path"
+        }" /no-such-path \
         --replace "$man" /no-such-path
     '' + lib.optionalString crossCompiling
       ''

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -152,7 +152,10 @@ in
     inherit config overlays;
     stdenv = makeStdenv {
       inherit (prevStage) cc fetchurl;
-    } // { inherit (prevStage) fetchurl; };
+      overrides = prev: final: { inherit (prevStage) fetchurl; };
+    } // {
+      inherit (prevStage) fetchurl;
+    };
   })
 
   # Using that, build a stdenv that adds the ‘xz’ command (which most systems
@@ -162,7 +165,7 @@ in
     stdenv = makeStdenv {
       inherit (prevStage.stdenv) cc fetchurl;
       extraPath = [ prevStage.xz ];
-      overrides = self: super: { inherit (prevStage) xz; };
+      overrides = self: super: { inherit (prevStage) fetchurl xz; };
       extraNativeBuildInputs = if localSystem.isLinux then [ prevStage.patchelf ] else [];
     };
   })


### PR DESCRIPTION
###### Description of changes

Fixes an infinite recursion in `stagesNative` in `stdenv`:

Tested with `nix-build -A nix --option sandbox false --show-trace` after applying this diff:

```diff
diff --git a/pkgs/stdenv/default.nix b/pkgs/stdenv/default.nix
index 7a2ad665e09..2647250a578 100644
--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -38,7 +38,7 @@ let
 in
   if crossSystem != localSystem || crossOverlays != [] then stagesCross
   else if config ? replaceStdenv then stagesCustom
-  else if localSystem.isLinux then stagesLinux
+  else if localSystem.isLinux then stagesNix
   else if localSystem.isDarwin then stagesDarwin
   else # misc special cases
   { # switch
```

Before:
<details>

```
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nix-2.15.1'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'buildInputs' of derivation 'nix-2.15.1'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:350:7:

          349|       depsHostHost                = lib.elemAt (lib.elemAt dependencies 1) 0;
          350|       buildInputs                 = lib.elemAt (lib.elemAt dependencies 1) 1;
             |       ^
          351|       depsTargetTarget            = lib.elemAt (lib.elemAt dependencies 2) 0;

       … while evaluating derivation 'boost-1.79.0'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'buildInputs' of derivation 'boost-1.79.0'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:350:7:

          349|       depsHostHost                = lib.elemAt (lib.elemAt dependencies 1) 0;
          350|       buildInputs                 = lib.elemAt (lib.elemAt dependencies 1) 1;
             |       ^
          351|       depsTargetTarget            = lib.elemAt (lib.elemAt dependencies 2) 0;

       … while evaluating derivation 'expat-2.5.0'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'builder' of derivation 'expat-2.5.0'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:330:7:

          329|     }) // lib.optionalAttrs __structuredAttrs { env = checkedEnv; } // {
          330|       builder = attrs.realBuilder or stdenv.shell;
             |       ^
          331|       args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];

       … while evaluating derivation 'bash-5.2-p15'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'bash-5.2-p15'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:347:7:

          346|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          347|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          348|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;

       … while evaluating derivation 'bison-3.8.2'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'bison-3.8.2'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:347:7:

          346|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          347|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          348|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;

       … while evaluating derivation 'gnum4-1.4.19'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'src' of derivation 'gnum4-1.4.19'

         at /home/uri/nixpkgs/pkgs/development/tools/misc/gnum4/default.nix:12:3:

           11|
           12|   src = fetchurl {
             |   ^
           13|     url = "mirror://gnu/m4/m4-${version}.tar.bz2";

       … while evaluating derivation 'm4-1.4.19.tar.bz2'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'mirrorsFile' of derivation 'm4-1.4.19.tar.bz2'

         at /home/uri/nixpkgs/pkgs/build-support/fetchurl/default.nix:173:10:

          172|   curlOptsList = lib.escapeShellArgs curlOptsList;
          173|   inherit showURLs mirrorsFile postFetch downloadToTemp executable;
             |          ^
          174|

       … while evaluating derivation 'mirrors-list'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'stdenv' of derivation 'mirrors-list'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:332:14:

          331|       args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
          332|       inherit stdenv;
             |              ^
          333|

       … while evaluating derivation 'stdenv'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/default.nix:93:14

       … while evaluating attribute 'defaultNativeBuildInputs' of derivation 'stdenv'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/default.nix:126:14:

          125|
          126|       inherit initialPath shell
             |              ^
          127|         defaultNativeBuildInputs defaultBuildInputs;

       … while evaluating derivation 'patchelf-0.15.0'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'src' of derivation 'patchelf-0.15.0'

         at /home/uri/nixpkgs/pkgs/development/tools/misc/patchelf/default.nix:12:3:

           11|
           12|   src = fetchurl {
             |   ^
           13|     url = "https://github.com/NixOS/${pname}/releases/download/${version}/${pname}-${version}.tar.bz2";

       … while evaluating derivation 'patchelf-0.15.0.tar.bz2'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'patchelf-0.15.0.tar.bz2'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:347:7:

          346|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          347|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          348|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;

       … while evaluating derivation 'curl-8.1.1'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'configureFlags' of derivation 'curl-8.1.1'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:361:7:

          360|       # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
          361|       configureFlags = let inherit (lib) optional elem; in
             |       ^
          362|         configureFlags

       … from call site

         at /home/uri/nixpkgs/pkgs/tools/networking/curl/default.nix:117:8:

          116|       (lib.withFeatureAs idnSupport "libidn2" (lib.getDev libidn2))
          117|       (lib.withFeatureAs opensslSupport "openssl" (lib.getDev openssl))
             |        ^
          118|       (lib.withFeatureAs scpSupport "libssh2" (lib.getDev libssh2))

       … while calling 'withFeatureAs'

         at /home/uri/nixpkgs/lib/strings.nix:844:32:

          843|   */
          844|   withFeatureAs = with_: feat: value: withFeature with_ feat + optionalString with_ "=${value}";
             |                                ^
          845|

       … from call site

         at /home/uri/nixpkgs/lib/strings.nix:844:64:

          843|   */
          844|   withFeatureAs = with_: feat: value: withFeature with_ feat + optionalString with_ "=${value}";
             |                                                                ^
          845|

       … while calling 'optionalString'

         at /home/uri/nixpkgs/lib/strings.nix:242:5:

          241|     # String to return if condition is true
          242|     string: if cond then string else "";
             |     ^
          243|

       … while evaluating derivation 'openssl-3.0.9'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'openssl-3.0.9'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:347:7:

          346|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          347|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          348|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;

       … while evaluating derivation 'make-shell-wrapper-hook'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'shell' of derivation 'make-shell-wrapper-hook'

         at /home/uri/nixpkgs/pkgs/top-level/all-packages.nix:1147:7:

         1146|       # targetPackages.runtimeShell only exists when pkgs == targetPackages (when targetPackages is not  __raw)
         1147|       shell = if targetPackages ? runtimeShell then targetPackages.runtimeShell else throw "makeWrapper/makeShellWrapper must be in nativeBuildInputs";
             |       ^
         1148|     };

       … while evaluating derivation 'bash-5.2-p15'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'bash-5.2-p15'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:347:7:

          346|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          347|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          348|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;

       … while evaluating derivation 'bison-3.8.2'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'bison-3.8.2'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:347:7:

          346|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          347|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          348|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;

       … while evaluating derivation 'gnum4-1.4.19'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'src' of derivation 'gnum4-1.4.19'

         at /home/uri/nixpkgs/pkgs/development/tools/misc/gnum4/default.nix:12:3:

           11|
           12|   src = fetchurl {
             |   ^
           13|     url = "mirror://gnu/m4/m4-${version}.tar.bz2";

       … while evaluating derivation 'm4-1.4.19.tar.bz2'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'm4-1.4.19.tar.bz2'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:347:7:

          346|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          347|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          348|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;

       error: infinite recursion encountered

       at «none»:0: (source not available)
```

</details>

After:
<details>

```
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nix-2.15.1'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'buildInputs' of derivation 'nix-2.15.1'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:350:7:

          349|       depsHostHost                = lib.elemAt (lib.elemAt dependencies 1) 0;
          350|       buildInputs                 = lib.elemAt (lib.elemAt dependencies 1) 1;
             |       ^
          351|       depsTargetTarget            = lib.elemAt (lib.elemAt dependencies 2) 0;

       … while evaluating derivation 'boost-1.79.0'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'buildInputs' of derivation 'boost-1.79.0'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:350:7:

          349|       depsHostHost                = lib.elemAt (lib.elemAt dependencies 1) 0;
          350|       buildInputs                 = lib.elemAt (lib.elemAt dependencies 1) 1;
             |       ^
          351|       depsTargetTarget            = lib.elemAt (lib.elemAt dependencies 2) 0;

       … while evaluating derivation 'expat-2.5.0'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'src' of derivation 'expat-2.5.0'

         at /home/uri/nixpkgs/pkgs/development/libraries/expat/default.nix:21:3:

           20|
           21|   src = fetchurl {
             |   ^
           22|     url = "https://github.com/libexpat/libexpat/releases/download/R_${lib.replaceStrings ["."] ["_"] version}/${pname}-${version}.tar.xz";

       … while evaluating derivation 'expat-2.5.0.tar.xz'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'mirrorsFile' of derivation 'expat-2.5.0.tar.xz'

         at /home/uri/nixpkgs/pkgs/build-support/fetchurl/default.nix:173:10:

          172|   curlOptsList = lib.escapeShellArgs curlOptsList;
          173|   inherit showURLs mirrorsFile postFetch downloadToTemp executable;
             |          ^
          174|

       … while evaluating derivation 'mirrors-list'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'stdenv' of derivation 'mirrors-list'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:332:14:

          331|       args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
          332|       inherit stdenv;
             |              ^
          333|

       … while evaluating derivation 'stdenv'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/default.nix:93:14

       … while evaluating attribute 'initialPath' of derivation 'stdenv'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/default.nix:126:14:

          125|
          126|       inherit initialPath shell
             |              ^
          127|         defaultNativeBuildInputs defaultBuildInputs;

       … while evaluating derivation 'gnugrep-3.11'
         whose name attribute is located at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:303:7

       … while evaluating attribute 'buildInputs' of derivation 'gnugrep-3.11'

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:350:7:

          349|       depsHostHost                = lib.elemAt (lib.elemAt dependencies 1) 0;
          350|       buildInputs                 = lib.elemAt (lib.elemAt dependencies 1) 1;
             |       ^
          351|       depsTargetTarget            = lib.elemAt (lib.elemAt dependencies 2) 0;

       … from call site

         at /home/uri/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:321:9:

          320|         in
          321|         lib.strings.sanitizeDerivationName (
             |         ^
          322|           if attrs ? name

       … while calling anonymous lambda

         at /home/uri/nixpkgs/lib/strings.nix:1095:3:

         1094|   in
         1095|   string:
             |   ^
         1096|   # First detect the common case of already valid strings, to speed those up

       error: value is null while a set was expected
```

</details>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
