### PR TITLE
zsh-abbr: init at 5.1.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -657,6 +657,13 @@ in mkLicense lset) ({
     redistributable = true;
   };
 
+  hl3 = {
+    fullName = "Hippocratic License v3.0";
+    url = "https://firstdonoharm.dev/version/3/0/core.txt";
+    free = false;
+    redistributable = true;
+  };
+
   issl = {
     fullName = "Intel Simplified Software License";
     url = "https://software.intel.com/en-us/license/intel-simplified-software-license";

--- a/pkgs/shells/zsh/zsh-abbr/default.nix
+++ b/pkgs/shells/zsh/zsh-abbr/default.nix
@@ -1,0 +1,30 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation rec {
+  pname = "zsh-abbr";
+  version = "5.1.0";
+
+  src = fetchFromGitHub {
+    owner = "olets";
+    repo = "zsh-abbr";
+    rev = "v${version}";
+    hash = "sha256-iKL2vn7TmQr78y0Bn02DgNf9DS5jZyh6uK9MzYTFZaA";
+  };
+
+  strictDeps = true;
+
+  installPhase = ''
+    install -D zsh-abbr.zsh $out/share/zsh/${pname}/abbr.plugin.zsh
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/olets/zsh-abbr";
+    description = "The zsh manager for auto-expanding abbreviations, inspired by fish shell";
+    license = with licenses; [cc-by-nc-nd-40 hl3];
+    maintainers = with maintainers; [icy-thought];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14646,6 +14646,8 @@ with pkgs;
 
   zstxtns-utils = callPackage ../tools/text/zstxtns-utils { };
 
+  zsh-abbr = callPackage ../shells/zsh/zsh-abbr { };
+
   zsh-autoenv = callPackage ../tools/misc/zsh-autoenv { };
 
   zsh-autopair = callPackage ../shells/zsh/zsh-autopair { };


### PR DESCRIPTION
###### Description of changes
Adding:
1. zsh plugin which provides fish-like abbreviation completions.
2. Missing HL3 license which is used in the project.

Not certain about the `free` status of the `HL3` license since there has been some complaints about it being misleading and whatnot. Therefore I choose to set it to non-free. (correct me if I am mistaken!)

###### Related links
- https://github.com/olets/zsh-abbr
- https://firstdonoharm.dev/version/3/0/core.html
- https://twitter.com/OpenSourceOrg/status/1176229398929977344

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
