### PR TITLE
corsix-th: init at 0.66

### DIFF
--- a/pkgs/games/corsix-th/default.nix
+++ b/pkgs/games/corsix-th/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, doxygen
+, ffmpeg
+, freetype
+, lua
+, makeWrapper
+, SDL2
+, SDL2_mixer
+, timidity
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "corsix-th";
+  version = "0.66";
+
+  src = fetchFromGitHub {
+    owner = "CorsixTH";
+    repo = "CorsixTH";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-GsZU2FHcFRlwN3hnFTyQmUK6kJLwnarKDtvg+DDc+mk=";
+  };
+
+  luaEnv = lua.withPackages(p: with p; [ luafilesystem lpeg luasec luasocket ]);
+  nativeBuildInputs = [ cmake doxygen makeWrapper ];
+  buildInputs = [ ffmpeg freetype lua finalAttrs.luaEnv SDL2 SDL2_mixer timidity ];
+  cmakeFlags = [ "-Wno-dev" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/corsix-th \
+    --set LUA_PATH "$LUA_PATH" \
+    --set LUA_CPATH "$LUA_CPATH"
+  '';
+
+  meta = with lib; {
+    description = "A reimplementation of the 1997 Bullfrog business sim Theme Hospital.";
+    homepage = "https://corsixth.com/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hughobrien ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36457,6 +36457,8 @@ with pkgs;
 
   colobot = callPackage ../games/colobot { };
 
+  corsix-th = callPackage ../games/corsix-th { };
+
   enigma = callPackage ../games/enigma { };
 
   everspace = callPackage ../games/everspace { };


### PR DESCRIPTION
###### Description of changes
Introduce [Corsix-TH](https://corsixth.com/) an open source re-implementation of the Theme Hospital game engine. Note the original game assets are required to play (GoG work also).

Btw, it's €1.39 on [GoG](https://www.gog.com/en/game/theme_hospital) right now.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
