### PR TITLE
tor-browser-bundle-bin: 12.5 -> 12.5.1

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -89,7 +89,7 @@ let
   fteLibPath = lib.makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "12.5";
+  version = "12.5.1";
 
   lang = "ALL";
 
@@ -101,7 +101,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      hash = "sha256-ois/0ghnQVX6A4OsGybOX2Ph0eKHOHX0+qfR9rnA3v8=";
+      hash = "sha256-Kuq7ZNhaDl2nBcokWKm/XTIjJ8h4czEvwvsF2z3DzJ4=";
     };
 
     i686-linux = fetchurl {
@@ -111,7 +111,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      hash = "sha256-Wee3wCVT+Ius9qOJOLTdAEysMh6Z2+swoS9obF28bYo=";
+      hash = "sha256-WNIlwDNVUJyO5l33QxLwTn1knADXDzPvgG279QeRXl8=";
     };
   };
 


### PR DESCRIPTION
###### Description of changes

https://blog.torproject.org/new-release-tor-browser-1251/

> This release updates Firefox to 102.13.0esr, including bug fixes, stability improvements and important [security updates](https://www.mozilla.org/en-US/security/advisories/mfsa2023-23/). [...]
>
> The full changelog since [Tor Browser 12.5](https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/maint-12.5/projects/browser/Bundle-Data/Docs-TBB/ChangeLog.txt) is:
>
> * All Platforms
>   * Updated Translations
>   * Updated NoScript to 11.4.24
>   * [Bug tor-browser#41860](https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/41860): Rebase 12.5 stable to 102.13esr
> * Windows + macOS + Linux
>   * Updated Firefox to 102.13.0esr
>   * [Bug tor-browser#41854](https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/41854): Download Spam Protection cannot be overridden to allow legitimate downloads
>   * [Bug tor-browser#41856](https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/41856): Onion service authorization prompt's key field does not get focus when clicked
>   * [Bug tor-browser#41858](https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/41858): 'Learn more' link in onboarding links to 12.0 release notes and not 12.5
> * Android
>   * Updated GeckoView to 102.13.0esr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>tor-browser-bundle-bin</li>
  </ul>
</details>
