### PR TITLE
djvulibre: fix build with clang 16

### DIFF
--- a/pkgs/applications/misc/djvulibre/c++17-register-class.patch
+++ b/pkgs/applications/misc/djvulibre/c++17-register-class.patch
@@ -1,0 +1,21 @@
+diff -ur a/libdjvu/GBitmap.h b/libdjvu/GBitmap.h
+--- a/libdjvu/GBitmap.h	2020-11-20 09:57:32.000000000 -0700
++++ b/libdjvu/GBitmap.h	2023-07-07 07:07:45.519912414 -0600
+@@ -620,7 +620,7 @@
+ inline int
+ GBitmap::read_run(unsigned char *&data)
+ {
+-  register int z=*data++;
++  int z=*data++;
+   return (z>=RUNOVERFLOWVALUE)?
+     ((z&~RUNOVERFLOWVALUE)<<8)|(*data++):z;
+ }
+@@ -628,7 +628,7 @@
+ inline int
+ GBitmap::read_run(const unsigned char *&data)
+ {
+-  register int z=*data++;
++  int z=*data++;
+   return (z>=RUNOVERFLOWVALUE)?
+     ((z&~RUNOVERFLOWVALUE)<<8)|(*data++):z;
+ }

--- a/pkgs/applications/misc/djvulibre/default.nix
+++ b/pkgs/applications/misc/djvulibre/default.nix
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
     bash
   ];
 
+  # Remove uses of the `register` storage class specifier, which was removed in C++17.
+  # Fixes compilation with clang 16, which defaults to C++17.
+  patches = [ ./c++17-register-class.patch ];
+
   enableParallelBuilding = true;
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

This fixes the build with clang 16, which defaults to C++17. In C++17, the `register` storage class specifier was removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
