### PR TITLE
mutt: avoid build-only references in 'mutt -v'

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-TXc/IkIveQlve5S1e+5FZUrZolFl27NkY8WClbTNPYg=";
   };
 
-  patches = lib.optional smimeSupport (fetchpatch {
+  patches = [
+    # Avoid build-only references embedding into 'mutt -v' output.
+    ./no-build-only-refs.patch
+  ] ++ lib.optional smimeSupport (fetchpatch {
     url = "https://salsa.debian.org/mutt-team/mutt/raw/debian/1.10.1-2/debian/patches/misc/smime.rc.patch";
     sha256 = "0b4i00chvx6zj9pcb06x2jysmrcb2znn831lcy32cgfds6gr3nsi";
   });

--- a/pkgs/applications/networking/mailreaders/mutt/no-build-only-refs.patch
+++ b/pkgs/applications/networking/mailreaders/mutt/no-build-only-refs.patch
@@ -1,0 +1,24 @@
+Avoid build-only store references embedding into 'mutt -v'.
+--- a/txt2c.sh
++++ b/txt2c.sh
+@@ -21,8 +21,18 @@ txt2c_fallback () {
+ 	echo ";"
+ }
+ 
++nix_store_mangle() {
++	# consume stdin
++
++	# Avoid build-only references to nix store. These are usually
++	# 'gcc -v' output embedded into 'mutt -v'. But also might be
++	# ./configure-passed arguments.
++	sed \
++	    -e 's@'$NIX_STORE'/[a-z0-9]\{32\}-@/<<NIX>>/@g'
++}
++
+ if ./txt2c test </dev/null >/dev/null 2>&1; then
+-    ./txt2c "$1"
++    nix_store_mangle | ./txt2c "$1"
+ else
+-    txt2c_fallback "$1"
++    nix_store_mangle | txt2c_fallback "$1"
+ fi


### PR DESCRIPTION
The change removes `gcc` from runtime closure. This shrinks closure in half.

Before the change:

    nix path-info -Sh $(nix-build -A mutt) |& unnix
    $ /<<NIX>>/mutt-2.2.10     440.0M

After the change: 218M

    $ nix path-info -Sh $(nix-build -A mutt) |& unnix
    /<<NIX>>/mutt-2.2.10     218.7M

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
