### PR TITLE
doc syntax section into chapter, link from nixos manual

### DIFF
--- a/doc/contributing/contributing-to-documentation.chapter.md
+++ b/doc/contributing/contributing-to-documentation.chapter.md
@@ -1,4 +1,4 @@
-# Contributing to this documentation {#chap-contributing}
+# Contributing to Nixpkgs documentation {#chap-contributing}
 
 The sources of the Nixpkgs manual are in the [doc](https://github.com/NixOS/nixpkgs/tree/master/doc) subdirectory of the Nixpkgs repository. The manual is still partially written in DocBook but it is progressively being converted to [Markdown](#sec-contributing-markup).
 

--- a/nixos/doc/manual/contributing-to-this-manual.chapter.md
+++ b/nixos/doc/manual/contributing-to-this-manual.chapter.md
@@ -1,6 +1,7 @@
 # Contributing to this manual {#chap-contributing}
 
 The [DocBook] and CommonMark sources of the NixOS manual are in the [nixos/doc/manual](https://github.com/NixOS/nixpkgs/tree/master/nixos/doc/manual) subdirectory of the [Nixpkgs](https://github.com/NixOS/nixpkgs) repository.
+This manual uses the [Nixpkgs manual syntax](https://nixos.org/manual/nixpkgs/unstable/#sec-contributing-markup).
 
 You can quickly check your edits with the following:
 


### PR DESCRIPTION
We noticed that the NixOS manual doesn't explain its syntax.
Well, that syntax is from the nixpkgs manual.

Moved

```
Nixpkgs Manual / Contributing to Nixpkgs / Contributing to this documentation / Syntax
```

To

```
Nixpkgs Manual / Contributing to Nixpkgs / Nix documentation syntax
```

And provided a link to this new chapter under

```
NixOS Manual / Contributing to this manual
```

No further changes.

The id/anchor-link of the moved section-to-chapter is preserved, even though is starts with `sec-`, which is now less appropriate than `chap-`.

tag:alejandrosamemightyiam

Co-authored-by: Shahar "Dawn" Or <mightyiampresence@gmail.com>
