### PR TITLE
lomiri.geonames: init at 0.3.0

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -10,6 +10,7 @@ let
     #### Development tools / libraries
     cmake-extras = callPackage ./development/cmake-extras { };
     deviceinfo = callPackage ./development/deviceinfo { };
+    geonames = callPackage ./development/geonames { };
     gmenuharness = callPackage ./development/gmenuharness { };
     lomiri-api = callPackage ./development/lomiri-api { };
   };

--- a/pkgs/desktops/lomiri/development/geonames/default.nix
+++ b/pkgs/desktops/lomiri/development/geonames/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, fetchpatch
 , gitUpdater
 , testers
 , buildPackages
@@ -38,13 +39,18 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
+  patches = [
+    # Improves install locations of demo & docs
+    # Remove when https://gitlab.com/ubports/development/core/geonames/-/merge_requests/3 merged & in release
+    (fetchpatch {
+      name = "0001-geonames-Use-GNUInstallDirs-more.patch";
+      url = "https://gitlab.com/OPNA2608/geonames/-/commit/e64a391fc213b2629da1c8bbf975fd62a2973c51.patch";
+      hash = "sha256-HPYDtIy1WUrZLPzvKh4aezrT/LniZkNX+PeQ9YB85RY=";
+    })
+  ];
+
   postPatch = ''
     patchShebangs src/generate-locales.sh tests/setup-test-env.sh
-
-    substituteInPlace doc/reference/CMakeLists.txt \
-      --replace "\''${CMAKE_INSTALL_DATADIR}/gtk-doc/html/\''${PROJECT_NAME}" "\''${CMAKE_INSTALL_DOCDIR}"
-    substituteInPlace demo/CMakeLists.txt \
-      --replace 'RUNTIME DESTINATION bin' 'RUNTIME DESTINATION ''${CMAKE_INSTALL_BINDIR}'
   '';
 
   strictDeps = true;

--- a/pkgs/desktops/lomiri/development/geonames/default.nix
+++ b/pkgs/desktops/lomiri/development/geonames/default.nix
@@ -1,0 +1,117 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, testers
+, buildPackages
+, cmake
+, docbook-xsl-nons
+, docbook_xml_dtd_45
+, gettext
+, glib
+, glibcLocales
+, withExamples ? true
+, gtk3
+# Uses gtkdoc-scan* tools, which produces a binary linked against lib for hostPlatform and executes it to generate docs
+, withDocumentation ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
+, gtk-doc
+, pkg-config
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "geonames";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/geonames";
+    rev = finalAttrs.version;
+    hash = "sha256-Mo7Khj2pgdJ9kT3npFXnh1WTSsY/B1egWTccbAXFNY8=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ] ++ lib.optionals withExamples [
+    "bin"
+  ] ++ lib.optionals withDocumentation [
+    "doc"
+  ];
+
+  postPatch = ''
+    patchShebangs src/generate-locales.sh tests/setup-test-env.sh
+
+    substituteInPlace doc/reference/CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_DATADIR}/gtk-doc/html/\''${PROJECT_NAME}" "\''${CMAKE_INSTALL_DOCDIR}"
+    substituteInPlace demo/CMakeLists.txt \
+      --replace 'RUNTIME DESTINATION bin' 'RUNTIME DESTINATION ''${CMAKE_INSTALL_BINDIR}'
+  '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    # Built for hostPlatform, executed during build
+    substituteInPlace src/CMakeLists.txt \
+      --replace 'COMMAND mkdb' 'COMMAND ${stdenv.hostPlatform.emulator buildPackages} mkdb'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    glib # glib-compile-resources
+    pkg-config
+  ] ++ lib.optionals withDocumentation [
+    docbook-xsl-nons
+    docbook_xml_dtd_45
+    gtk-doc
+  ];
+
+  buildInputs = [
+    glib
+  ] ++ lib.optionals withExamples [
+    gtk3
+  ];
+
+  # Tests need to be able to check locale
+  LC_ALL = lib.optionalString finalAttrs.doCheck "en_US.UTF-8";
+  nativeCheckInputs = [
+    glibcLocales
+  ];
+
+  makeFlags = [
+    # gtkdoc-scan runs ld, can't find qsort & strncpy symbols
+    "LD=${stdenv.cc.targetPrefix}cc"
+  ];
+
+  cmakeFlags = [
+    "-DWANT_DOC=${lib.boolToString withDocumentation}"
+    "-DWANT_DEMO=${lib.boolToString withExamples}"
+    "-DWANT_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    # Keeps finding & using glib-compile-resources from buildInputs otherwise
+    "-DCMAKE_PROGRAM_PATH=${lib.makeBinPath [ buildPackages.glib.dev ]}"
+  ];
+
+  preInstall = lib.optionalString withDocumentation ''
+    # gtkdoc-mkhtml generates images without write permissions, errors out during install
+    chmod +w doc/reference/html/*
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Parse and query the geonames database dump";
+    homepage = "https://gitlab.com/ubports/development/core/geonames";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.all;
+    # Cross requires hostPlatform emulation during build
+    # https://gitlab.com/ubports/development/core/geonames/-/issues/1
+    broken = stdenv.buildPlatform != stdenv.hostPlatform && !stdenv.hostPlatform.emulatorAvailable buildPackages;
+    pkgConfigModules = [
+      "geonames"
+    ];
+  };
+})


### PR DESCRIPTION
###### Description of changes

Working towards #99090.

[Geonames](https://gitlab.com/ubports/development/core/geonames), a library for parsing and querying a local copy of the geonames.org database. Required by Lomiri & some of its system applications.

Cross-compilation is known-broken without some hostPlatform emulation: https://gitlab.com/ubports/development/core/geonames/-/issues/1. I've used `stdenv.hostPlatform.emulator buildPackages` to make at least `aarch64-linux` and `armv7l-linux` cross work. Upstream issue also mentions glibc -> musl cross for same buildPlatform being broken, but that fails much earlier in some dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
