### PR TITLE
quark-goldleaf: init at 0.10.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16575,6 +16575,14 @@
     githubId = 8577941;
     name = "Kevin Rauscher";
   };
+  tomasajt = {
+    github = "TomaSajt";
+    githubId = 62384384;
+    name = "TomaSajt";
+    keys = [{
+      fingerprint = "8CA9 8016 F44D B717 5B44  6032 F011 163C 0501 22A1";
+    }];
+  };
   tomaskala = {
     email = "public+nixpkgs@tomaskala.com";
     github = "tomaskala";

--- a/pkgs/applications/misc/quark-goldleaf/default.nix
+++ b/pkgs/applications/misc/quark-goldleaf/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, maven
+, wrapGAppsHook
+, jre
+, libXtst
+}:
+let
+  pname = "quark-goldleaf";
+  version = "0.10.1";
+
+  description = "A GUI tool to help Goldleaf with file-transfer between the Nintendo Switch and the PC";
+
+  configDir = "\${XDG_CONFIG_HOME:-~/.config}/${pname}";
+
+  goldleafSrc = fetchFromGitHub {
+    owner = "XorTroll";
+    repo = "Goldleaf";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-Kq9IkkPJgPCdTBWlpqz2AexYqp6auFnsy/hV/n980VQ=";
+  };
+
+  quarkUnwrapped = maven.buildMavenPackage {
+    pname = "${pname}-unwrapped";
+    inherit version;
+
+    src = goldleafSrc + "/Quark";
+    mvnHash = "sha256-eqe2NqtCC6aJg5kptKqd0wUlM7/FHDsEH48H1RHGzT0=";
+
+    nativeBuildInputs = [
+      makeWrapper
+      maven
+      wrapGAppsHook
+    ];
+
+    installPhase = ''
+      install -D target/Quark.jar $out/share/java/${pname}.jar
+      makeWrapper ${jre}/bin/java $out/bin/${pname} \
+            --add-flags "-jar $out/share/java/${pname}.jar" \
+            --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXtst ]}"
+    '';
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    install -Dm644 ${./switch.rules} $out/etc/udev/rules.d/99-switch.rules
+    # If wrapGAppsHook was used here, this wouldn't work properly
+    makeWrapper ${quarkUnwrapped}/bin/${pname} $out/bin/${pname} \
+          --run "mkdir -p ${configDir}" \
+          --append-flags "-cfgfile ${configDir}/quark.cfg"
+          '';
+
+  meta = with lib; {
+    inherit description;
+    homepage = "https://github.com/XorTroll/Goldleaf/blob/master/Quark.md";
+    longDescription = ''
+      ${description}
+
+      For it to work properly, you need to install the Nintendo Switch udev rules by adding
+
+      `services.udev.packages = [ pkgs.${pname} ]`
+
+      to your NixOS configuration
+    '';
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.tomasajt ];
+  };
+}

--- a/pkgs/applications/misc/quark-goldleaf/switch.rules
+++ b/pkgs/applications/misc/quark-goldleaf/switch.rules
@@ -1,0 +1,2 @@
+# Nintendo Switch (for Goldleaf+Quark connection)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="3000", MODE="0666"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11845,6 +11845,8 @@ with pkgs;
 
   pystring = callPackage ../development/libraries/pystring { };
 
+  quark-goldleaf = callPackage ../applications/misc/quark-goldleaf { };
+
   raysession = python3Packages.callPackage ../applications/audio/raysession {
     inherit (qt5) qttools;
   };


### PR DESCRIPTION
###### Description of changes

This PR adds the `quark-goldleaf` package.
The actual program is called Quark, however, there already exists a package named `quark` so this was called `quark-goldleaf` because the project is only used with the program called Goldleaf, running on the Nintendo Switch.

It also adds a `udev` rule which allows the Nintendo Switch to be detected by Quark.
When you disconnect and then reconnect the Nintendo Switch, I found that only by using `MODE="0666"` will it work without rebooting the PC.

Link to Goldleaf's repo: https://github.com/XorTroll/Goldleaf/
Inside the repo, the `/Quark` directory contains the project and `/Quark.md` contains the install instructions.

---

###### Notes:
I had to wrap the program twice:
- firstly, only the built `.jar` file , with its dependencies, applying `wrapGAppsHook`
- secondly, supplying the default `-cfgfile` file and making sure that the config dir exists (the program itself doesn't do it)

The reason for this double wrapping is that `wrapGAppsHook` changes the `makeWrapper` implementation, replacing it with `makeCWrapper`, which doesn't accept the `--run` flag.
Also, for some reason it can't process the default directory path as expected (probably something to do with the env-vars not being available).

---

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).