### PR TITLE
haskell.packages.ghc96.foundation: remove build patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -123,18 +123,6 @@ self: super: {
   # Compilation failure workarounds
   #
 
-  # Add missing Functor instance for Tuple2
-  # https://github.com/haskell-foundation/foundation/pull/572
-  foundation = appendPatches [
-      (pkgs.fetchpatch {
-        name = "foundation-pr-572.patch";
-        url =
-          "https://github.com/haskell-foundation/foundation/commit/d3136f4bb8b69e273535352620e53f2196941b35.patch";
-        sha256 = "sha256-oPadhQdCPJHICdCPxn+GsSQUARIYODG8Ed6g2sK+eC4=";
-        stripLen = 1;
-      })
-    ] (super.foundation);
-
   # Add support for time 1.10
   # https://github.com/vincenthz/hs-hourglass/pull/56
   hourglass = appendPatches [


### PR DESCRIPTION
###### Description of changes

The patch does not apply to foundation-0.0.30, because it already contains a build fix for ghc-9.6.x.

(Note: Upstream fixed the issue by removing `instance Bifunctor Tuple2` rather than adding `instance Functor (Tuple2 a)`.)

cc: @TristanCacqueray @sternenseemann

###### Things done

- [x] Built under NixOS on platform `x86_64-linux`.
- [x] Tested with `nix build .#haskell.packages.ghc96.foundation`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
