### PR TITLE
Enable Darwin for fdm and fix tdb install name

### DIFF
--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://samba/tdb/${pname}-${version}.tar.gz";
-    sha256 = "sha256-hDTJyFfRPOP6hGb3VgHyXDaTZ2s2kZ8VngrWEhuvXOg=";
+    hash = "sha256-hDTJyFfRPOP6hGb3VgHyXDaTZ2s2kZ8VngrWEhuvXOg=";
   };
 
   nativeBuildInputs = [
@@ -47,6 +47,10 @@ stdenv.mkDerivation rec {
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
   ];
+
+  postFixup = if stdenv.isDarwin
+    then ''install_name_tool -id $out/lib/libtdb.dylib $out/lib/libtdb.dylib''
+    else null;
 
   # python-config from build Python gives incorrect values when cross-compiling.
   # If python-config is not found, the build falls back to using the sysconfig

--- a/pkgs/tools/networking/fdm/default.nix
+++ b/pkgs/tools/networking/fdm/default.nix
@@ -8,17 +8,16 @@ stdenv.mkDerivation rec {
     owner = "nicm";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Gqpz+N1ELU5jQpPJAG9s8J9UHWOJNhkT+s7+xuQazd0=";
+    hash = "sha256-Gqpz+N1ELU5jQpPJAG9s8J9UHWOJNhkT+s7+xuQazd0=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ openssl tdb zlib flex bison ];
 
-
   meta = with lib; {
     description = "Mail fetching and delivery tool - should do the job of getmail and procmail";
     maintainers = with maintainers; [ raskin ];
-    platforms = with platforms; linux;
+    platforms = with platforms; linux ++ darwin;
     homepage = "https://github.com/nicm/fdm";
     downloadPage = "https://github.com/nicm/fdm/releases";
     license = licenses.isc;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**In Brief:**
This PR proposes changes to fix the install name for libtdb on darwin, adds the darwin platform for fdm and modernizes the packages by replacing `sha256` with `hash`.

**In Detail:**
I noticed an issue with libtdb on darwin while trying out fdm:
```sh
% fdm --help
dyld[80413]: Library not loaded: /private/tmp/nix-build-tdb-1.4.8.drv-0/tdb-1.4.8/bin/default/libtdb.inst.dylib
  Referenced from: <no uuid> /nix/store/c1nbf4cxfpp16xf87ar114ngcz13dj5c-fdm-2.2/bin/fdm
  Reason: tried: '/private/tmp/nix-build-tdb-1.4.8.drv-0/tdb-1.4.8/bin/default/libtdb.inst.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/private/tmp/nix-build-tdb-1.4.8.drv-0/tdb-1.4.8/bin/default/libtdb.inst.dylib' (no such file), '/private/tmp/nix-build-tdb-1.4.8.drv-0/tdb-1.4.8/bin/default/libtdb.inst.dylib' (no such file), '/usr/local/lib/libtdb.inst.dylib' (no such file), '/usr/lib/libtdb.inst.dylib' (no such file, not in dyld cache)
```

It seems the fdm references a libtdb path only available at build time. When displaying the names and versions of the shared libraries used by fdm, the libtdb entry shows a a temporary path instead of one in /nix/store
```sh
% otool -L `which fdm`
/nix/store/c1nbf4cxfpp16xf87ar114ngcz13dj5c-fdm-2.2/bin/fdm:
        /nix/store/kk0kcj5hnysillzkgqg8bin04s0my00h-openssl-3.0.9/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /nix/store/kk0kcj5hnysillzkgqg8bin04s0my00h-openssl-3.0.9/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /nix/store/ddkvnii8s4avzwfjr2gz3lqz8gldq2bv-zlib-1.2.13/lib/libz.dylib (compatibility version 1.0.0, current version 1.2.13)
        /private/tmp/nix-build-tdb-1.4.8.drv-0/tdb-1.4.8/bin/default/libtdb.inst.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
% otool -D /nix/store/1ppp2l8ky0714wd6pwc940x6zx0aqk74-tdb-1.4.8/lib/libtdb.dylib
/nix/store/1ppp2l8ky0714wd6pwc940x6zx0aqk74-tdb-1.4.8/lib/libtdb.dylib:
/private/tmp/nix-build-tdb-1.4.8.drv-0/tdb-1.4.8/bin/default/libtdb.inst.dylib
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
