### PR TITLE
csharp-ls: init at 0.8.0

### DIFF
--- a/pkgs/development/tools/language-servers/csharp-ls/default.nix
+++ b/pkgs/development/tools/language-servers/csharp-ls/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildDotnetGlobalTool
+, dotnetCorePackages
+}:
+let
+  inherit (dotnetCorePackages) sdk_7_0;
+in
+
+buildDotnetGlobalTool rec {
+  pname = "csharp-ls";
+  version = "0.8.0";
+
+  nugetSha256 = "sha256-F3N6ESE/VmQA5sOMm3eqSkhSNVCCsnAXTCC+McsAnQw=";
+
+  dotnet-sdk = sdk_7_0;
+  dotnet-runtime = sdk_7_0;
+
+  meta = with lib; {
+    description = "Roslyn-based LSP language server for C#";
+    homepage = "https://github.com/razzmatazz/csharp-language-server";
+    changelog = "https://github.com/razzmatazz/csharp-language-server/releases/tag/v${version}";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -786,6 +786,8 @@ with pkgs;
 
   # Dotnet
 
+  csharp-ls = callPackage ../development/tools/language-servers/csharp-ls { };
+
   dotnetCorePackages = recurseIntoAttrs (callPackage ../development/compilers/dotnet {});
 
   dotnet-sdk_2 = dotnetCorePackages.sdk_2_1;


### PR DESCRIPTION
###### Description of changes

Add [csharp-ls](https://github.com/razzmatazz/csharp-language-server), a language server for C#.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
