### PR TITLE
python310Packages.django-maintenance-mode: fix build

### DIFF
--- a/pkgs/development/python-modules/django-maintenance-mode/default.nix
+++ b/pkgs/development/python-modules/django-maintenance-mode/default.nix
@@ -1,9 +1,10 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , buildPythonPackage
-, pytest
 , django
 , python-fsutil
+, python
 , pythonOlder
 }:
 
@@ -21,18 +22,26 @@ buildPythonPackage rec {
     hash = "sha256-Mcj8O20hCINGf5T3PCG9jq0onSrm4R+Ke5CLMqMDmuU=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "fix-broken-test.patch";
+      url = "https://github.com/fabiocaccamo/django-maintenance-mode/commit/68cde8d9ceef00eeaa2068f420698c1c562fa9fc.patch";
+      hash = "sha256-K/zYYkcnmWGc7Knz4l9PgvUtT0IccPRXc3UFriC1ldc=";
+    })
+  ];
+
   propagatedBuildInputs = [
     django
     python-fsutil
   ];
 
-  nativeCheckInputs = [
-    pytest
-  ];
+  checkPhase = ''
+    runHook preCheck
 
-  pythonImportsCheck = [
-    "maintenance_mode"
-  ];
+    ${python.interpreter} runtests.py
+
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "Shows a 503 error page when maintenance-mode is on";


### PR DESCRIPTION
###### Description of changes

It can't be tested using pythonImportsCheck because it can't be imported without being inside of a Django app.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
