### PR TITLE
db: fix build on Darwin and clang 16

### DIFF
--- a/pkgs/development/libraries/db/clang-4.8.patch
+++ b/pkgs/development/libraries/db/clang-4.8.patch
@@ -139,3 +139,67 @@ index f3922e0..e40fcdf 100644
  		} else {
  			DB_ASSERT(env, sharecount > 0);
  			MEMBAR_EXIT();
+diff -ur a/dist/aclocal/clock.m4 b/dist/aclocal/clock.m4
+--- a/dist/aclocal/clock.m4	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/aclocal/clock.m4	2023-06-05 19:14:02.007080500 -0400
+@@ -21,6 +21,7 @@
+ AC_CACHE_CHECK([for clock_gettime monotonic clock], db_cv_clock_monotonic, [
+ AC_TRY_RUN([
+ #include <sys/time.h>
++int
+ main() {
+ 	struct timespec t;
+ 	return (clock_gettime(CLOCK_MONOTONIC, &t) != 0);
+diff -ur a/dist/aclocal/mutex.m4 b/dist/aclocal/mutex.m4
+--- a/dist/aclocal/mutex.m4	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/aclocal/mutex.m4	2023-06-05 19:14:47.214158196 -0400
+@@ -4,6 +4,7 @@
+ AC_DEFUN(AM_PTHREADS_SHARED, [
+ AC_TRY_RUN([
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -46,6 +47,7 @@
+ AC_DEFUN(AM_PTHREADS_PRIVATE, [
+ AC_TRY_RUN([
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+diff -ur a/dist/aclocal/sequence.m4 b/dist/aclocal/sequence.m4
+--- a/dist/aclocal/sequence.m4	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/aclocal/sequence.m4	2023-06-05 19:14:02.007869956 -0400
+@@ -43,6 +43,9 @@
+ 	# test, which won't test for the appropriate printf format strings.
+ 	if test "$db_cv_build_sequence" = "yes"; then
+ 		AC_TRY_RUN([
++		#include <string.h>
++		#include <stdio.h>
++		int
+ 		main() {
+ 			$db_cv_seq_type l;
+ 			unsigned $db_cv_seq_type u;
+@@ -59,7 +62,9 @@
+				return (1);
+ 			return (0);
+ 		}],, [db_cv_build_sequence="no"],
+-		AC_TRY_LINK(,[
++		AC_TRY_LINK([
++			#include <string.h>
++			#include <stdio.h>],[
+ 			$db_cv_seq_type l;
+ 			unsigned $db_cv_seq_type u;
+ 			char buf@<:@100@:>@;
+diff -ur a/dist/RELEASE b/dist/RELEASE
+--- a/dist/RELEASE	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/RELEASE	2023-07-02 17:32:34.703953049 -0400
+@@ -7,5 +7,5 @@
+ 
+ DB_VERSION_UNIQUE_NAME=`printf "_%d%03d" $DB_VERSION_MAJOR $DB_VERSION_MINOR`
+ 
+-DB_RELEASE_DATE=`date "+%B %e, %Y"`
++DB_RELEASE_DATE="April  9, 2010"
+ DB_VERSION_STRING="Berkeley DB $DB_VERSION: ($DB_RELEASE_DATE)"

--- a/pkgs/development/libraries/db/clang-5.3.patch
+++ b/pkgs/development/libraries/db/clang-5.3.patch
@@ -139,3 +139,111 @@ index 106b161..fc4de9d 100644
  		} else {
  			DB_ASSERT(env, sharecount > 0);
  			MEMBAR_EXIT();
+diff -ur a/dist/aclocal/clock.m4 b/dist/aclocal/clock.m4
+--- a/dist/aclocal/clock.m4	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/aclocal/clock.m4	2023-06-05 19:14:02.007080500 -0400
+@@ -21,6 +21,7 @@
+ AC_CACHE_CHECK([for clock_gettime monotonic clock], db_cv_clock_monotonic, [
+ AC_TRY_RUN([
+ #include <sys/time.h>
++int
+ main() {
+ 	struct timespec t;
+ 	return (clock_gettime(CLOCK_MONOTONIC, &t) != 0);
+diff -ur a/dist/aclocal/mmap.m4 b/dist/aclocal/mmap.m4
+--- a/dist/aclocal/mmap.m4	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/aclocal/mmap.m4	2023-06-05 19:14:02.007323624 -0400
+@@ -29,6 +29,8 @@
+      * system to system.
+      */
+     #include <stdio.h>
++    #include <stdlib.h>
++    #include <unistd.h>
+     #include <string.h>
+     #include <sys/types.h>
+     #include <sys/stat.h>
+@@ -42,12 +44,13 @@
+     #define MAP_FAILED (-1)
+     #endif
+
+-    int catch_sig(sig)
++    void catch_sig(sig)
+ 	    int sig;
+     {
+ 	    exit(1);
+     }
+
++    int
+     main() {
+ 	    const char *underlying;
+ 	    unsigned gapsize;
+@@ -88,8 +91,8 @@
+ 		    return (4);
+ 	    }
+
+-	    (void) signal(SIGSEGV, catch_sig);
+-	    (void) signal(SIGBUS, catch_sig);
++	    (void) signal(SIGSEGV, &catch_sig);
++	    (void) signal(SIGBUS, &catch_sig);
+
+ 	    for (i = sizeof(buf); i < total_size; i += gapsize)
+ 		    base[i] = 'A';
+diff -ur a/dist/aclocal/mutex.m4 b/dist/aclocal/mutex.m4
+--- a/dist/aclocal/mutex.m4	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/aclocal/mutex.m4	2023-06-05 19:14:47.214158196 -0400
+@@ -5,6 +5,7 @@
+ AC_TRY_RUN([
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -49,6 +50,7 @@
+ AC_TRY_RUN([
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -89,6 +91,7 @@
+ AC_TRY_RUN([
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_condattr_t condattr;
+@@ -110,6 +113,7 @@
+ AC_TRY_RUN([
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_rwlock_t rwlock;
+ 	pthread_rwlockattr_t rwlockattr;
+diff -ur a/dist/aclocal/sequence.m4 b/dist/aclocal/sequence.m4
+--- a/dist/aclocal/sequence.m4	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/aclocal/sequence.m4	2023-06-05 19:14:02.007869956 -0400
+@@ -43,6 +43,9 @@
+ 	# test, which won't test for the appropriate printf format strings.
+ 	if test "$db_cv_build_sequence" = "yes"; then
+ 		AC_TRY_RUN([
++		#include <string.h>
++		#include <stdio.h>
++		int
+ 		main() {
+ 			$db_cv_seq_type l;
+ 			unsigned $db_cv_seq_type u;
+@@ -59,7 +62,9 @@
+				return (1);
+ 			return (0);
+ 		}],, [db_cv_build_sequence="no"],
+-		AC_TRY_LINK(,[
++		AC_TRY_LINK([
++			#include <string.h>
++			#include <stdio.h>],[
+ 			$db_cv_seq_type l;
+ 			unsigned $db_cv_seq_type u;
+ 			char buf@<:@100@:>@;

--- a/pkgs/development/libraries/db/darwin-mutexes-4.8.patch
+++ b/pkgs/development/libraries/db/darwin-mutexes-4.8.patch
@@ -1,0 +1,55 @@
+diff -ur a/dist/aclocal/mutex.m4 b/dist/aclocal/mutex.m4
+--- a/dist/aclocal/mutex.m4	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/aclocal/mutex.m4	2023-06-05 19:14:47.214158196 -0400
+@@ -372,10 +376,11 @@
+ 
+ # _spin_lock_try/_spin_unlock: Apple/Darwin
+ if test "$db_cv_mutex" = no; then
+-AC_TRY_LINK(,[
+-	int x;
+-	_spin_lock_try(&x);
+-	_spin_unlock(&x);
++AC_TRY_LINK([
++#include <os/lock.h>],[
++	os_unfair_lock x = OS_UNFAIR_LOCK_INIT;
++	bool _ = os_unfair_lock_trylock(&x);
++	os_unfair_lock_unlock(&x);
+ ], [db_cv_mutex=Darwin/_spin_lock_try])
+ fi
+ 
+diff -ur a/dbinc/mutex_int.h b/dbinc/mutex_int.h
+--- a/dbinc/mutex_int.h	1969-12-31 19:00:01.000000000 -0500
++++ b/dbinc/mutex_int.h	2023-06-05 19:15:37.510514745 -0400
+@@ -154,14 +154,13 @@
+  * Apple/Darwin library functions.
+  *********************************************************************/
+ #ifdef HAVE_MUTEX_DARWIN_SPIN_LOCK_TRY
+-typedef u_int32_t tsl_t;
++#include <os/lock.h>
++typedef os_unfair_lock tsl_t;
+ 
+ #ifdef LOAD_ACTUAL_MUTEX_CODE
+-extern int _spin_lock_try(tsl_t *);
+-extern void _spin_unlock(tsl_t *);
+-#define	MUTEX_SET(tsl)          _spin_lock_try(tsl)
+-#define	MUTEX_UNSET(tsl)        _spin_unlock(tsl)
+-#define	MUTEX_INIT(tsl)         (MUTEX_UNSET(tsl), 0)
++#define	MUTEX_SET(tsl)          os_unfair_lock_trylock(tsl)
++#define	MUTEX_UNSET(tsl)        os_unfair_lock_unlock(tsl)
++#define	MUTEX_INIT(tsl)         ({ *(tsl) = OS_UNFAIR_LOCK_INIT; tsl; })
+ #endif
+ #endif
+ 
+diff -ur a/dbinc/mutex_int.h b/dbinc/mutex_int.h
+--- a/dbinc_auto/mutex_ext.h	1969-12-31 19:00:01.000000000 -0500
++++ b/dbinc_auto/mutex_ext.h	2023-07-01 22:38:20.749201366 -0400
+@@ -34,6 +34,9 @@
+ #if !defined(HAVE_ATOMIC_SUPPORT) && defined(HAVE_MUTEX_SUPPORT)
+ atomic_value_t __atomic_dec __P((ENV *, db_atomic_t *));
+ #endif
++#if !defined(HAVE_ATOMIC_SUPPORT) && defined(HAVE_MUTEX_SUPPORT)
++int atomic_compare_exchange __P((ENV *, db_atomic_t *, atomic_value_t, atomic_value_t));
++#endif
+ int __db_pthread_mutex_init __P((ENV *, db_mutex_t, u_int32_t));
+ int __db_pthread_mutex_lock __P((ENV *, db_mutex_t));
+ #if defined(HAVE_SHARED_LATCHES)

--- a/pkgs/development/libraries/db/darwin-mutexes.patch
+++ b/pkgs/development/libraries/db/darwin-mutexes.patch
@@ -1,0 +1,42 @@
+diff -ur a/dist/aclocal/mutex.m4 b/dist/aclocal/mutex.m4
+--- a/dist/aclocal/mutex.m4	1969-12-31 19:00:01.000000000 -0500
++++ b/dist/aclocal/mutex.m4	2023-06-05 19:14:47.214158196 -0400
+@@ -441,10 +445,11 @@
+ 
+ # _spin_lock_try/_spin_unlock: Apple/Darwin
+ if test "$db_cv_mutex" = no; then
+-AC_TRY_LINK(,[
+-	int x;
+-	_spin_lock_try(&x);
+-	_spin_unlock(&x);
++AC_TRY_LINK([
++#include <os/lock.h>],[
++	os_unfair_lock x = OS_UNFAIR_LOCK_INIT;
++	bool _ = os_unfair_lock_trylock(&x);
++	os_unfair_lock_unlock(&x);
+ ], [db_cv_mutex=Darwin/_spin_lock_try])
+ fi
+ 
+diff -ur a/src/dbinc/mutex_int.h b/src/dbinc/mutex_int.h
+--- a/src/dbinc/mutex_int.h	1969-12-31 19:00:01.000000000 -0500
++++ b/src/dbinc/mutex_int.h	2023-06-05 19:15:37.510514745 -0400
+@@ -154,14 +154,13 @@
+  * Apple/Darwin library functions.
+  *********************************************************************/
+ #ifdef HAVE_MUTEX_DARWIN_SPIN_LOCK_TRY
+-typedef u_int32_t tsl_t;
++#include <os/lock.h>
++typedef os_unfair_lock tsl_t;
+ 
+ #ifdef LOAD_ACTUAL_MUTEX_CODE
+-extern int _spin_lock_try(tsl_t *);
+-extern void _spin_unlock(tsl_t *);
+-#define	MUTEX_SET(tsl)          _spin_lock_try(tsl)
+-#define	MUTEX_UNSET(tsl)        _spin_unlock(tsl)
+-#define	MUTEX_INIT(tsl)         (MUTEX_UNSET(tsl), 0)
++#define	MUTEX_SET(tsl)          os_unfair_lock_trylock(tsl)
++#define	MUTEX_UNSET(tsl)        os_unfair_lock_unlock(tsl)
++#define	MUTEX_INIT(tsl)         ({ *(tsl) = OS_UNFAIR_LOCK_INIT; tsl; })
+ #endif
+ #endif
+

--- a/pkgs/development/libraries/db/db-4.8.nix
+++ b/pkgs/development/libraries/db/db-4.8.nix
@@ -3,7 +3,8 @@
 import ./generic.nix (args // {
   version = "4.8.30";
   sha256 = "0ampbl2f0hb1nix195kz1syrqqxpmvnvnfvphambj7xjrl3iljg0";
-  extraPatches = [ ./clang-4.8.patch ./CVE-2017-10140-4.8-cwd-db_config.patch ];
+  extraPatches = [ ./clang-4.8.patch ./CVE-2017-10140-4.8-cwd-db_config.patch ]
+    ++ lib.optionals stdenv.isDarwin [ ./darwin-mutexes-4.8.patch ];
 
   drvArgs.hardeningDisable = [ "format" ];
   drvArgs.doCheck = false;

--- a/pkgs/development/libraries/db/db-4.8.nix
+++ b/pkgs/development/libraries/db/db-4.8.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ... } @ args:
+{ lib, stdenv, fetchurl, autoreconfHook, ... } @ args:
 
 import ./generic.nix (args // {
   version = "4.8.30";

--- a/pkgs/development/libraries/db/db-5.3.nix
+++ b/pkgs/development/libraries/db/db-5.3.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ... } @ args:
+{ lib, stdenv, fetchurl, autoreconfHook, ... } @ args:
 
 import ./generic.nix (args // {
   version = "5.3.28";

--- a/pkgs/development/libraries/db/db-5.3.nix
+++ b/pkgs/development/libraries/db/db-5.3.nix
@@ -3,5 +3,6 @@
 import ./generic.nix (args // {
   version = "5.3.28";
   sha256 = "0a1n5hbl7027fbz5lm0vp0zzfp1hmxnz14wx3zl9563h83br5ag0";
-  extraPatches = [ ./clang-5.3.patch ./CVE-2017-10140-cwd-db_config.patch ];
+  extraPatches = [ ./clang-5.3.patch ./CVE-2017-10140-cwd-db_config.patch ]
+    ++ lib.optionals stdenv.isDarwin [ ./darwin-mutexes.patch ];
 })

--- a/pkgs/development/libraries/db/db-6.0.nix
+++ b/pkgs/development/libraries/db/db-6.0.nix
@@ -4,5 +4,6 @@ import ./generic.nix (args // {
   version = "6.0.20";
   sha256 = "00r2aaglq625y8r9xd5vw2y070plp88f1mb2gbq3kqsl7128lsl0";
   license = lib.licenses.agpl3;
-  extraPatches = [ ./clang-6.0.patch ./CVE-2017-10140-cwd-db_config.patch ];
+  extraPatches = [ ./clang-6.0.patch ./CVE-2017-10140-cwd-db_config.patch ]
+    ++ lib.optionals stdenv.isDarwin [ ./darwin-mutexes.patch ];
 })

--- a/pkgs/development/libraries/db/db-6.0.nix
+++ b/pkgs/development/libraries/db/db-6.0.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ... } @ args:
+{ lib, stdenv, fetchurl, autoreconfHook, ... } @ args:
 
 import ./generic.nix (args // {
   version = "6.0.20";

--- a/pkgs/development/libraries/db/db-6.2.nix
+++ b/pkgs/development/libraries/db/db-6.2.nix
@@ -4,5 +4,6 @@ import ./generic.nix (args // {
   version = "6.2.23";
   sha256 = "1isxx4jfmnh913jzhp8hhfngbk6dsg46f4kjpvvc56maj64jqqa7";
   license = lib.licenses.agpl3;
-  extraPatches = [ ./clang-6.0.patch ./CVE-2017-10140-cwd-db_config.patch ];
+  extraPatches = [ ./clang-6.0.patch ./CVE-2017-10140-cwd-db_config.patch ]
+    ++ lib.optionals stdenv.isDarwin [ ./darwin-mutexes.patch ];
 })

--- a/pkgs/development/libraries/db/db-6.2.nix
+++ b/pkgs/development/libraries/db/db-6.2.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ... } @ args:
+{ lib, stdenv, fetchurl, autoreconfHook, ... } @ args:
 
 import ./generic.nix (args // {
   version = "6.2.23";

--- a/pkgs/development/libraries/db/generic.nix
+++ b/pkgs/development/libraries/db/generic.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl
+{ lib, stdenv, fetchurl, autoreconfHook
 , cxxSupport ? true
 , compat185 ? true
 , dbmSupport ? false
@@ -10,6 +10,9 @@
 , drvArgs ? {}
 }:
 
+let
+  shouldReconfigure = stdenv.cc.isClang;
+in
 stdenv.mkDerivation (rec {
   pname = "db";
   inherit version;
@@ -19,9 +22,47 @@ stdenv.mkDerivation (rec {
     sha256 = sha256;
   };
 
+  # The provided configure script features `main` returning implicit `int`, which causes
+  # configure checks to work incorrectly with clang 16.
+  nativeBuildInputs = lib.optionals stdenv.cc.isClang [ autoreconfHook ];
+
   patches = extraPatches;
 
   outputs = [ "bin" "out" "dev" ];
+
+  # Required when regenerated the configure script to make sure the vendored macros are found.
+  autoreconfFlags = lib.optionalString shouldReconfigure [ "-fi" "-Iaclocal" "-Iaclocal_java" ];
+
+  preAutoreconf = lib.optionalString shouldReconfigure ''
+    pushd dist
+    # Upstream’s `dist/s_config` cats everything into `aclocal.m4`, but that doesn’t work with
+    # autoreconfHook, so cat `config.m4` to another file. Otherwise, it won’t be found by `aclocal`.
+    cat aclocal/config.m4 >> aclocal/options.m4
+  '';
+
+  # This isn’t pretty. The version information is kept separate from the configure script.
+  # After the configure script is regenerated, the version information has to be replaced with the
+  # contents of `dist/RELEASE`.
+  postAutoreconf = lib.optionalString shouldReconfigure ''
+    (
+      declare -a vars=(
+        "DB_VERSION_FAMILY"
+        "DB_VERSION_RELEASE"
+        "DB_VERSION_MAJOR"
+        "DB_VERSION_MINOR"
+        "DB_VERSION_PATCH"
+        "DB_VERSION_STRING"
+        "DB_VERSION_FULL_STRING"
+        "DB_VERSION_UNIQUE_NAME"
+        "DB_VERSION"
+      )
+      source RELEASE
+      for var in "''${vars[@]}"; do
+        sed -e "s/__EDIT_''${var}__/''${!var}/g" -i configure
+      done
+    )
+    popd
+  '';
 
   configureFlags =
     [


### PR DESCRIPTION
###### Description of changes

This PR updates Berkley DB’s configure scripts to build with clang 16. These changes were done to db5 then back and forward-ported to db4 and db6 as necessary.

* It adds missing implicit `int` to `main` in configure tests.
* It adds missing headers that cause tests  to fix a false negative results with clang 16.
* It corrects the call to `signal` and the signal handler’s definition in the mmap growth test to fix a false negative result with clang 16.

In addition, it replaces the mutex implementation with `os_unfair_lock` on Darwin. `_spin_lock_try` and `_spin_unlock` are private APIs and deprecated. The recommended replacement according to the deprecation message is `os_unfair_lock`. This also changes the db4 mutex implementation from pthreads to `os_unfair_lock` (even though db4 supported the other implementation, it wasn’t being used).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
