### PR TITLE
aria2: build with GNUTLS instead of OpenSSL

### DIFF
--- a/pkgs/tools/networking/aria2/default.nix
+++ b/pkgs/tools/networking/aria2/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook
-, openssl, c-ares, libxml2, sqlite, zlib, libssh2
+, gnutls, c-ares, libxml2, sqlite, zlib, libssh2
 , cppunit, sphinx
 , Security
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   nativeBuildInputs = [ pkg-config autoreconfHook sphinx ];
 
-  buildInputs = [ openssl c-ares libxml2 sqlite zlib libssh2 ] ++
+  buildInputs = [ gnutls c-ares libxml2 sqlite zlib libssh2 ] ++
     lib.optional stdenv.isDarwin Security;
 
   outputs = [ "bin" "dev" "out" "doc" "man" ];


### PR DESCRIPTION
###### Description of changes

Updates the aria2 derivation to use GNUTLS for SSL in place of OpenSSL, as a workaround for issues aria2 has with TLS v1.3 while running on Linux.

The Darwin build works fine with or without this change.

Searching for "protocol error" in the [aria2 issue tracker](https://github.com/aria2/aria2/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+%22protocol+error%22) comes up with multiple issues citing trouble with the default aria2 builds that use OpenSSL. [One of these issues](https://github.com/aria2/aria2/issues/1494) claims that building aria2 with GNUTLS yields a build of aria2 that works with TLS v1.3 correctly.

**aria2 from nixpkgs**

```
$ nix run nixpkgs#aria2 -- https://catboe.moe
07/05 12:26:53 [NOTICE] Downloading 1 item(s)

07/05 12:26:54 [ERROR] CUID#7 - Download aborted. URI=https://catbox.moe
Exception: [AbstractCommand.cc:351] errorCode=1 URI=https://catbox.moe
  -> [SocketCore.cc:1018] errorCode=1 SSL/TLS handshake failure: protocol error

07/05 12:26:54 [NOTICE] Download GID#f86420f990651763 not complete: 

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
f86420|ERR |       0B/s|https://catbox.moe

Status Legend:
(ERR):error occurred.

aria2 will resume download if the transfer is restarted.
If there are any errors, then see the log file. See '-l' option in help/man page for details.
```

**aria2 from this patch**

```
$ nix run github:msfjarvis/nixpkgs/hs/workaround-aria2c-tls-issues#aria2 -- https://catbox.moe

07/05 12:29:14 [NOTICE] Downloading 1 item(s)
[#7f09d7 0B/0B CN:1 DL:0B]                                                                                                                                                         
07/05 12:29:16 [NOTICE] Download complete: /home/msfjarvis/index.html

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
7f09d7|OK  |   4.4KiB/s|/home/msfjarvis/index.html

Status Legend:
(OK):download completed.

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
