### PR TITLE
Revert "lemmy: Support secret options"

### DIFF
--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -77,11 +77,6 @@ in
       };
     };
 
-    secretFile = mkOption {
-      type = with types; nullOr path;
-      default = null;
-      description = lib.mdDoc "Path to a secret JSON configuration file which is merged at runtime with the one generated from {option}`services.lemmy.settings`.";
-    };
   };
 
   config =
@@ -202,14 +197,11 @@ in
         }
       ];
 
-      systemd.services.lemmy = let
-        configFile = settingsFormat.generate "config.hjson" cfg.settings;
-        mergedConfig = "/run/lemmy/config.hjson";
-      in {
+      systemd.services.lemmy = {
         description = "Lemmy server";
 
         environment = {
-          LEMMY_CONFIG_LOCATION = if cfg.secretFile == null then configFile else mergedConfig;
+          LEMMY_CONFIG_LOCATION = "${settingsFormat.generate "config.hjson" cfg.settings}";
           LEMMY_DATABASE_URL = if cfg.database.uri != null then cfg.database.uri else (mkIf (cfg.database.createLocally) "postgres:///lemmy?host=/run/postgresql&user=lemmy");
         };
 
@@ -224,24 +216,10 @@ in
 
         requires = lib.optionals cfg.database.createLocally [ "postgresql.service" ];
 
-        path = mkIf (cfg.secretFile != null) [ pkgs.jq ];
-
-        # merge the two configs and prevent others from reading the result
-        # if somehow $CREDENTIALS_DIRECTORY is not set we fail
-        preStart = mkIf (cfg.secretFile != null) ''
-          set -u
-          umask 177
-          jq --slurp '.[0] * .[1]' ${lib.escapeShellArg configFile} "$CREDENTIALS_DIRECTORY/secretFile" > ${lib.escapeShellArg mergedConfig}
-        '';
-
         serviceConfig = {
           DynamicUser = true;
           RuntimeDirectory = "lemmy";
           ExecStart = "${cfg.server.package}/bin/lemmy_server";
-          LoadCredential = mkIf (cfg.secretFile != null) "secretFile:${toString cfg.secretFile}";
-          PrivateTmp = true;
-          MemoryDenyWriteExecute = true;
-          NoNewPrivileges = true;
         };
       };
 

--- a/nixos/tests/lemmy.nix
+++ b/nixos/tests/lemmy.nix
@@ -22,23 +22,15 @@ in
           # Without setup, the /feeds/* and /nodeinfo/* API endpoints won't return 200
           setup = {
             admin_username = "mightyiam";
+            admin_password = "ThisIsWhatIUseEverywhereTryIt";
             site_name = "Lemmy FTW";
             admin_email = "mightyiam@example.com";
           };
           # https://github.com/LemmyNet/lemmy/blob/50efb1d519c63a7007a07f11cc8a11487703c70d/crates/utils/src/settings/mod.rs#L52
           database.uri = "postgres:///lemmy?host=/run/postgresql&user=lemmy";
         };
-        secretFile = /etc/lemmy-config.hjson;
         caddy.enable = true;
       };
-
-      environment.etc."lemmy-config.hjson".text = ''
-        {
-          "setup": {
-            "admin_password": "ThisIsWhatIUseEverywhereTryIt"
-          }
-        }
-      '';
 
       networking.firewall.allowedTCPPorts = [ 80 ];
 
@@ -50,14 +42,8 @@ in
   testScript = ''
     server = ${lemmyNodeName}
 
-    with subtest("the merged config is secure"):
-        server.wait_for_unit("lemmy.service")
-        config_permissions = server.succeed("stat --format %A /run/lemmy/config.hjson").rstrip()
-        assert config_permissions == "-rw-------", f"merged config permissions {config_permissions} are insecure"
-        directory_permissions = server.succeed("stat --format %A /run/lemmy").rstrip()
-        assert directory_permissions[5] == directory_permissions[8] == "-", "merged config can be replaced"
-
     with subtest("the backend starts and responds"):
+        server.wait_for_unit("lemmy.service")
         server.wait_for_open_port(${toString backendPort})
         server.succeed("curl --fail localhost:${toString backendPort}/api/v3/site")
 


### PR DESCRIPTION
###### Description of changes

Revert "lemmy: Support secret options"

This reverts commit ee5cc38432031b66e7fe395b14235eeb4b2b0d6e (https://github.com/NixOS/nixpkgs/pull/239713).

Merging declarative NixOS configuration with out of store files is something that, afaik, we don't do anywhere else.
This breaks normal purity/reproducibility guarantees offered by the NixOS module system.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
