### PR TITLE
vimPlugins: clean up overrides

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -35,10 +35,10 @@ let
   # or for all grammars:
   # pkgs.vimPlugins.nvim-treesitter.withAllGrammars
   withPlugins =
-    f: self.nvim-treesitter.overrideAttrs (_: {
+    f: self.nvim-treesitter.overrideAttrs {
       passthru.dependencies = map grammarToPlugin
         (f (tree-sitter.builtGrammars // builtGrammars));
-    });
+    };
 
   withAllGrammars = withPlugins (_: allGrammars);
 in

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -128,18 +128,18 @@
 }:
 
 self: super: {
-  alpha-nvim = super.alpha-nvim.overrideAttrs(oa: {
+  alpha-nvim = super.alpha-nvim.overrideAttrs {
     dependencies = [
       self.nvim-web-devicons # required by the startify theme
     ];
     nvimRequireCheck = "alpha";
-  });
+  };
 
-  autosave-nvim = super.autosave-nvim.overrideAttrs(old: {
+  autosave-nvim = super.autosave-nvim.overrideAttrs {
     dependencies = with super; [ plenary-nvim ];
-  });
+  };
 
-  barbecue-nvim = super.barbecue-nvim.overrideAttrs (old: {
+  barbecue-nvim = super.barbecue-nvim.overrideAttrs {
     dependencies = with self; [ nvim-lspconfig nvim-navic nvim-web-devicons ];
     meta = {
       description = "A VS Code like winbar for Neovim";
@@ -147,13 +147,13 @@ self: super: {
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [ lightquantum ];
     };
-  });
+  };
 
-  ChatGPT-nvim = super.ChatGPT-nvim.overrideAttrs (old: {
+  ChatGPT-nvim = super.ChatGPT-nvim.overrideAttrs {
     dependencies = with self; [ nui-nvim plenary-nvim telescope-nvim ];
-  });
+  };
 
-  clang_complete = super.clang_complete.overrideAttrs (old: {
+  clang_complete = super.clang_complete.overrideAttrs {
     # In addition to the arguments you pass to your compiler, you also need to
     # specify the path of the C++ std header (if you are using C++).
     # These usually implicitly set by cc-wrapper around clang (pkgs/build-support/cc-wrapper).
@@ -166,117 +166,117 @@ self: super: {
       substituteInPlace "$out"/plugin/libclang.py \
         --replace "/usr/lib/clang" "${llvmPackages.clang.cc}/lib/clang"
     '';
-  });
+  };
 
-  clighter8 = super.clighter8.overrideAttrs (old: {
+  clighter8 = super.clighter8.overrideAttrs {
     preFixup = ''
       sed "/^let g:clighter8_libclang_path/s|')$|${llvmPackages.clang.cc.lib}/lib/libclang.so')|" \
         -i "$out"/plugin/clighter8.vim
     '';
-  });
+  };
 
-  clipboard-image-nvim = super.clipboard-image-nvim.overrideAttrs (old: {
+  clipboard-image-nvim = super.clipboard-image-nvim.overrideAttrs {
     postPatch = ''
       sed -i -e 's/require "health"/vim.health/' lua/clipboard-image/health.lua
     '';
-  });
+  };
 
-  cmp-clippy = super.cmp-clippy.overrideAttrs (old: {
+  cmp-clippy = super.cmp-clippy.overrideAttrs {
     dependencies = with self; [ nvim-cmp plenary-nvim ];
-  });
+  };
 
-  cmp-copilot = super.cmp-copilot.overrideAttrs (old: {
+  cmp-copilot = super.cmp-copilot.overrideAttrs {
     dependencies = with self; [ nvim-cmp copilot-vim ];
-  });
+  };
 
-  cmp-dap = super.cmp-dap.overrideAttrs (old: {
+  cmp-dap = super.cmp-dap.overrideAttrs {
     dependencies = with self; [ nvim-cmp nvim-dap ];
-  });
+  };
 
-  cmp-dictionary = super.cmp-dictionary.overrideAttrs (old: {
+  cmp-dictionary = super.cmp-dictionary.overrideAttrs {
     dependencies = with self; [ nvim-cmp ];
-  });
+  };
 
-  cmp-digraphs = super.cmp-digraphs.overrideAttrs (old: {
+  cmp-digraphs = super.cmp-digraphs.overrideAttrs {
     dependencies = with self; [ nvim-cmp ];
-  });
+  };
 
-  cmp-fish = super.cmp-fish.overrideAttrs (old: {
+  cmp-fish = super.cmp-fish.overrideAttrs {
     dependencies = with self; [ nvim-cmp fish ];
-  });
+  };
 
-  cmp-fuzzy-buffer = super.cmp-fuzzy-buffer.overrideAttrs (old: {
+  cmp-fuzzy-buffer = super.cmp-fuzzy-buffer.overrideAttrs {
     dependencies = with self; [ nvim-cmp fuzzy-nvim ];
-  });
+  };
 
-  cmp-fuzzy-path = super.cmp-fuzzy-path.overrideAttrs (old: {
+  cmp-fuzzy-path = super.cmp-fuzzy-path.overrideAttrs {
     dependencies = with self; [ nvim-cmp fuzzy-nvim ];
-  });
+  };
 
-  cmp-git = super.cmp-git.overrideAttrs (old: {
+  cmp-git = super.cmp-git.overrideAttrs {
     dependencies = with self; [ nvim-cmp curl git ];
-  });
+  };
 
-  cmp-greek = super.cmp-greek.overrideAttrs (old: {
+  cmp-greek = super.cmp-greek.overrideAttrs {
     dependencies = with self; [ nvim-cmp ];
-  });
+  };
 
-  cmp-look = super.cmp-look.overrideAttrs (old: {
+  cmp-look = super.cmp-look.overrideAttrs {
     dependencies = with self; [ nvim-cmp ];
-  });
+  };
 
-  cmp-neosnippet = super.cmp-neosnippet.overrideAttrs (old: {
+  cmp-neosnippet = super.cmp-neosnippet.overrideAttrs {
     dependencies = with self; [ nvim-cmp neosnippet-vim ];
-  });
+  };
 
-  cmp-npm = super.cmp-npm.overrideAttrs (old: {
+  cmp-npm = super.cmp-npm.overrideAttrs {
     dependencies = with self; [ nvim-cmp nodejs plenary-nvim ];
-  });
+  };
 
-  cmp-nvim-lsp-signature-help = super.cmp-nvim-lsp-signature-help.overrideAttrs (old: {
+  cmp-nvim-lsp-signature-help = super.cmp-nvim-lsp-signature-help.overrideAttrs {
     dependencies = with self; [ nvim-cmp ];
-  });
+  };
 
-  cmp-nvim-tags = super.cmp-nvim-tags.overrideAttrs (old: {
+  cmp-nvim-tags = super.cmp-nvim-tags.overrideAttrs {
     dependencies = with self; [ nvim-cmp ];
-  });
+  };
 
-  cmp-pandoc-nvim = super.cmp-pandoc-nvim.overrideAttrs (old: {
+  cmp-pandoc-nvim = super.cmp-pandoc-nvim.overrideAttrs {
     dependencies = with self; [ nvim-cmp pandoc plenary-nvim ];
-  });
+  };
 
-  cmp-rg = super.cmp-rg.overrideAttrs (old: {
+  cmp-rg = super.cmp-rg.overrideAttrs {
     dependencies = with self; [ nvim-cmp ripgrep ];
-  });
+  };
 
-  cmp-snippy = super.cmp-snippy.overrideAttrs (old: {
+  cmp-snippy = super.cmp-snippy.overrideAttrs {
     dependencies = with self; [ nvim-cmp nvim-snippy ];
-  });
+  };
 
-  cmp-tabnine = super.cmp-tabnine.overrideAttrs (old: {
+  cmp-tabnine = super.cmp-tabnine.overrideAttrs {
     buildInputs = [ tabnine ];
 
     postFixup = ''
       mkdir -p $target/binaries/${tabnine.version}
       ln -s ${tabnine}/bin/ $target/binaries/${tabnine.version}/${tabnine.passthru.platform}
     '';
-  });
+  };
 
-  cmp-tmux = super.cmp-tmux.overrideAttrs (old: {
+  cmp-tmux = super.cmp-tmux.overrideAttrs {
     dependencies = with self; [ nvim-cmp tmux ];
-  });
+  };
 
-  cmp-vim-lsp = super.cmp-vim-lsp.overrideAttrs (old: {
+  cmp-vim-lsp = super.cmp-vim-lsp.overrideAttrs {
     dependencies = with self; [ nvim-cmp vim-lsp ];
-  });
+  };
 
-  cmp-vimwiki-tags = super.cmp-vimwiki-tags.overrideAttrs (old: {
+  cmp-vimwiki-tags = super.cmp-vimwiki-tags.overrideAttrs {
     dependencies = with self; [ nvim-cmp vimwiki ];
-  });
+  };
 
-  cmp-zsh = super.cmp-zsh.overrideAttrs (old: {
+  cmp-zsh = super.cmp-zsh.overrideAttrs {
     dependencies = with self; [ nvim-cmp zsh ];
-  });
+  };
 
   coc-nginx = buildVimPluginFrom2Nix {
     pname = "coc-nginx";
@@ -284,7 +284,7 @@ self: super: {
     src = "${nodePackages."@yaegassy/coc-nginx"}/lib/node_modules/@yaegassy/coc-nginx";
   };
 
-  command-t = super.command-t.overrideAttrs (old: {
+  command-t = super.command-t.overrideAttrs {
     nativeBuildInputs = [ getconf ruby ];
     buildPhase = ''
       substituteInPlace lua/wincent/commandt/lib/Makefile \
@@ -293,47 +293,47 @@ self: super: {
       make build
       rm ruby/command-t/ext/command-t/*.o
     '';
-  });
+  };
 
-  compe-tabnine = super.compe-tabnine.overrideAttrs (old: {
+  compe-tabnine = super.compe-tabnine.overrideAttrs {
     buildInputs = [ tabnine ];
 
     postFixup = ''
       mkdir -p $target/binaries/${tabnine.version}
       ln -s ${tabnine}/bin/ $target/binaries/${tabnine.version}/${tabnine.passthru.platform}
     '';
-  });
+  };
 
-  compiler-explorer-nvim = super.compiler-explorer-nvim.overrideAttrs (old: {
+  compiler-explorer-nvim = super.compiler-explorer-nvim.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  completion-buffers = super.completion-buffers.overrideAttrs (old: {
+  completion-buffers = super.completion-buffers.overrideAttrs {
     dependencies = with self; [ completion-nvim ];
-  });
+  };
 
-  completion-tabnine = super.completion-tabnine.overrideAttrs (old: {
+  completion-tabnine = super.completion-tabnine.overrideAttrs {
     dependencies = with self; [ completion-nvim ];
     buildInputs = [ tabnine ];
     postFixup = ''
       mkdir -p $target/binaries
       ln -s ${tabnine}/bin/TabNine $target/binaries/TabNine_$(uname -s)
     '';
-  });
+  };
 
-  completion-treesitter = super.completion-treesitter.overrideAttrs (old: {
+  completion-treesitter = super.completion-treesitter.overrideAttrs {
     dependencies = with self; [ completion-nvim nvim-treesitter ];
-  });
+  };
 
-  copilot-vim = super.copilot-vim.overrideAttrs (old: {
+  copilot-vim = super.copilot-vim.overrideAttrs {
     postInstall = ''
       substituteInPlace $out/autoload/copilot/agent.vim \
         --replace "  let node = get(g:, 'copilot_node_command', ''\'''\')" \
                   "  let node = get(g:, 'copilot_node_command', '${nodejs}/bin/node')"
     '';
-  });
+  };
 
-  coq_nvim = super.coq_nvim.overrideAttrs (old: {
+  coq_nvim = super.coq_nvim.overrideAttrs {
     passthru.python3Dependencies = ps: with ps; [
       pynvim
       pyyaml
@@ -378,9 +378,9 @@ self: super: {
 
     # We need some patches so it stops complaining about not being in a venv
     patches = [ ./patches/coq_nvim/emulate-venv.patch ];
-  });
+  };
 
-  cpsm = super.cpsm.overrideAttrs (old: {
+  cpsm = super.cpsm.overrideAttrs {
     nativeBuildInputs = [ cmake ];
     buildInputs = [
       python3
@@ -393,13 +393,13 @@ self: super: {
       export PY3=ON
       ./install.sh
     '';
-  });
+  };
 
-  crates-nvim = super.crates-nvim.overrideAttrs (old: {
+  crates-nvim = super.crates-nvim.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  ctrlp-cmatcher = super.ctrlp-cmatcher.overrideAttrs (old: {
+  ctrlp-cmatcher = super.ctrlp-cmatcher.overrideAttrs {
     # drop Python 2 patches
     # https://github.com/JazzCore/ctrlp-cmatcher/pull/44
     patches = [
@@ -419,24 +419,24 @@ self: super: {
       patchShebangs .
       ./install.sh
     '';
-  });
+  };
 
-  defx-nvim = super.defx-nvim.overrideAttrs (old: {
+  defx-nvim = super.defx-nvim.overrideAttrs {
     dependencies = with self; [ nvim-yarp ];
-  });
+  };
 
-  denops-vim = super.denops-vim.overrideAttrs (old: {
+  denops-vim = super.denops-vim.overrideAttrs {
     postPatch = ''
       # Use Nix's Deno instead of an arbitrary install
       substituteInPlace ./autoload/denops.vim --replace "call denops#_internal#conf#define('denops#deno', 'deno')" "call denops#_internal#conf#define('denops#deno', '${deno}/bin/deno')"
     '';
-  });
+  };
 
-  deoplete-fish = super.deoplete-fish.overrideAttrs (old: {
+  deoplete-fish = super.deoplete-fish.overrideAttrs {
     dependencies = with self; [ deoplete-nvim vim-fish ];
-  });
+  };
 
-  deoplete-go = super.deoplete-go.overrideAttrs (old: {
+  deoplete-go = super.deoplete-go.overrideAttrs {
     buildInputs = [ python3 ];
     buildPhase = ''
       pushd ./rplugin/python3/deoplete/ujson
@@ -444,9 +444,9 @@ self: super: {
       popd
       find ./rplugin/ -name "ujson*.so" -exec mv -v {} ./rplugin/python3/ \;
     '';
-  });
+  };
 
-  deoplete-khard = super.deoplete-khard.overrideAttrs (old: {
+  deoplete-khard = super.deoplete-khard.overrideAttrs {
     dependencies = with self; [ deoplete-nvim ];
     passthru.python3Dependencies = ps: [ (ps.toPythonModule khard) ];
     meta = {
@@ -455,14 +455,14 @@ self: super: {
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [ jorsn ];
     };
-  });
+  };
 
-  diffview-nvim = super.diffview-nvim.overrideAttrs (old: {
+  diffview-nvim = super.diffview-nvim.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
 
     doInstallCheck = true;
     nvimRequireCheck = "diffview";
-  });
+  };
 
   direnv-vim = super.direnv-vim.overrideAttrs (old: {
     preFixup = old.preFixup or "" + ''
@@ -472,25 +472,25 @@ self: super: {
     '';
   });
 
-  executor-nvim = super.executor-nvim.overrideAttrs (old: {
+  executor-nvim = super.executor-nvim.overrideAttrs {
     dependencies = with self; [ nui-nvim ];
-  });
+  };
 
-  fcitx-vim = super.fcitx-vim.overrideAttrs (old: {
+  fcitx-vim = super.fcitx-vim.overrideAttrs {
     passthru.python3Dependencies = ps: with ps; [ dbus-python ];
     meta = {
       description = "Keep and restore fcitx state when leaving/re-entering insert mode or search mode";
       license = lib.licenses.mit;
     };
-  });
+  };
 
-  flit-nvim = super.flit-nvim.overrideAttrs (old: {
+  flit-nvim = super.flit-nvim.overrideAttrs {
     dependencies = with self; [ leap-nvim ];
-  });
+  };
 
-  forms = super.forms.overrideAttrs (old: {
+  forms = super.forms.overrideAttrs {
     dependencies = [ self.self ];
-  });
+  };
 
   fruzzy =
     let
@@ -527,19 +527,19 @@ self: super: {
       '';
     });
 
-  fuzzy-nvim = super.fuzzy-nvim.overrideAttrs (old: {
+  fuzzy-nvim = super.fuzzy-nvim.overrideAttrs {
     dependencies = with self; [ telescope-fzy-native-nvim ];
-  });
+  };
 
-  fzf-checkout-vim = super.fzf-checkout-vim.overrideAttrs (old: {
+  fzf-checkout-vim = super.fzf-checkout-vim.overrideAttrs {
     # The plugin has a makefile which tries to run tests in a docker container.
     # This prevents it.
     prePatch = ''
       rm Makefile
     '';
-  });
+  };
 
-  fzf-hoogle-vim = super.fzf-hoogle-vim.overrideAttrs (old: {
+  fzf-hoogle-vim = super.fzf-hoogle-vim.overrideAttrs {
 
     # add this to your lua config to prevent the plugin from trying to write in the
     # nix store:
@@ -549,15 +549,15 @@ self: super: {
       gawk
     ];
     dependencies = with self; [ fzf-vim ];
-  });
+  };
 
-  fzf-lua = super.fzf-lua.overrideAttrs (old: {
+  fzf-lua = super.fzf-lua.overrideAttrs {
     propagatedBuildInputs = [ fzf ];
-  });
+  };
 
-  fzf-vim = super.fzf-vim.overrideAttrs (old: {
+  fzf-vim = super.fzf-vim.overrideAttrs {
     dependencies = with self; [ fzfWrapper ];
-  });
+  };
 
   # Mainly used as a dependency for fzf-vim. Wraps the fzf program as a vim
   # plugin, since part of the fzf vim plugin is included in the main fzf
@@ -570,29 +570,29 @@ self: super: {
     '';
   };
 
-  ghcid = super.ghcid.overrideAttrs (old: {
+  ghcid = super.ghcid.overrideAttrs {
     configurePhase = "cd plugins/nvim";
-  });
+  };
 
-  gitlinker-nvim = super.gitlinker-nvim.overrideAttrs (old: {
+  gitlinker-nvim = super.gitlinker-nvim.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  gitsigns-nvim = super.gitsigns-nvim.overrideAttrs (old: {
+  gitsigns-nvim = super.gitsigns-nvim.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  harpoon = super.harpoon.overrideAttrs (old: {
+  harpoon = super.harpoon.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  hex-nvim = super.hex-nvim.overrideAttrs (old: {
+  hex-nvim = super.hex-nvim.overrideAttrs {
     postPatch = ''
       substituteInPlace lua/hex.lua --replace xxd ${xxd}/bin/xxd
     '';
-  });
+  };
 
-  himalaya-vim = super.himalaya-vim.overrideAttrs (old: {
+  himalaya-vim = super.himalaya-vim.overrideAttrs {
     buildInputs = [ himalaya ];
     src = fetchFromSourcehut {
       owner = "~soywod";
@@ -600,7 +600,8 @@ self: super: {
       rev = "v${himalaya.version}";
       sha256 = "W+91hnNeS6WkDiR9r1s7xPTK9JlCWiVkI/nXVYbepY0=";
     };
-  });
+  };
+
   # https://hurl.dev/
   hurl = buildVimPluginFrom2Nix {
     pname = "hurl";
@@ -611,18 +612,18 @@ self: super: {
 
   };
 
-  jedi-vim = super.jedi-vim.overrideAttrs (old: {
+  jedi-vim = super.jedi-vim.overrideAttrs {
     # checking for python3 support in vim would be neat, too, but nobody else seems to care
     buildInputs = [ python3.pkgs.jedi ];
     meta = {
       description = "code-completion for python using python-jedi";
       license = lib.licenses.mit;
     };
-  });
+  };
 
-  jellybeans-nvim = super.jellybeans-nvim.overrideAttrs (old: {
+  jellybeans-nvim = super.jellybeans-nvim.overrideAttrs {
     dependencies = with self; [ lush-nvim ];
-  });
+  };
 
   LanguageClient-neovim =
     let
@@ -661,23 +662,23 @@ self: super: {
       '';
     };
 
-  lazy-lsp-nvim = super.lazy-lsp-nvim.overrideAttrs (old: {
+  lazy-lsp-nvim = super.lazy-lsp-nvim.overrideAttrs {
     dependencies = with self; [ nvim-lspconfig ];
-  });
+  };
 
-  lazy-nvim = super.lazy-nvim.overrideAttrs (old: {
+  lazy-nvim = super.lazy-nvim.overrideAttrs {
     patches = [ ./patches/lazy-nvim/no-helptags.patch ];
-  });
+  };
 
-  lean-nvim = super.lean-nvim.overrideAttrs (old: {
+  lean-nvim = super.lean-nvim.overrideAttrs {
     dependencies = with self; [ nvim-lspconfig plenary-nvim ];
-  });
+  };
 
-  leap-ast-nvim = super.leap-ast-nvim.overrideAttrs (old: {
+  leap-ast-nvim = super.leap-ast-nvim.overrideAttrs {
     dependencies = with self; [ leap-nvim nvim-treesitter ];
-  });
+  };
 
-  lens-vim = super.lens-vim.overrideAttrs (old: {
+  lens-vim = super.lens-vim.overrideAttrs {
     # remove duplicate g:lens#animate in doc/lens.txt
     # https://github.com/NixOS/nixpkgs/pull/105810#issuecomment-740007985
     # https://github.com/camspiers/lens.vim/pull/40/files
@@ -687,15 +688,15 @@ self: super: {
         inherit languagetool;
       })
     ];
-  });
+  };
 
-  lf-vim = super.lf-vim.overrideAttrs (old: {
+  lf-vim = super.lf-vim.overrideAttrs {
     dependencies = with self; [ vim-floaterm ];
-  });
+  };
 
-  lir-nvim = super.lir-nvim.overrideAttrs (old: {
+  lir-nvim = super.lir-nvim.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
   magma-nvim-goose = buildVimPluginFrom2Nix {
     pname = "magma-nvim-goose";
@@ -720,12 +721,12 @@ self: super: {
     meta.homepage = "https://github.com/WhiteBlackGoose/magma-nvim-goose/";
   };
 
-  markdown-preview-nvim = super.markdown-preview-nvim.overrideAttrs (old: let
+  markdown-preview-nvim =  let
     # We only need its dependencies `node-modules`.
-    nodeDep = nodePackages."markdown-preview-nvim-../../applications/editors/vim/plugins/markdown-preview-nvim".overrideAttrs (old: {
+    nodeDep = nodePackages."markdown-preview-nvim-../../applications/editors/vim/plugins/markdown-preview-nvim".overrideAttrs {
       dontNpmInstall = true;
-    });
-  in {
+    };
+  in super.markdown-preview-nvim.overrideAttrs {
     patches = [
       (substituteAll {
         src = ./markdown-preview-nvim/fix-node-paths.patch;
@@ -741,15 +742,15 @@ self: super: {
     installCheckPhase = ''
       node $out/app/index.js --version
     '';
-  });
+  };
 
-  mason-lspconfig-nvim = super.mason-lspconfig-nvim.overrideAttrs (old: {
+  mason-lspconfig-nvim = super.mason-lspconfig-nvim.overrideAttrs {
     dependencies = with self; [ mason-nvim nvim-lspconfig ];
-  });
+  };
 
-  mason-tool-installer-nvim = super.mason-tool-installer-nvim.overrideAttrs (old: {
+  mason-tool-installer-nvim = super.mason-tool-installer-nvim.overrideAttrs {
     dependencies = with self; [ mason-nvim ];
-  });
+  };
 
   meson = buildVimPluginFrom2Nix {
     inherit (meson) pname version src;
@@ -757,7 +758,7 @@ self: super: {
     meta.maintainers = with lib.maintainers; [ vcunat ];
   };
 
-  minimap-vim = super.minimap-vim.overrideAttrs (old: {
+  minimap-vim = super.minimap-vim.overrideAttrs {
     preFixup = ''
       substituteInPlace $out/plugin/minimap.vim \
         --replace "code-minimap" "${code-minimap}/bin/code-minimap"
@@ -767,7 +768,7 @@ self: super: {
 
     doInstallCheck = true;
     vimCommandCheck = "MinimapToggle";
-  });
+  };
 
   minsnip-nvim = buildVimPluginFrom2Nix {
     pname = "minsnip.nvim";
@@ -781,103 +782,103 @@ self: super: {
     meta.homepage = "https://github.com/jose-elias-alvarez/minsnip.nvim/";
   };
 
-  ncm2 = super.ncm2.overrideAttrs (old: {
+  ncm2 = super.ncm2.overrideAttrs {
     dependencies = with self; [ nvim-yarp ];
-  });
+  };
 
-  ncm2-jedi = super.ncm2-jedi.overrideAttrs (old: {
+  ncm2-jedi = super.ncm2-jedi.overrideAttrs {
     dependencies = with self; [ nvim-yarp ncm2 ];
     passthru.python3Dependencies = ps: with ps; [ jedi ];
-  });
+  };
 
-  ncm2-neoinclude = super.ncm2-neoinclude.overrideAttrs (old: {
+  ncm2-neoinclude = super.ncm2-neoinclude.overrideAttrs {
     dependencies = with self; [ neoinclude-vim ];
-  });
+  };
 
-  ncm2-neosnippet = super.ncm2-neosnippet.overrideAttrs (old: {
+  ncm2-neosnippet = super.ncm2-neosnippet.overrideAttrs {
     dependencies = with self; [ neosnippet-vim ];
-  });
+  };
 
-  ncm2-syntax = super.ncm2-syntax.overrideAttrs (old: {
+  ncm2-syntax = super.ncm2-syntax.overrideAttrs {
     dependencies = with self; [ neco-syntax ];
-  });
+  };
 
-  ncm2-ultisnips = super.ncm2-ultisnips.overrideAttrs (old: {
+  ncm2-ultisnips = super.ncm2-ultisnips.overrideAttrs {
     dependencies = with self; [ ultisnips ];
-  });
+  };
 
-  neogit = super.neogit.overrideAttrs (old: {
+  neogit = super.neogit.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  neorg = super.neorg.overrideAttrs (old: {
+  neorg = super.neorg.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  neo-tree-nvim = super.neo-tree-nvim.overrideAttrs (old: {
+  neo-tree-nvim = super.neo-tree-nvim.overrideAttrs {
     dependencies = with self; [ plenary-nvim nui-nvim ];
-  });
+  };
 
-  noice-nvim = super.noice-nvim.overrideAttrs(old: {
+  noice-nvim = super.noice-nvim.overrideAttrs {
     dependencies = with self; [ nui-nvim ];
-  });
+  };
 
-  null-ls-nvim = super.null-ls-nvim.overrideAttrs (old: {
+  null-ls-nvim = super.null-ls-nvim.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  nvim-coverage = super.nvim-coverage.overrideAttrs(old: {
+  nvim-coverage = super.nvim-coverage.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  nvim-dap-python = super.nvim-dap-python.overrideAttrs (old: {
+  nvim-dap-python = super.nvim-dap-python.overrideAttrs {
     dependencies = with self; [ nvim-dap ];
-  });
+  };
 
-  nvim-lsputils = super.nvim-lsputils.overrideAttrs (old: {
+  nvim-lsputils = super.nvim-lsputils.overrideAttrs {
     dependencies = with self; [ popfix ];
-  });
+  };
 
-  nvim-metals = super.nvim-metals.overrideAttrs (old: {
+  nvim-metals = super.nvim-metals.overrideAttrs {
     dontBuild = true;
-  });
+  };
 
-  vim-mediawiki-editor = super.vim-mediawiki-editor.overrideAttrs (old: {
+  vim-mediawiki-editor = super.vim-mediawiki-editor.overrideAttrs {
     passthru.python3Dependencies = [ python3.pkgs.mwclient ];
-  });
+  };
 
-  nvim-spectre = super.nvim-spectre.overrideAttrs (old: {
+  nvim-spectre = super.nvim-spectre.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  nvim-teal-maker = super.nvim-teal-maker.overrideAttrs (old: {
+  nvim-teal-maker = super.nvim-teal-maker.overrideAttrs {
     postPatch = ''
       substituteInPlace lua/tealmaker/init.lua \
         --replace cyan ${luaPackages.cyan}/bin/cyan
     '';
     vimCommandCheck = "TealBuild";
-  });
+  };
 
-  nvim-treesitter = super.nvim-treesitter.overrideAttrs (old:
+  nvim-treesitter = super.nvim-treesitter.overrideAttrs (
     callPackage ./nvim-treesitter/overrides.nix { } self super
   );
   nvim-treesitter-parsers = lib.recurseIntoAttrs self.nvim-treesitter.grammarPlugins;
 
-  nvim-ufo = super.nvim-ufo.overrideAttrs (old: {
+  nvim-ufo = super.nvim-ufo.overrideAttrs {
     dependencies = with self; [ promise-async ];
-  });
+  };
 
-  octo-nvim = super.octo-nvim.overrideAttrs (old: {
+  octo-nvim = super.octo-nvim.overrideAttrs {
     dependencies = with self; [ telescope-nvim plenary-nvim ];
-  });
+  };
 
-  onehalf = super.onehalf.overrideAttrs (old: {
+  onehalf = super.onehalf.overrideAttrs {
     configurePhase = "cd vim";
-  });
+  };
 
   # The plugin depends on either skim-vim or fzf-vim, but we don't want to force the user so we
   # avoid choosing one of them and leave it to the user
-  openscad-nvim = super.openscad-nvim.overrideAttrs (old: {
+  openscad-nvim = super.openscad-nvim.overrideAttrs {
     buildInputs = [ zathura htop openscad ];
 
     patches = [
@@ -888,11 +889,11 @@ self: super: {
         zathura = lib.getExe zathura;
       })
     ];
-  });
+  };
 
-  orgmode = super.orgmode.overrideAttrs (old: {
+  orgmode = super.orgmode.overrideAttrs {
     dependencies = with self; [ (nvim-treesitter.withPlugins (p: [ p.org ])) ];
-  });
+  };
 
   inherit parinfer-rust;
 
@@ -904,14 +905,14 @@ self: super: {
     '';
   };
 
-  playground = super.playground.overrideAttrs (old: {
+  playground = super.playground.overrideAttrs {
     dependencies = with self; [
       # we need the 'query' grammer to make
       (nvim-treesitter.withPlugins (p: [ p.query ]))
     ];
-  });
+  };
 
-  plenary-nvim = super.plenary-nvim.overrideAttrs (old: {
+  plenary-nvim = super.plenary-nvim.overrideAttrs {
     postPatch = ''
       sed -Ei lua/plenary/curl.lua \
           -e 's@(command\s*=\s*")curl(")@\1${curl}/bin/curl\2@'
@@ -919,23 +920,23 @@ self: super: {
 
     doInstallCheck = true;
     nvimRequireCheck = "plenary";
-  });
+  };
 
-  range-highlight-nvim = super.range-highlight-nvim.overrideAttrs (old: {
+  range-highlight-nvim = super.range-highlight-nvim.overrideAttrs {
     dependencies = with self; [ cmd-parser-nvim ];
-  });
+  };
 
-  refactoring-nvim = super.refactoring-nvim.overrideAttrs (old: {
+  refactoring-nvim = super.refactoring-nvim.overrideAttrs {
     dependencies = with self; [ nvim-treesitter plenary-nvim ];
-  });
+  };
 
   # needs  "http" and "json" treesitter grammars too
-  rest-nvim = super.rest-nvim.overrideAttrs (old: {
+  rest-nvim = super.rest-nvim.overrideAttrs {
     dependencies = with self; [
       plenary-nvim
       (nvim-treesitter.withPlugins (p: [ p.http p.json ]))
     ];
-  });
+  };
 
   sg-nvim = super.sg-nvim.overrideAttrs (old:
     let
@@ -971,9 +972,9 @@ self: super: {
     src = skim.vim;
   };
 
-  skim-vim = super.skim-vim.overrideAttrs (old: {
+  skim-vim = super.skim-vim.overrideAttrs {
     dependencies = [ self.skim ];
-  });
+  };
 
   sniprun =
     let
@@ -1025,18 +1026,18 @@ self: super: {
     meta.homepage = "https://github.com/ackyshake/Spacegray.vim/";
   };
 
-  sqlite-lua = super.sqlite-lua.overrideAttrs (old: {
+  sqlite-lua = super.sqlite-lua.overrideAttrs {
     postPatch = let
       libsqlite = "${sqlite.out}/lib/libsqlite3${stdenv.hostPlatform.extensions.sharedLibrary}";
     in ''
       substituteInPlace lua/sqlite/defs.lua \
         --replace "path = vim.g.sqlite_clib_path" "path = vim.g.sqlite_clib_path or ${lib.escapeShellArg libsqlite}"
     '';
-  });
+  };
 
-  ssr = super.ssr-nvim.overrideAttrs (old: {
+  ssr = super.ssr-nvim.overrideAttrs {
     dependencies = with self; [ nvim-treesitter ];
-  });
+  };
 
   statix = buildVimPluginFrom2Nix rec {
     inherit (statix) pname src meta;
@@ -1052,13 +1053,13 @@ self: super: {
     '';
   };
 
-  stylish-nvim = super.stylish-nvim.overrideAttrs (old: {
-      postPatch = ''
-        substituteInPlace lua/stylish/common/mouse_hover_handler.lua --replace xdotool ${xdotool}/bin/xdotool
-        substituteInPlace lua/stylish/components/menu.lua --replace xdotool ${xdotool}/bin/xdotool
-        substituteInPlace lua/stylish/components/menu.lua --replace xwininfo ${xorg.xwininfo}/bin/xwininfo
-      '';
-  });
+  stylish-nvim = super.stylish-nvim.overrideAttrs {
+    postPatch = ''
+      substituteInPlace lua/stylish/common/mouse_hover_handler.lua --replace xdotool ${xdotool}/bin/xdotool
+      substituteInPlace lua/stylish/components/menu.lua --replace xdotool ${xdotool}/bin/xdotool
+      substituteInPlace lua/stylish/components/menu.lua --replace xwininfo ${xorg.xwininfo}/bin/xwininfo
+    '';
+  };
 
   sved =
     let
@@ -1078,7 +1079,7 @@ self: super: {
         '';
       };
     in
-    super.sved.overrideAttrs (old: {
+    super.sved.overrideAttrs {
       preferLocalBuild = true;
       postPatch = ''
         rm ftplugin/evinceSync.py
@@ -1087,29 +1088,30 @@ self: super: {
       meta = {
         description = "synctex support between vim/neovim and evince";
       };
-    });
+    };
 
   taskwarrior = buildVimPluginFrom2Nix {
     inherit (taskwarrior) version pname;
     src = "${taskwarrior.src}/scripts/vim";
   };
-  telescope-cheat-nvim = super.telescope-cheat-nvim.overrideAttrs (old: {
-    dependencies = with self; [ sqlite-lua telescope-nvim ];
-  });
 
-  telescope-frecency-nvim = super.telescope-frecency-nvim.overrideAttrs (old: {
+  telescope-cheat-nvim = super.telescope-cheat-nvim.overrideAttrs {
     dependencies = with self; [ sqlite-lua telescope-nvim ];
-  });
+  };
 
-  telescope-fzf-native-nvim = super.telescope-fzf-native-nvim.overrideAttrs (old: {
+  telescope-frecency-nvim = super.telescope-frecency-nvim.overrideAttrs {
+    dependencies = with self; [ sqlite-lua telescope-nvim ];
+  };
+
+  telescope-fzf-native-nvim = super.telescope-fzf-native-nvim.overrideAttrs {
     dependencies = with self; [ telescope-nvim ];
     buildPhase = "make";
     meta.platforms = lib.platforms.all;
-  });
+  };
 
-  telescope-fzf-writer-nvim = super.telescope-fzf-writer-nvim.overrideAttrs (old: {
+  telescope-fzf-writer-nvim = super.telescope-fzf-writer-nvim.overrideAttrs {
     dependencies = with self; [ telescope-nvim ];
-  });
+  };
 
   telescope-fzy-native-nvim = super.telescope-fzy-native-nvim.overrideAttrs (old: {
     dependencies = with self; [ telescope-nvim ];
@@ -1136,27 +1138,27 @@ self: super: {
     meta.platforms = lib.platforms.all;
   });
 
-  telescope-media-files-nvim = super.telescope-media-files-nvim.overrideAttrs (old: {
+  telescope-media-files-nvim = super.telescope-media-files-nvim.overrideAttrs {
     dependencies = with self; [ telescope-nvim popup-nvim plenary-nvim ];
-  });
+  };
 
-  telescope-nvim = super.telescope-nvim.overrideAttrs (old: {
+  telescope-nvim = super.telescope-nvim.overrideAttrs {
     dependencies = with self; [ plenary-nvim ];
-  });
+  };
 
-  telescope-symbols-nvim = super.telescope-symbols-nvim.overrideAttrs (old: {
+  telescope-symbols-nvim = super.telescope-symbols-nvim.overrideAttrs {
     dependencies = with self; [ telescope-nvim ];
-  });
+  };
 
-  telescope-undo-nvim = super.telescope-undo-nvim.overrideAttrs (old: {
+  telescope-undo-nvim = super.telescope-undo-nvim.overrideAttrs {
     dependencies = with self; [ telescope-nvim ];
-  });
+  };
 
-  telescope-z-nvim = super.telescope-z-nvim.overrideAttrs (old: {
+  telescope-z-nvim = super.telescope-z-nvim.overrideAttrs {
     dependencies = with self; [ telescope-nvim ];
-  });
+  };
 
-  telescope-zoxide = super.telescope-zoxide.overrideAttrs (old: {
+  telescope-zoxide = super.telescope-zoxide.overrideAttrs {
     dependencies = with self; [ telescope-nvim ];
 
     buildInputs = [ zoxide ];
@@ -1165,7 +1167,7 @@ self: super: {
       substituteInPlace lua/telescope/_extensions/zoxide/config.lua \
         --replace "zoxide query -ls" "${zoxide}/bin/zoxide query -ls"
     '';
-  });
+  };
 
   tup =
     let
@@ -1192,7 +1194,7 @@ self: super: {
         sha256 = "16b0jzvvzarnlxdvs2izd5ia0ipbd87md143dc6lv6xpdqcs75s9";
       };
     in
-    super.unicode-vim.overrideAttrs (old: {
+    super.unicode-vim.overrideAttrs {
 
       # redirect to /dev/null else changes terminal color
       buildPhase = ''
@@ -1200,51 +1202,51 @@ self: super: {
         echo "Building unicode cache"
         ${vim}/bin/vim --cmd ":set rtp^=$PWD" -c 'ru plugin/unicode.vim' -c 'UnicodeCache' -c ':echohl Normal' -c ':q' > /dev/null
       '';
-    });
+    };
 
-  unison = super.unison.overrideAttrs (old: {
+  unison = super.unison.overrideAttrs {
     # Editor stuff isn't at top level
     postPatch = "cd editor-support/vim";
-  });
+  };
 
-  vCoolor-vim = super.vCoolor-vim.overrideAttrs (old: {
+  vCoolor-vim = super.vCoolor-vim.overrideAttrs {
     # on linux can use either Zenity or Yad.
     propagatedBuildInputs = [ gnome.zenity ];
     meta = {
       description = "Simple color selector/picker plugin";
       license = lib.licenses.publicDomain;
     };
-  });
+  };
 
-  vim-addon-actions = super.vim-addon-actions.overrideAttrs (old: {
+  vim-addon-actions = super.vim-addon-actions.overrideAttrs {
     dependencies = with self; [ vim-addon-mw-utils tlib_vim ];
-  });
+  };
 
-  vim-addon-async = super.vim-addon-async.overrideAttrs (old: {
+  vim-addon-async = super.vim-addon-async.overrideAttrs {
     dependencies = with self; [ vim-addon-signs ];
-  });
+  };
 
-  vim-addon-background-cmd = super.vim-addon-background-cmd.overrideAttrs (old: {
+  vim-addon-background-cmd = super.vim-addon-background-cmd.overrideAttrs {
     dependencies = with self; [ vim-addon-mw-utils ];
-  });
+  };
 
-  vim-addon-completion = super.vim-addon-completion.overrideAttrs (old: {
+  vim-addon-completion = super.vim-addon-completion.overrideAttrs {
     dependencies = with self; [ tlib_vim ];
-  });
+  };
 
-  vim-addon-goto-thing-at-cursor = super.vim-addon-goto-thing-at-cursor.overrideAttrs (old: {
+  vim-addon-goto-thing-at-cursor = super.vim-addon-goto-thing-at-cursor.overrideAttrs {
     dependencies = with self; [ tlib_vim ];
-  });
+  };
 
-  vim-addon-manager = super.vim-addon-manager.overrideAttrs (old: {
+  vim-addon-manager = super.vim-addon-manager.overrideAttrs {
     buildInputs = lib.optional stdenv.isDarwin Cocoa;
-  });
+  };
 
-  vim-addon-mru = super.vim-addon-mru.overrideAttrs (old: {
+  vim-addon-mru = super.vim-addon-mru.overrideAttrs {
     dependencies = with self; [ vim-addon-other vim-addon-mw-utils ];
-  });
+  };
 
-  vim-addon-nix = super.vim-addon-nix.overrideAttrs (old: {
+  vim-addon-nix = super.vim-addon-nix.overrideAttrs {
     dependencies = with self; [
       vim-addon-completion
       vim-addon-goto-thing-at-cursor
@@ -1253,44 +1255,44 @@ self: super: {
       vim-addon-mw-utils
       tlib_vim
     ];
-  });
+  };
 
-  vim-addon-sql = super.vim-addon-sql.overrideAttrs (old: {
+  vim-addon-sql = super.vim-addon-sql.overrideAttrs {
     dependencies = with self; [ vim-addon-completion vim-addon-background-cmd tlib_vim ];
-  });
+  };
 
-  vim-addon-syntax-checker = super.vim-addon-syntax-checker.overrideAttrs (old: {
+  vim-addon-syntax-checker = super.vim-addon-syntax-checker.overrideAttrs {
     dependencies = with self; [ vim-addon-mw-utils tlib_vim ];
-  });
+  };
 
-  vim-addon-toggle-buffer = super.vim-addon-toggle-buffer.overrideAttrs (old: {
+  vim-addon-toggle-buffer = super.vim-addon-toggle-buffer.overrideAttrs {
     dependencies = with self; [ vim-addon-mw-utils tlib_vim ];
-  });
+  };
 
-  vim-addon-xdebug = super.vim-addon-xdebug.overrideAttrs (old: {
+  vim-addon-xdebug = super.vim-addon-xdebug.overrideAttrs {
     dependencies = with self; [ webapi-vim vim-addon-mw-utils vim-addon-signs vim-addon-async ];
-  });
+  };
 
-  vim-agda = super.vim-agda.overrideAttrs (old: {
+  vim-agda = super.vim-agda.overrideAttrs {
     preFixup = ''
       substituteInPlace "$out"/autoload/agda.vim \
         --replace "jobstart(['agda'" "jobstart(['${agda}/bin/agda'"
     '';
-  });
+  };
 
-  vim-bazel = super.vim-bazel.overrideAttrs (old: {
+  vim-bazel = super.vim-bazel.overrideAttrs {
     dependencies = with self; [ vim-maktaba ];
-  });
+  };
 
-  vim-beancount = super.vim-beancount.overrideAttrs (old: {
+  vim-beancount = super.vim-beancount.overrideAttrs {
     passthru.python3Dependencies = ps: with ps; [ beancount ];
-  });
+  };
 
   vim-clap = callPackage ./vim-clap { };
 
-  vim-codefmt = super.vim-codefmt.overrideAttrs (old: {
+  vim-codefmt = super.vim-codefmt.overrideAttrs {
     dependencies = with self; [ vim-maktaba ];
-  });
+  };
 
   # Due to case-sensitivety issues, the hash differs on Darwin systems, see:
   # https://github.com/NixOS/nixpkgs/issues/157609
@@ -1302,18 +1304,18 @@ self: super: {
     });
   });
 
-  vim-dadbod-ui = super.vim-dadbod-ui.overrideAttrs (old: {
+  vim-dadbod-ui = super.vim-dadbod-ui.overrideAttrs {
     dependencies = with self; [ vim-dadbod ];
-  });
+  };
 
-  vim-dasht = super.vim-dasht.overrideAttrs (old: {
+  vim-dasht = super.vim-dasht.overrideAttrs {
     preFixup = ''
       substituteInPlace $out/autoload/dasht.vim \
         --replace "['dasht']" "['${dasht}/bin/dasht']"
     '';
-  });
+  };
 
-  vim-easytags = super.vim-easytags.overrideAttrs (old: {
+  vim-easytags = super.vim-easytags.overrideAttrs {
     dependencies = with self; [ vim-misc ];
     patches = [
       (fetchpatch {
@@ -1322,16 +1324,16 @@ self: super: {
         sha256 = "0x0xabb56xkgdqrg1mpvhbi3yw4d829n73lsnnyj5yrxjffy4ax4";
       })
     ];
-  });
+  };
 
-  vim-fzf-coauthorship = super.vim-fzf-coauthorship.overrideAttrs (old: {
+  vim-fzf-coauthorship = super.vim-fzf-coauthorship.overrideAttrs {
     dependencies = with self; [ fzf-vim ];
-  });
+  };
 
   # change the go_bin_path to point to a path in the nix store. See the code in
   # fatih/vim-go here
   # https://github.com/fatih/vim-go/blob/155836d47052ea9c9bac81ba3e937f6f22c8e384/autoload/go/path.vim#L154-L159
-  vim-go = super.vim-go.overrideAttrs (old:
+  vim-go =
     let
       binPath = lib.makeBinPath [
         # TODO: package commented packages
@@ -1359,17 +1361,17 @@ self: super: {
         # revive
       ];
     in
-    {
+    super.vim-go.overrideAttrs {
       postPatch = ''
         sed -i autoload/go/config.vim -Ee 's@"go_bin_path", ""@"go_bin_path", "${binPath}"@g'
       '';
-    });
+    };
 
-  vim-gist = super.vim-gist.overrideAttrs (old: {
+  vim-gist = super.vim-gist.overrideAttrs {
     dependencies = with self; [ webapi-vim ];
-  });
+  };
 
-  vim-grammarous = super.vim-grammarous.overrideAttrs (old: {
+  vim-grammarous = super.vim-grammarous.overrideAttrs {
     # use `:GrammarousCheck` to initialize checking
     # In neovim, you also want to use set
     #   let g:grammarous#show_first_error = 1
@@ -1380,7 +1382,7 @@ self: super: {
         inherit languagetool;
       })
     ];
-  });
+  };
 
   vim-hexokinase = super.vim-hexokinase.overrideAttrs (old: {
     preFixup =
@@ -1398,16 +1400,16 @@ self: super: {
     meta.platforms = lib.platforms.all;
   });
 
-  vim-hier = super.vim-hier.overrideAttrs (old: {
+  vim-hier = super.vim-hier.overrideAttrs {
     buildInputs = [ vim ];
-  });
+  };
 
-  vim-isort = super.vim-isort.overrideAttrs (old: {
+  vim-isort = super.vim-isort.overrideAttrs {
     postPatch = ''
       substituteInPlace ftplugin/python_vimisort.vim \
         --replace 'import vim' 'import vim; import sys; sys.path.append("${python3.pkgs.isort}/${python3.sitePackages}")'
     '';
-  });
+  };
 
   vim-markdown-composer =
     let
@@ -1419,25 +1421,25 @@ self: super: {
         doCheck = false;
       };
     in
-    super.vim-markdown-composer.overrideAttrs (old: {
+    super.vim-markdown-composer.overrideAttrs {
       preFixup = ''
         substituteInPlace "$out"/after/ftplugin/markdown/composer.vim \
           --replace "s:plugin_root . '/target/release/markdown-composer'" \
           "'${vim-markdown-composer-bin}/bin/markdown-composer'"
       '';
-    });
+    };
 
-  vim-metamath = super.vim-metamath.overrideAttrs (old: {
+  vim-metamath = super.vim-metamath.overrideAttrs {
     preInstall = "cd vim";
-  });
+  };
 
-  vim-snipmate = super.vim-snipmate.overrideAttrs (old: {
+  vim-snipmate = super.vim-snipmate.overrideAttrs {
     dependencies = with self; [ vim-addon-mw-utils tlib_vim ];
-  });
+  };
 
-  vim-speeddating = super.vim-speeddating.overrideAttrs (old: {
+  vim-speeddating = super.vim-speeddating.overrideAttrs {
     dependencies = with self; [ vim-repeat ];
-  });
+  };
 
   vim-stylish-haskell = super.vim-stylish-haskell.overrideAttrs (old: {
     postPatch = old.postPatch or "" + ''
@@ -1447,20 +1449,20 @@ self: super: {
     '';
   });
 
-  vim-surround = super.vim-surround.overrideAttrs (old: {
+  vim-surround = super.vim-surround.overrideAttrs {
     dependencies = with self; [ vim-repeat ];
-  });
+  };
 
-  vim-textobj-entire = super.vim-textobj-entire.overrideAttrs (old: {
+  vim-textobj-entire = super.vim-textobj-entire.overrideAttrs {
     dependencies = with self; [ vim-textobj-user ];
     meta.maintainers = with lib.maintainers; [ farlion ];
-  });
+  };
 
-  vim-unimpaired = super.vim-unimpaired.overrideAttrs (old: {
+  vim-unimpaired = super.vim-unimpaired.overrideAttrs {
     dependencies = with self; [ vim-repeat ];
-  });
+  };
 
-  vim-wakatime = super.vim-wakatime.overrideAttrs (old: {
+  vim-wakatime = super.vim-wakatime.overrideAttrs {
     buildInputs = [ python3 ];
     patchPhase = ''
       substituteInPlace plugin/wakatime.vim \
@@ -1469,26 +1471,26 @@ self: super: {
         --replace 'autocmd CursorMoved,CursorMovedI' \
                   'autocmd CursorMoved,CursorMovedI,BufEnter'
     '';
-  });
+  };
 
-  vim-xdebug = super.vim-xdebug.overrideAttrs (old: {
+  vim-xdebug = super.vim-xdebug.overrideAttrs {
     postInstall = null;
-  });
+  };
 
-  vim-xkbswitch = super.vim-xkbswitch.overrideAttrs (old: {
+  vim-xkbswitch = super.vim-xkbswitch.overrideAttrs {
     patchPhase = ''
       substituteInPlace plugin/xkbswitch.vim \
         --replace /usr/local/lib/libxkbswitch.so ${xkb-switch}/lib/libxkbswitch.so
     '';
     buildInputs = [ xkb-switch ];
-  });
+  };
 
-  vim-yapf = super.vim-yapf.overrideAttrs (old: {
+  vim-yapf = super.vim-yapf.overrideAttrs {
     buildPhase = ''
       substituteInPlace ftplugin/python_yapf.vim \
         --replace '"yapf"' '"${python3.pkgs.yapf}/bin/yapf"'
     '';
-  });
+  };
 
   vim2nix = buildVimPluginFrom2Nix {
     pname = "vim2nix";
@@ -1497,7 +1499,7 @@ self: super: {
     dependencies = with self; [ vim-addon-manager ];
   };
 
-  vimacs = super.vimacs.overrideAttrs (old: {
+  vimacs = super.vimacs.overrideAttrs {
     buildPhase = ''
       substituteInPlace bin/vim \
         --replace '/usr/bin/vim' 'vim' \
@@ -1511,7 +1513,7 @@ self: super: {
       license = licenses.gpl2Plus;
       maintainers = with lib.maintainers; [ millerjason ];
     };
-  });
+  };
 
   # The GitHub repository returns 404, which breaks the update script
   VimCompletesMe = buildVimPluginFrom2Nix {
@@ -1526,15 +1528,15 @@ self: super: {
     meta.homepage = "https://github.com/ackyshake/VimCompletesMe/";
   };
 
-  vimsence = super.vimsence.overrideAttrs (old: {
+  vimsence = super.vimsence.overrideAttrs {
     meta = with lib; {
       description = "Discord rich presence for Vim";
       homepage = "https://github.com/hugolgst/vimsence";
       maintainers = with lib.maintainers; [ hugolgst ];
     };
-  });
+  };
 
-  vimproc-vim = super.vimproc-vim.overrideAttrs (old: {
+  vimproc-vim = super.vimproc-vim.overrideAttrs {
     buildInputs = [ which ];
 
     buildPhase = ''
@@ -1544,21 +1546,21 @@ self: super: {
         --replace vimproc_linux32.so vimproc_unix.so
       make -f make_unix.mak
     '';
-  });
+  };
 
-  vimshell-vim = super.vimshell-vim.overrideAttrs (old: {
+  vimshell-vim = super.vimshell-vim.overrideAttrs {
     dependencies = with self; [ vimproc-vim ];
-  });
+  };
 
-  vim-zettel = super.vim-zettel.overrideAttrs (old: {
+  vim-zettel = super.vim-zettel.overrideAttrs {
     dependencies = with self; [ vimwiki fzf-vim ];
-  });
+  };
 
-  YankRing-vim = super.YankRing-vim.overrideAttrs (old: {
+  YankRing-vim = super.YankRing-vim.overrideAttrs {
     sourceRoot = ".";
-  });
+  };
 
-  YouCompleteMe = super.YouCompleteMe.overrideAttrs (old: {
+  YouCompleteMe = super.YouCompleteMe.overrideAttrs {
     buildPhase = ''
       substituteInPlace plugin/youcompleteme.vim \
         --replace "'ycm_path_to_python_interpreter', '''" \
@@ -1575,16 +1577,16 @@ self: super: {
       maintainers = with maintainers; [ marcweber jagajaga ];
       platforms = platforms.unix;
     };
-  });
+  };
 
-  zoxide-vim = super.zoxide-vim.overrideAttrs (old: {
+  zoxide-vim = super.zoxide-vim.overrideAttrs {
     buildInputs = [ zoxide ];
 
     postPatch = ''
       substituteInPlace autoload/zoxide.vim \
         --replace "'zoxide_executable', 'zoxide'" "'zoxide_executable', '${zoxide}/bin/zoxide'"
     '';
-  });
+  };
 
 } // (
   let


### PR DESCRIPTION
###### Description of changes

Since #241328, we are now able to use `overrideAttrs` with an attrset instead of a function. This utilizes that and simplifies vim overrides

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
