### PR TITLE
cups-brother-hl2260d: init at 3.2.0-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16812,6 +16812,12 @@
     githubId = 1983821;
     name = "Eric Wolf";
   };
+  u2x1 = {
+    email = "u2x1@outlook.com";
+    github = "u2x1";
+    githubId = 30677291;
+    name = "u2x1";
+  };
   uakci = {
     name = "uakci";
     email = "uakci@uakci.pl";

--- a/pkgs/misc/cups/drivers/hl2260d/default.nix
+++ b/pkgs/misc/cups/drivers/hl2260d/default.nix
@@ -1,0 +1,89 @@
+{ lib, stdenv, fetchurl, cups, dpkg, gnused, makeWrapper, ghostscript, coreutils, perl, gnugrep, which
+, debugLvl ? "0"
+}:
+
+let
+  version = "3.2.0-1";
+  lprdeb = fetchurl {
+    url = "https://download.brother.com/welcome/dlf102692/hl2260dlpr-${version}.i386.deb";
+    hash = "sha256-R+cM2SKc/MP6keo3PUrKXPC6a2dEQQdBunrpNtAHlH0=";
+  };
+
+  cupsdeb = fetchurl {
+    url = "https://download.brother.com/welcome/dlf102693/hl2260dcupswrapper-${version}.i386.deb";
+    hash = "sha256-k6+ulZVoFTpEY6WJ9TO9Rzp2c4dwPqL3NY5/XYJpvOc=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "cups-brother-hl2260d";
+  inherit version;
+
+  nativeBuildInputs = [ makeWrapper dpkg ];
+  buildInputs = [ cups ghostscript perl ];
+
+  dontPatchELF = true;
+  dontBuild = true;
+
+  unpackPhase = ''
+    mkdir -p $out
+    dpkg-deb -x ${cupsdeb} $out
+    dpkg-deb -x ${lprdeb} $out
+  '';
+
+  patchPhase = ''
+    # Patch lpr
+    INFDIR=$out/opt/brother/Printers/HL2260D/inf
+    LPDDIR=$out/opt/brother/Printers/HL2260D/lpd
+
+    substituteInPlace $LPDDIR/filter_HL2260D \
+      --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$out/opt/brother/Printers/HL2260D\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"HL2260D\"; #"
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $INFDIR/braddprinter
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/brprintconflsr3
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/rawtobr3
+
+    # Patch cupswrapper
+    WRAPPER=$out/opt/brother/Printers/HL2260D/cupswrapper/brother_lpdwrapper_HL2260D
+    PAPER_CFG=$out/opt/brother/Printers/HL2260D/cupswrapper/paperconfigml1
+
+    substituteInPlace $WRAPPER \
+      --replace "basedir =~" "basedir = \"$out/opt/brother/Printers/HL2260D\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"HL2260D\"; #" \
+      --replace "\$DEBUG=0;" "\$DEBUG=${debugLvl};"
+    substituteInPlace $WRAPPER \
+      --replace "\`cp " "\`cp -p " \
+      --replace "\$TEMPRC\`" "\$TEMPRC; chmod a+rw \$TEMPRC\`" \
+      --replace "\`mv " "\`cp -p "
+    # This config script make this assumption that the *.ppd are found in a global location `/etc/cups/ppd`.
+    substituteInPlace $PAPER_CFG \
+      --replace "/etc/cups/ppd" "$out/share/cups/model"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/cups/model
+    ln -s $out/opt/brother/Printers/HL2260D/cupswrapper/brother-HL2260D-cups-en.ppd $out/share/cups/model
+
+    mkdir -p $out/lib/cups/filter/
+    makeWrapper \
+      $out/opt/brother/Printers/HL2260D/cupswrapper/brother_lpdwrapper_HL2260D \
+      $out/lib/cups/filter/brother_lpdwrapper_HL2260D \
+      --prefix PATH : ${lib.makeBinPath [coreutils gnugrep gnused]}
+
+    wrapProgram $out/opt/brother/Printers/HL2260D/lpd/filter_HL2260D \
+      --prefix PATH ":" ${ lib.makeBinPath [ ghostscript which ] }
+    '';
+
+  meta = with lib; {
+    homepage = "http://www.brother.com/";
+    description = "Brother HL-2260D printer driver";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    downloadPage = "https://support.brother.com/g/b/downloadtop.aspx?c=cn_ot&lang=en&prod=hl2260d_cn";
+    maintainers = with maintainers; [ u2x1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39407,6 +39407,8 @@ with pkgs;
 
   cups-brother-hl1210w = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1210w { };
 
+  cups-brother-hl2260d = pkgsi686Linux.callPackage ../misc/cups/drivers/hl2260d { };
+
   cups-brother-hl3140cw = pkgsi686Linux.callPackage ../misc/cups/drivers/hl3140cw { };
 
   cups-brother-hll2340dw = pkgsi686Linux.callPackage  ../misc/cups/drivers/hll2340dw { };


### PR DESCRIPTION
###### Description of changes

This commit adds a driver to cups for the Brother HL2260D printer.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

This package is based on [`brgenml1cupswrapper`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/misc/cups/drivers/brgenml1cupswrapper/default.nix) and [`brgenml1lpr`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/misc/cups/drivers/brgenml1lpr/default.nix), and merged into a single Nix file.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
