### PR TITLE
xv: init at 4.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5751,6 +5751,11 @@
     githubId = 7047019;
     name = "Florent Becker";
   };
+  galen = {
+    github = "galenhuntington";
+    githubId = 1851962;
+    name = "Galen Huntington";
+  };
   gamb = {
     email = "adam.gamble@pm.me";
     github = "gamb";

--- a/pkgs/applications/graphics/xv/default.nix
+++ b/pkgs/applications/graphics/xv/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  xorg,
+  libpng,
+  libwebp,
+  libtiff,
+  libjpeg,
+  jasper,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xv";
+  version = "4.1.1";
+
+  src = fetchFromGitHub {
+    owner = "jasper-software";
+    repo = "xv";
+    rev = "v${version}";
+    sha256 = "vwSUKWr4Hffx04ATUI58m7UOS/lVTnIVDC3ZTWRwJMM=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ xorg.libX11 xorg.libXt libpng libwebp libtiff jasper ];
+
+  meta = {
+    description = "Classic image viewer and editor for X.";
+    homepage = "http://www.trilon.com/xv/";
+    license = {
+      fullName = "XV License";
+      url = "https://github.com/jasper-software/xv/blob/main/src/README";
+      free = false;
+    };
+    maintainers = with lib.maintainers; [ galen ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1847,7 +1847,6 @@ mapAliases ({
   ); # Added 2022-08-02
   xpraGtk3 = throw "'xpraGtk3' has been renamed to/replaced by 'xpra'"; # Converted to throw 2022-02-22
   xtrt = throw "xtrt has been removed due to being abandoned"; # Added 2023-05-25
-  xv = xxv; # Added 2020-02-22
   xvidcap = throw "'xvidcap' has been removed because of a broken dependency"; # Added 2022-11-08
   xvfb_run = xvfb-run; # Added 2021-05-07
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36094,6 +36094,8 @@ with pkgs;
 
   xnotify = callPackage ../tools/X11/xnotify { };
 
+  xv = callPackage ../applications/graphics/xv { };
+
   xygrib = libsForQt5.callPackage ../applications/misc/xygrib { };
 
   xzgv = callPackage ../applications/graphics/xzgv { };


### PR DESCRIPTION
###### Description of changes

XV is a classic X image viewer ([Wikipedia](https://en.wikipedia.org/wiki/Xv_%28software%29)).  Over the years, various Linux distros have patched it to keep it up to date, including with more image support.  More recently, a repo was created to consolidate and build on this work and update it further (https://github.com/jasper-software/xv).

The license is old-school shareware, with distribution allowed but payment required for commercial use, so I have marked it as unfree.  There shouldn't be any issue with including it as is in nixpkgs.

There was an alias for the old name `xv` of the xxv package, which will have to be removed.  The alias is well over three years old (2020-02-22).

I'm still a Nix beginner so this may not be perfect, but it "works for me".

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).