### PR TITLE
jextract: init at unstable-2023-04-14

### DIFF
--- a/pkgs/development/tools/java/jextract/default.nix
+++ b/pkgs/development/tools/java/jextract/default.nix
@@ -1,0 +1,99 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, emptyDirectory
+, writeText
+, makeWrapper
+, gradle
+, jdk20
+, llvmPackages
+}:
+
+let
+  gradleInit = writeText "init.gradle" ''
+    logger.lifecycle 'Replacing Maven repositories with empty directory...'
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        buildscript {
+          repositories {
+            clear()
+            maven { url '${emptyDirectory}' }
+          }
+        }
+        repositories {
+          clear()
+          maven { url '${emptyDirectory}' }
+        }
+      }
+    }
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          maven { url '${emptyDirectory}' }
+        }
+      }
+    }
+  '';
+in
+
+stdenv.mkDerivation {
+  pname = "jextract";
+  version = "unstable-2023-04-14";
+
+  src = fetchFromGitHub {
+    owner = "openjdk";
+    repo = "jextract";
+    rev = "cf3afe9ca71592c8ebb32f219707285dd1d5b28a";
+    hash = "sha256-8qRD1Xg39vxtFAdguD8XvkQ8u7YzFU55MhyyJozVffo=";
+  };
+
+  nativeBuildInputs = [
+    gradle
+    makeWrapper
+  ];
+
+  env = {
+    ORG_GRADLE_PROJECT_llvm_home = llvmPackages.libclang.lib;
+    ORG_GRADLE_PROJECT_jdk20_home = jdk20;
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    export GRADLE_USER_HOME=$(mktemp -d)
+    gradle --console plain --init-script "${gradleInit}" assemble
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    gradle --console plain --init-script "${gradleInit}" verify
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D --mode=0444 --target-directory="$out/share/java" \
+      ./build/libs/org.openjdk.jextract-unspecified.jar
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper "${jdk20}/bin/java" "$out/bin/jextract" \
+      --add-flags "--enable-preview" \
+      --add-flags "--class-path $out/share/java/org.openjdk.jextract-unspecified.jar" \
+      --add-flags "org.openjdk.jextract.JextractTool"
+  '';
+
+  meta = with lib; {
+    description = "A tool which mechanically generates Java bindings from a native library headers";
+    homepage = "https://github.com/openjdk/jextract";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ sharzy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25215,6 +25215,8 @@ with pkgs;
 
   fastjar = callPackage ../development/tools/java/fastjar { };
 
+  jextract = callPackage ../development/tools/java/jextract { };
+
   httpunit = callPackage ../development/libraries/java/httpunit { };
 
   javaCup = callPackage ../development/libraries/java/cup {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
jextract is a tool which mechanically generates Java bindings from a native library headers.

Homepage: https://github.com/openjdk/jextract

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
