### PR TITLE
prettierd: init at 0.23.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11211,6 +11211,16 @@
     githubId = 22817873;
     name = "Ember Keske";
   };
+  n3oney = {
+    name = "Michał Minarowski";
+    email = "nixpkgs@neoney.dev";
+    github = "n3oney";
+    githubId = 30625554;
+    matrix = "@neoney:matrix.org";
+    keys = [{
+      fingerprint = "9E6A 25F2 C1F2 9D76 ED00  1932 1261 173A 01E1 0298";
+    }];
+  };
   nadrieril = {
     email = "nadrieril@gmail.com";
     github = "Nadrieril";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11786,9 +11786,10 @@
   };
   NotAShelf = {
     name = "NotAShelf";
-    email = "itsashelf@gmail.com";
+    email = "raf@notashelf.dev";
     github = "NotAShelf";
     githubId = 62766066;
+    matrix = "@raf:notashelf.dev";
   };
   notbandali = {
     name = "Amin Bandali";

--- a/pkgs/development/tools/prettierd/default.nix
+++ b/pkgs/development/tools/prettierd/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, mkYarnPackage
+, fetchFromGitHub
+, makeWrapper
+, nodejs
+, fetchYarnDeps
+,
+}:
+mkYarnPackage rec {
+  pname = "prettierd";
+  version = "0.23.4";
+
+  src = fetchFromGitHub {
+    owner = "fsouza";
+    repo = "prettierd";
+    rev = "v${version}";
+    hash = "sha256-GTukjkA/53N9ICdfCJr5HAqhdL5T0pth6zAk8Fu/cis=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = src + "/yarn.lock";
+    hash = "sha256-32wMwkVgO5DQuROWnujVGNeCAUq1D6jJurecsD2ROOU=";
+  };
+
+  packageJSON = ./package.json;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildPhase = ''
+    runHook preBuild
+    export HOME=$(mktemp -d)
+    yarn --offline build
+    runHook postBuild
+  '';
+
+  # prettierd needs to be wrapped with nodejs so that it can be executed
+  postInstall = ''
+    wrapProgram "$out/bin/prettierd" --prefix PATH : "${nodejs}/bin"
+  '';
+
+  doDist = false;
+
+  meta = with lib; {
+    description = "Prettier, as a daemon, for improved formatting speed";
+    homepage = "https://github.com/fsouza/prettierd";
+    license = licenses.isc;
+    changelog = "https://github.com/fsouza/prettierd/blob/${src.rev}/CHANGELOG.md";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ NotAShelf n3oney ];
+  };
+}

--- a/pkgs/development/tools/prettierd/package.json
+++ b/pkgs/development/tools/prettierd/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@fsouza/prettierd",
+  "version": "0.23.4",
+  "description": "prettier, as a daemon",
+  "bin": {
+    "prettierd": "./bin/prettierd"
+  },
+  "scripts": {
+    "prepare": "yarn build",
+    "build": "tsc -b",
+    "run": "node bin/prettierd",
+    "start": "node bin/prettierd start",
+    "prettier:check": "prettier --check .",
+    "prettier:fix": "prettier --write ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fsouza/prettierd.git"
+  },
+  "author": "Francisco Souza",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/fsouza/prettierd/issues"
+  },
+  "homepage": "https://github.com/fsouza/prettierd",
+  "devDependencies": {
+    "@types/node": "^20.2.5",
+    "@types/prettier": "^2.7.2",
+    "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "core_d": "^5.0.1",
+    "nanolru": "^1.0.0",
+    "prettier": "^2.8.8"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "optionalDependencies": {
+    "@babel/parser": "^7.22.3",
+    "@typescript-eslint/typescript-estree": "^5.59.7"
+  }
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11576,6 +11576,8 @@ with pkgs;
 
   pretender = callPackage ../tools/security/pretender { };
 
+  prettierd = callPackage ../development/tools/prettierd { };
+
   pretty-simple = callPackage ../development/tools/pretty-simple { };
 
   prettyping = callPackage ../tools/networking/prettyping { };


### PR DESCRIPTION
###### Description of changes

Continuation of #231712. Cleans up the derivation and gets rid of the IDFs, adds the nodejs wrapper and a list of arguments to be passed to the daemon using `wrapProgram`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

