### PR TITLE
python311Packages.xontrib-*: init at various

### DIFF
--- a/pkgs/by-name/xo/xonsh/package.nix
+++ b/pkgs/by-name/xo/xonsh/package.nix
@@ -7,6 +7,7 @@
   gitUpdater,
   glibcLocales,
   python3Packages,
+  python3,
 }:
 
 let
@@ -103,6 +104,7 @@ let
       python = python3Packages.python; # To the wrapper
       wrapper = callPackage ./wrapper.nix { };
       updateScript = gitUpdater { };
+      xontribs = import ./xontribs { inherit python3; };
     };
 
     meta = {

--- a/pkgs/by-name/xo/xonsh/xontribs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/default.nix
@@ -1,0 +1,26 @@
+{
+  python3,
+}:
+let
+  callPackage = python3.pkgs.callPackage;
+in {
+  xonsh-direnv = callPackage ./xonsh-direnv { };
+
+  xontrib-abbrevs = callPackage ./xontrib-abbrevs { };
+
+  xontrib-bashisms = callPackage ./xontrib-bashisms { };
+
+  xontrib-debug-tools = callPackage ./xontrib-debug-tools { };
+
+  xontrib-distributed = callPackage ./xontrib-distributed { };
+
+  xontrib-fish-completer = callPackage ./xontrib-fish-completer { };
+
+  xontrib-jedi = callPackage ./xontrib-jedi { };
+
+  xontrib-jupyter = callPackage ./xontrib-jupyter { };
+
+  xontrib-vox = callPackage ./xontrib-vox { };
+
+  xontrib-whole-word-jumping = callPackage ./xontrib-whole-word-jumping { };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xonsh-direnv/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xonsh-direnv/default.nix
@@ -9,24 +9,14 @@
 
 buildPythonPackage rec {
   pname = "xonsh-direnv";
-  version = "1.7.0";
+  version = "1.6.2";
 
   src = fetchFromGitHub {
-    owner = "greg-hellings";
+    owner = "74th";
     repo = pname;
     rev = version;
-    hash = "sha256-LPSYUK07TQuTI+u0EmUuGL48znUfRDVGEIS/mmzcETU=";
+    hash = "sha256-bp1mK+YO9htEQcRSD5wJkAZtQKK2t3IOW7Kdc6b8Lb0=";
   };
-
-  prePatch = ''
-    substituteInPlace xontrib/direnv.xsh \
-      --replace '__direnv_post_rc()' \
-                '__direnv_post_rc(**kwargs)' \
-      --replace '__direnv_chdir(olddir: str, newdir: str)' \
-                '__direnv_chdir(olddir: str, newdir: str, **kwargs)' \
-      --replace '__direnv_postcommand(cmd: str, rtn: int, out: str or None, ts: list)' \
-                '__direnv_postcommand(cmd: str, rtn: int, out: str or None, ts: list, **kwargs)'
-  '';
 
   propagatedBuildInputs = [
     direnv

--- a/pkgs/by-name/xo/xonsh/xontribs/xonsh-direnv/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xonsh-direnv/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  direnv,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "xonsh-direnv";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "greg-hellings";
+    repo = pname;
+    rev = version;
+    hash = "sha256-LPSYUK07TQuTI+u0EmUuGL48znUfRDVGEIS/mmzcETU=";
+  };
+
+  prePatch = ''
+    substituteInPlace xontrib/direnv.xsh \
+      --replace '__direnv_post_rc()' \
+                '__direnv_post_rc(**kwargs)' \
+      --replace '__direnv_chdir(olddir: str, newdir: str)' \
+                '__direnv_chdir(olddir: str, newdir: str, **kwargs)' \
+      --replace '__direnv_postcommand(cmd: str, rtn: int, out: str or None, ts: list)' \
+                '__direnv_postcommand(cmd: str, rtn: int, out: str or None, ts: list, **kwargs)'
+  '';
+
+  propagatedBuildInputs = [
+    direnv
+  ];
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  meta = with lib; {
+    description = "Direnv support for Xonsh";
+    homepage = "https://github.com/74th/xonsh-direnv/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-abbrevs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-abbrevs/default.nix
@@ -1,0 +1,54 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+
+  setuptools,
+  poetry-core,
+  prompt-toolkit,
+  pytestCheckHook,
+  xonsh
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-abbrevs";
+  version = "0.0.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-abbrevs";
+    rev = version;
+    hash = "sha256-DrZRIU5mzu8RUzm0jak/Eo12wbvWYusJpmqgIAVwe00=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"xonsh>=0.12.5", ' ""
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    prompt-toolkit
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    xonsh
+  ];
+
+  meta = with lib; {
+    description = "Command abbreviations. This expands input words as you type.";
+    homepage = "https://github.com/xonsh/xontrib-abbrevs";
+    license = licenses.mit;
+    maintainers = [ maintainers.greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-bashisms/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-bashisms/default.nix
@@ -1,0 +1,47 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+
+  setuptools,
+  pytestCheckHook,
+  xonsh,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-bashisms";
+  version = "0.0.5";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-bashisms";
+    rev = version;
+    hash = "sha256-R1DCGMrRCJLnz/QMk6QB8ai4nx88vvyPdaCKg3od5/I=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"xonsh>=0.12.5"' ""
+  '';
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    xonsh
+  ];
+
+  meta = with lib; {
+    description = "Bash-like interactive mode extensions for the xonsh shell. ";
+    homepage = "https://github.com/xonsh/xontrib-bashisms";
+    license = licenses.mit;
+    maintainers = [ maintainers.greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-debug-tools/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-debug-tools/default.nix
@@ -1,0 +1,41 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+
+  pytestCheckHook,
+  xonsh,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-debug-tools";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-debug-tools";
+    rev = version;
+    hash = "sha256-Z8AXKk94NxmF5rO2OMZzNX0GIP/Vj+mOtYUaifRX1cw=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"xonsh>=0.12.5"' ""
+  '';
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    xonsh
+  ];
+
+  meta = with lib; {
+    description = "Debug tools for xonsh shell.";
+    homepage = "https://github.com/xonsh/xontrib-debug-tools";
+    license = licenses.mit;
+    maintainers = [ maintainers.greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-distributed/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-distributed/default.nix
@@ -1,0 +1,51 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+
+  distributed,
+  poetry-core,
+  pytestCheckHook,
+  xonsh
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-distributed";
+  version = "0.0.4";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-distributed";
+    rev = "v${version}";
+    hash = "sha256-Hb7S3PqHi0w6zb9ki8ADMtgdYVv8O5WQZMgJzKF74qE=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'xonsh = ">=0.12"' ""
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    distributed
+  ];
+
+  # v0.0.4 has no tests associated with it
+  doCheck = false;
+
+  checkInputs = [
+    pytestCheckHook
+    xonsh
+  ];
+
+  meta = with lib; {
+    description = "Dask Distributed integration for Xonsh";
+    homepage = "https://github.com/xonsh/xontrib-distributed";
+    license = licenses.mit;
+    maintainers = [ maintainers.greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-fish-completer/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-fish-completer/default.nix
@@ -1,0 +1,47 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+
+  pytestCheckHook,
+  pytest-subprocess,
+  xonsh,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-fish-completer";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-fish-completer";
+    rev = version;
+    hash = "sha256-PhhdZ3iLPDEIG9uDeR5ctJ9zz2+YORHBhbsiLrJckyA=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"xonsh>=0.12.5"' ""
+  '';
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  disabledTests = [
+    "test_interpreter"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-subprocess
+    xonsh
+  ];
+
+  meta = with lib; {
+    description = "Populate rich completions using fish and remove the default bash based completer";
+    homepage = "https://github.com/xonsh/xontrib-fish-completer";
+    license = licenses.mit;
+    maintainers = [ maintainers.greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
@@ -1,0 +1,54 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+
+  jedi,
+  poetry-core,
+  pytestCheckHook,
+  xonsh,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-jedi";
+  version = "0.1.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-jedi";
+    rev = "v${version}";
+    hash = "sha256-bHVSIN+V4dhKPgNURkvMQyAbz49gEgYtJ1LqDLo0wYY=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'xonsh = ">=0.12"' ""
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    jedi
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+    substituteInPlace tests/test_jedi.py \
+      --replace "/usr/bin" "${jedi}/bin"
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    xonsh
+  ];
+
+  meta = with lib; {
+    description = "Xonsh Python mode completions using jedi";
+    homepage = "https://github.com/xonsh/xontrib-jedi";
+    license = licenses.mit;
+    maintainers = [ maintainers.greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-jupyter/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-jupyter/default.nix
@@ -1,0 +1,54 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+  pkgs,
+
+  jupyter-client,
+  poetry-core,
+  pytestCheckHook,
+  xonsh,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-jupyter";
+  version = "0.3.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "greg-hellings";
+    repo = "xontrib-jupyter";
+    # https://github.com/xonsh/xontrib-jupyter/pull/37
+    rev = "add_kwargs";
+    hash = "sha256-12IMDUIoW265asXrw8sikfWFFWZXPAF54fQr2lSjZVk=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'xonsh = ">=0.12"' ""
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    jupyter-client
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    xonsh
+  ];
+
+  meta = with lib; {
+    description = "Xonsh jupyter kernel allows to run Xonsh shell code in Jupyter, JupyterLab, Euporia, etc.";
+    homepage = "https://github.com/xonsh/xontrib-jupyter";
+    license = licenses.mit;
+    maintainers = [ maintainers.greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-vox/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-vox/default.nix
@@ -1,0 +1,52 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+
+  pytestCheckHook,
+  pytest-subprocess,
+  xonsh,
+  virtualenv,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-vox";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-vox";
+    rev = version;
+    hash = "sha256-OB1O5GZYkg7Ucaqak3MncnQWXhMD4BM4wXsYCDD0mhk=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"xonsh>=0.12.5"' ""
+  '';
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  disabledTests = [
+    "test_interpreter"
+  ];
+
+  propagatedInputs = [
+    virtualenv
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-subprocess
+    xonsh
+  ];
+
+  meta = with lib; {
+    description = "Python virtual environment manager for the xonsh shell";
+    homepage = "https://github.com/xonsh/xontrib-vox";
+    license = licenses.mit;
+    maintainers = [ maintainers.greg ];
+  };
+}

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-whole-word-jumping/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-whole-word-jumping/default.nix
@@ -1,0 +1,41 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+
+  pytestCheckHook,
+  xonsh,
+}:
+
+buildPythonPackage rec {
+  pname = "xontrib-whole-word-jumping";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xontrib-whole-word-jumping";
+    rev = version;
+    hash = "sha256-zLAOGW9prjYDQBDITFNMggn4X1JTyAnVdjkBOH9gXPs=";
+  };
+
+  prePatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"xonsh>=0.12.5", ' ""
+  '';
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    xonsh
+  ];
+
+  meta = with lib; {
+    description = "Additional keyboard navigation for interactive xonsh shells";
+    homepage = "https://github.com/xonsh/xontrib-whole-word-jumping";
+    license = licenses.mit;
+    maintainers = [ maintainers.greg ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add xontrib packages that improve on basic functionality of the Xonsh shell. This is the list of xontribs maintained by the same people who produce Xonsh itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).