### PR TITLE
python311Packages.autobahn: 22.7.1 -> 23.6.2

### DIFF
--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , attrs
 , argon2-cffi
 , base58
@@ -21,7 +20,7 @@
 , msgpack
 , passlib
 , py-ecc
-, py-eth-sig-utils
+# , py-eth-sig-utils
 , py-multihash
 , py-ubjson
 , pynacl
@@ -49,22 +48,14 @@
 
 buildPythonPackage rec {
   pname = "autobahn";
-  version = "22.7.1";
+  version = "23.6.2";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/crossbario/autobahn-python/pull/1604
-      url = "https://github.com/crossbario/autobahn-python/commit/ffe679fae4ebcdde964d4ee88cb82a9c65c40529.patch";
-      hash = "sha256-QNnQkxMZJsFbiYUp4Os+dWo7jdCa96+kyb/2HxSMU8k=";
-    })
-  ];
+  disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-i0Yuouaq1rTcDtRfuAC2y/6wMl5/5pg5B/Ei8r5KH+k=";
+    hash = "sha256-7JQhxSohAzZNHvBGgDbmAZ7oT3FyHoazb+Ga1pZsEYE=";
   };
 
   postPatch = ''
@@ -110,7 +101,7 @@ buildPythonPackage rec {
     serialization = [ cbor2 flatbuffers msgpack ujson py-ubjson ];
     twisted = [ attrs args.twisted zope_interface ];
     ui = [ pygobject3 ];
-    xbr = [ base58 cbor2 click ecdsa eth-abi jinja2 hkdf mnemonic py-ecc py-eth-sig-utils py-multihash rlp spake2 twisted /* web3 xbr */ yapf /* zlmdb */ ];
+    xbr = [ base58 cbor2 click ecdsa eth-abi jinja2 hkdf mnemonic py-ecc /* py-eth-sig-utils */ py-multihash rlp spake2 twisted /* web3 xbr */ yapf /* zlmdb */ ];
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

While updating python311Packages.autobahn version, also fixing a future blocker identified in https://github.com/NixOS/nixpkgs/pull/240007#issuecomment-1622038374

* Bump version to 23.6.2
* Fixes:
 - remove the problematic extra dependency of `py-eth-sig-utils`
 - `disabled = pythonOlder "3.9"` in accordance with the upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
