### PR TITLE
linuxPackages.ax99100: Fix build with Linux 6.4

### DIFF
--- a/pkgs/os-specific/linux/ax99100/default.nix
+++ b/pkgs/os-specific/linux/ax99100/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation {
     ./kernel-6.1-set_termios-const-ktermios.patch
   ] ++ lib.optionals (lib.versionAtLeast kernel.version "6.2") [
     ./kernel-6.2-fix-pointer-type.patch
+    ./kernel-6.4-fix-define-semaphore.patch
   ];
 
   patchFlags = [ "-p0" ];

--- a/pkgs/os-specific/linux/ax99100/kernel-6.4-fix-define-semaphore.patch
+++ b/pkgs/os-specific/linux/ax99100/kernel-6.4-fix-define-semaphore.patch
@@ -1,0 +1,14 @@
+--- ax99100_sp.c
++++ ax99100_sp.c
+@@ -2670,8 +2670,10 @@ static void serial99100_dma_tx_tasklet (unsigned long param)
+ 
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,37)
+ static DECLARE_MUTEX(serial99100_sem);
+-#else
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
+ static DEFINE_SEMAPHORE(serial99100_sem);
++#else
++static DEFINE_SEMAPHORE(serial99100_sem, 1);
+ #endif
+ 
+ static struct uart_driver starex_serial_driver = {


### PR DESCRIPTION
###### Description of changes

The ax99100 serial driver needs to be adapted to be compatible with Linux 6.4. The signature of `DEFINE_SEMAPHORE` has changed to now include the initial counter, which in this case should be 1 to form a mutex.

This will need to be backport to 23.05 as Linux 6.4 was added there and prevents the build of `linuxPackages_latest.ax99100`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@messemar 