### PR TITLE
mutest: unstable-2019-08-26 → 0-unstable-2023-02-24

### DIFF
--- a/pkgs/development/libraries/mutest/default.nix
+++ b/pkgs/development/libraries/mutest/default.nix
@@ -1,20 +1,22 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitHub
 , meson
 , ninja
+, unstableGitUpdater
 }:
 
 stdenv.mkDerivation {
   pname = "mutest";
-  version = "unstable-2019-08-26";
+  version = "0-unstable-2023-02-24";
 
   outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
     owner = "ebassi";
     repo = "mutest";
-    rev = "e6246c9ae4f36ffe8c021f0a80438f6c7a6efa3a";
-    sha256 = "0gdqwq6fvk06wld4rhnw5752hahrvhd69zrci045x25rwx90x26q";
+    rev = "18a20071773f7c4b75e82a931ef9b916b273b3e5";
+    sha256 = "z0kASte0/I48Fgxhblu24MjGHidWomhfFOhfStGtPn4=";
   };
 
   nativeBuildInputs = [
@@ -24,8 +26,12 @@ stdenv.mkDerivation {
 
   doCheck = true;
 
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
   meta = with lib; {
-    homepage = "https://ebassi.github.io/mutest/mutest.md.html";
+    homepage = "https://github.com/ebassi/mutest";
     description = "A BDD testing framework for C, inspired by Mocha";
     license = licenses.mit;
     maintainers = with maintainers; [ jtojnar ];


### PR DESCRIPTION
###### Description of changes

https://github.com/ebassi/mutest/compare/e6246c9ae4f36ffe8c021f0a80438f6c7a6efa3a...18a20071773f7c4b75e82a931ef9b916b273b3e5

- Use new version schema.
- Add update script.
- Use more convenient homepage.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Built `graphene`
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
