### PR TITLE
kitchenowl: init at 0.4.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16575,6 +16575,14 @@
     githubId = 8577941;
     name = "Kevin Rauscher";
   };
+  tomasajt = {
+    github = "TomaSajt";
+    githubId = 62384384;
+    name = "TomaSajt";
+    keys = [{
+      fingerprint = "8CA9 8016 F44D B717 5B44  6032 F011 163C 0501 22A1";
+    }];
+  };
   tomaskala = {
     email = "public+nixpkgs@tomaskala.com";
     github = "tomaskala";

--- a/pkgs/applications/misc/kitchenowl/default.nix
+++ b/pkgs/applications/misc/kitchenowl/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, flutter
+, fetchFromGitHub
+, autoPatchelfHook
+}:
+
+flutter.buildFlutterApplication rec {
+  pname = "kitchenowl";
+  version = "0.4.6";
+
+  src = fetchFromGitHub {
+    owner = "TomBursch";
+    repo = "kitchenowl";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-fhqs9jWhS2YC+zpE37mJgs3vcJHi+8AdSbk1S8Ai+LQ=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  depsListFile = ./deps.json;
+  vendorHash = "sha256-tm35ZdrguWiEQ26l7A/3pv/YTpv2BgMiE7IIWYSdlIs=";
+
+  meta = {
+    homepage = "https://kitchenowl.org";
+    description = "A smart grocery list and recipe manager";
+    longDescription = ''
+      KitchenOwl is a smart self-hosted grocery list and recipe manager.
+      Easily add items to your shopping list before you go shopping.
+      You can also create recipes and get suggestions on what you want to cook.
+      Track your expenses so you know how much you've spent.
+    '';
+    changelog = "https://github.com/TomBursch/kitchenowl/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/applications/misc/kitchenowl/deps.json
+++ b/pkgs/applications/misc/kitchenowl/deps.json
@@ -1,0 +1,1731 @@
+[
+  {
+    "name": "kitchenowl",
+    "version": "0.4.6+77",
+    "kind": "root",
+    "source": "root",
+    "dependencies": [
+      "flutter",
+      "flutter_localizations",
+      "intl",
+      "cupertino_icons",
+      "collection",
+      "path_provider",
+      "flutter_secure_storage",
+      "shared_preferences",
+      "flutter_bloc",
+      "animations",
+      "shimmer",
+      "equatable",
+      "url_launcher",
+      "flutter_custom_tabs",
+      "package_info_plus",
+      "device_info_plus",
+      "http",
+      "diffutil_dart",
+      "responsive_builder",
+      "dynamic_color",
+      "azlistview",
+      "flutter_markdown",
+      "tuple",
+      "community_charts_flutter",
+      "fl_chart",
+      "cached_network_image",
+      "image_picker",
+      "file_picker",
+      "photo_view",
+      "share_handler",
+      "reorderables",
+      "flutter_colorpicker",
+      "sliver_tools",
+      "go_router",
+      "font_awesome_flutter",
+      "flutter_test",
+      "flutter_launcher_icons",
+      "flutter_lints",
+      "dart_code_metrics"
+    ]
+  },
+  {
+    "name": "dart_code_metrics",
+    "version": "5.7.5",
+    "kind": "dev",
+    "source": "hosted",
+    "dependencies": [
+      "analyzer",
+      "analyzer_plugin",
+      "ansicolor",
+      "args",
+      "collection",
+      "crypto",
+      "dart_code_metrics_presets",
+      "file",
+      "glob",
+      "html",
+      "http",
+      "meta",
+      "path",
+      "platform",
+      "pub_updater",
+      "source_span",
+      "uuid",
+      "xml",
+      "yaml"
+    ]
+  },
+  {
+    "name": "yaml",
+    "version": "3.1.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "source_span",
+      "string_scanner"
+    ]
+  },
+  {
+    "name": "string_scanner",
+    "version": "1.2.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "source_span"
+    ]
+  },
+  {
+    "name": "source_span",
+    "version": "1.9.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "path",
+      "term_glyph"
+    ]
+  },
+  {
+    "name": "term_glyph",
+    "version": "1.2.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "path",
+    "version": "1.8.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "collection",
+    "version": "1.17.1",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "xml",
+    "version": "6.3.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "meta",
+      "petitparser"
+    ]
+  },
+  {
+    "name": "petitparser",
+    "version": "5.4.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "meta"
+    ]
+  },
+  {
+    "name": "meta",
+    "version": "1.9.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "uuid",
+    "version": "3.0.7",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "crypto"
+    ]
+  },
+  {
+    "name": "crypto",
+    "version": "3.0.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "typed_data"
+    ]
+  },
+  {
+    "name": "typed_data",
+    "version": "1.3.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "collection"
+    ]
+  },
+  {
+    "name": "pub_updater",
+    "version": "0.3.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "http",
+      "json_annotation",
+      "process",
+      "pub_semver"
+    ]
+  },
+  {
+    "name": "pub_semver",
+    "version": "2.1.4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "meta"
+    ]
+  },
+  {
+    "name": "process",
+    "version": "4.2.4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "file",
+      "path",
+      "platform"
+    ]
+  },
+  {
+    "name": "platform",
+    "version": "3.1.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "file",
+    "version": "6.1.4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "meta",
+      "path"
+    ]
+  },
+  {
+    "name": "json_annotation",
+    "version": "4.8.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "meta"
+    ]
+  },
+  {
+    "name": "http",
+    "version": "0.13.6",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "async",
+      "http_parser",
+      "meta"
+    ]
+  },
+  {
+    "name": "http_parser",
+    "version": "4.0.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "source_span",
+      "string_scanner",
+      "typed_data"
+    ]
+  },
+  {
+    "name": "async",
+    "version": "2.11.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "meta"
+    ]
+  },
+  {
+    "name": "html",
+    "version": "0.15.4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "csslib",
+      "source_span"
+    ]
+  },
+  {
+    "name": "csslib",
+    "version": "1.0.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "source_span"
+    ]
+  },
+  {
+    "name": "glob",
+    "version": "2.1.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "async",
+      "collection",
+      "file",
+      "path",
+      "string_scanner"
+    ]
+  },
+  {
+    "name": "dart_code_metrics_presets",
+    "version": "1.8.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "args",
+    "version": "2.4.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "ansicolor",
+    "version": "2.0.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "analyzer_plugin",
+    "version": "0.11.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "analyzer",
+      "collection",
+      "dart_style",
+      "pub_semver",
+      "yaml"
+    ]
+  },
+  {
+    "name": "dart_style",
+    "version": "2.3.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "analyzer",
+      "args",
+      "path",
+      "pub_semver",
+      "source_span"
+    ]
+  },
+  {
+    "name": "analyzer",
+    "version": "5.13.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "_fe_analyzer_shared",
+      "collection",
+      "convert",
+      "crypto",
+      "glob",
+      "meta",
+      "package_config",
+      "path",
+      "pub_semver",
+      "source_span",
+      "watcher",
+      "yaml"
+    ]
+  },
+  {
+    "name": "watcher",
+    "version": "1.1.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "async",
+      "path"
+    ]
+  },
+  {
+    "name": "package_config",
+    "version": "2.1.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "path"
+    ]
+  },
+  {
+    "name": "convert",
+    "version": "3.1.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "typed_data"
+    ]
+  },
+  {
+    "name": "_fe_analyzer_shared",
+    "version": "61.0.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "meta"
+    ]
+  },
+  {
+    "name": "flutter_lints",
+    "version": "2.0.2",
+    "kind": "dev",
+    "source": "hosted",
+    "dependencies": [
+      "lints"
+    ]
+  },
+  {
+    "name": "lints",
+    "version": "2.1.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "flutter_launcher_icons",
+    "version": "0.13.1",
+    "kind": "dev",
+    "source": "hosted",
+    "dependencies": [
+      "args",
+      "checked_yaml",
+      "cli_util",
+      "image",
+      "json_annotation",
+      "path",
+      "yaml"
+    ]
+  },
+  {
+    "name": "image",
+    "version": "4.0.17",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "archive",
+      "meta",
+      "xml"
+    ]
+  },
+  {
+    "name": "archive",
+    "version": "3.3.7",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "crypto",
+      "path",
+      "pointycastle"
+    ]
+  },
+  {
+    "name": "pointycastle",
+    "version": "3.7.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "convert",
+      "js"
+    ]
+  },
+  {
+    "name": "js",
+    "version": "0.6.7",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "meta"
+    ]
+  },
+  {
+    "name": "cli_util",
+    "version": "0.4.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "meta",
+      "path"
+    ]
+  },
+  {
+    "name": "checked_yaml",
+    "version": "2.0.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "json_annotation",
+      "source_span",
+      "yaml"
+    ]
+  },
+  {
+    "name": "flutter_test",
+    "version": "0.0.0",
+    "kind": "dev",
+    "source": "sdk",
+    "dependencies": [
+      "flutter",
+      "test_api",
+      "path",
+      "fake_async",
+      "clock",
+      "stack_trace",
+      "vector_math",
+      "async",
+      "boolean_selector",
+      "characters",
+      "collection",
+      "js",
+      "matcher",
+      "material_color_utilities",
+      "meta",
+      "source_span",
+      "stream_channel",
+      "string_scanner",
+      "term_glyph"
+    ]
+  },
+  {
+    "name": "stream_channel",
+    "version": "2.1.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "async"
+    ]
+  },
+  {
+    "name": "material_color_utilities",
+    "version": "0.2.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "matcher",
+    "version": "0.12.15",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "async",
+      "meta",
+      "stack_trace",
+      "term_glyph",
+      "test_api"
+    ]
+  },
+  {
+    "name": "test_api",
+    "version": "0.5.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "async",
+      "boolean_selector",
+      "collection",
+      "meta",
+      "source_span",
+      "stack_trace",
+      "stream_channel",
+      "string_scanner",
+      "term_glyph",
+      "matcher"
+    ]
+  },
+  {
+    "name": "stack_trace",
+    "version": "1.11.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "path"
+    ]
+  },
+  {
+    "name": "boolean_selector",
+    "version": "2.1.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "source_span",
+      "string_scanner"
+    ]
+  },
+  {
+    "name": "characters",
+    "version": "1.3.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "vector_math",
+    "version": "2.1.4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "clock",
+    "version": "1.1.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "fake_async",
+    "version": "1.3.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "clock",
+      "collection"
+    ]
+  },
+  {
+    "name": "flutter",
+    "version": "0.0.0",
+    "kind": "direct",
+    "source": "sdk",
+    "dependencies": [
+      "characters",
+      "collection",
+      "js",
+      "material_color_utilities",
+      "meta",
+      "vector_math",
+      "sky_engine"
+    ]
+  },
+  {
+    "name": "sky_engine",
+    "version": "0.0.99",
+    "kind": "transitive",
+    "source": "sdk",
+    "dependencies": []
+  },
+  {
+    "name": "font_awesome_flutter",
+    "version": "10.5.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "go_router",
+    "version": "9.0.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "flutter",
+      "flutter_web_plugins",
+      "logging",
+      "meta"
+    ]
+  },
+  {
+    "name": "logging",
+    "version": "1.2.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "flutter_web_plugins",
+    "version": "0.0.0",
+    "kind": "transitive",
+    "source": "sdk",
+    "dependencies": [
+      "flutter",
+      "js",
+      "characters",
+      "collection",
+      "material_color_utilities",
+      "meta",
+      "vector_math"
+    ]
+  },
+  {
+    "name": "sliver_tools",
+    "version": "0.2.10",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "flutter_colorpicker",
+    "version": "1.0.3",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "reorderables",
+    "version": "0.6.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "share_handler",
+    "version": "0.0.17",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "share_handler_android",
+      "share_handler_ios",
+      "share_handler_platform_interface"
+    ]
+  },
+  {
+    "name": "share_handler_platform_interface",
+    "version": "0.0.6",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "plugin_platform_interface"
+    ]
+  },
+  {
+    "name": "plugin_platform_interface",
+    "version": "2.1.4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "meta"
+    ]
+  },
+  {
+    "name": "share_handler_ios",
+    "version": "0.0.10",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "share_handler_platform_interface"
+    ]
+  },
+  {
+    "name": "share_handler_android",
+    "version": "0.0.7",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "share_handler_platform_interface"
+    ]
+  },
+  {
+    "name": "photo_view",
+    "version": "0.14.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "file_picker",
+    "version": "5.3.2",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_web_plugins",
+      "flutter_plugin_android_lifecycle",
+      "plugin_platform_interface",
+      "ffi",
+      "path",
+      "win32"
+    ]
+  },
+  {
+    "name": "win32",
+    "version": "5.0.5",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "ffi"
+    ]
+  },
+  {
+    "name": "ffi",
+    "version": "2.0.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "flutter_plugin_android_lifecycle",
+    "version": "2.0.15",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "image_picker",
+    "version": "1.0.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "image_picker_android",
+      "image_picker_for_web",
+      "image_picker_ios",
+      "image_picker_linux",
+      "image_picker_macos",
+      "image_picker_platform_interface",
+      "image_picker_windows"
+    ]
+  },
+  {
+    "name": "image_picker_windows",
+    "version": "0.2.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "file_selector_platform_interface",
+      "file_selector_windows",
+      "flutter",
+      "image_picker_platform_interface"
+    ]
+  },
+  {
+    "name": "image_picker_platform_interface",
+    "version": "2.8.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "cross_file",
+      "flutter",
+      "http",
+      "plugin_platform_interface"
+    ]
+  },
+  {
+    "name": "cross_file",
+    "version": "0.3.3+4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "js",
+      "meta"
+    ]
+  },
+  {
+    "name": "file_selector_windows",
+    "version": "0.9.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "cross_file",
+      "file_selector_platform_interface",
+      "flutter"
+    ]
+  },
+  {
+    "name": "file_selector_platform_interface",
+    "version": "2.6.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "cross_file",
+      "flutter",
+      "http",
+      "plugin_platform_interface"
+    ]
+  },
+  {
+    "name": "image_picker_macos",
+    "version": "0.2.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "file_selector_macos",
+      "file_selector_platform_interface",
+      "flutter",
+      "image_picker_platform_interface"
+    ]
+  },
+  {
+    "name": "file_selector_macos",
+    "version": "0.9.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "cross_file",
+      "file_selector_platform_interface",
+      "flutter"
+    ]
+  },
+  {
+    "name": "image_picker_linux",
+    "version": "0.2.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "file_selector_linux",
+      "file_selector_platform_interface",
+      "flutter",
+      "image_picker_platform_interface"
+    ]
+  },
+  {
+    "name": "file_selector_linux",
+    "version": "0.9.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "cross_file",
+      "file_selector_platform_interface",
+      "flutter"
+    ]
+  },
+  {
+    "name": "image_picker_ios",
+    "version": "0.8.8",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "image_picker_platform_interface"
+    ]
+  },
+  {
+    "name": "image_picker_for_web",
+    "version": "2.2.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_web_plugins",
+      "image_picker_platform_interface",
+      "mime"
+    ]
+  },
+  {
+    "name": "mime",
+    "version": "1.0.4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "image_picker_android",
+    "version": "0.8.7+3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_plugin_android_lifecycle",
+      "image_picker_platform_interface"
+    ]
+  },
+  {
+    "name": "cached_network_image",
+    "version": "3.2.3",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_cache_manager",
+      "octo_image",
+      "cached_network_image_platform_interface",
+      "cached_network_image_web"
+    ]
+  },
+  {
+    "name": "cached_network_image_web",
+    "version": "1.0.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_cache_manager",
+      "cached_network_image_platform_interface"
+    ]
+  },
+  {
+    "name": "cached_network_image_platform_interface",
+    "version": "2.0.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_cache_manager"
+    ]
+  },
+  {
+    "name": "flutter_cache_manager",
+    "version": "3.3.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "clock",
+      "collection",
+      "file",
+      "flutter",
+      "http",
+      "path",
+      "path_provider",
+      "pedantic",
+      "rxdart",
+      "sqflite",
+      "uuid"
+    ]
+  },
+  {
+    "name": "sqflite",
+    "version": "2.2.8+4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "sqflite_common",
+      "path"
+    ]
+  },
+  {
+    "name": "sqflite_common",
+    "version": "2.4.5+1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "synchronized",
+      "path",
+      "meta"
+    ]
+  },
+  {
+    "name": "synchronized",
+    "version": "3.1.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "rxdart",
+    "version": "0.27.7",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "pedantic",
+    "version": "1.11.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "path_provider",
+    "version": "2.0.15",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "path_provider_android",
+      "path_provider_foundation",
+      "path_provider_linux",
+      "path_provider_platform_interface",
+      "path_provider_windows"
+    ]
+  },
+  {
+    "name": "path_provider_windows",
+    "version": "2.1.7",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "ffi",
+      "flutter",
+      "path",
+      "path_provider_platform_interface",
+      "win32"
+    ]
+  },
+  {
+    "name": "path_provider_platform_interface",
+    "version": "2.0.6",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "platform",
+      "plugin_platform_interface"
+    ]
+  },
+  {
+    "name": "path_provider_linux",
+    "version": "2.1.11",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "ffi",
+      "flutter",
+      "path",
+      "path_provider_platform_interface",
+      "xdg_directories"
+    ]
+  },
+  {
+    "name": "xdg_directories",
+    "version": "1.0.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "meta",
+      "path",
+      "process"
+    ]
+  },
+  {
+    "name": "path_provider_foundation",
+    "version": "2.2.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "path_provider_platform_interface"
+    ]
+  },
+  {
+    "name": "path_provider_android",
+    "version": "2.0.27",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "path_provider_platform_interface"
+    ]
+  },
+  {
+    "name": "octo_image",
+    "version": "1.0.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_blurhash"
+    ]
+  },
+  {
+    "name": "flutter_blurhash",
+    "version": "0.7.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "fl_chart",
+    "version": "0.63.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "equatable",
+      "flutter"
+    ]
+  },
+  {
+    "name": "equatable",
+    "version": "2.0.5",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "meta"
+    ]
+  },
+  {
+    "name": "community_charts_flutter",
+    "version": "1.0.1",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "meta",
+      "community_charts_common",
+      "flutter"
+    ]
+  },
+  {
+    "name": "community_charts_common",
+    "version": "1.0.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "intl",
+      "collection",
+      "meta",
+      "vector_math"
+    ]
+  },
+  {
+    "name": "intl",
+    "version": "0.18.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "clock",
+      "meta",
+      "path"
+    ]
+  },
+  {
+    "name": "tuple",
+    "version": "2.0.2",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "flutter_markdown",
+    "version": "0.6.15+1",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "markdown",
+      "meta",
+      "path"
+    ]
+  },
+  {
+    "name": "markdown",
+    "version": "7.1.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "args",
+      "meta"
+    ]
+  },
+  {
+    "name": "azlistview",
+    "version": "2.0.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "scrollable_positioned_list"
+    ]
+  },
+  {
+    "name": "scrollable_positioned_list",
+    "version": "0.2.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "collection"
+    ]
+  },
+  {
+    "name": "dynamic_color",
+    "version": "1.6.5",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_test",
+      "material_color_utilities"
+    ]
+  },
+  {
+    "name": "responsive_builder",
+    "version": "0.7.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "provider"
+    ]
+  },
+  {
+    "name": "provider",
+    "version": "6.0.5",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "collection",
+      "flutter",
+      "nested"
+    ]
+  },
+  {
+    "name": "nested",
+    "version": "1.0.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "diffutil_dart",
+    "version": "3.0.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "device_info_plus",
+    "version": "9.0.2",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "device_info_plus_platform_interface",
+      "ffi",
+      "file",
+      "flutter",
+      "flutter_web_plugins",
+      "meta",
+      "win32",
+      "win32_registry"
+    ]
+  },
+  {
+    "name": "win32_registry",
+    "version": "1.1.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "ffi",
+      "win32"
+    ]
+  },
+  {
+    "name": "device_info_plus_platform_interface",
+    "version": "7.0.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "meta",
+      "plugin_platform_interface"
+    ]
+  },
+  {
+    "name": "package_info_plus",
+    "version": "4.0.2",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "ffi",
+      "flutter",
+      "flutter_web_plugins",
+      "http",
+      "meta",
+      "path",
+      "package_info_plus_platform_interface",
+      "win32"
+    ]
+  },
+  {
+    "name": "package_info_plus_platform_interface",
+    "version": "2.0.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "meta",
+      "plugin_platform_interface"
+    ]
+  },
+  {
+    "name": "flutter_custom_tabs",
+    "version": "1.0.4",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_custom_tabs_platform_interface",
+      "flutter_custom_tabs_web",
+      "meta"
+    ]
+  },
+  {
+    "name": "flutter_custom_tabs_web",
+    "version": "1.0.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_web_plugins",
+      "flutter_custom_tabs_platform_interface",
+      "meta",
+      "url_launcher_web",
+      "url_launcher_platform_interface"
+    ]
+  },
+  {
+    "name": "url_launcher_platform_interface",
+    "version": "2.1.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "plugin_platform_interface"
+    ]
+  },
+  {
+    "name": "url_launcher_web",
+    "version": "2.0.17",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_web_plugins",
+      "url_launcher_platform_interface"
+    ]
+  },
+  {
+    "name": "flutter_custom_tabs_platform_interface",
+    "version": "1.0.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "plugin_platform_interface",
+      "meta"
+    ]
+  },
+  {
+    "name": "url_launcher",
+    "version": "6.1.11",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "url_launcher_android",
+      "url_launcher_ios",
+      "url_launcher_linux",
+      "url_launcher_macos",
+      "url_launcher_platform_interface",
+      "url_launcher_web",
+      "url_launcher_windows"
+    ]
+  },
+  {
+    "name": "url_launcher_windows",
+    "version": "3.0.6",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "url_launcher_platform_interface"
+    ]
+  },
+  {
+    "name": "url_launcher_macos",
+    "version": "3.0.5",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "url_launcher_platform_interface"
+    ]
+  },
+  {
+    "name": "url_launcher_linux",
+    "version": "3.0.5",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "url_launcher_platform_interface"
+    ]
+  },
+  {
+    "name": "url_launcher_ios",
+    "version": "6.1.4",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "url_launcher_platform_interface"
+    ]
+  },
+  {
+    "name": "url_launcher_android",
+    "version": "6.0.36",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "url_launcher_platform_interface"
+    ]
+  },
+  {
+    "name": "shimmer",
+    "version": "3.0.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "animations",
+    "version": "2.0.7",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter"
+    ]
+  },
+  {
+    "name": "flutter_bloc",
+    "version": "8.1.3",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "bloc",
+      "flutter",
+      "provider"
+    ]
+  },
+  {
+    "name": "bloc",
+    "version": "8.1.2",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "meta"
+    ]
+  },
+  {
+    "name": "shared_preferences",
+    "version": "2.2.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "shared_preferences_android",
+      "shared_preferences_foundation",
+      "shared_preferences_linux",
+      "shared_preferences_platform_interface",
+      "shared_preferences_web",
+      "shared_preferences_windows"
+    ]
+  },
+  {
+    "name": "shared_preferences_windows",
+    "version": "2.3.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "file",
+      "flutter",
+      "path",
+      "path_provider_platform_interface",
+      "path_provider_windows",
+      "shared_preferences_platform_interface"
+    ]
+  },
+  {
+    "name": "shared_preferences_platform_interface",
+    "version": "2.3.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "plugin_platform_interface"
+    ]
+  },
+  {
+    "name": "shared_preferences_web",
+    "version": "2.2.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_web_plugins",
+      "shared_preferences_platform_interface"
+    ]
+  },
+  {
+    "name": "shared_preferences_linux",
+    "version": "2.3.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "file",
+      "flutter",
+      "path",
+      "path_provider_linux",
+      "path_provider_platform_interface",
+      "shared_preferences_platform_interface"
+    ]
+  },
+  {
+    "name": "shared_preferences_foundation",
+    "version": "2.3.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "shared_preferences_platform_interface"
+    ]
+  },
+  {
+    "name": "shared_preferences_android",
+    "version": "2.2.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "shared_preferences_platform_interface"
+    ]
+  },
+  {
+    "name": "flutter_secure_storage",
+    "version": "8.0.0",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_secure_storage_linux",
+      "flutter_secure_storage_macos",
+      "flutter_secure_storage_platform_interface",
+      "flutter_secure_storage_web",
+      "flutter_secure_storage_windows",
+      "meta"
+    ]
+  },
+  {
+    "name": "flutter_secure_storage_windows",
+    "version": "2.0.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_secure_storage_platform_interface"
+    ]
+  },
+  {
+    "name": "flutter_secure_storage_platform_interface",
+    "version": "1.0.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "plugin_platform_interface"
+    ]
+  },
+  {
+    "name": "flutter_secure_storage_web",
+    "version": "1.1.1",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_secure_storage_platform_interface",
+      "flutter_web_plugins",
+      "js"
+    ]
+  },
+  {
+    "name": "flutter_secure_storage_macos",
+    "version": "3.0.0",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_secure_storage_platform_interface"
+    ]
+  },
+  {
+    "name": "flutter_secure_storage_linux",
+    "version": "1.1.3",
+    "kind": "transitive",
+    "source": "hosted",
+    "dependencies": [
+      "flutter",
+      "flutter_secure_storage_platform_interface"
+    ]
+  },
+  {
+    "name": "cupertino_icons",
+    "version": "1.0.5",
+    "kind": "direct",
+    "source": "hosted",
+    "dependencies": []
+  },
+  {
+    "name": "flutter_localizations",
+    "version": "0.0.0",
+    "kind": "direct",
+    "source": "sdk",
+    "dependencies": [
+      "flutter",
+      "intl",
+      "characters",
+      "clock",
+      "collection",
+      "js",
+      "material_color_utilities",
+      "meta",
+      "path",
+      "vector_math"
+    ]
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9335,6 +9335,8 @@ with pkgs;
 
   kismet = callPackage ../applications/networking/sniffers/kismet { };
 
+  kitchenowl = callPackage ../applications/misc/kitchenowl { };
+
   kiterunner = callPackage ../tools/security/kiterunner { };
 
   klick = callPackage ../applications/audio/klick { };


### PR DESCRIPTION
###### Description of changes

This PR adds the `kitchenowl` package.
Kitchenowl is a smart grocery list and recipe manager.

Read more about it at: https://kitchenowl.org/
Repo: https://github.com/tombursch/kitchenowl
Closes https://github.com/NixOS/nixpkgs/issues/240552

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
