### PR TITLE
jitterentropy: 3.3.1 -> 3.4.1

### DIFF
--- a/pkgs/development/libraries/jitterentropy/default.nix
+++ b/pkgs/development/libraries/jitterentropy/default.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   hardeningDisable = [ "fortify" ]; # avoid warnings
 
+  # prevent jitterentropy from builtin strip to allow controlling this from the derivation's
+  # settings. Also fixes a strange issue, where this strip may fail when cross-compiling.
   installFlags = [
+    "INSTALL_STRIP=install"
     "PREFIX=${placeholder "out"}"
   ];
 

--- a/pkgs/development/libraries/jitterentropy/default.nix
+++ b/pkgs/development/libraries/jitterentropy/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "jitterentropy";
-  version = "3.3.1";
+  version = "3.4.1";
 
   src = fetchFromGitHub {
     owner = "smuellerDD";
     repo = "jitterentropy-library";
     rev = "v${version}";
-    hash = "sha256-go7eGwBoZ58LkgKL7t8oZSc1cFlE6fPOT/ML3Aa8+CM=";
+    hash = "sha256-GSGlupTN1o8BbTN287beqYSRFDaXOk6SlIRvtjpvmhQ=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -55,7 +55,17 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
-  preCheck = "patchShebangs tests/*.sh";
+  preCheck = ''
+    patchShebangs tests/*.sh
+    export RNGD_JITTER_TIMEOUT=10
+  '';
+  # After updating to jitterentropy 3.4.1 jitterentropy initialization seams
+  # to have increased. On some system rng-tools fail therefore to initialize the
+  # jitterentropy entropy source. You can increase the init timeout with a command-line
+  # option (-O jitter:timeout:SECONDS). The environment variable above only has effect
+  # for the test cases.
+  # Patching the timeout to a larger value was declined upstream,
+  # see (https://github.com/nhorman/rng-tools/pull/178).
   nativeCheckInputs = [ psmisc ]; # rngtestjitter.sh needs killall
 
   doInstallCheck = true;


### PR DESCRIPTION
###### Description of changes

Update jitterentropy to 3.4.1 in order to enable ARM64 support for direct high resolution timestamp reading.
Furthermore, disable jitterentropy's own install with strip, as it is redundant and failed for me when cross-compiling
x86-64 to aarch64.

For a complete changelog, see: https://www.chronox.de/jent.html

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).