### PR TITLE
ubootTeresA64: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8882,6 +8882,16 @@
     githubId = 4032;
     name = "Kristoffer Thømt Ravneberg";
   };
+  kreyren = {
+    name = "Jacob KREYREN Hrbek";
+    email = "kreyren@proton.me";
+    matrix = "@mwkbarnjbblghgo4gudng:karp.lol";
+    github = "kreyren";
+    githubId = 11302521;
+    keys = [{
+        fingerprint = "D050 1F79 80EA 70D1 92C0 3A52 667F 0DAF AF09 BA2B";
+      }];
+  };
   kristian-brucaj = {
     email = "kbrucaj@gmail.com";
     github = "Flameslice";

--- a/pkgs/misc/crust/default.nix
+++ b/pkgs/misc/crust/default.nix
@@ -1,0 +1,143 @@
+###! Libre Power Management firmware for sunxi System On Chip ("SoC") for implementing system suspend/resume, and (onboards without a PMIC) soft poweroff/on. The package has to be built using (OpenRISC 1000, *not RISC-V*) compiler which is officially supported in upstream GCC starting with GCC 9.1.0.
+###!
+###! To build only the crust firmware derivation use:
+###!   $ nix-build -A pkgsCross.or1k.crustTeresA64
+###!
+###! When packaging for linux make sure that you have the following patches otherwise crust won't be able to cleanly share the clock controller and PMIC bus controller hardware: https://github.com/torvalds/linux/compare/master...crust-firmware:linux:crust
+###!
+###! If you are faced with issues while building the firmware then take a look at https://github.com/crust-firmware/crust#building-the-firmware
+
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, bison
+, flex
+, buildPackages
+}:
+
+###! The package declaration is heavily inspired by the U-Boot package to make maintenance easier, but should stay as an invidual declaration since it's processing has different requirements and including it in the U-Boot would bloat the definition and would be harder to understand and maintain
+
+let
+  defaultVersion = "unstable-2023-03-04";
+  defaultSrc = fetchFromGitHub {
+    owner = "crust-firmware";
+    repo = "crust";
+    rev = "c308a504853e7fdb47169796c9a832796410ece8";
+    sha256 = "AobVD3Jo/6s0cExHXpYYAqZv/gCplxLlDYVscSCIS6M=";
+  };
+  buildCrust = {
+    version ? defaultVersion
+  , src ? defaultSrc
+  , defconfig
+  , extraConfig ? ""
+  , extraPatches ? []
+  , extraMakeFlags ? []
+  , extraMeta ? {}
+  , ... } @ args: stdenv.mkDerivation ({
+    # Strip "_defconfig" suffix from 'defconfig' if it's present for clearer output
+    # builtins.match returns 'Null' if the string matches so we have to then check if it's Null
+    # FIXME-QA(Krey): I hate this, but am not aware of better way to write this
+    pname = if (builtins.isNull ((builtins.match "_defconfig$" defconfig)))
+      then "crust-${lib.strings.removeSuffix "_defconfig" defconfig}"
+      else "crust-${defconfig}";
+
+    inherit version;
+    inherit src;
+
+    ###! The package has upstream definitions of configurations for set devices and thus the defconfig has to be always included, beyond that the options are designed to be as flexible as possible to accompany special requirements of various devices
+    ###!
+    ###! Avoid declaring extra configuration (extraConfig) when possible as those should go to the upstream unless you use special usecase device e.g. modded teres-A64
+
+    defconfig = if defconfig == null then
+      throw "crust config not defined!"
+      else defconfig;
+
+    # Only for global crust patches, per-device paches should be included as extras to avoid adding noise which would complicate debugging
+    patches = [] ++ extraPatches;
+
+    postPatch = "";
+
+    nativeBuildInputs = [
+      flex
+      bison
+    ];
+
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+    makeFlags = [
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    ] ++ extraMakeFlags;
+
+    ###! Phases
+    configurePhase = ''
+      runHook preConfigure
+
+      echo "Configuring for ${defconfig}"
+      make ${defconfig}
+
+      # The variable 'extraConfigPath' is often parsed as blank resulting in a scenario where `cat` is expecting interactive input followed by line-break to continue, this is to reduce the risk of that happening
+      [ -z "$extraConfigPath" ] || {
+        cat $extraConfigPath >> .config
+      }
+
+      runHook postConfigure
+    '';
+
+    # The package has only one output which is located in `build/scp/scp.bin`
+    installPhase = ''
+      runHook preInstall
+
+      mkdir "$out"
+      cp -v "build/scp/scp.bin" "$out/scp.bin"
+
+      runHook postInstall
+    '';
+
+    ###! Hardening
+    ###! * 'bindnow' is ignored by the package
+    ###! * 'pie' is already applied by default to musl and disabled for glibc where in our scenario it seems to be unsupported
+    ###! * 'relro' is ignored by the package, likely due to it breaking dynamic objects. Issue https://github.com/crust-firmware/crust/issues/216 has been submitted to verify
+    ###! Refer to https://nixos.org/manual/nixpkgs/stable/#sec-hardening-in-nixpkgs for details
+    hardeningDisable = [
+      "bindnow"
+      "relro"
+    ];
+
+    # Default Metadata
+    meta = with lib; {
+      homepage = "https://github.com/crust-firmware/crust";
+      # Try to adjust the description per package so that it's not all with generic wording
+      description = "SCP (power management) firmware for sunxi SoCs";
+      # Project using 3rdparty components https://github.com/crust-firmware/crust/blob/master/LICENSE.md#crust-firmware-licensing
+      license = with licenses; [
+        bsd1
+        bsd3
+        mit
+        gpl2
+      ];
+    } // extraMeta;
+  } // removeAttrs args [ "extraMeta" ]);
+
+in {
+  inherit buildCrust;
+
+  # Example configuration:
+  ## crustExample = buildCrust {
+  ##   defconfig = "example_defconfig";
+  ##   extraMeta = {
+  ##     description = "SCP (power management) firmware for Example";
+  ##     platforms = [ "or1k-none" ];
+  ##     maintainers = with lib.maintainers; [ your-usename-here ];
+  ##   };
+  ## };
+
+  crustTeresA64 = buildCrust {
+    defconfig = "teres_i_defconfig";
+    extraMeta = {
+      description = "SCP (power management) firmware for the odrysian king";
+      platforms = [ "or1k-none" ];
+      maintainers = with lib.maintainers; [ kreyren ];
+    };
+  };
+}

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -20,6 +20,8 @@
 , armTrustedFirmwareRK3328
 , armTrustedFirmwareRK3399
 , armTrustedFirmwareS905
+, crustTeresA64
+, pkgsCross
 , buildPackages
 }:
 
@@ -540,6 +542,21 @@ in {
     defconfig = "sopine_baseboard_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+  };
+
+  # Refer to https://nixos.wiki/wiki/NixOS_on_ARM/OLIMEX_Teres-A64
+  ubootTeresA64 = buildUBoot {
+    defconfig = "teres_i_defconfig";
+    extraMeta = {
+      platforms = ["aarch64-linux"];
+      maintainers = with lib.maintainers; [ kreyren ];
+    };
+    BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    # U-Boot requires crust built using OpenRISC 1000 compiler for power management
+    SCP = if stdenv.hostPlatform.isOr1k
+      then "${crustTeresA64}/scp.bin"
+      else "${pkgsCross.or1k.crustTeresA64}/scp.bin";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28267,6 +28267,7 @@ with pkgs;
     ubootROCPCRK3399
     ubootSheevaplug
     ubootSopine
+    ubootTeresA64
     ubootUtilite
     ubootWandboard
     ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28214,6 +28214,12 @@ with pkgs;
 
   twingate = callPackage ../applications/networking/twingate { };
 
+  # Upstream Crust
+  inherit (callPackage ../misc/crust {})
+    buildCrust
+    crustTeresA64
+    ;
+
   # Upstream U-Boots:
   inherit (callPackage ../misc/uboot {})
     buildUBoot


### PR DESCRIPTION
###### Description of changes

<img src="https://github.com/NixOS/nixpkgs/assets/11302521/a18c3480-7cbf-45a8-967e-907d29089d61" width=100%/>


This merge request will add an official support of NixOS for the Open-Source Hardware+Software OLIMEX Teres-A64 through integrating U-Boot with crust for the device.

Requires: https://github.com/NixOS/nixpkgs/pull/241358

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [NOT TESTED] aarch64-linux
  - [UNABLE] x86_64-darwin
  - [UNABLE] aarch64-darwin
- [IRELEVANT] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ASKED_NOT_TO] (Package updates) Added a release notes entry if the change is major or breaking
  - [IRELEVANT] (Module updates) Added a release notes entry if the change is significant
  - [IRELEVANT] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [ ] Custom
  - [ ] Make sure that crust patches are available in NixOS: https://github.com/torvalds/linux/compare/master...crust-firmware:linux:crust

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Additional notes

`or1k-none` cannot be set as a binfmt:

> error: Cannot create binfmt registration for system or1k-none

So i decided to use the crossPkgs definition for SCP in uboot

###### Wikipage

I've created a wikipage for the device on https://nixos.wiki/wiki/NixOS_on_ARM/OLIMEX_Teres-A64
