### PR TITLE
nitrocli: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15952,6 +15952,15 @@
     githubId = 506181;
     name = "Peter Marheine";
   };
+  tarnacious = {
+    name = "Tarn Barford";
+    email = "tarn@tarnbarford.net";
+    github = "tarnacious";
+    githubId = 170085;
+    keys = [{
+      fingerprint = "93AF D786 C784 F7A6 6206  969E 02A7 0172 0778 ECD5";
+    }];
+  };
   tasmo = {
     email = "tasmo@tasmo.de";
     github = "tasmo";

--- a/pkgs/tools/security/nitrocli/default.nix
+++ b/pkgs/tools/security/nitrocli/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, hidapi
+, python3
+, bashInteractive
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nitrocli";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "d-e-s-o";
+    repo = "nitrocli";
+    rev = "7991b9cb4a8fee2ea5ffd11f6fed2bd7f5cded21";
+    sha256 = "0xy169qf5vckvzx48lmkcpd83pw5crnvfl8a7p5wp2cbkrl60pnc";
+  };
+
+  cargoHash = "sha256-sEM8aznsz5tw9W/N2ZtCpPY8SqOEUBS+WG7V26Qms0g=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  buildInputs = [
+    hidapi
+  ];
+
+  # Some patches are required for three of the tests to pass. Alternatively the
+  # build will succeed if these three tests are skipped.
+  prePatch = ''
+     pythonInterpreterEscaped=$(echo ${python3}/bin/python3 | sed 's/\//\\\//g')
+     sed -i "s/\/usr\/bin\/env python/$pythonInterpreterEscaped/" src/tests/run.rs
+
+     bashInterpreterEscaped=$(echo ${bashInteractive}/bin/bash | sed 's/\//\\\//g')
+     sed -i "s/process::Command::new(\"bash\")/process::Command::new(\"$bashInterpreterEscaped\")/" var/shell-complete.rs
+  '';
+
+  # Instead of applying the patches above, these tests can skipped.
+  #checkFlags = [
+  #  # these tests require a python shebang to substituted
+  #  "--skip=tests::run::extension"
+  #  "--skip=tests::run::extension_failure"
+
+  #  # this test requires a command to run bash to be substituted
+  #  "--tests::complete_all_the_things"
+  #];
+
+  postInstall = ''
+    installManPage doc/nitrocli.1
+
+    installShellCompletion --cmd nitrocli \
+     --bash <($out/bin/shell-complete bash) \
+     --fish <($out/bin/shell-complete fish) \
+     --zsh <($out/bin/shell-complete zsh)
+
+    rm $out/bin/shell-complete
+  '';
+
+  meta = {
+    description = "A command line tool for interacting with Nitrokey devices";
+    homepage = "https://github.com/d-e-s-o/nitrocli";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.tarnacious ];
+    # There are reports of sucess and problems on darwin. It sounds like this
+    # could be solved with Nix but it's currently only supported on Linux.
+    # https://github.com/d-e-s-o/nitrocli/issues/1
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40892,6 +40892,8 @@ with pkgs;
 
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
 
+  nitrocli = callPackage ../tools/security/nitrocli { };
+
   fpm2 = callPackage ../tools/security/fpm2 { };
 
   simplenote = callPackage ../applications/misc/simplenote { };


### PR DESCRIPTION
###### Description of changes

Add `nitrocli` package:

"nitrocli is a program that provides a command line interface for interaction with [Nitrokey Pro](https://shop.nitrokey.com/shop/product/nitrokey-pro-2-3), [Nitrokey Storage](https://shop.nitrokey.com/shop/product/nitrokey-storage-2-56), and [Librem Key](https://puri.sm/products/librem-key/) devices."

https://github.com/d-e-s-o/nitrocli

Packages are available for:

Arch Linux: [nitrocli](https://archlinux.org/packages/community/x86_64/nitrocli/)
Debian: [nitrocli](https://packages.debian.org/stable/nitrocli) (since Debian Buster)
Gentoo Linux: [app-crypt/nitrocli](https://packages.gentoo.org/packages/app-crypt/nitrocli) ebuild
Ubuntu: [nitrocli](https://packages.ubuntu.com/search?keywords=nitrocli) (since Ubuntu 19.04)

Nixpks already contains a [module](https://github.com/NixOS/nixpkgs/blob/dd05cbb4bd2d408c75725c241da6a41b6a28450a/nixos/modules/hardware/nitrokey.nix#L7) for Nitrokey devices and the "official" [Nitrokey GUI](https://github.com/NixOS/nixpkgs/blob/dd05cbb4bd2d408c75725c241da6a41b6a28450a/pkgs/tools/security/nitrokey-app/default.nix#L13).  

The Nitrokey site links to the CLI tool here:

https://www.nitrokey.com/news/2017/nitrokey-app-library-and-cli

This package currently only supports the Linux platform, but it may be possible to package it to support Darwin too with some work.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've tested the tools work well, both using `nix build` and by adding my nixpkgs fork as an additional channel on my nixos system. nitrocli is a really great package and I hope we can get it into nixpkgs. 

I haven't reviewed any packages yet, sorry. I'd like to be more involved in the project in the future. 