### PR TITLE
veryl: init at 0.5.5

### DIFF
--- a/pkgs/development/compilers/veryl/default.nix
+++ b/pkgs/development/compilers/veryl/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "veryl";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "dalance";
+    repo = pname;
+    rev = "veryl-v${version}";
+    hash = "sha256-lTDJNtaNd+tY+HXyuja0eeY6ubNmuZ85mHYKRHlyR34=";
+  };
+
+  cargoHash = "sha256-xBeQA+18ox+yjKoCypSsebVwypHZNh6SYDJP8QwBhBY=";
+
+  doCheck = false; # Impure due to file I/O
+
+  meta = with lib; {
+    description = "A modern hardware description language";
+    homepage = "https://github.com/dalance/veryl";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ omasanori ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13775,6 +13775,8 @@ with pkgs;
 
   versus = callPackage ../applications/networking/versus { };
 
+  veryl = callPackage ../development/compilers/veryl { };
+
   vexctl = callPackage ../tools/security/vexctl { };
 
   vgrep = callPackage ../tools/text/vgrep { };


### PR DESCRIPTION
###### Description of changes

This change adds a new package for Veryl, a modern hardware description language (HDL) that aims for an alternative to SystemVerilog.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@dalance I am happy if you are willing to join the maintainers of this package. Your thought?