### PR TITLE
wasilibc: add flag for thread support; add extra test case

### DIFF
--- a/pkgs/development/compilers/llvm/16/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/16/libcxx/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
       # libcxx appears to require unwind and doesn't pull it in via other means.
       "-DLIBCXX_ADDITIONAL_LIBRARIES=unwind"
     ] ++ lib.optionals stdenv.hostPlatform.isWasm [
-      "-DLIBCXX_ENABLE_THREADS=OFF"
+      "-DLIBCXX_ENABLE_THREADS=${if stdenv.cc.libc.hasThreads then "ON" else "OFF"}"
       "-DLIBCXX_ENABLE_FILESYSTEM=OFF"
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
       "-DUNIX=ON" # Required otherwise libc++ fails to detect the correct linker

--- a/pkgs/development/compilers/llvm/16/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/16/libcxxabi/default.nix
@@ -71,12 +71,22 @@ stdenv.mkDerivation rec {
     # pkgsLLVM.libcxxabi (which uses clangNoCompilerRtWithLibc).
     "-DCMAKE_EXE_LINKER_FLAGS=-nostdlib"
     "-DCMAKE_SHARED_LINKER_FLAGS=-nostdlib"
-  ] ++ lib.optionals stdenv.hostPlatform.isWasm [
-    "-DCMAKE_C_COMPILER_WORKS=ON"
-    "-DLIBCXXABI_ENABLE_THREADS=OFF"
-    "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
-    "-DUNIX=ON" # Required otherwise libc++ fails to detect the correct linker
-  ] ++ lib.optionals (!enableShared) [
+  ] ++ lib.optionals stdenv.hostPlatform.isWasm (
+    [
+      "-DCMAKE_C_COMPILER_WORKS=ON"
+      "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
+      "-DUNIX=ON" # Required otherwise libc++ fails to detect the correct linker
+    ]
+    ++ (if stdenv.cc.libc.hasThreads then [
+      "-DLIBCXXABI_ENABLE_THREADS=ON"
+      "-DLIBCXXABI_HAS_PTHREAD_API=ON"
+      "-DLIBCXXABI_HAS_EXTERNAL_THREAD_API=OFF"
+      "-DLIBCXXABI_BUILD_EXTERNAL_THREAD_LIBRARY=OFF"
+      "-DLIBCXXABI_HAS_WIN32_THREAD_API=OFF"
+    ] else [
+      "-DLIBCXXABI_ENABLE_THREADS=OFF"
+    ])
+  ) ++ lib.optionals (!enableShared) [
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
   ];
 

--- a/pkgs/development/compilers/llvm/16/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/16/libcxxabi/default.nix
@@ -73,7 +73,6 @@ stdenv.mkDerivation rec {
     "-DCMAKE_SHARED_LINKER_FLAGS=-nostdlib"
   ] ++ lib.optionals stdenv.hostPlatform.isWasm [
     "-DCMAKE_C_COMPILER_WORKS=ON"
-    "-DCMAKE_CXX_COMPILER_WORKS=ON"
     "-DLIBCXXABI_ENABLE_THREADS=OFF"
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
     "-DUNIX=ON" # Required otherwise libc++ fails to detect the correct linker

--- a/pkgs/development/libraries/wasilibc/default.nix
+++ b/pkgs/development/libraries/wasilibc/default.nix
@@ -2,6 +2,9 @@
 , buildPackages
 , fetchFromGitHub
 , lib
+# Enable experimental wasilibc pthread support
+, enableThreads ? false
+# For tests
 , firefox-unwrapped
 , firefox-esr-unwrapped
 }:
@@ -38,8 +41,7 @@ stdenv.mkDerivation {
       "SYSROOT_LIB:=$SYSROOT_LIB"
       "SYSROOT_INC:=$SYSROOT_INC"
       "SYSROOT_SHARE:=$SYSROOT_SHARE"
-      # https://bugzilla.mozilla.org/show_bug.cgi?id=1773200
-      "BULK_MEMORY_SOURCES:="
+      "THREAD_MODEL=${if enableThreads then "posix" else "single"}"
     )
 
   '';
@@ -53,8 +55,11 @@ stdenv.mkDerivation {
     ln -s $share/share/undefined-symbols.txt $out/lib/wasi.imports
   '';
 
-  passthru.tests = {
-    inherit firefox-unwrapped firefox-esr-unwrapped;
+  passthru = {
+    tests = {
+      inherit firefox-unwrapped firefox-esr-unwrapped;
+    };
+    hasThreads = enableThreads;
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

GHC's wasm backend needs LLVM 16 (due to new flags), bumping the default version for WASM seems like the simplest solution for this. While we're at it, update `wasilibc` which uses LLVM 16 in release 20 as well.

* [ ] Port to at least `_git`
* Tests
  * [x] firefox (retest)
  * [x] firefox-esr
* [ ] Finish #225000

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
