### PR TITLE
nixos/unpackerr: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -16,6 +16,8 @@
 
 - [GoToSocial](https://gotosocial.org/), an ActivityPub social network server, written in Golang. Available as [services.gotosocial](#opt-services.gotosocial.enable).
 
+- [Unpackerr](https://unpackerr.zip/), a service to automate unpacking archive files. Available as [services.unpackerr](#opt-services.unpackerr.enable).
+
 - [Anuko Time Tracker](https://github.com/anuko/timetracker), a simple, easy to use, open source time tracking system. Available as [services.anuko-time-tracker](#opt-services.anuko-time-tracker.enable).
 
 - [sitespeed-io](https://sitespeed.io), a tool that can generate metrics (timings, diagnostics) for websites. Available as [services.sitespeed-io](#opt-services.sitespeed-io.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -718,6 +718,7 @@
   ./services/misc/tp-auto-kbbl.nix
   ./services/misc/tzupdate.nix
   ./services/misc/uhub.nix
+  ./services/misc/unpackerr.nix
   ./services/misc/weechat.nix
   ./services/misc/xmr-stak.nix
   ./services/misc/xmrig.nix

--- a/nixos/modules/services/misc/unpackerr.nix
+++ b/nixos/modules/services/misc/unpackerr.nix
@@ -1,0 +1,66 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.unpackerr;
+  format = pkgs.formats.toml {};
+  configFile = format.generate "unpackerr.conf" cfg.settings;
+in
+{
+  options = {
+    services.unpackerr = {
+      enable = mkEnableOption (lib.mdDoc "Unpackerr");
+
+      settings = mkOption {
+        type = format.type;
+        default = {
+          # Config needs to be non-empty, otherwise unpackerr
+          # crashes. debug=false is the default value.
+          debug = false;
+        };
+        description = lib.mdDoc ''
+          Unpackerr configuration. Refer to
+          <https://unpackerr.zip/docs/install/configuration> for
+          details.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "nobody";
+        description = lib.mdDoc "User account under which Unpackerr runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nogroup";
+        description = lib.mdDoc "Group under which Unpackerr runs.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.unpackerr;
+        defaultText = literalExpression "pkgs.unpackerr";
+        description = lib.mdDoc ''
+          Unpackerr package to use.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.unpackerr = {
+      description = "Unpackerr";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${cfg.package}/bin/unpackerr -c ${configFile}";
+        Restart = "on-failure";
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add nixos module for unpackerr. Software is already in nixpkgs, just needed nixos config

Works for me, I left default user/group set to nobody/nogroup because this needs to run as the owner of archive files so there is no good default

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
