### PR TITLE
kitty: make possible to override goModules

### DIFF
--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -100,7 +100,7 @@ buildPythonApplication rec {
   CGO_ENABLED = 0;
   GOFLAGS = "-trimpath";
 
-  go-modules = (buildGoModule {
+  goModules = (buildGoModule {
     pname = "kitty-go-modules";
     inherit src vendorHash version;
   }).go-modules;
@@ -109,7 +109,7 @@ buildPythonApplication rec {
     export GOCACHE=$TMPDIR/go-cache
     export GOPATH="$TMPDIR/go"
     export GOPROXY=off
-    cp -r --reflink=auto ${go-modules} vendor
+    cp -r --reflink=auto $goModules vendor
   '';
 
   buildPhase = let


### PR DESCRIPTION
go-modules name had to be changed to goModules so it becomes a env var (bash vars can't contain -)

enables overriding the build without overriding configurePhase

```nix
pkgs.kitty.overrideAttrs (finalAttrs: previousAttrs: {
  name = "kitty-master";
  version = "master";
  src = pkgs.fetchFromGitHub {
    owner = "kovidgoyal";
    repo = "kitty";
    rev = "66a2efd191f98a1a5b3c2d4fdc9569204b445a2f";
    sha256 = "sha256-pJuhnJOjGBflHXOOYKrg9/e3c+VGEESZtfka84ARCd4=";
  };
  goModules = (pkgs.buildGoModule {
    pname = "kitty-go-modules";
    inherit (finalAttrs) src version;
    vendorHash = "sha256-eAovZ/7JnvXlnlFyt0skhYJ1Nrzy2XCpRlQvSmWCyaY=";
  }).go-modules;
})
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
