### PR TITLE
ocamlPackages.camomile: add v2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/camomile/1.0.2.nix
+++ b/pkgs/development/ocaml-modules/camomile/1.0.2.nix
@@ -1,0 +1,34 @@
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, cppo }:
+
+buildDunePackage rec {
+  pname = "camomile";
+  version = "1.0.2";
+
+  duneVersion = "2";
+
+  src = fetchFromGitHub {
+    owner = "yoriyuki";
+    repo = pname;
+    rev = version;
+    sha256 = "00i910qjv6bpk0nkafp5fg97isqas0bwjf7m6rz11rsxilpalzad";
+  };
+
+  nativeBuildInputs = [ cppo ];
+
+  configurePhase = ''
+    runHook preConfigure
+    ocaml configure.ml --share $out/share/camomile
+    runHook postConfigure
+  '';
+
+  postInstall = ''
+    echo "version = \"${version}\"" >> $out/lib/ocaml/${ocaml.version}/site-lib/camomile/META
+  '';
+
+  meta = {
+    inherit (src.meta) homepage;
+    maintainers = [ lib.maintainers.vbgl ];
+    license = lib.licenses.lgpl21;
+    description = "A Unicode library for OCaml";
+  };
+}

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,29 +1,24 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, cppo }:
+{ lib, fetchFromGitHub, buildDunePackage
+, dune-site, camlp-streams
+}:
 
 buildDunePackage rec {
   pname = "camomile";
-  version = "1.0.2";
+  version = "2.0.0";
 
-  useDune2 = true;
+  minimalOCamlVersion = "4.13";
 
   src = fetchFromGitHub {
-    owner = "yoriyuki";
+    owner = "ocaml-community";
     repo = pname;
-    rev = version;
-    sha256 = "00i910qjv6bpk0nkafp5fg97isqas0bwjf7m6rz11rsxilpalzad";
+    rev = "v${version}";
+    hash = "sha256-HklX+VPD0Ta3Knv++dBT2rhsDSlDRH90k4Cj1YtWIa8=";
   };
 
-  nativeBuildInputs = [ cppo ];
-
-  configurePhase = ''
-    runHook preConfigure
-    ocaml configure.ml --share $out/share/camomile
-    runHook postConfigure
-  '';
-
-  postInstall = ''
-    echo "version = \"${version}\"" >> $out/lib/ocaml/${ocaml.version}/site-lib/camomile/META
-  '';
+  propagatedBuildInputs = [
+    dune-site
+    camlp-streams
+  ];
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,4 +1,5 @@
-{ lib, fetchFromGitHub, buildDunePackage
+{ lib, fetchFromGitHub, nix-update-script
+, buildDunePackage
 , dune-site, camlp-streams
 }:
 
@@ -19,6 +20,8 @@ buildDunePackage rec {
     dune-site
     camlp-streams
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,6 +1,12 @@
-{ lib, fetchFromGitHub, nix-update-script
+{ lib
+, stdenv
 , buildDunePackage
-, dune-site, camlp-streams
+, fetchFromGitHub
+, writeScriptBin
+, darwin
+, dune-site
+, camlp-streams
+, nix-update-script
 }:
 
 buildDunePackage rec {
@@ -15,6 +21,18 @@ buildDunePackage rec {
     rev = "v${version}";
     hash = "sha256-HklX+VPD0Ta3Knv++dBT2rhsDSlDRH90k4Cj1YtWIa8=";
   };
+
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [
+    # libc++abi: terminating with uncaught exception of type SigTool::NotAMachOFileException: std::exception
+    (writeScriptBin "codesign" ''
+      #!${stdenv.shell}
+    '')
+  ];
+
+  propagatedNativeBuildInputs = [
+    # Error: Program codesign not found in the tree or in PATH
+    darwin.sigtool
+  ];
 
   propagatedBuildInputs = [
     dune-site

--- a/pkgs/development/ocaml-modules/charInfo_width/default.nix
+++ b/pkgs/development/ocaml-modules/charInfo_width/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchzip, buildDunePackage, camomile, result }:
+{ lib, fetchzip, buildDunePackage, camomile_1, result }:
 
 buildDunePackage rec {
   pname = "charInfo_width";
@@ -9,7 +9,7 @@ buildDunePackage rec {
     sha256 = "19mnq9a1yr16srqs8n6hddahr4f9d2gbpmld62pvlw1ps7nfrp9w";
   };
 
-  propagatedBuildInputs = [ camomile result ];
+  propagatedBuildInputs = [ camomile_1 result ];
 
   meta = {
     homepage = "https://bitbucket.org/zandoye/charinfo_width/";

--- a/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
@@ -1,10 +1,10 @@
-{ lib, buildDunePackage, ocaml, ocaml_gettext, camomile, ounit, fileutils }:
+{ lib, buildDunePackage, ocaml, ocaml_gettext, camomile_1, ounit, fileutils }:
 
 buildDunePackage {
   pname = "gettext-camomile";
   inherit (ocaml_gettext) src version;
 
-  propagatedBuildInputs = [ camomile ocaml_gettext ];
+  propagatedBuildInputs = [ camomile_1 ocaml_gettext ];
 
   doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ ounit fileutils ];

--- a/pkgs/development/tools/headache/default.nix
+++ b/pkgs/development/tools/headache/default.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
 
   duneVersion = "3";
 
-  propagatedBuildInputs = [ camomile ];
+  propagatedBuildInputs = [ camomile_1 ];
 
   meta = with lib; {
     homepage = "https://github.com/frama-c/${pname}";

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
     ocamlPackages.mm
     ocamlPackages.ocaml_pcre
     ocamlPackages.menhir ocamlPackages.menhirLib
-    ocamlPackages.camomile
+    ocamlPackages.camomile_1
     ocamlPackages.ocurl
     ocamlPackages.uri
     ocamlPackages.sedlex

--- a/pkgs/tools/typesetting/soupault/default.nix
+++ b/pkgs/tools/typesetting/soupault/default.nix
@@ -25,7 +25,7 @@ ocamlPackages.buildDunePackage {
   };
 
   patches = lib.lists.optional
-    (lib.strings.versionAtLeast "2.0.0" ocamlPackages.camomile.version)
+    (lib.strings.versionAtLeast "2.0.0" ocamlPackages.camomile_1.version)
     (fetchpatch {
       name = "camomile-1_x";
       url = "https://files.baturin.org/software/soupault/soupault-4.7.0-camomile-1.x.patch";
@@ -34,7 +34,7 @@ ocamlPackages.buildDunePackage {
 
   buildInputs = with ocamlPackages; [
     base64
-    camomile
+    camomile_1
     containers
     csv
     digestif

--- a/pkgs/tools/typesetting/soupault/default.nix
+++ b/pkgs/tools/typesetting/soupault/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitea
-, fetchpatch
 , ocamlPackages
 , soupault
 , testers
@@ -24,17 +23,9 @@ ocamlPackages.buildDunePackage {
     sha256 = "nwXyOwDUbkMnyHPrvCvmToyONdbg5kJm2mt5rWrB6HA=";
   };
 
-  patches = lib.lists.optional
-    (lib.strings.versionAtLeast "2.0.0" ocamlPackages.camomile_1.version)
-    (fetchpatch {
-      name = "camomile-1_x";
-      url = "https://files.baturin.org/software/soupault/soupault-4.7.0-camomile-1.x.patch";
-      sha256 = "V7+OUjXqWtXwjUa35MlY9iyAlqOkst9Th7DgfDXkXZg=";
-    });
-
   buildInputs = with ocamlPackages; [
     base64
-    camomile_1
+    camomile
     containers
     csv
     digestif

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -151,6 +151,7 @@ let
       if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/camomile/1.0.2.nix { }
       else callPackage ../development/ocaml-modules/camomile/0.8.5.nix { };
+    camomile = callPackage ../development/ocaml-modules/camomile { };
 
     caqti = callPackage ../development/ocaml-modules/caqti { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -147,9 +147,9 @@ let
 
     camlzip = callPackage ../development/ocaml-modules/camlzip { };
 
-    camomile =
+    camomile_1 =
       if lib.versionOlder "4.02" ocaml.version
-      then callPackage ../development/ocaml-modules/camomile { }
+      then callPackage ../development/ocaml-modules/camomile/1.0.2.nix { }
       else callPackage ../development/ocaml-modules/camomile/0.8.5.nix { };
 
     caqti = callPackage ../development/ocaml-modules/caqti { };


### PR DESCRIPTION
###### Description of changes

The OCaml package Camomile used to be at [yoriyuki/camomile](https://github.com/yoriyuki/camomile). There is now a fork [ocaml-community/camomile](https://github.com/ocaml-community/camomile) that provides a v2.0.0. This is the one included in OPAM and therefore I think this is the one we should follow in nixpkgs.

Because the API changed so much between Camomile v1 and v2, and because some other packages depend on Camomile, I decided to rename `ocamlPackages.camomile` into `ocamlPackages.camomile_1` (following the change in other packages) and to add a new `ocamlPackages.camomile` package containing v2. I am not sure if that is the right way to do things.

- Release: https://github.com/ocaml-community/Camomile/releases/tag/v2.0.0
- Change log: https://github.com/ocaml-community/Camomile/blob/v2.0.0/CHANGES.md
- Changes: https://github.com/ocaml-community/camomile/compare/d7d8843c88fae774f513610f8e09a613778e64b3...v2.0.0

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
