### PR TITLE
nyxt: 3.1.0 -> 3.3.0

### DIFF
--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -273,14 +273,14 @@ let
     };
   };
 
-  cl-colors2_0_5_3 = build-asdf-system {
+  cl-colors2_0_5_4 = build-asdf-system {
     inherit (super.cl-colors2) pname systems lispLibs;
-    version = "0.5.3";
+    version = "0.5.4";
 
     src = pkgs.fetchgit {
       url = "https://notabug.org/cage/cl-colors2";
-      rev = "refs/tags/v0.5.3";
-      sha256 = "sha256-anYkLJoNOVBQoXzWVBgbEusQDdud0RA8nZzedl8V93w=";
+      rev = "refs/tags/v0.5.4";
+      sha256 = "sha256-JbT1BKjaXDwdlzHLPjX1eg0RMIOT86R17SPgbe2h+tA=";
     };
   };
 
@@ -396,12 +396,12 @@ let
 
   nyxt-gtk = build-asdf-system {
     inherit (super.nyxt) pname;
-    version = "3.1.0";
+    version = "3.3.0";
 
     lispLibs = with super; [
       self.nasdf-unstable
       self.prompter
-      self.cl-colors2_0_5_3
+      self.cl-colors2_0_5_4
       self.njson_1_0_0
       self.nsymbols_0_3_1
       self.nclasses_0_5_0
@@ -464,8 +464,8 @@ let
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nyxt";
-      rev = "3.1.0";
-      sha256 = "sha256-H3AlslECb/VvIC6zAGkLNTaGJ/nb97J6RXAN8sEgAgY=";
+      rev = "3.3.0";
+      sha256 = "sha256-hSu+XGb87yzZPbJgcUhU81VGhNdMiN6GKspGQJU+SxY=";
     };
 
     nativeBuildInputs = [ pkgs.makeWrapper ];


### PR DESCRIPTION
###### Description of changes

- Update `nyxt` to 3.3.0
  - Release notes since 3.1.0:
    - https://nyxt.atlas.engineer/article/release-3.3.0.org
    - https://nyxt.atlas.engineer/article/release-3.2.1.org
    - https://nyxt.atlas.engineer/article/release-3.2.0.org
- Update version of `cl-colors2` that `nyxt` relies on to 0.5.4 
  - I could not find a changelog nor other information on changes between releases

However, according to `nixpkgs-review`, this change results in `sbclPackages.nyxt-ubuntu-package` failing to build. Unfortunately, I cannot figure out how to get a more up to date version from https://beta.quicklisp.org

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
