### PR TITLE
Provide NixOS module option to enable the paperless exporter.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -308,6 +308,9 @@
 
 - `bind.cacheNetworks` now only controls access for recursive queries, where it previously controlled access for all queries.
 
+- The paperless module now has an option for regular automatic export of
+  documents data using the integrated document exporter.
+
 - Caddy can now be built with plugins by using `caddy.withPlugins`, a `passthru` function that accepts an attribute set as a parameter. The `plugins` argument represents a list of Caddy plugins, with each Caddy plugin being a versioned module. The `hash` argument represents the `vendorHash` of the resulting Caddy source code with the plugins added.
 
   Example:

--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -8,6 +8,15 @@ import ./make-test-python.nix ({ lib, ... }: {
       services.paperless = {
         enable = true;
         passwordFile = builtins.toFile "password" "admin";
+
+        exporter = {
+          enable = true;
+
+          settings = {
+            "no-color" = lib.mkForce false; # override a default option
+            "no-thumbnail" = true; # add a new option
+          };
+        };
       };
     };
     postgres = { config, pkgs, ... }: {
@@ -72,6 +81,25 @@ import ./make-test-python.nix ({ lib, ... }: {
 
         metadata = json.loads(node.succeed("curl -u admin:admin -fs localhost:28981/api/documents/3/metadata/"))
         assert "original_checksum" in metadata
+
+      with subtest("Exporter"):
+          node.succeed("systemctl start --wait paperless-exporter")
+          node.wait_for_unit("paperless-web.service")
+          node.wait_for_unit("paperless-consumer.service")
+          node.wait_for_unit("paperless-scheduler.service")
+          node.wait_for_unit("paperless-task-queue.service")
+
+          node.succeed("ls -lah /var/lib/paperless/export/manifest.json")
+
+          timers = node.succeed("systemctl list-timers paperless-exporter")
+          print(timers)
+          assert "paperless-exporter.timer paperless-exporter.service" in timers, "missing timer"
+          assert "1 timers listed." in timers, "incorrect number of timers"
+
+          # Double check that our attrset option override works as expected
+          cmdline = node.succeed("grep 'paperless-manage' $(systemctl cat paperless-exporter | grep ExecStart | cut -f 2 -d=)")
+          print(f"Exporter command line {cmdline!r}")
+          assert cmdline.strip() == "./paperless-manage document_exporter /var/lib/paperless/export --compare-checksums --delete --no-progress-bar --no-thumbnail", "Unexpected exporter command line"
 
     test_paperless(simple)
     simple.send_monitor_command("quit")


### PR DESCRIPTION
###### Description of changes

Integrate the paperless document exporter as a backup feature into the module.

Also fixes a configuration (quoting) issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
