### PR TITLE
make pre-commit use venv's even for `meta` hooks

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -101,11 +101,17 @@ buildPythonApplication rec {
     deactivate
   '';
 
-  # Propagating dependencies leaks them through $PYTHONPATH which causes issues
-  # when used in nix-shell.
+
+  # Propagating inputs causes them to show up in $PYTHONPATH in a nix shell,
+  # this is problematic because they might conflict with the user's dependencies,
+  # so we remove them...
   postFixup = ''
     rm $out/nix-support/propagated-build-inputs
   '';
+
+  # ...but now we've hidden parts of pre-commit from itself (e.g. the built-in hooks)
+  # so we restore PYTHONPATH, but only inside of the wrapper.
+  makeWrapperArgs = ''--set PYTHONPATH $PYTHONPATH'';
 
   disabledTests = [
     # ERROR: The install method you used for conda--probably either `pip install conda`


### PR DESCRIPTION
I'm not a seasoned nixpkgs contributor, nor a pre-commit expert, so I'm hoping somebody comes along and shows me a better way.  This is a little hacky.

### The Problem

Previously, the nixpkgs pre-commit package propagated its build inputs into user devshells.  This caused [problems](https://github.com/nix-community/poetry2nix/issues/1076), so I "[fixed it](https://github.com/NixOS/nixpkgs/pull/235123)" to make pre-commit more self-contained.  

That is, to make it behave more like an app and less like a library.  I made it so that you can't import pre-commit or its dependencies in your python code without explicitly including it in your python environment.  i.e. having it as a package in your nix shell lets you run it like an app, but not import it in your code.   

This fix was premature.  It turns out that [I broke meta imports](https://github.com/NixOS/nixpkgs/issues/238345)(shame on me for not testing more thoroughly).

Most pre-commit hooks live in external repositories, so pre-commit clones them and creates environments for them.  `meta` hooks, however live in the pre-commit repo and are called directly.  So unlike the others, they're expecting pre-commit to be treated "like a library" and not "like an app".

When I switched the package from library mode to app mode, I removed pre-commit from the environment that the `meta` hooks were using.  Now they break like so:

```
Check hooks apply to the repository......................................Failed
- hook id: check-hooks-apply
- exit code: 1

/nix/store/6jx4nc20v3cfphlbypqid30q41i5vh5x-python3-3.10.11/bin/python3.10: Error while finding module specification for 'pre_commit.meta_hooks.check_hooks_apply' (ModuleNotFoundError: No module named 'pre_commit')
```

I'm uncertain about whether this is better or worse than it was before.  On one hand, the failure is more likely to appear.  On the other hand, it's less of a mystery and easier to work around.  These hooks are linting your pre-commit config so that *other* hooks can lint your code (or whatever else you're using pre-commit for).  They're more safely ignored than some others.  It's still no fun that they break.

### My Solution

**EDIT: This solution was abandoned, scroll down to @anund's comments to see the better one**

The patch included in this PR mutates the pre-commit repo so that it provides the `meta` hooks in the same way that any other repo might provide any other hook (see comments below for how this works).

