### PR TITLE
python3Packages.pyamg: enable tests

### DIFF
--- a/pkgs/development/python-modules/pyamg/default.nix
+++ b/pkgs/development/python-modules/pyamg/default.nix
@@ -4,6 +4,7 @@
 , numpy
 , scipy
 , pytest
+, python
 , pybind11
 , setuptools-scm
 , pythonOlder
@@ -32,12 +33,16 @@ buildPythonPackage rec {
     pybind11
   ];
 
-  # failed with "ModuleNotFoundError: No module named 'pyamg.amg_core.evolution_strength'"
-  doCheck = false;
-  # taken from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-pyamg#n27
-  # checkPhase = ''
-  #   PYTHONPATH="$PWD/build/lib.linux-*:$PYTHONPATH" ${python3.interpreter} -c "import pyamg; pyamg.test()"
-  # '';
+  checkPhase = ''
+    runHook preCheck
+
+    # The `pyamg` directory in PWD doesn't have the compiled Cython modules in it, but has higher import priority compared to the properly built and installed `pyamg`.
+    # It's easier to just remove the package directory in PWD.
+    rm -r pyamg
+    ${python.interpreter} -c "import pyamg; pyamg.test()"
+
+    runHook postCheck
+  '';
 
   pythonImportsCheck = [
     "pyamg"


### PR DESCRIPTION
###### Description of changes

This PR enables tests. Because of the default module import priority, the package in the source directory gets imported. It becomes an issue with Cythonized modules, as their .so libraries aren't there. As we don't use the source package at `checkPhase` and later, it would be the simplest to remove it to make Python use the installed one with all modules in place.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).