### PR TITLE
maintainers: add script for checking unstable version strings

### DIFF
--- a/doc/contributing/coding-conventions.chapter.md
+++ b/doc/contributing/coding-conventions.chapter.md
@@ -224,6 +224,8 @@ There are a few naming guidelines:
 
 Example: Given a project had its latest releases `2.2` in November 2021, and `3.0` in January 2022, a commit authored on March 15, 2022 for an upcoming bugfix release `2.2.1` would have `version = "2.2-unstable-2022-03-15"`.
 
+(Reviewers: you can often check that a package's unstable version is correct, or get a suggestion for what to use instead, by running [`maintainers/scripts/check-unstable-version.sh $PR_NUMBER`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/scripts/check-unstable-version.sh). This script isn't foolproof; common sense and this manual take precedence.)
+
 - Dashes in the package `pname` _should_ be preserved in new variable names, rather than converted to underscores or camel cased — e.g., `http-parser` instead of `http_parser` or `httpParser`. The hyphenated style is preferred in all three package names.
 
 - If there are multiple versions of a package, this _should_ be reflected in the variable names in `all-packages.nix`, e.g. `json-c_0_9` and `json-c_0_11`. If there is an obvious “default” version, make an attribute like `json-c = json-c_0_9;`. See also [](#sec-versioning)

--- a/maintainers/scripts/check-unstable-version.sh
+++ b/maintainers/scripts/check-unstable-version.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p git nix
+
+set -eou pipefail
+shopt -s extglob
+
+if [[ "$#" -eq 0 ]]; then
+    echo "Usage: $0 [--in-current-worktree] [PR number] attrPath..." >&2
+    echo "Attribute paths are optional only if PR is specified" >&2
+    exit 1
+fi
+
+nixpkgsRemote=https://github.com/NixOS/nixpkgs.git
+
+inCurrentWorktree=
+if [[ "$1" == --in-current-worktree ]]; then
+    inCurrentWorktree=y
+    shift
+fi
+
+pr=
+if [[ "$1" =~ ^[1-9] ]]; then
+    pr=$1
+    shift
+fi
+attrPaths=("$@")
+
+cleanupHooks=()
+function cleanup {
+    for ((i = ${#cleanupHooks[@]} - 1; i >= 0; i--)); do
+        ${cleanupHooks[$i]}
+    done
+}
+trap cleanup EXIT
+
+function mkWorktree {
+    if [[ "$inCurrentWorktree" ]]; then
+        worktree=$PWD
+    else
+        worktree=$(mktemp -d)
+        cleanupHooks+=(rmWorktree)
+    fi
+}
+
+function rmWorktree {
+    cd
+    rm -rf "$worktree"
+}
+
+function mkGitWorktree {
+    if [[ "$inCurrentWorktree" ]]; then
+        git checkout --quiet --detach "$1"
+        cleanupHooks+=(revertGitCheckout)
+    else
+        git worktree add --quiet -d "$worktree" "$1"
+        cleanupHooks+=(rmGitWorktree)
+    fi
+}
+
+function rmGitWorktree {
+    git worktree remove -f "$worktree"
+}
+
+function revertGitCheckout {
+    git checkout --quiet -
+}
+
+function mkBareSrcDir {
+    bareSrcDir=$(mktemp -u)
+    cleanupHooks+=(rmBareSrcDir)
+}
+
+function rmBareSrcDir {
+    rm -rf "$bareSrcDir"
+}
+
+if [[ "$pr" ]]; then
+    mkWorktree
+    git fetch --quiet "$nixpkgsRemote" "pull/$pr/head"
+    mkGitWorktree FETCH_HEAD
+    cd "$worktree"
+    if [[ "$inCurrentWorktree" ]]; then
+        mkBareSrcDir
+    else
+        mkdir .src
+        bareSrcDir="$worktree/.src"
+    fi
+
+    if [[ "${#attrPaths[@]}" == 0 ]]; then
+        git fetch --quiet "$nixpkgsRemote" master
+        readarray -t attrPaths < <(git log --format=%s FETCH_HEAD..HEAD | cut -s -f1 -d:)
+    fi
+else
+    mkBareSrcDir
+fi
+
+suggestions=
+for attrPath in "${attrPaths[@]}"; do
+    IFS=$'\t' read -r curVer gitRepoUrl rev < <(nix eval --extra-experimental-features nix-command --impure --raw --expr "with import ./. {}; \"\${$attrPath.version}\\t\${$attrPath.src.gitRepoUrl or \"-\"}\\t\${$attrPath.src.rev}\\n\"")
+    if ! [[ "$curVer" =~ unstable ]]; then
+        echo "$attrPath version $curVer is not unstable" >&2
+    elif [[ "$gitRepoUrl" == - ]]; then
+        echo "$attrPath doesn't fetch from a Git repository" >&2
+    else
+        git clone --quiet --bare "$gitRepoUrl" "$bareSrcDir"
+        verPart=$(GIT_DIR=$bareSrcDir git describe --tags --always --candidates=50 "$rev")
+        if [[ "$verPart" =~ - ]]; then
+            verPart=${verPart##*([^0-9])}
+            # Chop the commit abbreviation
+            verPart=${verPart%-*}
+            # Then chop the number of commits since the tag
+            verPart=${verPart%-*}
+        else
+            verPart=0
+        fi
+        datePart=$(GIT_DIR=$bareSrcDir git show -s --format="%cs" "$rev")
+        suggestVer=$verPart-unstable-$datePart
+        if [[ "$curVer" == "$suggestVer" ]]; then
+            echo "$attrPath version $curVer looks correct" >&2
+        else
+            echo "$attrPath version $curVer should perhaps be $suggestVer"
+            suggestions=y
+        fi
+        rm -rf "$bareSrcDir"
+    fi
+done
+
+if [[ "$suggestions" ]]; then
+    exit 2
+fi


### PR DESCRIPTION
This script is mainly to address complaints that the new unstable version format policy makes it difficult for PR reviewers to verify that an unstable version is correct.

Try it out on some recent PRs:
```
maintainers/scripts/check-unstable-version.sh 240960
maintainers/scripts/check-unstable-version.sh 241201
maintainers/scripts/check-unstable-version.sh 241393
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
