### PR TITLE
ocamlPackages: small cleanup for OCaml 5.0

### DIFF
--- a/pkgs/development/ocaml-modules/gsl/default.nix
+++ b/pkgs/development/ocaml-modules/gsl/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, buildDunePackage, pkg-config, gsl, darwin, dune-configurator }:
+{ lib, stdenv, ocaml, fetchFromGitHub, fetchpatch, buildDunePackage, pkg-config, gsl, darwin, dune-configurator }:
+
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "gsl is not available for OCaml ${ocaml.version}"
 
 buildDunePackage rec {
   pname = "gsl";
@@ -35,8 +38,6 @@ buildDunePackage rec {
       sha256 = "sha256-bsIKkvj9W8oAYSvP6ZfbqSgt5fSirc780O08WBhVRmI=";
     })
   ];
-
-  duneVersion = "3";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator gsl ];

--- a/pkgs/development/ocaml-modules/printbox/text.nix
+++ b/pkgs/development/ocaml-modules/printbox/text.nix
@@ -1,11 +1,12 @@
-{ buildDunePackage, printbox, uucp, uutf, mdx }:
+{ buildDunePackage, lib, ocaml, printbox, uucp, uutf, mdx }:
 
 buildDunePackage {
   pname = "printbox-text";
-  inherit (printbox) src version useDune2 doCheck;
+  inherit (printbox) src version;
 
   propagatedBuildInputs = [ printbox uucp uutf ];
 
+  doCheck = printbox.doCheck && lib.versionOlder ocaml.version "5.0";
   nativeCheckInputs = [ mdx.bin ];
 
   meta = printbox.meta // {


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
