### PR TITLE
python3Packages.python-jenkins: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -12,15 +12,17 @@
 , requests
 , requests-mock
 , stestr
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
   pname = "python-jenkins";
-  version = "1.7.0";
+  version = "1.8.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "01jid5s09lr3kayr2h1z9n8h9nhyw3jxv9c4b5hrlxijknkqzvfy";
+    hash = "sha256-AYClRj9o4uARDzgrQkjSKEvGhIHbShb8v2H09VgBwx8=";
   };
 
   # test uses timeout mechanism unsafe for use with the "spawn"
@@ -30,16 +32,23 @@ buildPythonPackage rec {
       --replace test_jenkins_open_no_timeout dont_test_jenkins_open_no_timeout
   '';
 
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+  pythonRelaxDeps = [
+    "setuptools"
+  ];
+
   buildInputs = [ mock ];
   propagatedBuildInputs = [ pbr pyyaml setuptools six multi_key_dict requests ];
 
-   nativeCheckInputs = [ stestr testscenarios requests-mock ];
-   checkPhase = ''
-     # Skip tests that fail due to setuptools>=66.0.0 rejecting PEP 440
-     # non-conforming versions. See
-     # https://github.com/pypa/setuptools/issues/2497 for details.
-     stestr run -E "tests.test_plugins.(PluginsTestScenarios.test_plugin_version_comparison|PluginsTestScenarios.test_plugin_version_object_comparison|PluginsTest.test_plugin_equal|PluginsTest.test_plugin_not_equal)"
-   '';
+  nativeCheckInputs = [ stestr testscenarios requests-mock ];
+  checkPhase = ''
+    # Skip tests that fail due to setuptools>=66.0.0 rejecting PEP 440
+    # non-conforming versions. See
+    # https://github.com/pypa/setuptools/issues/2497 for details.
+    stestr run -E "tests.test_plugins.(PluginsTestScenarios.test_plugin_version_comparison|PluginsTestScenarios.test_plugin_version_object_comparison|PluginsTest.test_plugin_equal|PluginsTest.test_plugin_not_equal)"
+  '';
 
   meta = with lib; {
     description = "Python bindings for the remote Jenkins API";


### PR DESCRIPTION
###### Description of changes

Minor update. Only changed commit: https://opendev.org/jjb/python-jenkins/commit/70dc3e4f711088e0cc9f0a92706fee3cb0757bac

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
