### PR TITLE
lib/tests: invalidate hashes

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -64,9 +64,9 @@ checkConfigOutput '^"one two"$' config.result ./shorthand-meta.nix
 checkConfigOutput '^true$' config.result ./test-mergeAttrDefinitionsWithPrio.nix
 
 # types.pathInStore
-checkConfigOutput '".*/store/5lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./types.nix
-checkConfigOutput '".*/store/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15"' config.pathInStore.ok2 ./types.nix
-checkConfigOutput '".*/store/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15/bin/bash"' config.pathInStore.ok3 ./types.nix
+checkConfigOutput '".*/store/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./types.nix
+checkConfigOutput '".*/store/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15"' config.pathInStore.ok2 ./types.nix
+checkConfigOutput '".*/store/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15/bin/bash"' config.pathInStore.ok3 ./types.nix
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ""' config.pathInStore.bad1 ./types.nix
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ".*/store"' config.pathInStore.bad2 ./types.nix
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ".*/store/"' config.pathInStore.bad3 ./types.nix

--- a/lib/tests/modules/types.nix
+++ b/lib/tests/modules/types.nix
@@ -12,9 +12,9 @@ in
     pathInStore = mkOption { type = types.lazyAttrsOf types.pathInStore; };
   };
   config = {
-    pathInStore.ok1 = "${storeDir}/5lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv";
-    pathInStore.ok2 = "${storeDir}/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15";
-    pathInStore.ok3 = "${storeDir}/xfb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15/bin/bash";
+    pathInStore.ok1 = "${storeDir}/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv";
+    pathInStore.ok2 = "${storeDir}/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15";
+    pathInStore.ok3 = "${storeDir}/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15/bin/bash";
     pathInStore.bad1 = "";
     pathInStore.bad2 = "${storeDir}";
     pathInStore.bad3 = "${storeDir}/";


### PR DESCRIPTION
Having the current bash hash present in the nixpkgs tree makes Nix detect bash as a runtime dependency of nixpkgs, which in turn messes up `fetchFromGitHub` due to https://github.com/NixOS/nix/issues/6660

cc. @roberth 