### PR TITLE
everforest-gtk-theme: init at 2023.03.20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9597,6 +9597,12 @@
     githubId = 54179289;
     name = "Jason Miller";
   };
+  jn-sena = {
+    email = "jn-sena@proton.me";
+    github = "jn-sena";
+    githubId = 45771313;
+    name = "Sena";
+  };
   jnsgruk = {
     email = "jon@sgrs.uk";
     github = "jnsgruk";

--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gnome-themes-extra
+, gtk-engine-murrine
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "everforest-gtk-theme";
+  version = "0-unstable-2023-03-20";
+
+  src = fetchFromGitHub {
+    owner = "Fausto-Korpsvart";
+    repo = "Everforest-GTK-Theme";
+    rev = "8481714cf9ed5148694f1916ceba8fe21e14937b";
+    sha256 = "sha256-NO12ku8wnW/qMHKxi5TL/dqBxH0+cZbe+fU0iicb9JU=";
+  };
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  buildInputs = [
+    gnome-themes-extra
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/share/"{themes,icons}
+    cp -a icons/* "$out/share/icons/"
+    cp -a themes/* "$out/share/themes/"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Everforest colour palette for GTK";
+    homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ jn-sena ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Everforest colour palette for GTK
https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
