### PR TITLE
ocamlPackages.tdigest: add passthru.updateScript and bump to 2.1.2

### DIFF
--- a/pkgs/development/ocaml-modules/tdigest/default.nix
+++ b/pkgs/development/ocaml-modules/tdigest/default.nix
@@ -5,13 +5,13 @@
 
 buildDunePackage rec {
   pname = "tdigest";
-  version = "2.1.1";
+  version = "2.1.2";
 
   src = fetchFromGitHub {
     owner = "SGrondin";
     repo = pname;
     rev = version;
-    sha256 = "sha256-R1uaCN/6NiW+jdGQiflwfihaidngvaWjJM7UFyR4vxs=";
+    sha256 = "sha256-pkJRJeEbBbAR1STb6v3Zu11twvHkAKAO0YjifRBFTDw=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/tdigest/default.nix
+++ b/pkgs/development/ocaml-modules/tdigest/default.nix
@@ -1,4 +1,5 @@
-{ lib, fetchFromGitHub, buildDunePackage
+{ lib, fetchFromGitHub, nix-update-script
+, buildDunePackage
 , core
 }:
 
@@ -18,6 +19,8 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     core
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/SGrondin/${pname}";


### PR DESCRIPTION
###### Description of changes

- Add `passthru.updateScript`:
  - Allows to use `nix-shell maintainers/scripts/update.nix --argstr package ocamlPackages.tdigest`
  - Should hook into general nixpkgs autoupdate process.

- Bump from 2.1.1 to 2.1.2:
  - Release: https://github.com/SGrondin/tdigest/releases/tag/2.1.2
  - Changes: https://github.com/SGrondin/tdigest/compare/2.1.1...2.1.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
