### PR TITLE
odig: Init at 0.0.9

### DIFF
--- a/pkgs/build-support/ocaml/topkg.nix
+++ b/pkgs/build-support/ocaml/topkg.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchurl, ocaml, findlib, topkg, ocamlbuild, cmdliner, odoc, b0
+}:
+
+{ pname, version, nativeBuildInputs ? [ ], buildInputs ? [ ], ... }@args:
+
+lib.throwIf (args ? minimalOCamlVersion
+  && lib.versionOlder ocaml.version args.minimalOCamlVersion)
+"${pname}-${version} is not available for OCaml ${ocaml.version}"
+
+stdenv.mkDerivation ({
+
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [ ];
+  strictDeps = true;
+  inherit (topkg) buildPhase installPhase;
+
+} // (builtins.removeAttrs args [ "minimalOCamlVersion" ]) // {
+
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ] ++ nativeBuildInputs;
+  buildInputs = [ topkg ] ++ buildInputs;
+
+  meta = (args.meta or { }) // {
+    platforms = args.meta.platforms or ocaml.meta.platforms;
+  };
+
+})

--- a/pkgs/development/ocaml-modules/b0/default.nix
+++ b/pkgs/development/ocaml-modules/b0/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv, fetchurl, ocaml, findlib, topkg, ocamlbuild, cmdliner }:
+
+let
+
+in lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
+"b0 is not available for OCaml ${ocaml.version}"
+
+stdenv.mkDerivation rec {
+
+  pname = "ocaml${ocaml.version}-b0";
+  version = "0.0.5";
+
+  src = fetchurl {
+    url = "${meta.homepage}/releases/b0-${version}.tbz";
+    sha256 = "sha256-ty04JQcP4RCme/VQw0ko2IBebWWX5cBU6nRTTeV1I/I=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg cmdliner ];
+
+  inherit (topkg) buildPhase installPhase;
+
+  meta = with lib; {
+    description = "Software construction and deployment kit";
+    longDescription = ''
+      WARNING this package is unstable and work in progress, do not depend on
+      it.
+      B0 describes software construction and deployments using modular and
+      customizable definitions written in OCaml. B0 describes:
+      * Build environments.
+      * Software configuration, build and testing.
+      * Source and binary deployments.
+      * Software life-cycle procedures.
+      B0 also provides the B00 build library which provides abitrary build
+      abstraction with reliable and efficient incremental rebuilds. The B00
+      library can be – and has been – used on its own to devise domain specific
+      build systems.
+    '';
+    homepage = "https://erratique.ch/software/b0";
+    inherit (ocaml.meta) platforms;
+    license = licenses.isc;
+    maintainers = [ maintainers.Julow ];
+  };
+}

--- a/pkgs/development/ocaml-modules/odig/default.nix
+++ b/pkgs/development/ocaml-modules/odig/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchurl, buildTopkgPackage, cmdliner, odoc, b0 }:
+
+buildTopkgPackage rec {
+  pname = "odig";
+  version = "0.0.9";
+
+  src = fetchurl {
+    url = "${meta.homepage}/releases/odig-${version}.tbz";
+    sha256 = "sha256-sYKvGYkxeF5FmrNQdOyMAtlsJqhlmUESi9SkPn/cjM4=";
+  };
+
+  buildInputs = [ cmdliner odoc b0 ];
+
+  meta = with lib; {
+    description = "Lookup documentation of installed OCaml packages";
+    longDescription = ''
+      odig is a command line tool to lookup documentation of installed OCaml
+      packages. It shows package metadata, readmes, change logs, licenses,
+      cross-referenced `odoc` API documentation and manuals.
+    '';
+    homepage = "https://erratique.ch/software/odig";
+    license = licenses.isc;
+    maintainers = [ maintainers.Julow ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16863,6 +16863,8 @@ with pkgs;
     ocamlformat_0_22_4 ocamlformat_0_23_0 ocamlformat_0_24_1 ocamlformat_0_25_1
     ocamlformat_0_26_0;
 
+  inherit (ocamlPackages) odig;
+
   orc = callPackage ../development/compilers/orc { };
 
   orocos-kdl = callPackage ../development/libraries/orocos-kdl { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1890,6 +1890,8 @@ let
 
     buildOasisPackage = callPackage ../build-support/ocaml/oasis.nix { };
 
+    buildTopkgPackage = callPackage ../build-support/ocaml/topkg.nix { };
+
     # Apps from all-packages, to be eventually removed
 
     google-drive-ocamlfuse = callPackage ../applications/networking/google-drive-ocamlfuse { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1332,6 +1332,8 @@ let
 
     odate = callPackage ../development/ocaml-modules/odate { };
 
+    odig = callPackage ../development/ocaml-modules/odig { };
+
     odoc = callPackage ../development/ocaml-modules/odoc { };
 
     odoc-parser = callPackage ../development/ocaml-modules/odoc-parser { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -60,6 +60,8 @@ let
 
     ### B ###
 
+    b0 = callPackage ../development/ocaml-modules/b0 { };
+
     bap = janeStreet_0_15.bap;
 
     base64 = callPackage ../development/ocaml-modules/base64 { };


### PR DESCRIPTION
###### Description of changes

This PR adds `odig`, a tool for locally building documentation of OCaml libraries and two missing dependencies:
- `ocamlPackages.buildTopkgPackage`, a function for building `topkg` packages. Very similar to `buildDunePackage`.
  This function helps building an OCaml package that builds with topkg. There are currently many such packages in nixpkgs and this function would greatly simplify adding more.
  This is heavily inspired by `ocamlPackages.buildDunePackage`.
  I did not modify the existing packages to use this new function.
- `ocamlPackages.b0`, a dependency of `odig`.

`odig` is added to `all-packages` as it is a binary tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
