### PR TITLE
python311Packages.dirty-equals: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/dirty-equals/default.nix
+++ b/pkgs/development/python-modules/dirty-equals/default.nix
@@ -2,24 +2,25 @@
 , buildPythonPackage
 , fetchFromGitHub
 , hatchling
+, pydantic
+, pytest-examples
 , pytestCheckHook
 , pythonOlder
 , pytz
-, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "dirty-equals";
-  version = "0.5.0";
+  version = "0.6.0";
   format = "pyproject";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "samuelcolvin";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-yYptO6NPhQRlF0T2eXliw2WBms9uqTZVzdYzGj9pCug=";
+    hash = "sha256-j+EqsKVRG2DDka1G3Px8ExYZt8QkqHkhojRnAHObdR4=";
   };
 
   nativeBuildInputs = [
@@ -28,10 +29,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     pytz
-    typing-extensions
   ];
 
   nativeCheckInputs = [
+    pydantic
+    pytest-examples
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/dirty-equals/default.nix
+++ b/pkgs/development/python-modules/dirty-equals/default.nix
@@ -42,6 +42,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Module for doing dirty (but extremely useful) things with equals";
     homepage = "https://github.com/samuelcolvin/dirty-equals";
+    changelog = "https://github.com/samuelcolvin/dirty-equals/releases/tag/v${version}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/pytest-examples/default.nix
+++ b/pkgs/development/python-modules/pytest-examples/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, black
+, buildPythonPackage
+, fetchFromGitHub
+, hatchling
+, pytest
+, pytestCheckHook
+, pythonOlder
+, pythonRelaxDepsHook
+, ruff
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-examples";
+  version = "0.0.9";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "pydantic";
+    repo = "pytest-examples";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ecxSLbPnHdL60vlc7EjKmw5rATTePqJCa5QIdyxevv0=";
+  };
+
+  postPatch = ''
+    # ruff binary is used directly, the ruff Python package is not needed
+    substituteInPlace pytest_examples/lint.py \
+      --replace "'ruff'" "'${ruff}/bin/ruff'"
+  '';
+
+  pythonRemoveDeps = [
+    "ruff"
+  ];
+
+  nativeBuildInputs = [
+    hatchling
+    pythonRelaxDepsHook
+  ];
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    black
+    ruff
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pytest_examples"
+  ];
+
+  meta = with lib; {
+    description = "Pytest plugin for testing examples in docstrings and markdown files";
+    homepage = "https://github.com/pydantic/pytest-examples";
+    changelog = "https://github.com/pydantic/pytest-examples/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9715,6 +9715,8 @@ self: super: with self; {
 
   pytest-error-for-skips = callPackage ../development/python-modules/pytest-error-for-skips { };
 
+  pytest-examples = callPackage ../development/python-modules/pytest-examples { };
+
   pytest-expect = callPackage ../development/python-modules/pytest-expect { };
 
   pytest-factoryboy = callPackage ../development/python-modules/pytest-factoryboy { };


### PR DESCRIPTION
Diff: https://github.com/samuelcolvin/dirty-equals/compare/refs/tags/v0.5.0...v0.6.0

Changelog: https://github.com/samuelcolvin/dirty-equals/releases/tag/v0.6.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
