### PR TITLE
db: make patches and autoreconfHook unconditional

### DIFF
--- a/pkgs/development/libraries/db/db-4.8.nix
+++ b/pkgs/development/libraries/db/db-4.8.nix
@@ -3,8 +3,11 @@
 import ./generic.nix (args // {
   version = "4.8.30";
   sha256 = "0ampbl2f0hb1nix195kz1syrqqxpmvnvnfvphambj7xjrl3iljg0";
-  extraPatches = [ ./clang-4.8.patch ./CVE-2017-10140-4.8-cwd-db_config.patch ]
-    ++ lib.optionals stdenv.isDarwin [ ./darwin-mutexes-4.8.patch ];
+  extraPatches = [
+    ./clang-4.8.patch
+    ./CVE-2017-10140-4.8-cwd-db_config.patch
+    ./darwin-mutexes-4.8.patch
+  ];
 
   drvArgs.hardeningDisable = [ "format" ];
   drvArgs.doCheck = false;

--- a/pkgs/development/libraries/db/db-5.3.nix
+++ b/pkgs/development/libraries/db/db-5.3.nix
@@ -3,6 +3,9 @@
 import ./generic.nix (args // {
   version = "5.3.28";
   sha256 = "0a1n5hbl7027fbz5lm0vp0zzfp1hmxnz14wx3zl9563h83br5ag0";
-  extraPatches = [ ./clang-5.3.patch ./CVE-2017-10140-cwd-db_config.patch ]
-    ++ lib.optionals stdenv.isDarwin [ ./darwin-mutexes.patch ];
+  extraPatches = [
+    ./clang-5.3.patch
+    ./CVE-2017-10140-cwd-db_config.patch
+    ./darwin-mutexes.patch
+  ];
 })

--- a/pkgs/development/libraries/db/db-6.0.nix
+++ b/pkgs/development/libraries/db/db-6.0.nix
@@ -4,6 +4,9 @@ import ./generic.nix (args // {
   version = "6.0.20";
   sha256 = "00r2aaglq625y8r9xd5vw2y070plp88f1mb2gbq3kqsl7128lsl0";
   license = lib.licenses.agpl3;
-  extraPatches = [ ./clang-6.0.patch ./CVE-2017-10140-cwd-db_config.patch ]
-    ++ lib.optionals stdenv.isDarwin [ ./darwin-mutexes.patch ];
+  extraPatches = [
+    ./clang-6.0.patch
+    ./CVE-2017-10140-cwd-db_config.patch
+    ./darwin-mutexes.patch
+  ];
 })

--- a/pkgs/development/libraries/db/db-6.2.nix
+++ b/pkgs/development/libraries/db/db-6.2.nix
@@ -4,6 +4,9 @@ import ./generic.nix (args // {
   version = "6.2.23";
   sha256 = "1isxx4jfmnh913jzhp8hhfngbk6dsg46f4kjpvvc56maj64jqqa7";
   license = lib.licenses.agpl3;
-  extraPatches = [ ./clang-6.0.patch ./CVE-2017-10140-cwd-db_config.patch ]
-    ++ lib.optionals stdenv.isDarwin [ ./darwin-mutexes.patch ];
+  extraPatches = [
+    ./clang-6.0.patch
+    ./CVE-2017-10140-cwd-db_config.patch
+    ./darwin-mutexes.patch
+  ];
 })

--- a/pkgs/development/libraries/db/generic.nix
+++ b/pkgs/development/libraries/db/generic.nix
@@ -10,9 +10,6 @@
 , drvArgs ? {}
 }:
 
-let
-  shouldReconfigure = stdenv.cc.isClang;
-in
 stdenv.mkDerivation (rec {
   pname = "db";
   inherit version;
@@ -24,16 +21,16 @@ stdenv.mkDerivation (rec {
 
   # The provided configure script features `main` returning implicit `int`, which causes
   # configure checks to work incorrectly with clang 16.
-  nativeBuildInputs = lib.optionals stdenv.cc.isClang [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   patches = extraPatches;
 
   outputs = [ "bin" "out" "dev" ];
 
   # Required when regenerated the configure script to make sure the vendored macros are found.
-  autoreconfFlags = lib.optionalString shouldReconfigure [ "-fi" "-Iaclocal" "-Iaclocal_java" ];
+  autoreconfFlags = [ "-fi" "-Iaclocal" "-Iaclocal_java" ];
 
-  preAutoreconf = lib.optionalString shouldReconfigure ''
+  preAutoreconf = ''
     pushd dist
     # Upstream’s `dist/s_config` cats everything into `aclocal.m4`, but that doesn’t work with
     # autoreconfHook, so cat `config.m4` to another file. Otherwise, it won’t be found by `aclocal`.
@@ -43,7 +40,7 @@ stdenv.mkDerivation (rec {
   # This isn’t pretty. The version information is kept separate from the configure script.
   # After the configure script is regenerated, the version information has to be replaced with the
   # contents of `dist/RELEASE`.
-  postAutoreconf = lib.optionalString shouldReconfigure ''
+  postAutoreconf = ''
     (
       declare -a vars=(
         "DB_VERSION_FAMILY"


### PR DESCRIPTION
###### Description of changes

This simplifies the derivation a little bit by removing unnecessary conditional checks. Thank you to @SuperSandro2000 for the suggestion in #241178.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
