### PR TITLE
backintime: add missing dependency 'packaging'

### DIFF
--- a/pkgs/applications/networking/sync/backintime/qt.nix
+++ b/pkgs/applications/networking/sync/backintime/qt.nix
@@ -1,7 +1,7 @@
 { mkDerivation, backintime-common, python3 }:
 
 let
-  python' = python3.withPackages (ps: with ps; [ pyqt5 backintime-common ]);
+  python' = python3.withPackages (ps: with ps; [ pyqt5 backintime-common packaging ]);
 in
 mkDerivation {
   inherit (backintime-common)


### PR DESCRIPTION
###### Description of changes

Fixes this error:

```
  $ ./result/bin/backintime-qt
  /nix/store/fpr65b2gwpa4q9w3k6z8kjcd9yprmg6s-backintime-qt-1.3.3
  Traceback (most recent call last):
    File "/nix/store/fpr65b2gwpa4q9w3k6z8kjcd9yprmg6s-backintime-qt-1.3.3/share/backintime/qt/app.py", line 35, in <module>
      import qttools
    File "/nix/store/fpr65b2gwpa4q9w3k6z8kjcd9yprmg6s-backintime-qt-1.3.3/share/backintime/qt/qttools.py", line 32, in <module>
      from packaging.version import Version
  ModuleNotFoundError: No module named 'packaging'
```

Fixes https://github.com/NixOS/nixpkgs/issues/241966.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
