### PR TITLE
mk-python-derivation: fix passthru.updateScript being merged into the derivation

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -252,7 +252,10 @@ let
   passthru.updateScript = let
       filename = builtins.head (lib.splitString ":" self.meta.position);
     in attrs.passthru.updateScript or [ update-python-libraries filename ];
-in lib.extendDerivation
-  (disabled -> throw "${name} not supported for interpreter ${python.executable}")
-  passthru
-  self
+in
+  if disabled then
+    throw "${name} not supported for interpreter ${python.executable}"
+else
+  self.overrideAttrs (attrs: {
+    passthru = lib.recursiveUpdate passthru attrs.passthru;
+  })


### PR DESCRIPTION
Before updateScript was being merged down to pdm.updateScript. With this commit it is being moved to the expected location pdm.passthru.updateScript

###### Description of changes
Before:
```
nix-repl> pdm.updateScript
[ « derivation /nix/store/asycy2psbh2nsrdh492bnw7g42d96bzw-update-python-libraries.drv » "/home/sandro/src/nixpkgs/pkgs/tools/package-management/pdm/default.nix" ]

nix-repl> pdm.passthru.updateScript
error:
       … while evaluating the attribute 'passthru.updateScript'

         at /home/sandro/src/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:539:13:

          538|
          539|      inherit passthru overrideAttrs;
             |             ^
          540|      inherit meta;

       error: attribute 'updateScript' missing

       at «string»:1:1:

            1| pdm.passthru.updateScript
             | ^
```

after:

```
nix-repl> pdm.passthru.updateScript
[ « derivation /nix/store/asycy2psbh2nsrdh492bnw7g42d96bzw-update-python-libraries.drv » "/home/sandro/src/nixpkgs/pkgs/tools/package-management/pdm/default.nix" ]

nix-repl> pdm.updateScript
error: attribute 'updateScript' missing

       at «string»:1:1:

            1| pdm.updateScript
             | ^
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
