### PR TITLE
python3Packages.celery-singleton: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/celery-singleton/default.nix
+++ b/pkgs/development/python-modules/celery-singleton/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, buildPythonPackage
+, fetchpatch
+, fetchFromGitHub
+, poetry-core
+, celery
+, redis
+, pytestCheckHook
+, pytest-celery
+}:
+
+buildPythonPackage rec {
+  pname = "celery-singleton";
+  version = "0.3.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "steinitzu";
+    repo = "celery-singleton";
+    rev = version;
+    hash = "sha256-fHlakxxjYIADELZdxIj6rvsZ/+1QfnKvAg3w5cdzvDc=";
+  };
+
+  postPatch = ''
+    # Disable coverage reporting in tests
+    substituteInPlace setup.cfg \
+      --replace "--cov" "" \
+      --replace "--no-cov-on-fail" ""
+  '';
+
+  patches = [
+    # chore(poetry): use poetry-core
+    # https://github.com/steinitzu/celery-singleton/pull/54
+    (fetchpatch {
+      name = "use-poetry-core.patch";
+      url = "https://github.com/steinitzu/celery-singleton/pull/54/commits/634a001c92a1dff1fae513fc95d733ea9b87e4cf.patch";
+      hash = "sha256-lXN4khwyL96pWyBS+iuSkGEkegv4HxYtym+6JUcPa94=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    celery
+    redis
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-celery
+  ];
+
+  pytestFlagsArray = [ "tests" ];
+
+  # Tests require a running Redis backend
+  disabledTests = [
+    "TestLock"
+    "TestUnlock"
+    "TestClear"
+    "TestSimpleTask"
+    "TestRaiseOnDuplicateConfig"
+    "TestUniqueOn"
+  ];
+
+  pythonImportsCheck = [ "celery_singleton" ];
+
+  meta = with lib; {
+    description = "Seamlessly prevent duplicate executions of celery tasks";
+    homepage = "https://github.com/steinitzu/celery-singleton";
+    changelog = "https://github.com/steinitzu/celery-singleton/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1707,6 +1707,8 @@ self: super: with self; {
 
   celery-redbeat = callPackage ../development/python-modules/celery-redbeat { };
 
+  celery-singleton = callPackage ../development/python-modules/celery-singleton { };
+
   cement = callPackage ../development/python-modules/cement { };
 
   cemm = callPackage ../development/python-modules/cemm { };


### PR DESCRIPTION
###### Description of changes

Part of the effort of merging this PR https://github.com/NixOS/nixpkgs/pull/236877

Initial work of packaging this python module done by @RaitoBezarius . Enabled some extra pytests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
