### PR TITLE
ocamlPackages.js_of_ocaml: 4.1.0 → 5.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/gen_js_api/default.nix
+++ b/pkgs/development/ocaml-modules/gen_js_api/default.nix
@@ -1,4 +1,5 @@
 { buildDunePackage
+, ocaml
 , lib
 , ppxlib
 , fetchFromGitHub
@@ -10,7 +11,6 @@
 buildDunePackage rec {
   pname = "gen_js_api";
   version = "1.1.1";
-  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "LexiFi";
@@ -23,7 +23,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ ojs ppxlib ];
   nativeCheckInputs = [ js_of_ocaml-compiler nodejs ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.13";
 
   meta = {
     homepage = "https://github.com/LexiFi/gen_js_api";

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -1,24 +1,22 @@
 { lib, fetchurl, buildDunePackage
 , cmdliner, yojson, ppxlib, findlib
-, menhir, menhirLib
+, menhir, menhirLib, sedlex
 }:
 
 buildDunePackage rec {
   pname = "js_of_ocaml-compiler";
-  version = "4.1.0";
-  duneVersion = "3";
+  version = "5.3.0";
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-    sha256 = "sha256-kXk/KaWvPeq6P301zqsR5znP4KXMMFVvYgFGGm1CNu8=";
+    hash = "sha256-vp497rmOXSjxvLLZhHwE0ohfwH7VjM2LCKpLZijNZNI=";
   };
 
   nativeBuildInputs = [ menhir ];
   buildInputs = [ cmdliner ppxlib ];
 
-  configurePlatforms = [];
-  propagatedBuildInputs = [ menhirLib yojson findlib ];
+  propagatedBuildInputs = [ menhirLib yojson findlib sedlex ];
 
   meta = {
     description = "Compiler from OCaml bytecode to Javascript";

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -6,7 +6,6 @@ buildDunePackage {
   pname = "js_of_ocaml";
 
   inherit (js_of_ocaml-compiler) version src;
-  duneVersion = "3";
 
   buildInputs = [ ppxlib ];
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
@@ -6,7 +6,6 @@ buildDunePackage {
   pname = "js_of_ocaml-lwt";
 
   inherit (js_of_ocaml-compiler) version src;
-  duneVersion = "3";
 
   buildInputs = [ js_of_ocaml-ppx ];
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
@@ -7,7 +7,6 @@ buildDunePackage {
   pname = "js_of_ocaml-ppx";
 
   inherit (js_of_ocaml-compiler) version src;
-  duneVersion = "3";
 
   buildInputs = [ js_of_ocaml ];
   propagatedBuildInputs = [ ppxlib ];

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
@@ -6,7 +6,6 @@ buildDunePackage {
   pname = "js_of_ocaml-ppx_deriving_json";
 
   inherit (js_of_ocaml-compiler) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [ js_of_ocaml ppxlib ];
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/toplevel.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/toplevel.nix
@@ -1,7 +1,6 @@
 { lib, buildDunePackage, js_of_ocaml-compiler, ppxlib }:
 
 buildDunePackage {
-  duneVersion = "3";
   pname = "js_of_ocaml-toplevel";
   inherit (js_of_ocaml-compiler) src version;
   buildInputs = [ ppxlib ];

--- a/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
@@ -7,7 +7,6 @@ buildDunePackage {
   pname = "js_of_ocaml-tyxml";
 
   inherit (js_of_ocaml-compiler) version src;
-  duneVersion = "3";
 
   buildInputs = [ js_of_ocaml-ppx ];
 


### PR DESCRIPTION
ocamlPackages.gen_js_api: disable checks with OCaml < 4.13

###### Description of changes

https://github.com/ocsigen/js_of_ocaml/blob/5.3.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
