### PR TITLE
WIP: element-desktop cross build issues

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/keytar/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element/keytar/default.nix
@@ -15,6 +15,8 @@ in stdenv.mkDerivation rec {
     hash = pinData.srcHash;
   };
 
+  depsBuildBuild = [ pkg-config ];
+
   nativeBuildInputs = [
     nodejs python3 pkg-config
     npmHooks.npmConfigHook

--- a/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, callPackage, sqlcipher, nodejs, python3, yarn, fixup_yarn_lock, CoreServices, fetchYarnDeps, removeReferencesTo }:
+{ lib, stdenv, rust, rustPlatform, fetchFromGitHub, callPackage, sqlcipher, nodejs, python3, yarn, fixup_yarn_lock, CoreServices, fetchYarnDeps, removeReferencesTo }:
 
 let
   pinData = lib.importJSON ./pin.json;
@@ -36,7 +36,8 @@ in rustPlatform.buildRustPackage rec {
     fixup_yarn_lock yarn.lock
     yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
     patchShebangs node_modules/
-    node_modules/.bin/neon build --release
+    # Pass `--target` to allow cross-compilation, also force output name to let neon find cross-built library.
+    node_modules/.bin/neon build --release -- --target ${rust.toRustTargetSpec stdenv.hostPlatform} -Z unstable-options --out-dir target/release
     runHook postBuild
   '';
 

--- a/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
@@ -16,7 +16,7 @@ in rustPlatform.buildRustPackage rec {
 
   sourceRoot = "${src.name}/seshat-node/native";
 
-  nativeBuildInputs = [ nodejs python3 yarn ];
+  nativeBuildInputs = [ nodejs python3 yarn fixup_yarn_lock ];
   buildInputs = [ sqlcipher ] ++ lib.optional stdenv.isDarwin CoreServices;
 
   npm_config_nodedir = nodejs;
@@ -33,7 +33,7 @@ in rustPlatform.buildRustPackage rec {
     export HOME=$PWD/tmp
     mkdir -p $HOME
     yarn config --offline set yarn-offline-mirror $yarnOfflineCache
-    ${fixup_yarn_lock}/bin/fixup_yarn_lock yarn.lock
+    fixup_yarn_lock yarn.lock
     yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
     patchShebangs node_modules/
     node_modules/.bin/neon build --release


### PR DESCRIPTION
element-desktop fails to build with crosscompilation.

I fixed 2 problems (pkg-config invocation, as well as calling `fix_yarn_lock`), but it uncover two more problems.
* keytar haven't access to libsecret-1 via pkg-config (even if it correctly invoked)
* seshat unable to link with libsqlcipher.so (even if it detect correct aarch64-linux crosscoompiled library)

proper command for reproducing: `nix-build -A pkgsCross.aarch64-multiplatform.element-desktop`