### PR TITLE
nixos/user-groups: Add to $NIX_PROFILES paths

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -681,6 +681,7 @@ in {
 
     environment.profiles = [
       "$HOME/.nix-profile"
+      "\${XDG_STATE_HOME:-$HOME/.local/state}/nix/profile"
       "/etc/profiles/per-user/$USER"
     ];
 


### PR DESCRIPTION
###### Description of changes
Closes #243826, #243899
fixes packages installed by `nix profile` and `nix-env` not being added to `$NIX_PROFILES` with `nix.settings.use-xdg-base-directories = true;`
###### Things done
- [x] Tested the module
