### PR TITLE
vlc: refactor

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -90,7 +90,6 @@
 , skins2Support ? !onlyLibVLC
 , waylandSupport ? true
 , withQt5 ? true
-, withLibcaca ? true
 }:
 
 # chromecastSupport requires TCP port 8010 to be open for it to work.
@@ -146,6 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
     libarchive
     libass
     libbluray
+    libcaca
     libcddb
     libdc1394
     libdvbpsi
@@ -188,7 +188,6 @@ stdenv.mkDerivation (finalAttrs: {
     xcbutilkeysyms
     zlib
   ]
-  ++ optional withLibcaca libcaca
   ++ optional (!stdenv.hostPlatform.isAarch && !onlyLibVLC) live555
   ++ optional jackSupport libjack2
   ++ optionals chromecastSupport [ libmicrodns protobuf ]

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -14,8 +14,15 @@
 , flac
 , fluidsynth
 , freefont_ttf
+, freetype
 , fribidi
 , gnutls
+, libSM
+, libXext
+, libXinerama
+, libXpm
+, libXv
+, libXvMC
 , libarchive
 , libass
 , libbluray
@@ -31,6 +38,7 @@
 , libkate
 , libmad
 , libmatroska
+, libmicrodns
 , libmodplug
 , libmtp
 , liboggz
@@ -56,6 +64,11 @@
 , ncurses
 , perl
 , pkg-config
+, protobuf
+, qtbase
+, qtsvg
+, qtwayland
+, qtx11extras
 , removeReferencesTo
 , samba
 , schroedinger
@@ -64,14 +77,20 @@
 , systemd
 , taglib
 , unzip
-, xorg
+, wayland
+, wayland-protocols
+, wrapGAppsHook
+, wrapQtAppsHook
+, xcbutilkeysyms
 , zlib
-, chromecastSupport ? true, libmicrodns, protobuf
+
+, chromecastSupport ? true
 , jackSupport ? false
 , onlyLibVLC ? false
-, skins2Support ? !onlyLibVLC, freetype
-, waylandSupport ? true, wayland, wayland-protocols
-, withQt5 ? true, qtbase, qtsvg, qtwayland, qtx11extras, wrapQtAppsHook, wrapGAppsHook
+, skins2Support ? !onlyLibVLC
+, waylandSupport ? true
+, withQt5 ? true
+, withLibcaca ? true
 }:
 
 # chromecastSupport requires TCP port 8010 to be open for it to work.
@@ -81,14 +100,28 @@
 let
   inherit (lib) optionalString optional optionals;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "${optionalString onlyLibVLC "lib"}vlc";
   version = "3.0.18";
 
   src = fetchurl {
-    url = "http://get.videolan.org/vlc/${version}/vlc-${version}.tar.xz";
-    sha256 = "sha256-VwlEOcNl2KqLm0H6MIDMDu8r7+YCW7XO9yKszGJa7ew=";
+    url = "http://get.videolan.org/vlc/${finalAttrs.version}/vlc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-VwlEOcNl2KqLm0H6MIDMDu8r7+YCW7XO9yKszGJa7ew=";
   };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    perl
+    pkg-config
+    removeReferencesTo
+    unzip
+    wrapGAppsHook
+  ]
+  ++ optionals withQt5 [ wrapQtAppsHook ]
+  ++ optionals waylandSupport [
+    wayland
+    wayland-protocols
+  ];
 
   # VLC uses a *ton* of libraries for various pieces of functionality, many of
   # which are not included here for no other reason that nobody has mentioned
@@ -106,10 +139,13 @@ stdenv.mkDerivation rec {
     fluidsynth
     fribidi
     gnutls
+    libSM
+    libXpm
+    libXv
+    libXvMC
     libarchive
     libass
     libbluray
-    libcaca
     libcddb
     libdc1394
     libdvbpsi
@@ -121,8 +157,8 @@ stdenv.mkDerivation rec {
     libkate
     libmad
     libmatroska
-    libmtp
     libmodplug
+    libmtp
     liboggz
     libopus
     libplacebo
@@ -149,46 +185,29 @@ stdenv.mkDerivation rec {
     srt
     systemd
     taglib
+    xcbutilkeysyms
     zlib
   ]
-  ++ (with xorg; [
-    libSM
-    libXpm
-    libXv
-    libXvMC
-    xcbutilkeysyms
-  ])
+  ++ optional withLibcaca libcaca
   ++ optional (!stdenv.hostPlatform.isAarch && !onlyLibVLC) live555
   ++ optional jackSupport libjack2
   ++ optionals chromecastSupport [ libmicrodns protobuf ]
-  ++ optionals skins2Support (with xorg; [
+  ++ optionals skins2Support [
     freetype
     libXext
     libXinerama
     libXpm
-  ])
+  ]
   ++ optionals waylandSupport [ wayland wayland-protocols ]
   ++ optionals withQt5 [ qtbase qtsvg qtx11extras ]
   ++ optional (waylandSupport && withQt5) qtwayland;
 
-  nativeBuildInputs = [
-    autoreconfHook
-    perl
-    pkg-config
-    removeReferencesTo
-    unzip
-    wrapGAppsHook
-  ]
-  ++ optionals withQt5 [ wrapQtAppsHook ]
-  ++ optionals waylandSupport [ wayland wayland-protocols ];
-
-  enableParallelBuilding = true;
-
-  LIVE555_PREFIX = if stdenv.hostPlatform.isAarch then null else live555;
-
-  # vlc depends on a c11-gcc wrapper script which we don't have so we need to
-  # set the path to the compiler
-  BUILDCC = "${stdenv.cc}/bin/gcc";
+  env = {
+    LIVE555_PREFIX = if stdenv.hostPlatform.isAarch then null else live555;
+    # vlc depends on a c11-gcc wrapper script which we don't have so we need to
+    # set the path to the compiler
+    BUILDCC = "${stdenv.cc}/bin/gcc";
+  };
 
   patches = [
     # patch to build with recent live555
@@ -210,9 +229,9 @@ stdenv.mkDerivation rec {
       /usr/share/fonts/truetype/freefont ${freefont_ttf}/share/fonts/truetype
   '';
 
+  enableParallelBuilding = true;
 
-  # to prevent double wrapping of Qtwrap and Gwrap
-  dontWrapGApps = true;
+  dontWrapGApps = true; # to prevent double wrapping of Qtwrap and Gwrap
 
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
@@ -259,11 +278,11 @@ stdenv.mkDerivation rec {
     cp -R share/hrtfs $out/share/vlc
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Cross-platform media player and streaming server";
     homepage = "http://www.videolan.org/vlc/";
-    license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
-    platforms = platforms.linux;
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ AndersonTorres ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35592,15 +35592,11 @@ with pkgs;
     # Newest libcaca changed the API, and libvlc didn't catch it. Until next
     # version arrives, it is safer to disable it.
     # Upstream thread: https://code.videolan.org/videolan/vlc/-/issues/26389
-    libcaca = null;
+    withLibcaca = false;
   };
 
   libvlc = vlc.override {
     withQt5 = false;
-    qtbase = null;
-    qtsvg = null;
-    qtx11extras = null;
-    wrapQtAppsHook = null;
     onlyLibVLC = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35588,12 +35588,7 @@ with pkgs;
 
   vkeybd = callPackage ../applications/audio/vkeybd { };
 
-  vlc = libsForQt5.callPackage ../applications/video/vlc {
-    # Newest libcaca changed the API, and libvlc didn't catch it. Until next
-    # version arrives, it is safer to disable it.
-    # Upstream thread: https://code.videolan.org/videolan/vlc/-/issues/26389
-    withLibcaca = false;
-  };
+  vlc = libsForQt5.callPackage ../applications/video/vlc { };
 
   libvlc = vlc.override {
     withQt5 = false;


### PR DESCRIPTION
- Remove xorg indirection
- Reorder lists
- Use new rec-less overlay style overridable recursive attributes (operative since https://github.com/NixOS/nixpkgs/pull/119942)
- Put env vars under `env`
- Remove `null`ities
- Remove `with lib;` (following rationale from https://nix.dev/recipes/best-practices#with-scopes)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
