### PR TITLE
python3Packages.array-record: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/array-record/default.nix
+++ b/pkgs/development/python-modules/array-record/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, absl-py
+, buildPythonPackage
+, etils
+, fetchPypi
+, importlib-resources
+, python
+, typing-extensions
+, zipp
+}:
+
+buildPythonPackage rec {
+  pname = "array-record";
+  version = "0.4.0";
+  format = "wheel";
+
+  disabled = python.pythonVersion != "3.10";
+
+  src = fetchPypi {
+    inherit version format;
+    pname = "array_record";
+    dist = "py310";
+    python = "py310";
+    hash = "sha256-VHDU6RLR/z3/tNxJiDdAruz1cva6cHu5NzMlsKrLYXg=";
+  };
+
+  propagatedBuildInputs = [
+    absl-py
+    etils
+    importlib-resources
+    typing-extensions
+    zipp
+  ];
+
+  pythonImportsCheck = [ "array_record" ];
+
+  meta = with lib; {
+    description = "ArrayRecord is a new file format derived from Riegeli, achieving a new frontier of IO efficiency";
+    homepage = "https://github.com/google/array_record";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -632,6 +632,8 @@ self: super: with self; {
 
   arnparse = callPackage ../development/python-modules/arnparse { };
 
+  array-record = callPackage ../development/python-modules/array-record { };
+
   arrayqueues = callPackage ../development/python-modules/arrayqueues { };
 
   arris-tg2492lg = callPackage ../development/python-modules/arris-tg2492lg { };


### PR DESCRIPTION
###### Description of changes

Add the [array_record](https://github.com/google/array_record) python package.
I used the `wheel` fetched from Pypi because the usual `python setup.py install` approach is not working (independently from Nix packaging).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
