### PR TITLE
millipixels: init at 0.22.0

### DIFF
--- a/pkgs/by-name/mi/millipixels/package.nix
+++ b/pkgs/by-name/mi/millipixels/package.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, glib
+, meson
+, ninja
+, pkg-config
+, rustc
+, libbsd
+, libcamera
+, gtk3
+, libtiff
+, zbar
+, libjpeg
+, libexif
+, libraw
+, libpulseaudio
+, ffmpeg-headless
+, v4l-utils
+, makeWrapper
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "millipixels";
+  version = "0.22.0";
+
+  src = fetchFromGitLab {
+    owner = "Librem5";
+    repo = pname;
+    rev = "v${version}";
+    domain = "source.puri.sm";
+    hash = "sha256-pRREQRYyD9+dpRvcfsNiNthFy08Yeup9xDn+x+RWDrE=";
+  };
+
+  nativeBuildInputs = [
+    glib
+    meson
+    ninja
+    pkg-config
+    rustc
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libbsd
+    libcamera
+    gtk3
+    libtiff
+    zbar
+    libpulseaudio
+    libraw
+    libexif
+    libjpeg
+    python3
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/millipixels \
+      --prefix PATH : ${lib.makeBinPath [ v4l-utils ffmpeg-headless ]}
+  '';
+
+  meta = with lib; {
+    description = "Camera application for the Librem 5";
+    homepage = "https://source.puri.sm/Librem5/millipixels";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ _999eagle ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Description of changes

This adds millipixels, a fork of megapixels for the Librem 5.

Upstream repository: https://source.puri.sm/Librem5/millipixels

Tested on my Librem 5 with https://git.catgirl.cloud/999eagle/nix-librem5/ which is based on https://github.com/NixOS/nixos-hardware/pull/557. Additionally, millipixels requires a kernel built with `CMA_SIZE_MBYTES = "320"` (instead of NixOS' default value of 32) but I don't know whether this requirement can be declared in this package.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
