### PR TITLE
vimix-cursor-theme: init at 2020-02-24

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2416,6 +2416,12 @@
     github = "bryanhonof";
     githubId = 5932804;
   };
+  bryceberger = {
+    name = "Bryce Berger";
+    email = "bryce.z.berger@gmail.com";
+    github = "bryceberger";
+    githubId = 9222441;
+  };
   bsima = {
     email = "ben@bsima.me";
     github = "bsima";

--- a/pkgs/data/icons/vimix-cursor-theme/default.nix
+++ b/pkgs/data/icons/vimix-cursor-theme/default.nix
@@ -1,0 +1,34 @@
+{ stdenvNoCC
+, fetchFromGitHub
+, lib
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "vimix-cursor-theme";
+  version = "2020-02-24";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = "Vimix-cursors";
+    rev = finalAttrs.version;
+    sha256 = "sha256-TfcDer85+UOtDMJVZJQr81dDy4ekjYgEvH1RE1IHMi4=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/icons/Vimix{,-white}-cursors
+    cp -r dist/{cursors,index.theme} $out/share/icons/Vimix-cursors
+    cp -r dist-white/{cursors,index.theme} $out/share/icons/Vimix-white-cursors
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An x-cursor theme inspired by Materia design and based on caitaine-cursors";
+    homepage = "https://github.com/vinceliuice/Vimix-cursors";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [
+      bryceberger
+    ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29522,6 +29522,8 @@ with pkgs;
 
   victor-mono = callPackage ../data/fonts/victor-mono { };
 
+  vimix-cursor-theme = callPackage ../data/icons/vimix-cursor-theme { };
+
   vimix-gtk-themes = callPackage ../data/themes/vimix {
     inherit (gnome) gnome-shell;
   };


### PR DESCRIPTION
###### Description of changes

Add [vimix cursors](https://github.com/vinceliuice/Vimix-cursors) as a package.

First contribution, added myself to maintainers list.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
