### PR TITLE
ncurses: provide pkg-config alias files for libtinfo / libtic

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -139,6 +139,13 @@ stdenv.mkDerivation (finalAttrs: {
       done
     done
 
+    # add pkg-config aliases for libraries that are built-in to libncurses(w)
+    for library in tinfo tic; do
+      for suffix in "" w; do
+        ln -svf ncurses$suffix.pc $dev/lib/pkgconfig/$library$suffix.pc
+      done
+    done
+
     # move some utilities to $bin
     # these programs are used at runtime and don't really belong in $dev
     moveToOutput "bin/clear" "$out"


### PR DESCRIPTION
###### Description of changes

Some build scripts (e.g. [u-boot tools](https://github.com/u-boot/u-boot/blob/afdfcb11f97cc6d96cb8cca10e35960b54466364/tools/Makefile#L202)) look for pkg-config configuration for libtinfo specifically. The way ncurses is configured for nixpkgs, libtinfo and libtic functionality is provided by libncursesw, so alias the pkg-config .pc with some symlinks.

Inspired-by: https://gitlab.archlinux.org/archlinux/packaging/packages/ncurses/-/blob/3c2606603aa4a5a3b2d29e560a1bc14986153f49/PKGBUILD#L82

Tested: built enough stuff to be able to cross-build u-boot (which includes: Python 3, gdb, picocom, etc.)

Alternative option: we could build a split libtinfo/libtic (--with-termlib) like e.g. Debian or Gentoo are doing, but then that means we need to fixup the .pc files for ncursesw since a bunch of software isn't properly differentiating between ncursesw and libtinfo and use the wrong lib flags. That seems like a bunch of pain, Debian does it, I don't think it's worth it, but I also have a grand total of 15min of experience with this derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
