### PR TITLE
tmux: provide `tmux-256color` terminfo on macOS

### DIFF
--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -1,12 +1,12 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , autoreconfHook
 , bison
 , libevent
 , ncurses
 , pkg-config
+, runCommand
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
 , withUtf8proc ? true, utf8proc # gets Unicode updates faster than glibc
 , withUtempter ? stdenv.isLinux && !stdenv.hostPlatform.isMusl, libutempter
@@ -23,7 +23,7 @@ let
 
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tmux";
   version = "3.3a";
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tmux";
     repo = "tmux";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-SygHxTe7N4y7SdzKixPFQvqRRL57Fm8zWYHfTpW+yVY=";
   };
 
@@ -65,7 +65,24 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share/bash-completion/completions
     cp -v ${bashCompletion}/completions/tmux $out/share/bash-completion/completions/tmux
+  '' + lib.optionalString stdenv.isDarwin ''
+    mkdir $out/nix-support
+    echo "${finalAttrs.passthru.terminfo}" >> $out/nix-support/propagated-user-env-packages
   '';
+
+  passthru = {
+    terminfo = runCommand "tmux-terminfo" { nativeBuildInputs = [ ncurses ]; } (if stdenv.isDarwin then ''
+      mkdir -p $out/share/terminfo/74
+      cp -v ${ncurses}/share/terminfo/74/tmux $out/share/terminfo/74
+      # macOS ships an old version (5.7) of ncurses which does not include tmux-256color so we need to provide it from our ncurses.
+      # However, due to a bug in ncurses 5.7, we need to first patch the terminfo before we can use it with macOS.
+      # https://gpanders.com/blog/the-definitive-guide-to-using-tmux-256color-on-macos/
+      tic -o $out/share/terminfo -x <(TERMINFO_DIRS=${ncurses}/share/terminfo infocmp -x tmux-256color | sed 's|pairs#0x10000|pairs#32767|')
+    '' else ''
+      mkdir -p $out/share/terminfo/t
+      ln -sv ${ncurses}/share/terminfo/t/{tmux,tmux-256color,tmux-direct} $out/share/terminfo/t
+    '');
+  };
 
   meta = {
     homepage = "https://tmux.github.io/";
@@ -82,9 +99,9 @@ stdenv.mkDerivation rec {
         * Terminal locking, manually or after a timeout.
         * A clean, easily extended, BSD-licensed codebase, under active development.
     '';
-    changelog = "https://github.com/tmux/tmux/raw/${version}/CHANGES";
+    changelog = "https://github.com/tmux/tmux/raw/${finalAttrs.version}/CHANGES";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thammers fpletz SuperSandro2000 srapenne ];
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

Fixes `tput: unknown terminal "tmux-256color"` on macOS

Removes the need for setting `default-terminal` to `screen-256color` in `tmux.conf`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).