### PR TITLE
Modernize psutils and fix Darwin build

### DIFF
--- a/pkgs/tools/typesetting/psutils/default.nix
+++ b/pkgs/tools/typesetting/psutils/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     description = "Collection of useful utilities for manipulating PS documents";
     homepage = "http://knackered.knackered.org/angus/psutils/";
     license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/typesetting/psutils/default.nix
+++ b/pkgs/tools/typesetting/psutils/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
       Makefile.unix > Makefile
   '';
 
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
   preInstall = ''
     mkdir -p $out/bin $out/share/man/man1
   '';

--- a/pkgs/tools/typesetting/psutils/default.nix
+++ b/pkgs/tools/typesetting/psutils/default.nix
@@ -5,8 +5,8 @@ stdenv.mkDerivation rec {
   version = "17";
 
   src = fetchurl {
-    url = "ftp://ftp.knackered.org/pub/psutils/psutils-p${version}.tar.gz";
-    sha256 = "1r4ab1fvgganm02kmm70b2r1azwzbav2am41gbigpa2bb1wynlrq";
+    url = "http://knackered.knackered.org/angus/download/${pname}/${pname}-p${version}.tar.gz";
+    hash = "sha256-OFPreVhLqPvieoFUJbZan38Vsljg1DoFqFa9t11YiuQ=";
   };
 
   configurePhase = ''
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin $out/share/man/man1
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Collection of useful utilities for manipulating PS documents";
     homepage = "http://knackered.knackered.org/angus/psutils/";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
   };
 }


### PR DESCRIPTION
###### Description of changes

When building psutils using `nix shell nixpkgs#psutils` the build fails with exit code 2 `gcc: command not found`.

<details><summary>last 10 log lines</summary>

```sh
error: builder for '/nix/store/ax00m59llahk44w81698h92jnp9knhrs-psutils-17.drv' failed with exit code 2;
       last 10 log lines:
       > source root is psutils
       > setting SOURCE_DATE_EPOCH to timestamp 858120785 of file psutils/showchar.sh
       > patching sources
       > updateAutotoolsGnuConfigScriptsPhase
       > configuring
       > building
       > build flags: SHELL=/nix/store/mxvgjwzdvrl81plvgqnzbrqb14ccnji6-bash-5.2-p15/bin/bash
       > gcc -DPAPER=\"a4\" -DUNIX -O -Wall   -c -o psbook.o psbook.c
       > /nix/store/mxvgjwzdvrl81plvgqnzbrqb14ccnji6-bash-5.2-p15/bin/bash: line 1: gcc: command not found
       > make: *** [<builtin>: psbook.o] Error 127
       For full logs, run 'nix log /nix/store/ax00m59llahk44w81698h92jnp9knhrs-psutils-17.drv'
```

</details>

Adding `makeFlags` resolved the issue for me on aarch64-darwin.

❓ Should the `makeFlags` only be applied on Darwin or are they acceptable or even also desirable on other platforms?

Additionally I went ahead and "modernized" the package to the best of my knowledge and changed the src URL as the ftp URL timed out for me.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
