### PR TITLE
epsonscan2: init at 6.7.61.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7296,6 +7296,11 @@
     github = "jali-clarke";
     githubId = 17733984;
   };
+  james-atkins = {
+    name = "James Atkins";
+    github = "james-atkins";
+    githubId = 9221409;
+  };
   jamiemagee = {
     email = "jamie.magee@gmail.com";
     github = "JamieMagee";

--- a/pkgs/misc/drivers/epsonscan2/build.patch
+++ b/pkgs/misc/drivers/epsonscan2/build.patch
@@ -1,0 +1,91 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a9daee7..7c6da08 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,7 +17,6 @@
+ #  CMakeLists.txt -- template and derived ESC/I ESC/I-2 protocol commands
+ 
+ project (epsonscan2)
+-set (CMAKE_INSTALL_PREFIX "/usr")
+ cmake_minimum_required (VERSION 2.8.12.2)
+ 
+ include(GNUInstallDirs)
+@@ -86,7 +85,6 @@ set(COMMON_ETC_PATH ${CMAKE_INSTALL_FULL_SYSCONFDIR})
+ set(EPSON_WORK_PATH /tmp/epsonWork/)
+ set(EPSON_SETTINGS_PATH $ENV{HOME}/.epsonscan2/)
+ 
+-SET (CMAKE_INSTALL_PREFIX /usr)
+ set(EPSON_INSTALL_PATH ${CMAKE_INSTALL_FULL_LIBDIR}/epsonscan2/)
+ set(COMMON_SHARE_PATH ${CMAKE_INSTALL_FULL_DATAROOTDIR})
+ 
+@@ -113,8 +111,8 @@ add_subdirectory(src)
+ 
+ install(DIRECTORY Resources DESTINATION ${EPSON_INSTALL_ROOT}${EPSON_INSTALL_PATH})
+ 
+-install(FILES epsonscan2.rules DESTINATION ${EPSON_INSTALL_ROOT}/lib/udev/rules.d/ RENAME 60-epsonscan2.rules)
+-install(FILES epsonscan2 DESTINATION ${EPSON_INSTALL_ROOT}/etc/sane.d/dll.d)
++install(FILES epsonscan2.rules DESTINATION ${EPSON_INSTALL_ROOT}${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d/ RENAME 60-epsonscan2.rules)
++install(FILES epsonscan2 DESTINATION ${EPSON_INSTALL_ROOT}${CMAKE_INSTALL_PREFIX}/etc/sane.d/dll.d)
+ install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${EPSON_INSTALL_ROOT}${CMAKE_INSTALL_FULL_LIBDIR}/sane/)")
+ install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../epsonscan2/libsane-epsonscan2.so ${EPSON_INSTALL_ROOT}${CMAKE_INSTALL_FULL_LIBDIR}/sane/libsane-epsonscan2.so.1)")
+ install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../epsonscan2/libsane-epsonscan2.so ${EPSON_INSTALL_ROOT}${CMAKE_INSTALL_FULL_LIBDIR}/sane/libsane-epsonscan2.so.1.0.0)")
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index c884d83..5ddff0c 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -26,7 +26,9 @@ add_subdirectory(ES2Command/Linux)
+ add_subdirectory(ES2FileFormat/Linux)
+ add_subdirectory(Controller)
+ add_subdirectory(SaneWrapper/Linux)
++if (NOT DEFINED NO_GUI)
+ add_subdirectory(Standalone)
+ add_subdirectory(DetectAlert)
++endif ()
+ add_subdirectory(ScanSDK)
+ 
+diff --git a/src/Controller/Src/Filter/GetOrientation.cpp b/src/Controller/Src/Filter/GetOrientation.cpp
+index 387561e..15448ad 100644
+--- a/src/Controller/Src/Filter/GetOrientation.cpp
++++ b/src/Controller/Src/Filter/GetOrientation.cpp
+@@ -12,14 +12,7 @@ namespace epsonscan
+ 
+ static std::string GetExecPath()
+ {
+-#ifdef AKBMODE
+-    std::string strDst = "/usr/libexec/";
+-    strDst = strDst + DRIVER_NAME;
+-    strDst = strDst + "-ocr/ocr-engine-getrotate";
+-    return strDst.c_str() ;
+-#else
+-    return "/usr/libexec/epsonscan2-ocr/ocr-engine-getrotate" ;
+-#endif
++    return "@OCR_ENGINE_GETROTATE@";
+ }
+ static const int kMaxBuf = 256;
+ 
+diff --git a/src/Controller/Src/Scanner/Engine.cpp b/src/Controller/Src/Scanner/Engine.cpp
+index 9489d4b..670bad9 100644
+--- a/src/Controller/Src/Scanner/Engine.cpp
++++ b/src/Controller/Src/Scanner/Engine.cpp
+@@ -263,8 +263,8 @@ SDIError Engine::Open()
+ 	//kill es2netif
+ 	//kill es2intif
+ 
+-	system("killall -9 -q es2netif > /dev/null");
+-	system("killall -9 -q es2intif > /dev/null");
++	system("@KILLALL@ -9 -q es2netif > /dev/null");
++	system("@KILLALL@ -9 -q es2intif > /dev/null");
+ 
+ 	if (engine_) {
+ 		return ExchangeError(engine_->Open());
+diff --git a/src/Standalone/CMakeLists.txt b/src/Standalone/CMakeLists.txt
+index eff3dd3..c2b3803 100644
+--- a/src/Standalone/CMakeLists.txt
++++ b/src/Standalone/CMakeLists.txt
+@@ -167,5 +167,5 @@ target_link_libraries(es2standalone ${QT_LIBRARIES}
+ )
+ 
+ QT5_USE_MODULES(es2standalone Widgets)
+-install(TARGETS es2standalone DESTINATION "${EPSON_INSTALL_ROOT}/usr/bin")
++install(TARGETS es2standalone DESTINATION "${EPSON_INSTALL_ROOT}${CMAKE_INSTALL_FULL_BINDIR}")
+ 

--- a/pkgs/misc/drivers/epsonscan2/default.nix
+++ b/pkgs/misc/drivers/epsonscan2/default.nix
@@ -1,0 +1,162 @@
+{ lib
+, stdenv
+, autoPatchelfHook
+, boost
+, cmake
+, copyDesktopItems
+, imagemagick
+, fetchpatch
+, fetchzip
+, killall
+, libjpeg
+, libpng
+, libtiff
+, libtool
+, libusb1
+, makeDesktopItem
+, qtbase
+, wrapQtAppsHook
+
+, withGui ? true
+, withNonFreePlugins ? false
+}:
+
+let
+  pname = "epsonscan2";
+  description = "Epson Scan 2 scanner driver for many modern Epson scanners and multifunction printers";
+  version = "6.7.61.0";
+
+  system = stdenv.hostPlatform.system;
+
+  src = fetchzip {
+    url = "https://download3.ebz.epson.net/dsc/f/03/00/14/53/67/1a6447b4acc5568dfd970feba0518fabea35bca2/epsonscan2-${version}-1.src.tar.gz";
+    hash = "sha256-xwvdgmV6Mrs1RC18U2mA+HlTYybeYb0V5lz5hCvC7+8=";
+  };
+  bundle = {
+    "i686-linux" = fetchzip {
+      name = "${pname}-bundle";
+      url = "https://download3.ebz.epson.net/dsc/f/03/00/14/53/69/3151031c0fb4deea3f48781fd051411b983ccee4/epsonscan2-bundle-${version}.i686.deb.tar.gz";
+      hash = "sha256-nq3Nqunt8aMcCf7U7JBYrVscvrhhcwcn8RlhYXLmC2c=";
+    };
+
+    "x86_64-linux" = fetchzip {
+      name = "${pname}-bundle";
+      url = "https://download3.ebz.epson.net/dsc/f/03/00/14/53/68/a5e06101ba3f328dd747888e3dddebbb677bb8c8/epsonscan2-bundle-${version}.x86_64.deb.tar.gz";
+      hash = "sha256-cFx54CKkZtvhZ5ABuBwB8+IzhT2lu8D3+GZFaMuWf3Y=";
+    };
+  }."${system}" or (throw "Unsupported system: ${system}");
+
+in
+stdenv.mkDerivation {
+  inherit pname src version;
+
+  patches = [
+    ./build.patch
+    (fetchpatch {
+      url = "https://github.com/flathub/net.epson.epsonscan2/raw/master/patches/epsonscan2-crash.patch";
+      hash = "sha256-srMxlFfnZuJ3ed5veFcJIiZuW27F/3xOS0yr4ywn4FI=";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/flathub/net.epson.epsonscan2/master/patches/epsonscan2-oob-container.patch";
+      hash = "sha256-FhXZT0bIBYwdFow2USRJl8Q7j2eqpq98Hh0lHFQlUQY=";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/flathub/net.epson.epsonscan2/master/patches/epsonscan2-xdg-open.patch";
+      hash = "sha256-4ih3vZjPwWiiAxKfpLIwbbsk1K2oXSuxGbT5PVwfUsc=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace src/Controller/Src/Scanner/Engine.cpp \
+      --replace '@KILLALL@' ${killall}/bin/killall
+
+    substituteInPlace src/Controller/Src/Filter/GetOrientation.cpp \
+      --replace '@OCR_ENGINE_GETROTATE@' $out/libexec/epsonscan2-ocr/ocr-engine-getrotate
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optionals withGui [
+    imagemagick # to make icons
+    wrapQtAppsHook
+  ] ++ lib.optionals withNonFreePlugins [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    boost
+    libjpeg
+    libpng
+    libtiff
+    libusb1
+  ] ++ lib.optionals withGui [
+    copyDesktopItems
+    qtbase
+  ] ++ lib.optionals withNonFreePlugins [
+    libtool.lib
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    # The non-free (Debian) packages uses this directory structure so do the same when compiling
+    # from source so we can easily merge them.
+    "-DCMAKE_INSTALL_LIBDIR=lib/${system}-gnu"
+  ] ++ lib.optionals (!withGui) [
+    "-DNO_GUI=ON"
+  ];
+
+  postInstall = ''
+    # But when we put all the libraries in lib/${system}-gnu, then SANE can't find the
+    # required libraries so create a symlink to where it expects them to be.
+    mkdir -p $out/lib/sane
+    for file in $out/lib/${system}-gnu/sane/*.so.*; do
+      ln -s $file $out/lib/sane/
+    done
+  '' + lib.optionalString withGui ''
+    # The icon file extension is .ico but it's actually a png!
+    mkdir -p $out/share/icons/hicolor/{48x48,128x128}/apps
+    convert $src/Resources/Icons/escan2_app.ico -resize 48x48 $out/share/icons/hicolor/48x48/apps/epsonscan2.png
+    convert $src/Resources/Icons/escan2_app.ico -resize 128x128 $out/share/icons/hicolor/128x128/apps/epsonscan2.png
+  '' + lib.optionalString withNonFreePlugins ''
+    ar xf ${bundle}/plugins/epsonscan2-non-free-plugin_*.deb
+    tar Jxf data.tar.xz
+    cp -r usr/* $out
+  '';
+
+  desktopItems = lib.optionals withGui [
+    (makeDesktopItem {
+      name = pname;
+      exec = "epsonscan2";
+      icon = "epsonscan2";
+      desktopName = "Epson Scan 2";
+      genericName = "Epson Scan 2";
+      comment = description;
+      categories = [ "Graphics" "Scanning" ];
+    })
+  ];
+
+  meta = {
+    inherit description;
+    longDescription = ''
+      Epson Scan 2 scanner driver including optional non-free plugins such as OCR and network
+      scanning.
+
+      To use the SANE backend:
+      <literal>
+      hardware.sane.extraBackends = [ pkgs.epsonscan2 ];
+      </literal>
+
+      Overrides can be used to customise this package. For example, to enable non-free plugins and
+      disable the Epson GUI:
+      <literal>
+      pkgs.epsonscan2.override { withNonFreePlugins = true; withGui = false; }
+      </literal>
+    '';
+    homepage = "https://support.epson.net/linux/en/epsonscan2.php";
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ] ++ lib.optionals withNonFreePlugins [ binaryNativeCode ];
+    license = with lib.licenses; if withNonFreePlugins then unfree else lgpl21Plus;
+    maintainers = with lib.maintainers; [ james-atkins ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39398,6 +39398,8 @@ with pkgs;
 
   terminal-parrot = callPackage ../applications/misc/terminal-parrot { };
 
+  epsonscan2 = pkgs.libsForQt5.callPackage ../misc/drivers/epsonscan2 { };
+
   epson-alc1100 = callPackage ../misc/drivers/epson-alc1100 { };
 
   epson-escpr = callPackage ../misc/drivers/epson-escpr { };


### PR DESCRIPTION
###### Description of changes

Add the Epson Scan 2 scanning utility and drivers, with optional non-free plugins .

https://support.epson.net/linux/en/epsonscan2.php

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
