### PR TITLE
python310Packages.pvlib: 0.7.2 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/pvlib/default.nix
+++ b/pkgs/development/python-modules/pvlib/default.nix
@@ -1,48 +1,51 @@
-{ lib, buildPythonPackage, fetchPypi, fetchpatch, pythonOlder, numpy, pandas, pytz, six
-, pytestCheckHook, flaky, mock, pytest-mock, requests }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, h5py
+, numpy
+, pandas
+, pytestCheckHook
+, pytest-mock
+, pytest-remotedata
+, pytest-rerunfailures
+, pytest-timeout
+, pytz
+, requests
+, requests-mock
+, scipy
+, setuptools
+}:
 
 buildPythonPackage rec {
   pname = "pvlib";
-  version = "0.7.2";
-
-  # Support for Python <3.5 dropped in 0.6.3 on June 1, 2019.
-  disabled = pythonOlder "3.5";
+  version = "0.10.0";
+  format = "pyproject";
 
   src = fetchPypi{
     inherit pname version;
-    sha256 = "40708492ed0a41e900d36933b9b9ab7b575c72ebf3eee81293c626e301aa7ea1";
+    hash = "sha256-K/f6tjBznXYJz+Y5tVS1Bj+DKcPtCPlwiKe/YTEsGSI=";
   };
 
-  patches = [
-    # enable later pandas versions, remove next bump
-    (fetchpatch {
-      url = "https://github.com/pvlib/pvlib-python/commit/010a2adc9e9ef6fe9f2aea4c02d7e6ede9f96a53.patch";
-      sha256 = "0jibn4khixz6hv6racmp86m5mcms0ysz1y5bgpplw1kcvf8sn04x";
-      excludes = [
-        "pvlib/tests/test_inverter.py"
-        "docs/sphinx/source/whatsnew/v0.8.0.rst"
-        "ci/requirements-py35-min.yml"
-      ];
-    })
+  nativeBuildInputs = [
+    setuptools
   ];
 
-  nativeCheckInputs = [ pytestCheckHook flaky mock pytest-mock ];
-  propagatedBuildInputs = [ numpy pandas pytz six requests ];
+  propagatedBuildInputs = [
+    h5py
+    numpy
+    pandas
+    pytz
+    requests
+    scipy
+  ];
 
-  # Skip a few tests that try to access some URLs
-  pytestFlagsArray = [ "pvlib/tests" ];
-  disabledTests = [
-    "read_srml_dt_index"
-    "read_srml_month_from_solardata"
-    "get_psm3"
-    "pvgis"
-    "read_surfrad_network"
-    "remote"
-    # small rounding errors, E.g <1e-10^5
-    "calcparams_pvsyst"
-    "martin_ruiz_diffuse"
-    "hsu"
-    "backtrack"
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+    pytest-remotedata
+    pytest-rerunfailures
+    pytest-timeout
+    requests-mock
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

It's been awhile since we've updated this library. It currently fails building ever since `numpy` was updated to 1.24.*.

A lot has changed to the tests, including adding `pytest-remotedata` to skip tests that need access to the Internet by default, so let's try enabling all of them again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
