### PR TITLE
python311Packages.nose3: disable tests also on python 3.11

### DIFF
--- a/pkgs/development/python-modules/nose3/default.nix
+++ b/pkgs/development/python-modules/nose3/default.nix
@@ -3,6 +3,7 @@
 , coverage
 , fetchPypi
 , isPyPy
+, isPy311
 , python
 , stdenv
 }:
@@ -19,8 +20,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ coverage ];
 
   # PyPy hangs for unknwon reason
-  # darwin fails an assertion and I didn't find a way to find skip that test
-  doCheck = !isPyPy && !stdenv.isDarwin;
+  # Darwin and python 3.11 fail at various assertions and I didn't find an easy way to find skip those tests
+  doCheck = !isPyPy && !stdenv.isDarwin && !isPy311;
 
   checkPhase = ''
     ${python.pythonForBuild.interpreter} selftest.py


### PR DESCRIPTION
###### Description of changes

```
nose3> /nix/store/2bcsj4xpsyxrh6fgpqnmv2rqa00jz577-python3.11-setuptools-67.4.0/lib/python3.11/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
nose3>   warnings.warn("Setuptools is replacing distutils.")
nose3> F......................F..F......F.....F......nose.plugins.cover: ERROR: TOTAL Coverage did not reach minimum required: 100%
nose3> .nose.plugins.cover: ERROR: TOTAL Coverage did not reach minimum required: 100%
nose3> .nose.plugins.cover: ERROR: TOTAL Coverage did not reach minimum required: 100%
nose3> .nose.plugins.cover: ERROR: TOTAL Coverage did not reach minimum required: 100%
nose3> ./nix/store/gwgldmw9ajdqnp8cppjj772316wqngja-python3.11-coverage-7.2.1/lib/python3.11/site-packages/coverage/inorout.py:523: CoverageWarning: Module moo was previously imported, but not measured (module-not-measured)
nose3>   self.warn(msg, slug="module-not-measured")
nose3> nose.plugins.cover: ERROR: TOTAL Coverage did not reach minimum required: 100%
nose3> ................................................F.......................................S...S..........F....................................................................................S...............................................................................SSSS..................................................SS................/nix/store/2bcsj4xpsyxrh6fgpqnmv2rqa00jz577-python3.11-setuptools-67.4.0/lib/python3.11/site-packages/setuptools/_distutils/log.py:46: UserWarning: distutils.log.Log is deprecated, please use an alternative from `logging`.
nose3>   warnings.warn(Log.__doc__)  # avoid DeprecationWarning to ensure warn is shown
nose3> Test
nose3> ..........
nose3> ======================================================================
nose3> FAIL: Doctest: nose.plugins.errorclass
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/nix/store/xlpbkwgf4nrnr56a3r0k0r32jxlxyf59-python3-3.11.4/lib/python3.11/doctest.py", line 2222, in runTest
nose3>     raise self.failureException(self.format_failure(new.getvalue()))
nose3> AssertionError: Failed doctest test for nose.plugins.errorclass
nose3>   File "/build/nose3-1.3.8/nose/plugins/errorclass.py", line 0, in errorclass
nose3>
nose3> ----------------------------------------------------------------------
nose3> File "/build/nose3-1.3.8/nose/plugins/errorclass.py", line 68, in nose.plugins.errorclass
nose3> Failed example:
nose3>     _ = case(result) # doctest: +ELLIPSIS
nose3> Expected:
nose3>     runTest (....TestTodo) ... TODO: I need to test something
nose3> Got:
nose3>     runTest (nose.plugins.errorclass.TestTodo.runTest) ... TODO: I need to test something
nose3> ----------------------------------------------------------------------
nose3> File "/build/nose3-1.3.8/nose/plugins/errorclass.py", line 79, in nose.plugins.errorclass
nose3> Failed example:
nose3>     result.printErrors() # doctest: +ELLIPSIS
nose3> Expected:
nose3>     <BLANKLINE>
nose3>     ======================================================================
nose3>     TODO: runTest (....TestTodo)
nose3>     ----------------------------------------------------------------------
nose3>     Traceback (most recent call last):
nose3>     ...
nose3>     ...Todo: I need to test something
nose3>     <BLANKLINE>
nose3> Got:
nose3>     <BLANKLINE>
nose3>     ======================================================================
nose3>     TODO: runTest (nose.plugins.errorclass.TestTodo.runTest)
nose3>     ----------------------------------------------------------------------
nose3>     Traceback (most recent call last):
nose3>       File "<doctest nose.plugins.errorclass[7]>", line 3, in runTest
nose3>         raise Todo("I need to test something")
nose3>     nose.plugins.errorclass.Todo: I need to test something
nose3>     <BLANKLINE>
nose3>
nose3>
nose3> ======================================================================
nose3> FAIL: Doctest: imported_tests.rst
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/nix/store/xlpbkwgf4nrnr56a3r0k0r32jxlxyf59-python3-3.11.4/lib/python3.11/doctest.py", line 2222, in runTest
nose3>     raise self.failureException(self.format_failure(new.getvalue()))
nose3> AssertionError: Failed doctest test for imported_tests.rst
nose3>   File "/build/nose3-1.3.8/functional_tests/doc_tests/test_issue145/imported_tests.rst", line 0
nose3>
nose3> ----------------------------------------------------------------------
nose3> File "/build/nose3-1.3.8/functional_tests/doc_tests/test_issue145/imported_tests.rst", line 43, in imported_tests.rst
nose3> Failed example:
nose3>     run(argv=argv) # doctest: +REPORT_NDIFF
nose3> Differences (ndiff with -expected +actual):
nose3>       package1 setup
nose3>     - test (package1.test_module.TestCase) ... ok
nose3>     + test (package1.test_module.TestCase.test) ... ok
nose3>     ?                                    +++++
nose3>       package1.test_module.TestClass.test_class ... ok
nose3>       package1.test_module.test_function ... ok
nose3>       package2c setup
nose3>     - test (package2c.test_module.TestCase) ... ok
nose3>     + test (package2c.test_module.TestCase.test) ... ok
nose3>     ?                                     +++++
nose3>       package2c.test_module.TestClass.test_class ... ok
nose3>       package2f setup
nose3>       package2f.test_module.test_function ... ok
nose3>       <BLANKLINE>
nose3>       ----------------------------------------------------------------------
nose3>       Ran 6 tests in ...s
nose3>       <BLANKLINE>
nose3>       OK
nose3> ----------------------------------------------------------------------
nose3> File "/build/nose3-1.3.8/functional_tests/doc_tests/test_issue145/imported_tests.rst", line 72, in imported_tests.rst
nose3> Failed example:
nose3>     run(argv=argv) # doctest: +REPORT_NDIFF
nose3> Differences (ndiff with -expected +actual):
nose3>       package2c setup
nose3>     - test (package2c.test_module.TestCase) ... ok
nose3>     + test (package2c.test_module.TestCase.test) ... ok
nose3>     ?                                     +++++
nose3>       package2c.test_module.TestClass.test_class ... ok
nose3>       <BLANKLINE>
nose3>       ----------------------------------------------------------------------
nose3>       Ran 2 tests in ...s
nose3>       <BLANKLINE>
nose3>       OK
nose3> ----------------------------------------------------------------------
nose3> File "/build/nose3-1.3.8/functional_tests/doc_tests/test_issue145/imported_tests.rst", line 99, in imported_tests.rst
nose3> Failed example:
nose3>     run(argv=argv) # doctest: +REPORT_NDIFF
nose3> Differences (ndiff with -expected +actual):
nose3>       package2c setup
nose3>     - test (package2c.test_module.TestCase) ... ok
nose3>     + test (package2c.test_module.TestCase.test) ... ok
nose3>     ?                                     +++++
nose3>       <BLANKLINE>
nose3>       ----------------------------------------------------------------------
nose3>       Ran 1 test in ...s
nose3>       <BLANKLINE>
nose3>       OK
nose3>
nose3>
nose3> ======================================================================
nose3> FAIL: Doctest: selector_plugin.rst
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/nix/store/xlpbkwgf4nrnr56a3r0k0r32jxlxyf59-python3-3.11.4/lib/python3.11/doctest.py", line 2222, in runTest
nose3>     raise self.failureException(self.format_failure(new.getvalue()))
nose3> AssertionError: Failed doctest test for selector_plugin.rst
nose3>   File "/build/nose3-1.3.8/functional_tests/doc_tests/test_selector_plugin/selector_plugin.rst", line 0
nose3>
nose3> ----------------------------------------------------------------------
nose3> File "/build/nose3-1.3.8/functional_tests/doc_tests/test_selector_plugin/selector_plugin.rst", line 110, in selector_plugin.rst
nose3> Failed example:
nose3>     run(argv=argv, plugins=[UseMySelector()])
nose3> Expected:
nose3>     test_add (basic.TestBasicMath) ... ok
nose3>     test_sub (basic.TestBasicMath) ... ok
nose3>     test_tuple_groups (my_function.MyFunction) ... ok
nose3>     test_cat (cat.StringsCat) ... ok
nose3>     <BLANKLINE>
nose3>     ----------------------------------------------------------------------
nose3>     Ran 4 tests in ...s
nose3>     <BLANKLINE>
nose3>     OK
nose3> Got:
nose3>     test_add (basic.TestBasicMath.test_add) ... ok
nose3>     test_sub (basic.TestBasicMath.test_sub) ... ok
nose3>     test_tuple_groups (my_function.MyFunction.test_tuple_groups) ... ok
nose3>     test_cat (cat.StringsCat.test_cat) ... ok
nose3>     <BLANKLINE>
nose3>     ----------------------------------------------------------------------
nose3>     Ran 4 tests in ...s
nose3>     <BLANKLINE>
nose3>     OK
nose3>
nose3>
nose3> ======================================================================
nose3> FAIL: runTest (test_attribute_plugin.TestClassAndMethodAttrs.runTest)
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/build/nose3-1.3.8/functional_tests/test_attribute_plugin.py", line 23, in runTest
nose3>     self.verify()
nose3>   File "/build/nose3-1.3.8/functional_tests/test_attribute_plugin.py", line 153, in verify
nose3>     assert '(test_attr.TestClassAndMethodAttrs) ... ok' in self.output
nose3>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nose3> AssertionError:
nose3> -------------------- >> begin captured stdout << ---------------------
nose3> **********************************************************************
nose3> test_method (test_attr.TestClassAndMethodAttrs.test_method) ... ok
nose3>
nose3> ----------------------------------------------------------------------
nose3> Ran 1 test in 0.003s
nose3>
nose3> OK
nose3>
nose3> **********************************************************************
nose3>
nose3> --------------------- >> end captured stdout << ----------------------
nose3>
nose3> ======================================================================
nose3> FAIL: runTest (test_attribute_plugin.TestTopLevelNotSelected.runTest)
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/build/nose3-1.3.8/functional_tests/test_attribute_plugin.py", line 23, in runTest
nose3>     self.verify()
nose3>   File "/build/nose3-1.3.8/functional_tests/test_attribute_plugin.py", line 169, in verify
nose3>     assert 'test_a (test.TestBase) ... ok' in self.output
nose3>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nose3> AssertionError:
nose3> -------------------- >> begin captured stdout << ---------------------
nose3> **********************************************************************
nose3> test_a (test.TestBase.test_a) ... ok
nose3> test.test_b ... ok
nose3>
nose3> ----------------------------------------------------------------------
nose3> Ran 2 tests in 0.004s
nose3>
nose3> OK
nose3>
nose3> **********************************************************************
nose3>
nose3> --------------------- >> end captured stdout << ----------------------
nose3>
nose3> ======================================================================
nose3> FAIL: runTest (test_load_tests_from_test_case.TestLoadTestsFromTestCaseHook.runTest)
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/build/nose3-1.3.8/functional_tests/test_load_tests_from_test_case.py", line 53, in runTest
nose3>     self.assertEqual(line.strip(), expect.pop(0))
nose3> AssertionError: 'test_value (test_load_tests_from_test_case.Derived.test_value) ... ERROR' != 'test_value (test_load_tests_from_test_case.Derived) ... ERROR'
nose3> - test_value (test_load_tests_from_test_case.Derived.test_value) ... ERROR
nose3> ?                                                   -----------
nose3> + test_value (test_load_tests_from_test_case.Derived) ... ERROR
nose3>
nose3> -------------------- >> begin captured stdout << ---------------------
nose3> options
nose3> configure
nose3> Called!
nose3> test_value (test_load_tests_from_test_case.Derived.test_value) ... ERROR
nose3> test_value (tests.Tests.test_value) ... ok
nose3>
nose3> ======================================================================
nose3> ERROR: test_value (test_load_tests_from_test_case.Derived.test_value)
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/build/nose3-1.3.8/functional_tests/support/ltftc/tests.py", line 9, in test_value
nose3>     self.assertEqual(self.value, 1)
nose3>                      ^^^^^^^^^^
nose3> AttributeError: 'Derived' object has no attribute 'value'
nose3>
nose3> ----------------------------------------------------------------------
nose3> Ran 2 tests in 0.004s
nose3>
nose3> FAILED (errors=1)
nose3>
nose3>
nose3> --------------------- >> end captured stdout << ----------------------
nose3>
nose3> ======================================================================
nose3> FAIL: runTest (test_xunit.TestXUnitPlugin.runTest)
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/build/nose3-1.3.8/functional_tests/test_xunit.py", line 28, in runTest
nose3>     assert "test_skip (test_xunit_as_suite.TestForXunit) ... SKIP: skipit" in self.output
nose3>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nose3> AssertionError:
nose3> -------------------- >> begin captured stdout << ---------------------
nose3> test-generated output
nose3> test_error (test_xunit_as_suite.TestForXunit.test_error) ... ERROR
nose3> test_fail (test_xunit_as_suite.TestForXunit.test_fail) ... FAIL
nose3> test_non_ascii_error (test_xunit_as_suite.TestForXunit.test_non_ascii_error) ... ERROR
nose3> test_output (test_xunit_as_suite.TestForXunit.test_output) ... ok
nose3> test_skip (test_xunit_as_suite.TestForXunit.test_skip) ... SKIP: skipit
nose3> test_success (test_xunit_as_suite.TestForXunit.test_success) ... ok
nose3>
nose3> ======================================================================
nose3> ERROR: test_error (test_xunit_as_suite.TestForXunit.test_error)
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/build/nose3-1.3.8/functional_tests/support/xunit/test_xunit_as_suite.py", line 15, in test_error
nose3>     raise TypeError("oops, wrong type")
nose3> TypeError: oops, wrong type
nose3>
nose3> ======================================================================
nose3> ERROR: test_non_ascii_error (test_xunit_as_suite.TestForXunit.test_non_ascii_error)
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/build/nose3-1.3.8/functional_tests/support/xunit/test_xunit_as_suite.py", line 18, in test_non_ascii_error
nose3>     raise Exception(u"日本")
nose3> Exception: 日本
nose3>
nose3> ======================================================================
nose3> FAIL: test_fail (test_xunit_as_suite.TestForXunit.test_fail)
nose3> ----------------------------------------------------------------------
nose3> Traceback (most recent call last):
nose3>   File "/build/nose3-1.3.8/functional_tests/support/xunit/test_xunit_as_suite.py", line 12, in test_fail
nose3>     self.assertEqual("this","that")
nose3> AssertionError: 'this' != 'that'
nose3> - this
nose3> + that
nose3>
nose3>
nose3> ----------------------------------------------------------------------
nose3> XML: /build/nose3-1.3.8/functional_tests/support/xunit.xml
nose3> ----------------------------------------------------------------------
nose3> Ran 6 tests in 0.005s
nose3>
nose3> FAILED (SKIP=1, errors=2, failures=1)
nose3>
nose3>
nose3> --------------------- >> end captured stdout << ----------------------
nose3>
nose3> ----------------------------------------------------------------------
nose3> Ran 400 tests in 13.549s
nose3>
nose3> FAILED (SKIP=9, failures=7)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
