### PR TITLE
jack-link: init at latest commit

### DIFF
--- a/pkgs/tools/audio/jack-link/default.nix
+++ b/pkgs/tools/audio/jack-link/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, pkg-config
+, libjack2
+}:
+
+stdenv.mkDerivation {
+  pname = "jack-link";
+  version = "unstable-2023-05-31";
+
+  src = fetchFromGitHub {
+    owner = "rncbc";
+    repo = "jack_link";
+    rev = "b97b349033075d8d4e681c252d1e7c59108d45c0";
+    sha256 = "sha256-Jdahbv/VfGdOPRttBEoFxglzsqSCrv3fO8CY82WcugY=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libjack2
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/rncbc/jack_link";
+    description = "jack_link bridges JACK transport with Ableton Link.";
+    license = licenses.gpl2Plus;
+    mainProgram = "jack_link";
+    maintainers = with maintainers; [ PowerUser64 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32259,6 +32259,8 @@ with pkgs;
   jackmix = libsForQt5.callPackage ../applications/audio/jackmix { };
   jackmix_jack1 = jackmix.override { jack = jack1; };
 
+  jack-link = callPackage ../tools/audio/jack-link { };
+
   jaeles = callPackage ../tools/security/jaeles { };
 
   jalv = callPackage ../applications/audio/jalv { };


### PR DESCRIPTION
> Note: I haven't had time to work on getting this merged recently, but I have not forgotten about it! I'll get to it sometime in the next few weeks once I have time to work on nix things.

###### Description of changes

This PR adds [jack_link](https://github.com/rncbc/jack_link), an application to bridge JACK transport to Ableton Link.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
