### PR TITLE
avrdude: fix huge closure size by removing PostScript docs

### DIFF
--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation rec {
     "-DBUILD_DOC=ON"
   ];
 
+  # dvips output references texlive in comments, resulting in a huge closure
+  postInstall = lib.optionalString docSupport ''
+    rm $out/share/doc/${pname}/*.ps
+  '';
+
   meta = with lib; {
     description = "Command-line tool for programming Atmel AVR microcontrollers";
     longDescription = ''


### PR DESCRIPTION
###### Description of changes

After https://github.com/NixOS/nixpkgs/pull/233836 the closure size of `avrdude` increased to more than 1 GB on Linux, compared to the previous ≈100 MB:
```
/nix/store/jj4j4nrda65gd2b160zcx25pqm660z3c-avrdude-7.1	   3.0M	 102.9M
/nix/store/s9wq2kd1r2qvxjkzli0nm0cys9ip7qqv-avrdude-7.1	   4.6M	   1.1G
```
The problem was tracked down to the addition of the `share/doc/avrdude/avrdude.ps` file to the package — that file contains the full path of the used `dvips` executable in PostScript comments:
```ps
%DVIPSCommandLine:
%+ /nix/store/s318zscx6grakbs8jsmx894cijspkg7x-texlive-combined-medium-2022-final/bin/dvips
%+ -o avrdude.ps avrdude.dvi
```
The presence of that path resulted in adding the `texlive-combined-medium-2022-final` package to the runtime dependencies of the `avrdude` package, even though the intent of #233836 was to add texlive just to the build dependencies.

The simplest way to fix this problem is to remove the offending `avrdude.ps` file — the formatted documentation is still provided in the PDF format (`avrdude.pdf` in the same directory), which is probably more useful than a raw PostScript file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
