### PR TITLE
rng-tools: 6.15 -> 6.16

### DIFF
--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -7,23 +7,25 @@
 , psmisc
 , argp-standalone
 , openssl
+, libcap
 , jitterentropy, withJitterEntropy ? true
   # WARNING: DO NOT USE BEACON GENERATED VALUES AS SECRET CRYPTOGRAPHIC KEYS
   # https://www.nist.gov/programs-projects/nist-randomness-beacon
 , curl, jansson, libxml2, withNistBeacon ? false
 , libp11, opensc, withPkcs11 ? true
 , rtl-sdr, withRtlsdr ? true
+, withQrypt ? false
 }:
 
 stdenv.mkDerivation rec {
   pname = "rng-tools";
-  version = "6.15";
+  version = "6.16";
 
   src = fetchFromGitHub {
     owner = "nhorman";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-km+MEng3VWZF07sdvGLbAG/vf8/A1DxhA/Xa2Y+LAEQ=";
+    hash = "sha256-9pXQhG2nbu6bq4BnBgEOyyUBNkQTI5RhWmJIoLtFU+c=";
   };
 
   nativeBuildInputs = [ autoreconfHook libtool pkg-config ];
@@ -33,14 +35,16 @@ stdenv.mkDerivation rec {
     (lib.withFeature   (withNistBeacon)    "nistbeacon")
     (lib.withFeature   (withPkcs11)        "pkcs11")
     (lib.withFeature   (withRtlsdr)        "rtlsdr")
+    (lib.withFeature   (withQrypt)         "qrypt")
   ];
 
-  buildInputs = [ openssl ]
+  buildInputs = [ openssl libcap ]
     ++ lib.optionals stdenv.hostPlatform.isMusl [ argp-standalone ]
     ++ lib.optionals withJitterEntropy [ jitterentropy ]
     ++ lib.optionals withNistBeacon    [ curl jansson libxml2 ]
     ++ lib.optionals withPkcs11        [ libp11 libp11.passthru.openssl ]
-    ++ lib.optionals withRtlsdr        [ rtl-sdr ];
+    ++ lib.optionals withRtlsdr        [ rtl-sdr ]
+    ++ lib.optionals withQrypt         [ curl jansson ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes

Update rng-tools to 6.16 in order to be compatible to another update of jitterentropy to 3.4.1. Qrypt was added as another source of randomness and is therefore integrated in the package. libcap is a new default dependency.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
