### PR TITLE
ulid: init at 2.1.0

### DIFF
--- a/pkgs/development/tools/ulid/default.nix
+++ b/pkgs/development/tools/ulid/default.nix
@@ -1,0 +1,29 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+buildGoModule rec {
+  pname = "ulid";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "oklog";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-/oQPgcO1xKbHXutxz0WPfIduShPrfH1l+7/mj8jLst8=";
+  };
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  vendorSha256 = "sha256-s1YkEwFxE1zpUUCgwOAl8i6/9HB2rcGG+4kqnixTit0=";
+
+  meta = with lib; {
+    description = "A UUID compatible sortable identifier writen in Go";
+    license = licenses.asl20;
+    homepage = "https://github.com/oklog/ulid";
+    maintainers = with maintainers; [ poptart ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14222,6 +14222,8 @@ with pkgs;
     inherit (chickenPackages_4) eggDerivation fetchegg;
   };
 
+  ulid = callPackage ../development/tools/ulid { };
+
   ulogd = callPackage ../os-specific/linux/ulogd { };
 
   unar = callPackage ../tools/archivers/unar {


### PR DESCRIPTION
###### Description of changes

This package adds `ulid`, which is the Go implementation of [Universally Unique Lexicographically Sortable Identifier](https://github.com/ulid/spec), which can be used to create unique identifiers.

Some notes: 

- There are many implementations of ulid and there are other utility applications in https://github.com/ulid/spec#implementations-in-other-languages and many of those have similar names for their utilities. I was unsure if it was preferred to reference this somehow with `go-ulid` or some other manner. Happy to make the change if need be.

- My contributor entry in the maintainers list was committed to a non-merged #240634 but I didn't particularly want to make it dependent on that merge in case it lands first or make it off that branch, so I left the "fits contributor guidelines" unchecked in this PR. Wasn't positive what the preference was for the project.

Website/Repo: https://github.com/oklog/ulid

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
