### PR TITLE
python3Packages.django-cachalot: init at 2.5.3

### DIFF
--- a/pkgs/development/python-modules/django-cachalot/default.nix
+++ b/pkgs/development/python-modules/django-cachalot/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, django
+, django-debug-toolbar
+, psycopg2
+, beautifulsoup4
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "django-cachalot";
+  version = "2.5.3";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "noripyt";
+    repo = "django-cachalot";
+    rev = "v${version}";
+    hash = "sha256-ayAN+PgK3aIpt4R8aeC6c6mRGTnfObycmkoXPTjx4WI=";
+  };
+
+  patches = [
+    # Disable tests for unsupported caching and database types which would
+    # require additional running backends
+    ./disable-unsupported-tests.patch
+  ];
+
+  propagatedBuildInputs = [
+    django
+  ];
+
+  checkInputs = [
+    beautifulsoup4
+    django-debug-toolbar
+    psycopg2
+  ];
+
+  pythonImportsCheck = [ "cachalot" ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} runtests.py
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "No effort, no worry, maximum performance";
+    homepage = "https://github.com/noripyt/django-cachalot";
+    changelog = "https://github.com/noripyt/django-cachalot/blob/${src.rev}/CHANGELOG.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/python-modules/django-cachalot/disable-unsupported-tests.patch
+++ b/pkgs/development/python-modules/django-cachalot/disable-unsupported-tests.patch
@@ -1,0 +1,65 @@
+diff --git a/cachalot/tests/models.py b/cachalot/tests/models.py
+index 8c48640..817602c 100644
+--- a/cachalot/tests/models.py
++++ b/cachalot/tests/models.py
+@@ -77,11 +77,6 @@ class PostgresModel(Model):
+     date_range = DateRangeField(null=True, blank=True)
+     datetime_range = DateTimeRangeField(null=True, blank=True)
+ 
+-    class Meta:
+-        # Tests schema name in table name.
+-        db_table = '"public"."cachalot_postgresmodel"'
+-
+-
+ class UnmanagedModel(Model):
+     name = CharField(max_length=50)
+ 
+diff --git a/settings.py b/settings.py
+index 19d7560..7095367 100644
+--- a/settings.py
++++ b/settings.py
+@@ -8,18 +8,9 @@ DATABASES = {
+         'ENGINE': 'django.db.backends.sqlite3',
+         'NAME': 'cachalot.sqlite3',
+     },
+-    'postgresql': {
+-        'ENGINE': 'django.db.backends.postgresql',
+-        'NAME': 'cachalot',
+-        'USER': 'cachalot',
+-        'PASSWORD': 'password',
+-        'HOST': '127.0.0.1',
+-    },
+-    'mysql': {
+-        'ENGINE': 'django.db.backends.mysql',
+-        'NAME': 'cachalot',
+-        'USER': 'root',
+-        'HOST': '127.0.0.1',
++    'test': {
++        'ENGINE': 'django.db.backends.sqlite3',
++        'NAME': ':memory:',
+     },
+ }
+ if 'MYSQL_PASSWORD' in os.environ:
+@@ -36,22 +27,6 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+ DATABASE_ROUTERS = ['cachalot.tests.db_router.PostgresRouter']
+ 
+ CACHES = {
+-    'redis': {
+-        'BACKEND': 'django_redis.cache.RedisCache',
+-        'LOCATION': 'redis://127.0.0.1:6379/0',
+-        'OPTIONS': {
+-            # Since we are using both Python 2 & 3 in tests, we need to use
+-            # a compatible pickle version to avoid unpickling errors when
+-            # running a Python 2 test after a Python 3 test.
+-            'PICKLE_VERSION': 2,
+-        },
+-    },
+-    'memcached': {
+-        'BACKEND': 'django.core.cache.backends.memcached.'
+-                   + ('PyMemcacheCache' if __DJ_V[0] > 2
+-                      and (__DJ_V[1] > 1 or __DJ_V[0] > 3) else 'MemcachedCache'),
+-        'LOCATION': '127.0.0.1:11211',
+-    },
+     'locmem': {
+         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+         'OPTIONS': {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2699,6 +2699,8 @@ self: super: with self; {
 
   django-bootstrap4 = callPackage ../development/python-modules/django-bootstrap4 { };
 
+  django-cachalot = callPackage ../development/python-modules/django-cachalot { };
+
   django-cache-url = callPackage ../development/python-modules/django-cache-url { };
 
   django-cacheops = callPackage ../development/python-modules/django-cacheops { };


### PR DESCRIPTION
###### Description of changes

Part of the effort of merging this PR https://github.com/NixOS/nixpkgs/pull/236877

Initial work of packaging this python module done by @RaitoBezarius . Enabled some extra tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
