### PR TITLE
komga: 0.165.0 -> 1.1.0

### DIFF
--- a/pkgs/servers/komga/default.nix
+++ b/pkgs/servers/komga/default.nix
@@ -2,17 +2,17 @@
 , stdenvNoCC
 , fetchurl
 , makeWrapper
-, jdk11_headless
+, jdk17_headless
 , nixosTests
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "komga";
-  version = "0.165.0";
+  version = "1.1.0";
 
   src = fetchurl {
     url = "https://github.com/gotson/${pname}/releases/download/v${version}/${pname}-${version}.jar";
-    sha256 = "sha256-J8dpw7GzLJnLiiFSFVCoqZFQ6mI2z0zBZHdbmxMgmf8=";
+    sha256 = "sha256-uGzJgy+jfV11bZXvCMZAUdjuZasKCcv5rQBBUEidWQU=";
   };
 
   nativeBuildInputs = [
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation rec {
   ];
 
   buildCommand = ''
-    makeWrapper ${jdk11_headless}/bin/java $out/bin/komga --add-flags "-jar $src"
+    makeWrapper ${jdk17_headless}/bin/java $out/bin/komga --add-flags "-jar $src"
   '';
 
   passthru.tests = {
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Free and open source comics/mangas server";
     homepage = "https://komga.org/";
     license = licenses.mit;
-    platforms = jdk11_headless.meta.platforms;
+    platforms = jdk17_headless.meta.platforms;
     maintainers = with maintainers; [ govanify ];
   };
 


### PR DESCRIPTION
###### Description of changes

Default port changed and minimal java version changed for 1.0, see: https://komga.org/installation/configuration.html#optional-configuration

Changelog here: https://github.com/gotson/komga/releases/tag/v1.1.0

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
