### PR TITLE
pypy3Packages.sphinx: disable broken tests

### DIFF
--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -3,7 +3,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, fetchpatch
+, isPyPy
 
 # nativeBuildInputs
 , flit-core
@@ -144,6 +144,19 @@ buildPythonPackage rec {
     "test_auth_header_no_match"
     "test_follows_redirects_on_GET"
     "test_connect_to_selfsigned_fails"
+  ] ++ lib.optionals isPyPy [
+    # PyPy has not __builtins__ which get asserted
+    # https://doc.pypy.org/en/latest/cpython_differences.html#miscellaneous
+    "test_autosummary_generate_content_for_module"
+    "test_autosummary_generate_content_for_module_skipped"
+    # internals are asserted which are sightly different in PyPy
+    "test_autodoc_inherited_members_None"
+    "test_automethod_for_builtin"
+    "test_builtin_function"
+    "test_cython"
+    "test_isattributedescriptor"
+    "test_methoddescriptor"
+    "test_partialfunction"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

```
sphinx> =================================== FAILURES ===================================
sphinx> _____________________ test_autodoc_inherited_members_None ______________________
sphinx>
sphinx> app = <SphinxTestApp buildername='html'>
sphinx>
sphinx>     @pytest.mark.sphinx('html', testroot='ext-autodoc')
sphinx>     def test_autodoc_inherited_members_None(app):
sphinx>         options = {"members": None,
sphinx>                    "inherited-members": "None",
sphinx>                    "special-members": None}
sphinx>
sphinx>         # check methods for object class are shown
sphinx>         actual = do_autodoc(app, 'class', 'target.inheritance.Derived', options)
sphinx> >       assert '   .. py:method:: Derived.__init__()' in actual
sphinx> E       AssertionError: assert '   .. py:method:: Derived.__init__()' in StringList(['', '.. py:class:: Derived()', '   :module: target.inheritance', '', '', '   .. py:attribute:: Derived.inheritedattr', '      :module: target.inheritance', '      :value: None', '', '      docstring', '', '', '   .. py:method:: Derived.inheritedclassmeth()', '      :module: target.inheritance', '      :classmethod:', '', '      Inherited class method.', '', '', '   .. py:method:: Derived.inheritedmeth()', '      :module: target.inheritance', '', '      Inherited function.', '', '', '   .. py:method:: Derived.inheritedstaticmeth(cls)', '      :module: target.inheritance', '      :staticmethod:', '', '      Inherited static method.', ''], items=[('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedattr', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedattr', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedattr', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedattr', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedattr', 0), ('docstring of target.inheritance.Derived.inheritedattr', 0), ('docstring of target.inheritance.Derived.inheritedattr', 1), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedclassmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedclassmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedclassmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedclassmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedclassmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedclassmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedclassmeth', 1), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Derived.inheritedmeth', 1), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedstaticmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedstaticmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedstaticmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedstaticmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedstaticmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedstaticmeth', 0), ('/build/pytest-of-nixbld/pytest-0/ext-autodoc/target/inheritance.py:docstring of target.inheritance.Base.inheritedstaticmeth', 1)])
sphinx>
sphinx> tests/test_ext_autodoc.py:801: AssertionError
sphinx> --------------------------- Captured stdout teardown ---------------------------
sphinx> # testroot: root
sphinx> # builder: html
sphinx> # srcdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc
sphinx> # outdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc/_build/html
sphinx> # status:
sphinx> Running Sphinx v5.3.0
sphinx>
sphinx> # warning:
sphinx>
sphinx> _________________________ test_automethod_for_builtin __________________________
sphinx>
sphinx> app = <SphinxTestApp buildername='html'>
sphinx>
sphinx>     @pytest.mark.sphinx('html', testroot='ext-autodoc')
sphinx>     def test_automethod_for_builtin(app):
sphinx>         actual = do_autodoc(app, 'method', 'builtins.int.__add__')
sphinx> >       assert list(actual) == [
sphinx>             '',
sphinx>             '.. py:method:: int.__add__(value, /)',
sphinx>             '   :module: builtins',
sphinx>             '',
sphinx>             '   Return self+value.',
sphinx>             '',
sphinx>         ]
sphinx> E       AssertionError: assert ['', '.. py:method:: int.__add__(other)', '   :module: builtins', '', '   x.__add__(y) <==> x+y', ''] == ['', '.. py:method:: int.__add__(value, /)', '   :module: builtins', '', '   Return self+value.', '']
sphinx> E         At index 1 diff: '.. py:method:: int.__add__(other)' != '.. py:method:: int.__add__(value, /)'
sphinx> E         Full diff:
sphinx> E           [
sphinx> E            '',
sphinx> E         -  '.. py:method:: int.__add__(value, /)',
sphinx> E         ?                              ^^^^ ^^^
sphinx> E         +  '.. py:method:: int.__add__(other)',
sphinx> E         ?                              ^^^ ^
sphinx> E            '   :module: builtins',
sphinx> E            '',
sphinx> E         -  '   Return self+value.',
sphinx> E         +  '   x.__add__(y) <==> x+y',
sphinx> E            '',
sphinx> E           ]
sphinx>
sphinx> tests/test_ext_autodoc.py:1501: AssertionError
sphinx> --------------------------- Captured stdout teardown ---------------------------
sphinx> # testroot: root
sphinx> # builder: html
sphinx> # srcdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc
sphinx> # outdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc/_build/html
sphinx> # status:
sphinx> Running Sphinx v5.3.0
sphinx>
sphinx> # warning:
sphinx>
sphinx> _____________________________ test_partialfunction _____________________________
sphinx>
sphinx> app = <SphinxTestApp buildername='html'>
sphinx>
sphinx>     @pytest.mark.sphinx('html', testroot='ext-autodoc')
sphinx>     def test_partialfunction(app):
sphinx>         options = {"members": None}
sphinx>         actual = do_autodoc(app, 'module', 'target.partialfunction', options)
sphinx> >       assert list(actual) == [
sphinx>             '',
sphinx>             '.. py:module:: target.partialfunction',
sphinx>             '',
sphinx>             '',
sphinx>             '.. py:function:: func1(a, b, c)',
sphinx>             '   :module: target.partialfunction',
sphinx>             '',
sphinx>             '   docstring of func1',
sphinx>             '',
sphinx>             '',
sphinx>             '.. py:function:: func2(b, c)',
sphinx>             '   :module: target.partialfunction',
sphinx>             '',
sphinx>             '   docstring of func1',
sphinx>             '',
sphinx>             '',
sphinx>             '.. py:function:: func3(c)',
sphinx>             '   :module: target.partialfunction',
sphinx>             '',
sphinx>             '   docstring of func3',
sphinx>             '',
sphinx>             '',
sphinx>             '.. py:function:: func4()',
sphinx>             '   :module: target.partialfunction',
sphinx>             '',
sphinx>             '   docstring of func3',
sphinx>             '',
sphinx>         ]
sphinx> E       AssertionError: assert ['', '.. py:module:: target.partialfunction', '', '', '.. py:function:: func1(a, b, c)', '   :module: target.partialfunction', '', '   docstring of func1', '', '', '.. py:function:: func2(b, c)', '   :module: target.partialfunction', '', '   docstring of func1', '', '', '.. py:function:: func3(c)', '   :module: target.partialfunction', '', '   docstring of func3', '', '', '.. py:function:: func4()', '   :module: target.partialfunction', '', '   docstring of func1', ''] == ['', '.. py:module:: target.partialfunction', '', '', '.. py:function:: func1(a, b, c)', '   :module: target.partialfunction', '', '   docstring of func1', '', '', '.. py:function:: func2(b, c)', '   :module: target.partialfunction', '', '   docstring of func1', '', '', '.. py:function:: func3(c)', '   :module: target.partialfunction', '', '   docstring of func3', '', '', '.. py:function:: func4()', '   :module: target.partialfunction', '', '   docstring of func3', '']
sphinx> E         At index 25 diff: '   docstring of func1' != '   docstring of func3'
sphinx> E         Full diff:
sphinx> E           [
sphinx> E            '',
sphinx> E            '.. py:module:: target.partialfunction',
sphinx> E            '',
sphinx> E            '',
sphinx> E            '.. py:function:: func1(a, b, c)',
sphinx> E            '   :module: target.partialfunction',
sphinx> E            '',
sphinx> E            '   docstring of func1',
sphinx> E            '',
sphinx> E            '',
sphinx> E            '.. py:function:: func2(b, c)',
sphinx> E            '   :module: target.partialfunction',
sphinx> E            '',
sphinx> E            '   docstring of func1',
sphinx> E            '',
sphinx> E            '',
sphinx> E            '.. py:function:: func3(c)',
sphinx> E            '   :module: target.partialfunction',
sphinx> E            '',
sphinx> E            '   docstring of func3',
sphinx> E            '',
sphinx> E            '',
sphinx> E            '.. py:function:: func4()',
sphinx> E            '   :module: target.partialfunction',
sphinx> E            '',
sphinx> E         -  '   docstring of func3',
sphinx> E         ?                       ^
sphinx> E         +  '   docstring of func1',
sphinx> E         ?                       ^
sphinx> E            '',
sphinx> E           ]
sphinx>
sphinx> tests/test_ext_autodoc.py:1574: AssertionError
sphinx> --------------------------- Captured stdout teardown ---------------------------
sphinx> # testroot: root
sphinx> # builder: html
sphinx> # srcdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc
sphinx> # outdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc/_build/html
sphinx> # status:
sphinx> Running Sphinx v5.3.0
sphinx>
sphinx> # warning:
sphinx>
sphinx> _________________________________ test_cython __________________________________
sphinx>
sphinx> app = <SphinxTestApp buildername='html'>
sphinx>
sphinx>     @pytest.mark.skipif(sys.version_info > (3, 11),
sphinx>                         reason=('cython does not support python-3.11 yet. '
sphinx>                                 'see https://github.com/cython/cython/issues/4365'))
sphinx>     @pytest.mark.skipif(pyximport is None, reason='cython is not installed')
sphinx>     @pytest.mark.sphinx('html', testroot='ext-autodoc')
sphinx>     def test_cython(app):
sphinx>         options = {"members": None,
sphinx>                    "undoc-members": None}
sphinx>         actual = do_autodoc(app, 'module', 'target.cython', options)
sphinx> >       assert list(actual) == [
sphinx>             '',
sphinx>             '.. py:module:: target.cython',
sphinx>             '',
sphinx>             '',
sphinx>             '.. py:class:: Class()',
sphinx>             '   :module: target.cython',
sphinx>             '',
sphinx>             '   Docstring.',
sphinx>             '',
sphinx>             '',
sphinx>             '   .. py:method:: Class.meth(name: str, age: int = 0) -> None',
sphinx>             '      :module: target.cython',
sphinx>             '',
sphinx>             '      Docstring.',
sphinx>             '',
sphinx>             '',
sphinx>             '.. py:function:: foo(x: int, *args, y: str, **kwargs)',
sphinx>             '   :module: target.cython',
sphinx>             '',
sphinx>             '   Docstring.',
sphinx>             '',
sphinx>         ]
sphinx> E       AssertionError: assert ['', '.. py:module:: target.cython', '', '   module(name[, doc])', '', '   Create a module object.', '   The name must be a string; the optional doc argument can have any type.', '', '', '.. py:class:: Class()', '   :module: target.cython', '', '   Docstring.', '', '', '   .. py:method:: Class.meth(name: str, age: int = 0) -> None', '      :module: target.cython', '', '      Docstring.', '', '', '.. py:function:: foo(x: int, *args, y: str, **kwargs)', '   :module: target.cython', '', '   Docstring.', ''] == ['', '.. py:module:: target.cython', '', '', '.. py:class:: Class()', '   :module: target.cython', '', '   Docstring.', '', '', '   .. py:method:: Class.meth(name: str, age: int = 0) -> None', '      :module: target.cython', '', '      Docstring.', '', '', '.. py:function:: foo(x: int, *args, y: str, **kwargs)', '   :module: target.cython', '', '   Docstring.', '']
sphinx> E         At index 3 diff: '   module(name[, doc])' != ''
sphinx> E         Left contains 5 more items, first extra item: '.. py:function:: foo(x: int, *args, y: str, **kwargs)'
sphinx> E         Full diff:
sphinx> E           [
sphinx> E            '',
sphinx> E            '.. py:module:: target.cython',
sphinx> E         +  '',
sphinx> E         +  '   module(name[, doc])',
sphinx> E         +  '',
sphinx> E         +  '   Create a module object.',
sphinx> E         +  '   The name must be a string; the optional doc argument can have any type.',
sphinx> E            '',
sphinx> E            '',
sphinx> E            '.. py:class:: Class()',
sphinx> E            '   :module: target.cython',
sphinx> E            '',
sphinx> E            '   Docstring.',
sphinx> E            '',
sphinx> E            '',
sphinx> E            '   .. py:method:: Class.meth(name: str, age: int = 0) -> None',
sphinx> E            '      :module: target.cython',
sphinx> E            '',
sphinx> E            '      Docstring.',
sphinx> E            '',
sphinx> E            '',
sphinx> E            '.. py:function:: foo(x: int, *args, y: str, **kwargs)',
sphinx> E            '   :module: target.cython',
sphinx> E            '',
sphinx> E            '   Docstring.',
sphinx> E            '',
sphinx> E           ]
sphinx>
sphinx> tests/test_ext_autodoc.py:2166: AssertionError
sphinx> --------------------------- Captured stdout teardown ---------------------------
sphinx> # testroot: root
sphinx> # builder: html
sphinx> # srcdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc
sphinx> # outdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc/_build/html
sphinx> # status:
sphinx> Running Sphinx v5.3.0
sphinx>
sphinx> # warning:
sphinx>
sphinx> ____________________________ test_builtin_function _____________________________
sphinx>
sphinx> app = <SphinxTestApp buildername='html'>
sphinx>
sphinx>     @pytest.mark.sphinx('html', testroot='ext-autodoc')
sphinx>     def test_builtin_function(app):
sphinx>         actual = do_autodoc(app, 'function', 'os.umask')
sphinx> >       assert list(actual) == [
sphinx>             '',
sphinx>             '.. py:function:: umask(mask, /)',
sphinx>             '   :module: os',
sphinx>             '',
sphinx>             '   Set the current numeric umask and return the previous umask.',
sphinx>             '',
sphinx>         ]
sphinx> E       AssertionError: assert ['', '.. py:function:: umask(mask)', '   :module: os', '', '   Set the current numeric umask and return the previous umask.', ''] == ['', '.. py:function:: umask(mask, /)', '   :module: os', '', '   Set the current numeric umask and return the previous umask.', '']
sphinx> E         At index 1 diff: '.. py:function:: umask(mask)' != '.. py:function:: umask(mask, /)'
sphinx> E         Full diff:
sphinx> E           [
sphinx> E            '',
sphinx> E         -  '.. py:function:: umask(mask, /)',
sphinx> E         ?                              ---
sphinx> E         +  '.. py:function:: umask(mask)',
sphinx> E            '   :module: os',
sphinx> E            '',
sphinx> E            '   Set the current numeric umask and return the previous umask.',
sphinx> E            '',
sphinx> E           ]
sphinx>
sphinx> tests/test_ext_autodoc_autofunction.py:78: AssertionError
sphinx> --------------------------- Captured stdout teardown ---------------------------
sphinx> # testroot: root
sphinx> # builder: html
sphinx> # srcdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc
sphinx> # outdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc/_build/html
sphinx> # status:
sphinx> Running Sphinx v5.3.0
sphinx> loading pickled environment... done
sphinx>
sphinx> # warning:
sphinx>
sphinx> ____________________________ test_methoddescriptor _____________________________
sphinx>
sphinx> app = <SphinxTestApp buildername='html'>
sphinx>
sphinx>     @pytest.mark.sphinx('html', testroot='ext-autodoc')
sphinx>     def test_methoddescriptor(app):
sphinx>         actual = do_autodoc(app, 'function', 'builtins.int.__add__')
sphinx> >       assert list(actual) == [
sphinx>             '',
sphinx>             '.. py:function:: __add__(self, value, /)',
sphinx>             '   :module: builtins.int',
sphinx>             '',
sphinx>             '   Return self+value.',
sphinx>             '',
sphinx>         ]
sphinx> E       AssertionError: assert ['', '.. py:function:: __add__(self, other)', '   :module: builtins.int', '', '   x.__add__(y) <==> x+y', ''] == ['', '.. py:function:: __add__(self, value, /)', '   :module: builtins.int', '', '   Return self+value.', '']
sphinx> E         At index 1 diff: '.. py:function:: __add__(self, other)' != '.. py:function:: __add__(self, value, /)'
sphinx> E         Full diff:
sphinx> E           [
sphinx> E            '',
sphinx> E         -  '.. py:function:: __add__(self, value, /)',
sphinx> E         ?                                  ^^^^ ^^^
sphinx> E         +  '.. py:function:: __add__(self, other)',
sphinx> E         ?                                  ^^^ ^
sphinx> E            '   :module: builtins.int',
sphinx> E            '',
sphinx> E         -  '   Return self+value.',
sphinx> E         +  '   x.__add__(y) <==> x+y',
sphinx> E            '',
sphinx> E           ]
sphinx>
sphinx> tests/test_ext_autodoc_autofunction.py:91: AssertionError
sphinx> --------------------------- Captured stdout teardown ---------------------------
sphinx> # testroot: root
sphinx> # builder: html
sphinx> # srcdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc
sphinx> # outdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc/_build/html
sphinx> # status:
sphinx> Running Sphinx v5.3.0
sphinx> loading pickled environment... done
sphinx>
sphinx> # warning:
sphinx>
sphinx> _________________ test_autosummary_generate_content_for_module _________________
sphinx>
sphinx> app = <SphinxTestApp buildername='html'>
sphinx>
sphinx>     @pytest.mark.sphinx(testroot='ext-autosummary')
sphinx>     def test_autosummary_generate_content_for_module(app):
sphinx>         import autosummary_dummy_module
sphinx>         template = Mock()
sphinx>
sphinx>         generate_autosummary_content('autosummary_dummy_module', autosummary_dummy_module, None,
sphinx>                                      template, None, False, app, False, {})
sphinx>         assert template.render.call_args[0][0] == 'module'
sphinx>
sphinx>         context = template.render.call_args[0][1]
sphinx> >       assert context['members'] == ['CONSTANT1', 'CONSTANT2', 'Exc', 'Foo', '_Baz', '_Exc',
sphinx>                                       '__all__', '__builtins__', '__cached__', '__doc__',
sphinx>                                       '__file__', '__name__', '__package__', '_quux', 'bar',
sphinx>                                       'non_imported_member', 'quuz', 'qux']
sphinx> E       AssertionError: assert ['CONSTANT1', 'CONSTANT2', 'Exc', 'Foo', '_Baz', '_Exc', '__all__', '__cached__', '__doc__', '__file__', '__name__', '__package__', '_quux', 'bar', 'non_imported_member', 'quuz', 'qux'] == ['CONSTANT1', 'CONSTANT2', 'Exc', 'Foo', '_Baz', '_Exc', '__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__name__', '__package__', '_quux', 'bar', 'non_imported_member', 'quuz', 'qux']
sphinx> E         At index 7 diff: '__cached__' != '__builtins__'
sphinx> E         Right contains one more item: 'qux'
sphinx> E         Full diff:
sphinx> E           [
sphinx> E            'CONSTANT1',
sphinx> E            'CONSTANT2',
sphinx> E            'Exc',
sphinx> E            'Foo',
sphinx> E            '_Baz',
sphinx> E            '_Exc',
sphinx> E            '__all__',
sphinx> E         -  '__builtins__',
sphinx> E            '__cached__',
sphinx> E            '__doc__',
sphinx> E            '__file__',
sphinx> E            '__name__',
sphinx> E            '__package__',
sphinx> E            '_quux',
sphinx> E            'bar',
sphinx> E            'non_imported_member',
sphinx> E            'quuz',
sphinx> E            'qux',
sphinx> E           ]
sphinx>
sphinx> tests/test_ext_autosummary.py:210: AssertionError
sphinx> --------------------------- Captured stdout teardown ---------------------------
sphinx> # testroot: root
sphinx> # builder: html
sphinx> # srcdir: /build/pytest-of-nixbld/pytest-0/ext-autosummary
sphinx> # outdir: /build/pytest-of-nixbld/pytest-0/ext-autosummary/_build/html
sphinx> # status:
sphinx> Running Sphinx v5.3.0
sphinx> [autosummary] generating autosummary for: index.rst
sphinx> [autosummary] generating autosummary for: /build/pytest-of-nixbld/pytest-0/ext-autosummary/generated/autosummary_dummy_module.Foo.Bar.rst, /build/pytest-of-nixbld/pytest-0/ext-autosummary/generated/autosummary_dummy_module.Foo.rst, /build/pytest-of-nixbld/pytest-0/ext-autosummary/generated/autosummary_dummy_module.Foo.value.rst, /build/pytest-of-nixbld/pytest-0/ext-autosummary/generated/autosummary_dummy_module.bar.rst, /build/pytest-of-nixbld/pytest-0/ext-autosummary/generated/autosummary_dummy_module.qux.rst, /build/pytest-of-nixbld/pytest-0/ext-autosummary/generated/autosummary_dummy_module.rst
sphinx>
sphinx> # warning:
sphinx> WARNING: [autosummary] failed to import autosummary_importfail.
sphinx> Possible hints:
sphinx> * SystemExit: 1
sphinx> * KeyError: 'autosummary_importfail'
sphinx> * ValueError: not enough values to unpack (expected 2, got 1)
sphinx>
sphinx> _____________ test_autosummary_generate_content_for_module_skipped _____________
sphinx>
sphinx> app = <SphinxTestApp buildername='html'>
sphinx>
sphinx>     @pytest.mark.sphinx(testroot='ext-autosummary')
sphinx>     def test_autosummary_generate_content_for_module_skipped(app):
sphinx>         import autosummary_dummy_module
sphinx>         template = Mock()
sphinx>
sphinx>         def skip_member(app, what, name, obj, skip, options):
sphinx>             if name in ('Foo', 'bar', 'Exc'):
sphinx>                 return True
sphinx>
sphinx>         app.connect('autodoc-skip-member', skip_member)
sphinx>         generate_autosummary_content('autosummary_dummy_module', autosummary_dummy_module, None,
sphinx>                                      template, None, False, app, False, {})
sphinx>         context = template.render.call_args[0][1]
sphinx> >       assert context['members'] == ['CONSTANT1', 'CONSTANT2', '_Baz', '_Exc', '__all__',
sphinx>                                       '__builtins__', '__cached__', '__doc__', '__file__',
sphinx>                                       '__name__', '__package__', '_quux', 'non_imported_member',
sphinx>                                       'quuz', 'qux']
sphinx> E       AssertionError: assert ['CONSTANT1', 'CONSTANT2', '_Baz', '_Exc', '__all__', '__cached__', '__doc__', '__file__', '__name__', '__package__', '_quux', 'non_imported_member', 'quuz', 'qux'] == ['CONSTANT1', 'CONSTANT2', '_Baz', '_Exc', '__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__name__', '__package__', '_quux', 'non_imported_member', 'quuz', 'qux']
sphinx> E         At index 5 diff: '__cached__' != '__builtins__'
sphinx> E         Right contains one more item: 'qux'
sphinx> E         Full diff:
sphinx> E           [
sphinx> E            'CONSTANT1',
sphinx> E            'CONSTANT2',
sphinx> E            '_Baz',
sphinx> E            '_Exc',
sphinx> E            '__all__',
sphinx> E         -  '__builtins__',
sphinx> E            '__cached__',
sphinx> E            '__doc__',
sphinx> E            '__file__',
sphinx> E            '__name__',
sphinx> E            '__package__',
sphinx> E            '_quux',
sphinx> E            'non_imported_member',
sphinx> E            'quuz',
sphinx> E            'qux',
sphinx> E           ]
sphinx>
sphinx> tests/test_ext_autosummary.py:269: AssertionError
sphinx> --------------------------- Captured stdout teardown ---------------------------
sphinx> # testroot: root
sphinx> # builder: html
sphinx> # srcdir: /build/pytest-of-nixbld/pytest-0/ext-autosummary
sphinx> # outdir: /build/pytest-of-nixbld/pytest-0/ext-autosummary/_build/html
sphinx> # status:
sphinx> Running Sphinx v5.3.0
sphinx> [autosummary] generating autosummary for: generated/autosummary_dummy_module.Foo.Bar.rst, generated/autosummary_dummy_module.Foo.rst, generated/autosummary_dummy_module.Foo.value.rst, generated/autosummary_dummy_module.bar.rst, generated/autosummary_dummy_module.qux.rst, generated/autosummary_dummy_module.rst, index.rst
sphinx>
sphinx> # warning:
sphinx> WARNING: [autosummary] failed to import autosummary_importfail.
sphinx> Possible hints:
sphinx> * SystemExit: 1
sphinx> * KeyError: 'autosummary_importfail'
sphinx> * ValueError: not enough values to unpack (expected 2, got 1)
sphinx>
sphinx> __________________________ test_isattributedescriptor __________________________
sphinx>
sphinx> app = <SphinxTestApp buildername='html'>
sphinx>
sphinx>     @pytest.mark.sphinx(testroot='ext-autodoc')
sphinx>     def test_isattributedescriptor(app):
sphinx>         from target.methods import Base
sphinx>
sphinx>         class Descriptor:
sphinx>             def __get__(self, obj, typ=None):
sphinx>                 pass
sphinx>
sphinx>         assert inspect.isattributedescriptor(Base.prop) is True                    # property
sphinx>         assert inspect.isattributedescriptor(Base.meth) is False                   # method
sphinx>         assert inspect.isattributedescriptor(Base.staticmeth) is False             # staticmethod
sphinx>         assert inspect.isattributedescriptor(Base.classmeth) is False              # classmetho
sphinx>         assert inspect.isattributedescriptor(Descriptor) is False                  # custom descriptor class
sphinx>         assert inspect.isattributedescriptor(str.join) is False                    # MethodDescriptorType
sphinx>         assert inspect.isattributedescriptor(object.__init__) is False             # WrapperDescriptorType
sphinx>         assert inspect.isattributedescriptor(dict.__dict__['fromkeys']) is False   # ClassMethodDescriptorType
sphinx>         assert inspect.isattributedescriptor(types.FrameType.f_locals) is True     # GetSetDescriptorType
sphinx>         assert inspect.isattributedescriptor(datetime.timedelta.days) is True      # MemberDescriptorType
sphinx>
sphinx>         try:
sphinx>             # _testcapi module cannot be importable in some distro
sphinx>             # refs: https://github.com/sphinx-doc/sphinx/issues/9868
sphinx>             import _testcapi
sphinx>
sphinx>             testinstancemethod = _testcapi.instancemethod(str.__repr__)
sphinx> >           assert inspect.isattributedescriptor(testinstancemethod) is False      # instancemethod (C-API)
sphinx> E           assert True is False
sphinx> E            +  where True = <function isattributedescriptor at 0x00007ffff186bec0>(<<instancemethod __repr__> at 0x000000000ff35dd0>)
sphinx> E            +    where <function isattributedescriptor at 0x00007ffff186bec0> = inspect.isattributedescriptor
sphinx>
sphinx> tests/test_util_inspect.py:665: AssertionError
sphinx> ----------------------------- Captured stdout call -----------------------------
sphinx> creating /build/testcapi_25785f4a1323805f/nix
sphinx> creating /build/testcapi_25785f4a1323805f/nix/store
sphinx> creating /build/testcapi_25785f4a1323805f/nix/store/2yck3khdv7s33vp4fbz8hwlwyc0cipc9-pypy3.9-7.3.11
sphinx> creating /build/testcapi_25785f4a1323805f/nix/store/2yck3khdv7s33vp4fbz8hwlwyc0cipc9-pypy3.9-7.3.11/lib
sphinx> creating /build/testcapi_25785f4a1323805f/nix/store/2yck3khdv7s33vp4fbz8hwlwyc0cipc9-pypy3.9-7.3.11/lib/pypy3.9
sphinx> creating /build/testcapi_25785f4a1323805f/nix/store/2yck3khdv7s33vp4fbz8hwlwyc0cipc9-pypy3.9-7.3.11/lib/pypy3.9/lib_pypy
sphinx> gcc -DNDEBUG -O2 -fPIC -fPIC -Wimplicit-function-declaration -I/nix/store/2yck3khdv7s33vp4fbz8hwlwyc0cipc9-pypy3.9-7.3.11/lib/pypy3.9/include/pypy3.9 -c /nix/store/2yck3khdv7s33vp4fbz8hwlwyc0cipc9-pypy3.9-7.3.11/lib/pypy3.9/lib_pypy/_testcapimodule.c -o /build/testcapi_25785f4a1323805f/nix/store/2yck3khdv7s33vp4fbz8hwlwyc0cipc9-pypy3.9-7.3.11/lib/pypy3.9/lib_pypy/_testcapimodule.o
sphinx> gcc -pthread -shared -Wl,-Bsymbolic-functions /build/testcapi_25785f4a1323805f/nix/store/2yck3khdv7s33vp4fbz8hwlwyc0cipc9-pypy3.9-7.3.11/lib/pypy3.9/lib_pypy/_testcapimodule.o -o /build/testcapi_25785f4a1323805f/_testcapi.pypy39-pp73-x86_64-linux-gnu.so
sphinx> --------------------------- Captured stdout teardown ---------------------------
sphinx> # testroot: root
sphinx> # builder: html
sphinx> # srcdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc
sphinx> # outdir: /build/pytest-of-nixbld/pytest-0/ext-autodoc/_build/html
sphinx> # status:
sphinx> Running Sphinx v5.3.0
sphinx> loading pickled environment... done
sphinx>
sphinx> # warning:
sphinx> WARNING: while setting up extension sphinx.domains.changeset: directive 'deprecated' is already registered, it will be overridden
sphinx> WARNING: while setting up extension sphinx.domains.changeset: directive 'versionadded' is already registered, it will be overridden
sphinx> WARNING: while setting up extension sphinx.domains.changeset: directive 'versionchanged' is already registered, it will be overridden
sphinx> WARNING: while setting up extension sphinx.domains.index: directive 'index' is already registered, it will be overridden
sphinx> WARNING: while setting up extension sphinx.domains.index: role 'index' is already registered, it will be overridden
sphinx> WARNING: while setting up extension sphinx.domains.math: role 'eq' is already registered, it will be overridden
sphinx>
sphinx> =============================== warnings summary ===============================
sphinx> sphinx/ext/napoleon/iterators.py:9
sphinx>   /build/source/sphinx/ext/napoleon/iterators.py:9: RemovedInSphinx70Warning: sphinx.ext.napoleon.iterators is deprecated.
sphinx>     warnings.warn('sphinx.ext.napoleon.iterators is deprecated.',
sphinx>
sphinx> -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
sphinx> =========================== short test summary info ============================
sphinx> FAILED tests/test_ext_autodoc.py::test_autodoc_inherited_members_None - AssertionError: assert '   .. py:method:: Derived.__init__()' in StringList...
sphinx> FAILED tests/test_ext_autodoc.py::test_automethod_for_builtin - AssertionError: assert ['', '.. py:method:: int.__add__(other)', '   :modul...
sphinx> FAILED tests/test_ext_autodoc.py::test_partialfunction - AssertionError: assert ['', '.. py:module:: target.partialfunction', '', ''...
sphinx> FAILED tests/test_ext_autodoc.py::test_cython - AssertionError: assert ['', '.. py:module:: target.cython', '', '   module(...
sphinx> FAILED tests/test_ext_autodoc_autofunction.py::test_builtin_function - AssertionError: assert ['', '.. py:function:: umask(mask)', '   :module: os...
sphinx> FAILED tests/test_ext_autodoc_autofunction.py::test_methoddescriptor - AssertionError: assert ['', '.. py:function:: __add__(self, other)', '   :m...
sphinx> FAILED tests/test_ext_autosummary.py::test_autosummary_generate_content_for_module - AssertionError: assert ['CONSTANT1', 'CONSTANT2', 'Exc', 'Foo', '_Baz', '_E...
sphinx> FAILED tests/test_ext_autosummary.py::test_autosummary_generate_content_for_module_skipped - AssertionError: assert ['CONSTANT1', 'CONSTANT2', '_Baz', '_Exc', '__all__'...
sphinx> FAILED tests/test_util_inspect.py::test_isattributedescriptor - assert True is False
sphinx> = 9 failed, 1799 passed, 42 skipped, 12 deselected, 1 warning in 216.47s (0:03:36) =
sphinx> /nix/store/blpvf60m29q02c0lc5fyhim30ma4y1vv-stdenv-linux/setup: line 1596: pop_var_context: head of shell_variables not a function context
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
