### PR TITLE
lomiri.libusermetrics: init at 1.3.0

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -11,6 +11,7 @@ let
     cmake-extras = callPackage ./development/cmake-extras { };
     deviceinfo = callPackage ./development/deviceinfo { };
     gmenuharness = callPackage ./development/gmenuharness { };
+    libusermetrics = callPackage ./development/libusermetrics { };
     lomiri-api = callPackage ./development/lomiri-api { };
   };
 in

--- a/pkgs/desktops/lomiri/development/libusermetrics/default.nix
+++ b/pkgs/desktops/lomiri/development/libusermetrics/default.nix
@@ -1,0 +1,129 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, testers
+, cmake
+, cmake-extras
+, dbus
+, doxygen
+, gsettings-qt
+, gtest
+, intltool
+, json-glib
+, libapparmor
+, libqtdbustest
+, pkg-config
+, qdjango
+, qtbase
+, qtdeclarative
+, qtxmlpatterns
+, ubports-click
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libusermetrics";
+  version = "1.3.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/libusermetrics";
+    rev = finalAttrs.version;
+    hash = "sha256-yO9wZcXJBKt1HZ1GKoQ1flqYuwW9PlXiWLE3bl21PSQ=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  postPatch = ''
+    substituteInPlace data/CMakeLists.txt \
+      --replace '/etc' "$out/etc"
+
+    # Tries to query QMake for QT_INSTALL_QML variable, would return broken paths into /build/qtbase-<commit> even if qmake was available
+    substituteInPlace src/modules/UserMetrics/CMakeLists.txt \
+      --replace "\''${QT_IMPORTS_DIR}/UserMetrics" '${placeholder "out"}/${qtbase.qtQmlPrefix}/UserMetrics'
+
+    substituteInPlace src/libusermetricsinput/CMakeLists.txt \
+      --replace 'RUNTIME DESTINATION bin' 'RUNTIME DESTINATION ''${CMAKE_INSTALL_BINDIR}'
+
+    substituteInPlace doc/CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_DATAROOTDIR}/doc/libusermetrics-doc" "\''${CMAKE_INSTALL_DOCDIR}"
+  '' + lib.optionalString (!finalAttrs.doCheck) ''
+    # Only needed by tests
+    sed -i -e '/QTDBUSTEST/d' CMakeLists.txt
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    intltool
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    cmake-extras
+    gsettings-qt
+    json-glib
+    libapparmor
+    qdjango
+    qtxmlpatterns
+    ubports-click
+
+    # Plugin
+    qtbase
+  ];
+
+  nativeCheckInputs = [
+    dbus
+  ];
+
+  checkInputs = [
+    gtest
+    libqtdbustest
+    qtdeclarative
+  ];
+
+  cmakeFlags = [
+    "-DGSETTINGS_LOCALINSTALL=ON"
+    "-DGSETTINGS_COMPILE=ON"
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  checkPhase = ''
+    runHook preCheck
+
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/lib/qt-${qtbase.version}/plugins/
+    export QML2_IMPORT_PATH=${lib.getBin qtdeclarative}/lib/qt-${qtbase.version}/qml/
+    dbus-run-session --config-file=${dbus}/share/dbus-1/session.conf -- \
+      make test "''${enableParallelChecking:+-j $NIX_BUILD_CORES}"
+
+    runHook postCheck
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Enables apps to locally store interesting numerical data for later presentation";
+    homepage = "https://gitlab.com/ubports/development/core/libusermetrics";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    mainProgram = "usermetricsinput";
+    pkgConfigModules = [
+      "libusermetricsinput-1"
+      "libusermetricsoutput-1"
+    ];
+  };
+})


### PR DESCRIPTION
###### Description of changes

Working towards #99090.

[Libusermetrics](https://gitlab.com/ubports/development/core/libusermetrics), enables apps to locally store interesting numerical data for later presentation. Required by Lomiri & some of its system services & core applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
