### PR TITLE
lilex: init at 2.200

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3034,6 +3034,12 @@
     githubId = 538538;
     name = "Bryan Richter";
   };
+  chriscoffee = {
+    email = "millscj01@gmail.com";
+    github = "chriscoffee";
+    githubId = 7100370;
+    name = "Chris Mills";
+  };
   chrisjefferson = {
     email = "chris@bubblescope.net";
     github = "ChrisJefferson";
@@ -19000,6 +19006,5 @@
     githubId = 	59917878;
     name = "Mathias Zhang";
   };
-
 }
 /* Keep the list alphabetically sorted. */

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19000,5 +19000,6 @@
     githubId = 	59917878;
     name = "Mathias Zhang";
   };
+
 }
 /* Keep the list alphabetically sorted. */

--- a/pkgs/data/fonts/lilex/default.nix
+++ b/pkgs/data/fonts/lilex/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "lilex";
+  version = "2.200";
+
+  src = fetchzip {
+    url = "https://github.com/mishamyrt/Lilex/releases/download/${version}/Lilex.zip";
+    sha256 = "sha256-MPQfqCMFMjcAlMos1o4bC+I+cvQYwr2TjI4Q03QeuaQ=";
+    stripRoot = false;
+  };
+
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 variable/*.ttf -t $out/share/fonts/lilex
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Open source programming font";
+    longDescription = ''
+      Lilex is the modern programming font containing a set of ligatures for
+      common programming multi-character combinations.
+    '';
+    homepage = "https://github.com/mishamyrt/Lilex";
+
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ chriscoffee ];
+    platforms = lib.platforms; all;
+  };
+}

--- a/pkgs/data/fonts/lilex/default.nix
+++ b/pkgs/data/fonts/lilex/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenvNoCC, fetchzip }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "lilex";
   version = "2.200";
 
   src = fetchzip {
-    url = "https://github.com/mishamyrt/Lilex/releases/download/${version}/Lilex.zip";
-    sha256 = "sha256-MPQfqCMFMjcAlMos1o4bC+I+cvQYwr2TjI4Q03QeuaQ=";
+    url = "https://github.com/mishamyrt/Lilex/releases/download/${finalAttrs.version}/Lilex.zip";
+    hash = "sha256-MPQfqCMFMjcAlMos1o4bC+I+cvQYwr2TjI4Q03QeuaQ=";
     stripRoot = false;
   };
 
@@ -21,14 +21,13 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "Open source programming font";
+    homepage = "https://github.com/mishamyrt/Lilex";
+    license = lib.licenses.ofl;
     longDescription = ''
       Lilex is the modern programming font containing a set of ligatures for
       common programming multi-character combinations.
     '';
-    homepage = "https://github.com/mishamyrt/Lilex";
-
-    license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ chriscoffee ];
-    platforms = lib.platforms; all;
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16359,6 +16359,8 @@ with pkgs;
 
   lessc = nodePackages.less;
 
+  lilex = callPackage ../data/fonts/lilex { };
+
   liquibase = callPackage ../development/tools/database/liquibase { };
 
   lizardfs = callPackage ../tools/filesystems/lizardfs { };


### PR DESCRIPTION
###### Description of changes

Added lilex font in variable format for those that don't want to the
nerdfont derivative.

Note that there already exists a nerdfont version of this font existing
within: https://github.com/NixOS/nixpkgs/blob/8fa6417e9ffc1927608b2e3c098d12160a803553/pkgs/data/fonts/nerdfonts/shas.nix#L35

Added myself as maintainer, which also requires me to add myself to
maintainers-list.nix as I don't already exist there.

Added package to top-level all packages.

Further to this, following rough guidelines within
https://discourse.nixos.org/t/guidelines-on-packaging-fonts/7683/3 I've
tried to use mkDerivation with fetchzip and preferred hash type.

Let me know if I have missed anything given the documentation for font submissions is a little sparse (which I don't mind).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
