### PR TITLE
lomiri.deviceinfo: init at 0.2.0

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -9,6 +9,7 @@ let
   in {
     #### Development tools / libraries
     cmake-extras = callPackage ./development/cmake-extras { };
+    deviceinfo = callPackage ./development/deviceinfo { };
     gmenuharness = callPackage ./development/gmenuharness { };
     lomiri-api = callPackage ./development/lomiri-api { };
   };

--- a/pkgs/desktops/lomiri/development/deviceinfo/default.nix
+++ b/pkgs/desktops/lomiri/development/deviceinfo/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, testers
+, cmake
+, pkg-config
+, cmake-extras
+, gtest
+, yaml-cpp
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "deviceinfo";
+  version = "0.1.1";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/deviceinfo";
+    rev = finalAttrs.version;
+    hash = "sha256-LiMExXB3x8N/+hkAXzO2uytAjRGpQneJVTbPQBzonKk=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "bin"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    yaml-cpp
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DDISABLE_TESTS=${lib.boolToString (!finalAttrs.doCheck)}"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Library to detect and configure devices";
+    homepage = "https://gitlab.com/ubports/development/core/deviceinfo";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    mainProgram = "device-info";
+    pkgConfigModules = [
+      "deviceinfo"
+    ];
+  };
+})

--- a/pkgs/desktops/lomiri/development/deviceinfo/default.nix
+++ b/pkgs/desktops/lomiri/development/deviceinfo/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "deviceinfo";
-  version = "0.1.1";
+  version = "0.2.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/deviceinfo";
     rev = finalAttrs.version;
-    hash = "sha256-LiMExXB3x8N/+hkAXzO2uytAjRGpQneJVTbPQBzonKk=";
+    hash = "sha256-oKuX9JbYWIjroKgA2Y+/oqPkC26DPy3e6yHFU8mmbxQ=";
   };
 
   outputs = [


### PR DESCRIPTION
###### Description of changes

Working towards #99090.

[Deviceinfo](https://gitlab.com/ubports/development/core/deviceinfo), a library to detect and configure devices. Required by Lomiri & some of its system services.

~~0.2.0 bump not yet tested with the rest of Lomiri.~~ Bump seems fine, leaving it in.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
