### PR TITLE
vscode: fix vscode-insiders on darwin

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -12,10 +12,10 @@
 
 # Attributes inherit from specific versions
 , version, src, meta, sourceRoot, commandLineArgs
-, executableName, longName, shortName, pname, updateScript, sourceExecutableName
+, executableName, longName, shortName, pname, updateScript
 , dontFixup ? false
 , rev ? null, vscodeServer ? null
-
+, sourceExecutableName ? executableName
 , useVSCodeRipgrep ? false
 , ripgrep
 }:

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -12,13 +12,9 @@
 
 # Attributes inherit from specific versions
 , version, src, meta, sourceRoot, commandLineArgs
-, executableName, longName, shortName, pname, updateScript
+, executableName, longName, shortName, pname, updateScript, sourceExecutableName
 , dontFixup ? false
 , rev ? null, vscodeServer ? null
-
-# sourceExecutableName is the name of the binary in the source archive, over
-# which we have no control
-, sourceExecutableName ? executableName
 
 , useVSCodeRipgrep ? false
 , ripgrep

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -41,7 +41,7 @@ in
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
     version = "1.81.0";
-    pname = "vscode";
+    pname = "vscode" + lib.optionalString isInsiders "-insiders";
 
     # This is used for VS Code - Remote SSH test
     rev = "6445d93c81ebe42c4cbd7a60712e0b17d9463e97";

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -9,7 +9,7 @@
 # which we have no control and it is needed to run the insider version as
 # documented in https://nixos.wiki/wiki/Visual_Studio_Code#Insiders_Build
 # On MacOS the insider binary is still called code instead of code-insiders as
-# of 04-07-2023.
+# of 2023-08-06.
 , sourceExecutableName ? "code" + lib.optionalString (isInsiders && stdenv.isLinux) "-insiders"
 , commandLineArgs ? ""
 , useVSCodeRipgrep ? stdenv.isDarwin

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -5,6 +5,12 @@
 , nixosTests
 , srcOnly
 , isInsiders ? false
+# sourceExecutableName is the name of the binary in the source archive over
+# which we have no control and it is needed to run the insider version as
+# documented in https://nixos.wiki/wiki/Visual_Studio_Code#Insiders_Build
+# On MacOS the insider binary is still called code instead of code-insiders as
+# of 04-07-2023.
+, sourceExecutableName ? "code" + lib.optionalString (isInsiders && stdenv.isLinux) "-insiders"
 , commandLineArgs ? ""
 , useVSCodeRipgrep ? stdenv.isDarwin
 }:
@@ -43,7 +49,7 @@ in
     executableName = "code" + lib.optionalString isInsiders "-insiders";
     longName = "Visual Studio Code" + lib.optionalString isInsiders " - Insiders";
     shortName = "Code" + lib.optionalString isInsiders " - Insiders";
-    inherit commandLineArgs useVSCodeRipgrep;
+    inherit commandLineArgs useVSCodeRipgrep sourceExecutableName;
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";


### PR DESCRIPTION
###### Description of changes

Building vscode-insiders according to https://nixos.wiki/wiki/Visual_Studio_Code#Insiders_Build fails on darwin because the binary in the darwin vscode-insiders is still called `code` instead of `code-insiders`and thus the symlinking breaks (On linux it is correctly called `code-insiders`).

As this is likely to change again, I also moved the responsible `sourceExecutableName` argument one layer up from generic.nix to vscode.nix to make it more easily overridable in the future.

Lastly, I also set the pname to vscode-insiders if insiders = true for a better integration with home-manager since it uses the package name to set the extensions dir (e.g. ~/.code vs ~/.code-insiders) accordingly.

As a result, vscode-insiders builds with the documented expression and works out of the box if added to home-manager packages as shown below:

```nix
# home-manager config
vscode.package = (pkgs.vscode.override { isInsiders = true; }).overrideAttrs (oldAttrs: rec 
{
    src = (builtins.fetchTarball 
    {
        url    = "https://code.visualstudio.com/sha/download?build=insider&os=darwin-arm64";
        sha256 = "sha256:1cfd9x2shsh664cniysbj0vj5lkhyy7gxd84hl805nf2y9r6m8qs";
    });
    version = "latest";
});
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
