### PR TITLE
cudaPackages: add jetson support

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/flags.nix
+++ b/pkgs/development/compilers/cudatoolkit/flags.nix
@@ -1,6 +1,8 @@
 { config
-, lib
+, cudaCapabilities ? (config.cudaCapabilities or null)
+, cudaForwardCompat ? (config.cudaForwardCompat or true)
 , cudaVersion
+, lib
 }:
 
 # Type aliases
@@ -14,13 +16,13 @@ let
   # from improved performance, reduced file size, or greater hardware support by
   # passing a configuration based on your specific GPU environment.
   #
-  # config.cudaCapabilities :: List Capability
+  # cudaCapabilities :: List Capability
   # List of hardware generations to build.
   # E.g. [ "8.0" ]
   # Currently, the last item is considered the optional forward-compatibility arch,
   # but this may change in the future.
   #
-  # config.cudaForwardCompat :: Bool
+  # cudaForwardCompat :: Bool
   # Whether to include the forward compatibility gencode (+PTX)
   # to support future GPU generations.
   # E.g. true
@@ -165,6 +167,6 @@ assert (formatCapabilities { cudaCapabilities = [ "7.5" "8.6" ]; }) == {
   # dropDot :: String -> String
   inherit dropDot;
 } // formatCapabilities {
-  cudaCapabilities = config.cudaCapabilities or defaultCapabilities;
-  enableForwardCompat = config.cudaForwardCompat or true;
+  cudaCapabilities = if cudaCapabilities == null then defaultCapabilities else cudaCapabilities;
+  enableForwardCompat = cudaForwardCompat;
 }

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -4,21 +4,58 @@
 , fetchurl
 , autoPatchelfHook
 , autoAddOpenGLRunpathHook
+, manifestAttribute ? null
 }:
 
 pname:
 attrs:
 
 let
-  arch = "linux-x86_64";
+  systemToManifestAttribute = {
+    "x86_64-linux" = [ "linux-x86_64" ];
+    "aarch64-linux" = [ "linux-aarch64" "linux-sbsa" ];
+    "powerpc64le-linux" = [ "linux-ppc64le" ];
+  };
+  systemToManifestAttributeOrDefault = default: system:
+    if builtins.hasAttr system systemToManifestAttribute && builtins.length systemToManifestAttribute.${system} > 0
+    then builtins.head systemToManifestAttribute.${system}
+    else default; # Avoids evaluation errors on missing attributes
+  isSystemSupported = system: builtins.any (at: builtins.hasAttr at attrs) systemToManifestAttribute.${system};
+  supportedPlatforms = builtins.concatMap
+    (system: if isSystemSupported system then [ system ] else [ ])
+    (builtins.attrNames systemToManifestAttribute);
+
+  inherit (stdenv) system;
+
+  renames = {
+    manifestAttribute =
+      if manifestAttribute == null
+      then systemToManifestAttributeOrDefault "linux-x86_64" system
+      else manifestAttribute;
+  };
 in
+let
+  inherit (renames) manifestAttribute;
+
+  # Generally, we avoid assertions in favour of setting the `meta.broken`
+  # attribute, which can be overridden by the user. These tests are assertions
+  # because if they fail, they likely fail even without any overrides, and their
+  # failure signals a coding error right in this file.
+  validAttributeChoice = lib.assertMsg (builtins.hasAttr manifestAttribute attrs) "Trying to evaluate ${pname} for ${system}, but the chosen attribue (${manifestAttribute}) isn't in the manifest";
+in
+
+assert validAttributeChoice;
+assert builtins.all
+  (system: builtins.elem system lib.platforms.all)
+  (builtins.attrNames systemToManifestAttribute);
+
 backendStdenv.mkDerivation {
   inherit pname;
   inherit (attrs) version;
 
-  src = assert (lib.hasAttr arch attrs); fetchurl {
-    url = "https://developer.download.nvidia.com/compute/cuda/redist/${attrs.${arch}.relative_path}";
-    inherit (attrs.${arch}) sha256;
+  src = fetchurl {
+    url = "https://developer.download.nvidia.com/compute/cuda/redist/${attrs.${manifestAttribute}.relative_path}";
+    inherit (attrs.${manifestAttribute}) sha256;
   };
 
   nativeBuildInputs = [
@@ -56,11 +93,12 @@ backendStdenv.mkDerivation {
   '';
 
   passthru.stdenv = backendStdenv;
+  passthru.manifestAttribute = manifestAttribute;
 
   meta = {
     description = attrs.name;
     license = lib.licenses.unfree;
     maintainers = lib.teams.cuda.members;
-    platforms = lib.optionals (lib.hasAttr arch attrs) [ "x86_64-linux" ];
+    platforms = supportedPlatforms;
   };
 }

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -5,7 +5,7 @@
 , autoPatchelfHook
 , autoAddOpenGLRunpathHook
 , manifestAttribute ? null
-}:
+}@inputs:
 
 pname:
 attrs:
@@ -27,15 +27,10 @@ let
 
   inherit (stdenv) system;
 
-  renames = {
-    manifestAttribute =
-      if manifestAttribute == null
-      then systemToManifestAttributeOrDefault "linux-x86_64" system
-      else manifestAttribute;
-  };
-in
-let
-  inherit (renames) manifestAttribute;
+  manifestAttribute =
+    if !inputs?manifestAttribute || inputs.manifestAttribute == null
+    then systemToManifestAttributeOrDefault "linux-x86_64" system
+    else inputs.manifestAttribute;
 
   # Generally, we avoid assertions in favour of setting the `meta.broken`
   # attribute, which can be overridden by the user. These tests are assertions

--- a/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/build-cuda-redist-package.nix
@@ -13,7 +13,7 @@ attrs:
 let
   systemToManifestAttribute = {
     "x86_64-linux" = [ "linux-x86_64" ];
-    "aarch64-linux" = [ "linux-aarch64" "linux-sbsa" ];
+    "aarch64-linux" = [ "linux-sbsa" "linux-aarch64" ];
     "powerpc64le-linux" = [ "linux-ppc64le" ];
   };
   systemToManifestAttributeOrDefault = default: system:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6870,6 +6870,18 @@ with pkgs;
   cudaPackages_12_2 = callPackage ./cuda-packages.nix { cudaVersion = "12.2"; };
   cudaPackages_12 = cudaPackages_12_0;
 
+  cudaPackages_jetson = cudaPackages_11.overrideScope' (cuda-final: cuda-prev: {
+    cudaFlags = cuda-prev.cudaFlags.override {
+      cudaCapabilities = [
+        "5.3"
+        "6.2"
+        "7.2"
+        "8.7"
+      ];
+    };
+    manifestAttribute = if hostPlatform.system == "aarch64-linux" then "linux-aarch64" else null;
+  });
+
   # TODO: try upgrading once there is a cuDNN release supporting CUDA 12. No
   # such cuDNN release as of 2023-01-10.
   cudaPackages = recurseIntoAttrs cudaPackages_11;


### PR DESCRIPTION
###### Description of changes

It's a pretty small patch recovering jetson support as originally attempted in https://github.com/NixOS/nixpkgs/pull/194791, hopefully can be merged without any extra effort once ofborg goes through. I successfully built `cuda_nvcc` on an nvidia jetson host. One prerequisite for getting more complex stuff to work (like pytorch) would be https://github.com/NixOS/nixpkgs/pull/233581

CC https://github.com/NixOS/nixpkgs/pull/158350 @NixOS/cuda-maintainers 

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

```
❯ nix eval .#cudaPackages.cuda_nvcc.manifestAttribute
"linux-x86_64"
❯ nix eval .#cudaPackages.cuda_nvcc.meta.platforms
[ "aarch64-linux" "powerpc64le-linux" "x86_64-linux" ]
❯ nix eval .#pkgsCross.aarch64-multiplatform.cudaPackages.cuda_nvcc.manifestAttribute
"linux-aarch64"
❯ nix eval .#pkgsCross.aarch64-multiplatform.cudaPackages.cuda_nvcc.meta.platforms
[ "aarch64-linux" "powerpc64le-linux" "x86_64-linux" ]
```

###### What doesn't work

Idk how to use cross, but I tried this on an x86-64 host and it failed:

```
❯ NIXPKGS_ALLOW_UNFREE=1 nix build --impure .#pkgsCross.aarch64-multiplatform.cudaPackages.cuda_nvcc
...
       > error: auto-patchelf could not satisfy dependency libstdc++.so.6 wanted by /nix/store/9kv83k8nnnaxhv7wy2h27k15ww61xc75-cuda_nvcc-aarch64-unknown-linux-gnu-11.8.89/bin/__nvcc_device_query
       > error: auto-patchelf could not satisfy dependency libgcc_s.so.1 wanted by /nix/store/9kv83k8nnnaxhv7wy2h27k15ww61xc75-cuda_nvcc-aarch64-unknown-linux-gnu-11.8.89/bin/__nvcc_device_query
...
       > auto-patchelf failed to find all the required dependencies.
...
       For full logs, run 'nix log /nix/store/rmb71904ksdm8sbkn8wscnrzihvp5nkb-cuda_nvcc-aarch64-unknown-linux-gnu-11.8.89.drv'.
```

It's a shot in the dark, but I think this might be related to https://github.com/NixOS/nixpkgs/issues/226165