### PR TITLE
nixos/nftables: add redirect for /etc/hosts to checkRuleset

### DIFF
--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -44,11 +44,13 @@ in
     networking.nftables.checkRulesetRedirects = mkOption {
       type = types.addCheck (types.attrsOf types.path) (attrs: all types.path.check (attrNames attrs));
       default = {
+        "/etc/hosts" = config.environment.etc.hosts.source;
         "/etc/protocols" = config.environment.etc.protocols.source;
         "/etc/services" = config.environment.etc.services.source;
       };
       defaultText = literalExpression ''
         {
+          "/etc/hosts" = config.environment.etc.hosts.source;
           "/etc/protocols" = config.environment.etc.protocols.source;
           "/etc/services" = config.environment.etc.services.source;
         }

--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -44,13 +44,13 @@ in
     networking.nftables.checkRulesetRedirects = mkOption {
       type = types.addCheck (types.attrsOf types.path) (attrs: all types.path.check (attrNames attrs));
       default = {
-        "/etc/protocols" = "${pkgs.buildPackages.iana-etc}/etc/protocols";
-        "/etc/services" = "${pkgs.buildPackages.iana-etc}/etc/services";
+        "/etc/protocols" = config.environment.etc.protocols.source;
+        "/etc/services" = config.environment.etc.services.source;
       };
       defaultText = literalExpression ''
         {
-          "/etc/protocols" = "''${pkgs.buildPackages.iana-etc}/etc/protocols";
-          "/etc/services" = "''${pkgs.buildPackages.iana-etc}/etc/services";
+          "/etc/protocols" = config.environment.etc.protocols.source;
+          "/etc/services" = config.environment.etc.services.source;
         }
       '';
       description = mdDoc ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a redirect for `/etc/hosts` when checking the ruleset. For easier extension, redirects can be modified using the new `networking.nftables.checkRulesetRedirects` option. The defaults have been chosen to redirect to `environment.etc` so the ruleset check can utilize the same names as the built system.

Without this addition, hostnames defined via `networking.hosts` cannot be used while checking the ruleset, causing errors like this:
```
building '/nix/store/j07299i21rjvzmz9njykadh0skci50jc-nftables-rules.drv'...
In file included from ruleset.conf:3:1-63:
/nix/store/ayppg24dsajr3mf9cd2gh6h52cvz9qi4-nftables:79:14-20: Error: Could not resolve hostname: Temporary failure in name resolution
    ip saddr zonk tcp dport couchdb counter accept
             ^^^^
error: builder for '/nix/store/j07299i21rjvzmz9njykadh0skci50jc-nftables-rules.drv' failed with exit code 1
```

An alternative to this PR is to (ab-) use `networking.nftables.preCheckRuleset` to implement a custom check, e.g. like follows (but that's nothing friends would allow friends to do):
```nix
{
  networking.nftables.preCheckRuleset = ''
    export NIX_REDIRECTS=${escapeShellArg (concatStringsSep ":" (mapAttrsToList (name: value: "${name}=${value}") {
      "/etc/hosts" = config.environment.etc.hosts.source;
      "/etc/protocols" = config.environment.etc.protocols.source;
      "/etc/services" = config.environment.etc.services.source;
    }))}
    export LD_PRELOAD=${escapeShellArgs (toString [
      "${pkgs.buildPackages.libredirect}/lib/libredirect.so"
      "${pkgs.buildPackages.lklWithFirewall.lib}/lib/liblkl-hijack.so"
    ])}
    exec ${pkgs.buildPackages.nftables}/bin/nft --check --file ruleset.conf
  '';
}
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
