### PR TITLE
Click odoo contrib

### DIFF
--- a/pkgs/development/python-modules/click-odoo-contrib/default.nix
+++ b/pkgs/development/python-modules/click-odoo-contrib/default.nix
@@ -1,0 +1,43 @@
+{ buildPythonPackage
+, click-odoo
+, fetchPypi
+, importlib-resources
+, lib
+, manifestoo-core
+, nix-update-script
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "click-odoo-contrib";
+  version = "1.16.1";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-VFoS/lOw/jbJNj9xfgZHKzR6JDTwnlCAItq4mZ3RA6I=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    click-odoo
+    manifestoo-core
+  ] ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  passthru.updateScript = nix-update-script { };
+
+  pythonImportsCheck = [ "click_odoo_contrib" ];
+
+  meta = with lib; {
+    description = "Collection of community-maintained scripts for Odoo maintenance";
+    homepage = "https://github.com/acsone/click-odoo-contrib";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/click-odoo/default.nix
+++ b/pkgs/development/python-modules/click-odoo/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage
+, click
+, fetchPypi
+, lib
+, nix-update-script
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "click-odoo";
+  version = "1.6.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-zyfgsHzIoz4lnqANe63b2oqgD/oxBbTbJYEedfSHWQ8=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    click
+  ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Odoo scripting helper library";
+    homepage = "https://github.com/acsone/click-odoo";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/manifestoo-core/default.nix
+++ b/pkgs/development/python-modules/manifestoo-core/default.nix
@@ -1,0 +1,40 @@
+{ buildPythonPackage
+, typing-extensions
+, fetchPypi
+, lib
+, nix-update-script
+, hatch-vcs
+, pythonOlder
+, importlib-resources
+}:
+
+buildPythonPackage rec {
+  pname = "manifestoo-core";
+  version = "0.11.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "manifestoo_core";
+    hash = "sha256-ZZAJDOtGcYWm0yS5bMOUdM1Jf+kfurwiLsJwyTYPz/4=";
+  };
+
+  nativeBuildInputs = [
+    hatch-vcs
+  ];
+
+  propagatedBuildInputs =
+    lib.optionals (pythonOlder "3.7") [ importlib-resources ]
+    ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "A library to reason about Odoo addons manifests";
+    homepage = "https://github.com/acsone/manifestoo-core";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/manifestoo/default.nix
+++ b/pkgs/development/python-modules/manifestoo/default.nix
@@ -1,0 +1,51 @@
+{ buildPythonPackage
+, fetchPypi
+, hatch-vcs
+, importlib-metadata
+, lib
+, manifestoo-core
+, nix-update-script
+, pytestCheckHook
+, pythonOlder
+, textual
+, typer
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "manifestoo";
+  version = "0.7";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-gCGchc+fShBgt6fVJAx80+QnH+vxWo3jsIyePkFwhYE=";
+  };
+
+  nativeBuildInputs = [
+    hatch-vcs
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    manifestoo-core
+    textual
+    typer
+  ]
+  ++ typer.passthru.optional-dependencies.all
+  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "A tool to reason about Odoo addons manifests";
+    homepage = "https://github.com/acsone/manifestoo";
+    license = licenses.mit;
+    maintainers = with maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/syrupy/default.nix
+++ b/pkgs/development/python-modules/syrupy/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
+, python
 , poetry-core
 , pytest
 , colored
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   version = "4.0.2";
   format = "pyproject";
 
-  disabled = pythonOlder "3.8.1";
+  disabled = lib.versionOlder python.version "3.8.1";
 
   src = fetchFromGitHub {
     owner = "tophat";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1929,6 +1929,8 @@ self: super: with self; {
 
   click-log = callPackage ../development/python-modules/click-log { };
 
+  click-odoo = callPackage ../development/python-modules/click-odoo { };
+
   click-option-group = callPackage ../development/python-modules/click-option-group { };
 
   click-plugins = callPackage ../development/python-modules/click-plugins { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6097,6 +6097,8 @@ self: super: with self; {
 
   manifest-ml = callPackage ../development/python-modules/manifest-ml { };
 
+  manifestoo-core = callPackage ../development/python-modules/manifestoo-core { };
+
   manifestparser = callPackage ../development/python-modules/marionette-harness/manifestparser.nix { };
 
   manuel = callPackage ../development/python-modules/manuel { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6101,6 +6101,8 @@ self: super: with self; {
 
   manifest-ml = callPackage ../development/python-modules/manifest-ml { };
 
+  manifestoo = callPackage ../development/python-modules/manifestoo { };
+
   manifestoo-core = callPackage ../development/python-modules/manifestoo-core { };
 
   manifestparser = callPackage ../development/python-modules/marionette-harness/manifestparser.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1931,6 +1931,8 @@ self: super: with self; {
 
   click-odoo = callPackage ../development/python-modules/click-odoo { };
 
+  click-odoo-contrib = callPackage ../development/python-modules/click-odoo-contrib { };
+
   click-option-group = callPackage ../development/python-modules/click-option-group { };
 
   click-plugins = callPackage ../development/python-modules/click-plugins { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
New packages to help on Odoo maintenance:

-  python3Packages.manifestoo-core: init at 0.11.0 
-  python3Packages.click-odoo: init at 1.6.0 
-  python3Packages.click-odoo-contrib: init at 1.16.1 

Please notice that click-odoo[-contrib] won't work out of the box when using its binaries, if there's no Odoo package available into its surrounding python environment. This is on purpose. The package doesn't depend on Odoo because it can be used to abstract a script across many Odoo versions. However, I don't know how to reflect that here in nixpkgs, so I just left it without the dependency. FWIW, currently Odoo cannot be built without enabling some insecure dependencies (and that will be like that for the foreseeable future; see https://github.com/odoo/odoo/issues/86501 for context).

@moduon MT-1075

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
