### PR TITLE
tree-sitter-grammars-wasm: init at 0.20.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -211,6 +211,12 @@
     githubId = 241628;
     name = "Adam Russell";
   };
+  aabccd021 = {
+    email = "aabccd021@gmail.com";
+    github = "aabccd021";
+    githubId = 33031950;
+    name = "Muhamad Abdurahman";
+  };
   aacebedo = {
     email = "alexandre@acebedo.fr";
     github = "aacebedo";

--- a/pkgs/development/tools/parsing/tree-sitter/grammar-wasm.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar-wasm.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, nodejs
+, tree-sitter
+, lib
+, emscripten
+}:
+
+{ language
+, version
+, src
+, wasmName
+, location ? null
+, generate ? false
+, ...
+}@args:
+
+stdenv.mkDerivation ({
+  pname = "${language}-grammar-wasm";
+
+  inherit src version;
+
+  nativeBuildInputs = [
+    emscripten
+    tree-sitter
+  ] ++ lib.lists.optional generate nodejs;
+
+  configurePhase = lib.optionalString (location != null) ''
+    cd ${location}
+  '' + lib.optionalString generate ''
+    tree-sitter generate
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    tree-sitter build-wasm
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir $out
+    cp tree-sitter-${wasmName}.wasm $out
+    runHook postInstall
+  '';
+} // removeAttrs args [ "language" "wasmName" "location" ])

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19848,6 +19848,8 @@ with pkgs;
 
   tree-sitter-grammars = recurseIntoAttrs tree-sitter.builtGrammars;
 
+  tree-sitter-grammars-wasm = recurseIntoAttrs tree-sitter.builtGrammarsWasm;
+
   trellis = callPackage ../development/embedded/fpga/trellis { };
 
   ttyd = callPackage ../servers/ttyd { };


### PR DESCRIPTION
Accidentally closed previous PR #241981

###### Description of changes

[tree-sitter](https://github.com/tree-sitter/tree-sitter) is a code parsing tool and tree-sitter grammars (e.g. ) are the parser grammar for each language.

The tree-sitter grammars can be built into native build (used in native platform such as neovim) or wasm build (mainly used in browser / server-side javascript).
Nix packages for native build is already available on `tree-sitter-grammars.tree-sitter-*`.

This PR adds ones for wasm build on `tree-sitter-grammars-wasm.tree-sitter-*`.

Additional notes:
- [Build instruction for tree-sitter grammar wasm](https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_web/README.md#generate-wasm-language-files)
- LLVM grammar failed to build on my machine, hence omitted
- Some grammar has irregular wasm output file name (e.g `tree-sitter-ql-dbscheme` on PR), so it needs to be overrided manually via `wasmName` variable
- The new file [grammar-wasm.nix](https://github.com/NixOS/nixpkgs/blob/746b9b094f724e1669a2f2121c80b6e2c1cd48c9/pkgs/development/tools/parsing/tree-sitter/grammar-wasm.nix) was made based on similarly behaving [grammar.nix](https://github.com/NixOS/nixpkgs/blob/746b9b094f724e1669a2f2121c80b6e2c1cd48c9/pkgs/development/tools/parsing/tree-sitter/grammar.nix) for easier review

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
