### PR TITLE
headache: 1.06 -> 1.07

### DIFF
--- a/pkgs/development/tools/headache/default.nix
+++ b/pkgs/development/tools/headache/default.nix
@@ -4,17 +4,17 @@ with ocamlPackages;
 
 buildDunePackage rec {
   pname = "headache";
-  version = "1.06";
+  version = "1.07";
 
   src = fetchFromGitHub {
     owner = "frama-c";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-BA7u09MKYMyspFX8AcAkDVA6UUG5DKAdbIDdt+b3Fc4=";
+    sha256 = "sha256-RL80ggcJSJFu2UTECUNP6KufRhR8ZnG7sQeYzhrw37g=";
   };
 
   propagatedBuildInputs = [
-    (camomile.override { version = "1.0.2"; })
+    camomile
   ];
 
   meta = with lib; {

--- a/pkgs/development/tools/headache/default.nix
+++ b/pkgs/development/tools/headache/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, ocamlPackages }:
+{ lib, fetchFromGitHub, nix-update-script, ocamlPackages }:
 
 with ocamlPackages;
 
@@ -16,6 +16,8 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     camomile
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/frama-c/${pname}";


### PR DESCRIPTION
###### Description of changes

- Bump from 1.06 to 1.07:
  - Release: https://github.com/Frama-C/headache/releases/tag/v1.07
  - Changes: https://github.com/frama-c/headache/compare/v1.06...v1.07
  - **Important**: Headache v1.07 depends on Camomile v2. This PR builds on top of https://github.com/NixOS/nixpkgs/pull/242103 and should therefore only be merged afterwards.

- Add `passthru.updateScript`:
  - Allows to use `nix-shell maintainers/scripts/update.nix --argstr package headache`
  - Should hook into general nixpkgs autoupdate process.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
