### PR TITLE
python310Packages.requests-mock: 1.10.0 -> 1.11.0

### DIFF
--- a/pkgs/development/python-modules/requests-mock/default.nix
+++ b/pkgs/development/python-modules/requests-mock/default.nix
@@ -1,33 +1,40 @@
-{ lib, buildPythonPackage, fetchPypi, python
-, mock
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fixtures
 , purl
+, pytestCheckHook
+, python
 , requests
+, requests-futures
 , six
-, testrepository
 , testtools
-, pytest
 }:
 
 buildPythonPackage rec {
   pname = "requests-mock";
-  version = "1.10.0";
+  version = "1.11.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-WcnDJBmp+xroPsJC2Y6InEW9fXpl1IN1zCQ+wIRBZYs=";
+    hash = "sha256-7xC1crSJpfKOCbcIaXIIxKOyuJ74Cp8BWENA6jV+w8Q=";
   };
-
-  patchPhase = ''
-    sed -i 's@python@${python.interpreter}@' .testr.conf
-  '';
 
   propagatedBuildInputs = [ requests six ];
 
-  nativeCheckInputs = [ mock purl testrepository testtools pytest ];
+  nativeCheckInputs = [
+    fixtures
+    purl
+    pytestCheckHook
+    requests-futures
+    testtools
+  ];
 
   meta = with lib; {
     description = "Mock out responses from the requests package";
     homepage = "https://requests-mock.readthedocs.io";
+    changelog = "https://github.com/jamielennox/requests-mock/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = [ ];
   };


### PR DESCRIPTION
###### Description of changes

https://github.com/jamielennox/requests-mock/releases/tag/1.11.0

There are a couple of changes that warrant an explanation:

1. testrepository was removed in https://github.com/jamielennox/requests-mock/pull/229, so the postPatch hook can be removed.

2. The mock dependency is no longer needed on Python >= 3.4, so it has been removed.

3. Tests are now run properly by using `pytestCheckHook`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
