### PR TITLE
libtree: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/development/tools/misc/libtree/default.nix
+++ b/pkgs/development/tools/misc/libtree/default.nix
@@ -1,36 +1,42 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, binutils
-, chrpath
-, cmake
-, cxxopts
-, elfio
-, termcolor
-, gtest
+, testers
+, libtree
+, runCommand
+, coreutils
+, dieHook
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtree";
-  version = "3.1.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "haampie";
     repo = "libtree";
-    rev = "v${version}";
-    sha256 = "sha256-C5QlQsBL9Als80Tv13ex2XS5Yj50Ht8eDfGYAtnh/HI=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-q3JtQ9AxoP0ma9K96cC3gf6QmQ1FbS7T7I59qhkwbMk=";
   };
-
-  buildInputs = [ cxxopts elfio termcolor ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  # note: "make check" returns exit code 0 even when the tests fail.
-  # This has been reported upstream:
-  #  https://github.com/haampie/libtree/issues/77
-  nativeCheckInputs = [ gtest ];
-  checkTarget = [ "check" ];
-  doCheck = true;
+  # Fails at https://github.com/haampie/libtree/blob/v3.1.1/tests/07_origin_is_relative_to_symlink_location_not_realpath/Makefile#L28
+  doCheck = false;
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = libtree;
+      command = "libtree --version";
+      version = finalAttrs.version;
+    };
+    checkCoreUtils = runCommand "${finalAttrs.pname}-ls-test" {
+      nativeBuildInputs = [ finalAttrs.finalPackage dieHook ];
+    } ''
+      libtree ${coreutils}/bin/ls > $out || die "libtree failed to show dependencies."
+      [ -s $out ]
+    '';
+  };
 
   meta = with lib; {
     description = "Tree ldd with an option to bundle dependencies into a single folder";
@@ -39,4 +45,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ prusnak rardiol ];
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

This PR updates libtree to the latest version: https://github.com/haampie/libtree/releases/tag/v3.1.1

I also cleaned up the file with unneeded dependencies and added basic tests.

I could not manage to make the tests pass because of an unresolved fake lib: https://github.com/haampie/libtree/blob/v3.1.1/tests/07_origin_is_relative_to_symlink_location_not_realpath/Makefile#L28

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
