### PR TITLE
passage: use getopt from nix on darwin

### DIFF
--- a/pkgs/tools/security/passage/darwin-getopt-path.patch
+++ b/pkgs/tools/security/passage/darwin-getopt-path.patch
@@ -1,0 +1,12 @@
+diff --git a/src/platform/darwin.sh b/src/platform/darwin.sh
+index 9a1fda8..4f7ce3d 100644
+--- a/src/platform/darwin.sh
++++ b/src/platform/darwin.sh
+@@ -39,6 +39,6 @@ qrcode() {
+ 	fi
+ }
+ 
+-GETOPT="$({ test -x /usr/local/opt/gnu-getopt/bin/getopt && echo /usr/local/opt/gnu-getopt; } || brew --prefix gnu-getopt 2>/dev/null || { command -v port &>/dev/null && echo /opt/local; } || echo /usr/local)/bin/getopt"
++GETOPT="@GETOPT@"
+ SHRED="srm -f -z"
+ BASE64="openssl base64"

--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     sha256 = "1val8wl9kzlxj4i1rrh2iiyf97w9akffvr0idvbkdb09hfzz4lz8";
   };
 
-  patches = lib.optional stdenv.isDarwin [
+  patches = [
     (substituteAll {
       src = ./darwin-getopt-path.patch;
       GETOPT = "${getopt}/bin/getopt";

--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -2,8 +2,10 @@
 , stdenv
 , fetchFromGitHub
 , makeBinaryWrapper
+, substituteAll
 , bash
 , age
+, getopt
 , git ? null
 , xclip ? null
 # Used to pretty-print list of all stored passwords, but is not needed to fetch
@@ -21,6 +23,13 @@ stdenv.mkDerivation {
     rev = "1262d308f09db9b243513a428ab4b8fb1c30d31d";
     sha256 = "1val8wl9kzlxj4i1rrh2iiyf97w9akffvr0idvbkdb09hfzz4lz8";
   };
+
+  patches = lib.optional stdenv.isDarwin [
+    (substituteAll {
+      src = ./darwin-getopt-path.patch;
+      GETOPT = "${getopt}/bin/getopt";
+    })
+  ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 


### PR DESCRIPTION
This patches a hack from upstream which hard-codes a bunch of paths to find gnu-getopt (as opposed to darwins getopt in /usr/bin/getopt).

This lets nix-built passage fail on systems which don't have one of those already installed (i.e. from homebrew).

As upstream seemingly doesn't provide a way to override this easily yet, we do it ourselves.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
