### PR TITLE
flood-for-transmission: init at 2023-11-17T12-46-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -711,6 +711,15 @@
     githubId = 20405311;
     name = "Aksh Gupta";
   };
+  al3xtjames = {
+    email = "nix@alextjam.es";
+    github = "al3xtjames";
+    githubId = 5672538;
+    name = "Alex James";
+    keys = [{
+      fingerprint = "F354 FFAB EA89 A49D 33ED  2590 4729 B829 AC5F CC72";
+    }];
+  };
   alanpearce = {
     email = "alan@alanpearce.eu";
     github = "alanpearce";

--- a/pkgs/applications/networking/p2p/flood-for-transmission/default.nix
+++ b/pkgs/applications/networking/p2p/flood-for-transmission/default.nix
@@ -1,3 +1,4 @@
+# To use this package, use: `services.transmission.webHome = pkgs.flood-for-transmission;`
 { lib
 , buildNpmPackage
 , fetchFromGitHub

--- a/pkgs/applications/networking/p2p/flood-for-transmission/default.nix
+++ b/pkgs/applications/networking/p2p/flood-for-transmission/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+}:
+
+buildNpmPackage rec {
+  pname = "flood-for-transmission";
+  version = "2023-11-17T12-46-13";
+
+  src = fetchFromGitHub {
+    owner = "johman10";
+    repo = pname;
+    rev = version;
+    hash = "sha256-TaLWhly/4hOigWY1XP7FmgN4LbrdLb79NQ47z5JiiYE=";
+  };
+
+  npmDepsHash = "sha256-PCeknfS81K8ttU4hV2D841tgQsGfIVaAOVIEDXe8fVQ=";
+
+  npmInstallFlags = [ "--legacy-peer-deps" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r public $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Flood clone for Transmission";
+    homepage = "https://github.com/johman10/flood-for-transmission";
+    maintainers = with maintainers; [ al3xtjames ];
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -35,7 +35,6 @@
 , enableCli ? true
 , installLib ? false
 , apparmorRulesFromClosure
-, extraAppArmorPaths ? []
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -136,7 +135,6 @@ stdenv.mkDerivation (finalAttrs: {
       rwk /tmp/tr_session_id_*,
 
       r $out/share/transmission/public_html/**,
-      ${lib.strings.concatMapStrings (x: "r ${x},\n") extraAppArmorPaths}
 
       include <local/bin.transmission-daemon>
     }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3864,6 +3864,8 @@ with pkgs;
 
   flood = callPackage ../applications/networking/p2p/flood { };
 
+  flood-for-transmission = callPackage ../applications/networking/p2p/flood-for-transmission { };
+
   font-config-info = callPackage ../tools/misc/font-config-info { };
 
   foxdot = with python3Packages; toPythonApplication foxdot;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This change packages [flood-for-transmission](https://github.com/johman10/flood-for-transmission), an alternative web UI for Transmission. It's a Transmission-specific clone of [Flood](https://github.com/jesec/flood). The `services.transmission.webHome` option has also been added. It can be used to override the original web UI:

```nix
{ pkgs, ... }:

{
  services.transmission.webHome = pkgs.flood-for-transmission;
}
```

The service takes care of adding the path in `services.transmission.webHome` to the AppArmor configuration, so this works without having to override `extraAppArmorPaths` in `pkgs.transmission` or `pkgs.transmission_4`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
