### PR TITLE
epson-tm-m30ii: init at 3.0.0.0

### DIFF
--- a/pkgs/misc/drivers/epson-tm-m30ii/default.nix
+++ b/pkgs/misc/drivers/epson-tm-m30ii/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchurl, cups, cmake }:
+
+stdenv.mkDerivation {
+  pname = "epson-tm-m30ii";
+  version = "3.0.0.0";
+
+  src = fetchurl {
+    url = "https://www.epson-biz.com/modules/pos/download.php?fid=9468";
+    curlOptsList = ["-X" "POST" "-H" "Cookie: service=pos" "--data-raw" "DownloadSubmit=Download..."];
+    hash = "sha256-gQU0DyKw/wwwjK1cyF4Nnh6F1k6lCgIPq6ctmCfUjB0=";
+    name = "epson-tm-m30ii.tar.gz";
+  };
+
+  buildInputs = [ cups cmake ];
+
+  installPhase = ''
+    mkdir -p $out/lib/cups/filter
+    install -s rastertotmtr $out/lib/cups/filter
+
+    install -m 755 -d $out/share/cups/model/EPSON
+    install -m 755 ../ppd/*.ppd $out/share/cups/model/EPSON
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.epson-biz.com/modules/pos/index.php?page=prod&pcat=3&pid=6370";
+    description = "Driver for the EPSON TM-m30II thermal printer";
+    longDescription = ''
+      Epson thermal printer driver for the TM-m30ii printer for Linux
+      and the corresponding PPD files.
+
+      To use the driver adjust your configuration.nix file:
+        services.printing = {
+          enable = true;
+          drivers = [ pkgs.${pname} ];
+        };'';
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ esclear ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37437,6 +37437,8 @@ with pkgs;
 
   epson-201106w = callPackage ../misc/drivers/epson-201106w { };
 
+  epson-tm-m30ii = callPackage ../misc/drivers/epson-tm-m30ii { };
+
   epson-workforce-635-nx625-series = callPackage ../misc/drivers/epson-workforce-635-nx625-series { };
 
   foomatic-db = callPackage ../misc/cups/drivers/foomatic-db {};


### PR DESCRIPTION
###### Description of changes

This PR adds driver for the [EPSON TM-m30II thermal printer](https://www.epson-biz.com/modules/pos/index.php?page=prod&pcat=3&pid=6370).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
