### PR TITLE
nixos: Add test for crash kernel

### DIFF
--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -14,7 +14,7 @@ in
   config = {
 
     systemd.services.backdoor =
-      { wantedBy = [ "multi-user.target" ];
+      { wantedBy = [ "sysinit.target" ];
         requires = [ "dev-hvc0.device" "dev-${qemu-common.qemuSerialDevice}.device" ];
         after = [ "dev-hvc0.device" "dev-${qemu-common.qemuSerialDevice}.device" ];
         script =

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -200,6 +200,7 @@ in {
   corerad = handleTest ./corerad.nix {};
   coturn = handleTest ./coturn.nix {};
   couchdb = handleTest ./couchdb.nix {};
+  crashdump = handleTest ./crashdump.nix {};
   cri-o = handleTestOn ["aarch64-linux" "x86_64-linux"] ./cri-o.nix {};
   cups-pdf = handleTest ./cups-pdf.nix {};
   custom-ca = handleTest ./custom-ca.nix {};

--- a/nixos/tests/crashdump.nix
+++ b/nixos/tests/crashdump.nix
@@ -1,0 +1,24 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }: {
+  name = "crashdump";
+
+  nodes.machine = { config, ... }: {
+    boot.crashDump = {
+      enable = true;
+      kernelParams = config.boot.kernelParams ++ ["1"];
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("sysinit.target")
+
+    # /var/lib/nixos/ files get corrupted if you crash before changes
+    # from the users-groups activation script sync
+    machine.succeed("sync")
+
+    machine.execute("echo c > /proc/sysrq-trigger &", check_output=False)
+    machine.connected = False
+    machine.connect()
+    machine.wait_for_unit("rescue.target")
+    machine.succeed("stat /proc/vmcore")
+  '';
+})


### PR DESCRIPTION
###### Description of changes

Adds a test that crashes the kernel and verifies that `/proc/vmcore` exists.

Note: The crashdump-enabled kernel is not currently cached by Hydra. I wonder if we should change this?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
