### PR TITLE
rPackages.arrow: backport 11.0.0.3 -> 12.0.0

### DIFF
--- a/pkgs/development/r-modules/cran-packages.nix
+++ b/pkgs/development/r-modules/cran-packages.nix
@@ -6138,7 +6138,7 @@ in with self; {
   arrApply = derive2 { name="arrApply"; version="2.2"; sha256="0bp30622md9zzdgv9g1kqp5k450cd5yzpqji51wwcjp8l347fb6y"; depends=[Rcpp RcppArmadillo]; };
   arrangements = derive2 { name="arrangements"; version="1.1.9"; sha256="0nrlyxgn6667l2rb1q5rvps1anld9aq88qqr3ch2i6zchnqxrdg9"; depends=[gmp R6]; };
   arrayhelpers = derive2 { name="arrayhelpers"; version="1.1-0"; sha256="02rl530qxi1idiqpmzg5wr9vl5c7phizhpj64k5pn8xq9zfxbpaz"; depends=[svUnit]; };
-  arrow = derive2 { name="arrow"; version="11.0.0.3"; sha256="1bvf04pmxckz3is04acsl7a86lha5b6qrxb2zmn8w8glymqr94zb"; depends=[assertthat bit64 cpp11 glue purrr R6 rlang tidyselect vctrs]; };
+  arrow = derive2 { name="arrow"; version="12.0.0"; sha256="1hv18ksaghifj4jjdy1cf2ic0rrgfi7jbjpzxb7v6r3bbshs9vwi"; depends=[assertthat bit64 cpp11 glue purrr R6 rlang tidyselect vctrs]; };
   ars = derive2 { name="ars"; version="0.6"; sha256="0zs1rk3i7pc9wcvxrvjcls194mfbvmkz7cb6pwd1cm3fzjwsyxsp"; depends=[]; };
   arse = derive2 { name="arse"; version="1.0.0"; sha256="0ssaalc058m09gfcr1n0s729rx2plia3zkhlynj67drclyvhyb0i"; depends=[dplyr pracma]; };
   arsenal = derive2 { name="arsenal"; version="3.6.3"; sha256="0qvs3ld28djnjnggdhqjwq8sbv8zz322qahlvf7dnx35yqf6xkms"; depends=[knitr]; };


### PR DESCRIPTION
This is needed in order to be compatible with arrow-cpp 12.0.0.

Part of commit 4ae814f720030aab86dfd6f4372a57da54da8427.

Resolves https://github.com/NixOS/nixpkgs/issues/241026.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
