### PR TITLE
lambda-lisp: init at 2022-08-18

### DIFF
--- a/pkgs/development/interpreters/lambda-lisp/default.nix
+++ b/pkgs/development/interpreters/lambda-lisp/default.nix
@@ -1,0 +1,82 @@
+# Lambda Lisp has several backends, here we are using
+# the blc one. Ideally, this should be made into several
+# packages such as lambda-lisp-blc, lambda-lisp-lazyk,
+# lambda-lisp-clamb, etc.
+
+{ lib
+, gccStdenv
+, fetchFromGitHub
+, fetchurl
+, runtimeShell
+}:
+
+let
+  stdenv = gccStdenv;
+  s = import ./sources.nix { inherit fetchurl fetchFromGitHub; };
+in
+stdenv.mkDerivation rec {
+  pname = "lambda-lisp-blc";
+  version = s.lambdaLispVersion;
+  src = s.src;
+  flatSrc = s.flatSrc;
+  blcSrc = s.blcSrc;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p ./build
+    cp $blcSrc ./build/Blc.S
+    cp $flatSrc ./build/flat.lds
+    cd build;
+    cat Blc.S | sed -e 's/#define.*TERMS.*//' > Blc.ext.S;
+    $CC -c -DTERMS=50000000 -o Blc.o Blc.ext.S
+    ld.bfd -o Blc Blc.o -T flat.lds
+    cd ..;
+    mv build/Blc ./bin
+    install -D -t $out/bin bin/Blc
+    install -D -t $out/lib bin/lambdalisp.blc
+
+    cd build;
+    $CC ../tools/asc2bin.c -O2 -o asc2bin;
+    cd ..;
+    mv build/asc2bin ./bin;
+    chmod 755 ./bin/asc2bin;
+    install -D -t $out/bin bin/asc2bin
+
+    echo -e "#!${runtimeShell}\n( cat $out/lib/lambdalisp.blc | $out/bin/asc2bin; cat ) | $out/bin/Blc" > lambda-lisp-blc
+    chmod +x lambda-lisp-blc
+
+    install -D -t $out/bin lambda-lisp-blc
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+  runHook preInstallCheck
+
+  a=$(echo "(* (+ 1 2 3 4 5 6 7 8 9 10) 12020569 (- 2 5))" | $out/bin/lambda-lisp-blc | tr -d "> ");
+  test $a == -1983393885
+
+  runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    description = "A Lisp interpreter written in untyped lambda calculus";
+    homepage = "https://github.com/woodrush/lambdalisp";
+    longDescription = ''
+      LambdaLisp is a Lisp interpreter written as a closed untyped lambda calculus term.
+      It is written as a lambda calculus term LambdaLisp = λx. ... which takes a string
+      x as an input and returns a string as an output. The input x is the Lisp program
+      and the user's standard input, and the output is the standard output. Characters
+      are encoded into lambda term representations of natural numbers using the Church
+      encoding, and strings are encoded as a list of characters with lists expressed as
+      lambdas in the Mogensen-Scott encoding, so the entire computation process solely
+      consists of the beta-reduction of lambda terms, without introducing any
+      non-lambda-type object.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ cafkafk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/interpreters/lambda-lisp/sources.nix
+++ b/pkgs/development/interpreters/lambda-lisp/sources.nix
@@ -1,0 +1,50 @@
+let
+  lambdaLispVersion = "2022-08-18";
+  blcVersion = "2";
+  # Archive of "https://justine.lol/lambda/";
+  justineLolArchive = "https://web.archive.org/web/20230614065521if_/https://justine.lol/lambda/";
+in
+{ fetchFromGitHub, fetchurl }: {
+  inherit blcVersion;
+  inherit lambdaLispVersion;
+
+  src = fetchFromGitHub {
+    owner = "woodrush";
+    repo = "lambdalisp";
+    rev = "2119cffed1ab2005f08ab3cfca92028270f08725";
+    hash = "sha256-ml2xQ8s8sux+6GwTw8mID3PEOcH6hn8tyc/UI5tFaO0=";
+  };
+
+  uniCSrc = fetchFromGitHub {
+    owner = "tromp";
+    repo = "tromp.github.io";
+    rev = "b4de12e566c1fb0fa3f3babe89bac885f4c966a4";
+    hash = "sha256-JmbqQp2kkkkkkkkSWQmG3uBxdgyIu4r2Ch8bBGyQ4H4=";
+  };
+
+  # needed later
+  clambSrc = fetchFromGitHub {
+    owner = "irori";
+    repo = "clamb";
+    rev = "44c1208697f394e22857195be5ea73bfdd48ebd1";
+    hash = "sha256-1lGg2NBoxAKDCSnnPn19r/hwBC5paAKUnlcsUv3dpNY=";
+  };
+
+  # needed later
+  lazykSrc = fetchFromGitHub {
+    owner = "irori";
+    repo = "lazyk";
+    rev = "5edb0b834d0af5f7413c484eb3795d47ec2e3894";
+    hash = "sha256-1lGg2NBoxAKDCSnnPn19r/hwBC5paAKUnlcsUv3dpNY=";
+  };
+
+  blcSrc = fetchurl {
+    url = "${justineLolArchive}Blc.S?v=${blcVersion}";
+    hash = "sha256-qt7vDtn9WvDoBaLESCyyscA0u74914e8ZKhLiUAN52A=";
+  };
+
+  flatSrc = fetchurl {
+    url = "${justineLolArchive}flat.lds";
+    hash = "sha256-HxX+10rV86zPv+UtF+n72obtz3DosWLMIab+uskxIjA=";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17354,6 +17354,9 @@ with pkgs;
 
   konf = callPackage ../development/tools/konf { };
 
+  lambda-lisp = callPackage ../development/interpreters/lambda-lisp { };
+  lambda-lisp-blc = lambda-lisp;
+
   lolcode = callPackage ../development/interpreters/lolcode { };
 
   love_0_10 = callPackage ../development/interpreters/love/0.10.nix { };


### PR DESCRIPTION
###### Description of changes

This adds lambda-lisp, and the lambda-lisp-blc backend. Lambda lisp has several backends, this only adds the blc backend for now, as I'm unsure what the best practice is for adding multiple backends for a package like this. 

I added a sources file, which is a structure copied from the djgpp package. Ideally, there would be a lambda-lisp-blc, lambda-lisp-lazyk etc., this sets the package up for that. Also, currently, a user installing lambda-lisp will get lambda-lisp-blc, which should be the best choice, as it is the default backend.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
