### PR TITLE
mac-telnet: init at 0.4.4

### DIFF
--- a/pkgs/tools/networking/mac-telnet/default.nix
+++ b/pkgs/tools/networking/mac-telnet/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, gettext
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mac-telnet";
+  version = "0.4.4";
+
+  src = fetchFromGitHub {
+    owner = "haakonnessjoen";
+    repo = "MAC-Telnet";
+    rev = "v${version}";
+    hash = "sha256-ZBJ3GTTXV14DMcKZWkhNDfOzsL+cCahBzTtnJsRvw/w=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    gettext
+  ];
+
+  patchPhase = ''
+    runHook prePatch
+
+    # Remove unnecessary chmodding from Makefile
+    head -1 config/Makefile.am > config/Makefile.am
+
+    runHook postPatch
+  '';
+
+  fixupPhase = ''
+    runHook preFixup
+
+    rm -rf $out/sbin
+
+    runHook postFixup
+  '';
+
+  meta = with lib; {
+    description = "Open source MAC Telnet client and server for connecting to Microtik RouterOS routers and Posix machines via MAC address";
+    homepage = "https://github.com/haakonnessjoen/MAC-Telnet";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8585,6 +8585,8 @@ with pkgs;
 
   mac-fdisk = callPackage ../tools/system/mac-fdisk { };
 
+  mac-telnet = callPackage ../tools/networking/mac-telnet { };
+
   partclone = callPackage ../tools/backup/partclone { };
 
   partimage = callPackage ../tools/backup/partimage { };


### PR DESCRIPTION
###### Description of changes

Adds mac-telnet to nixpkgs because of https://twitter.com/kaihendry/status/1676929369795600386

To test, `nix shell github:matthewcroughan/nixpkgs/mc/mac-telnet#mac-telnet`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
