### PR TITLE
phpExtensions.inotify: update platforms

### DIFF
--- a/pkgs/development/php-packages/inotify/default.nix
+++ b/pkgs/development/php-packages/inotify/default.nix
@@ -1,6 +1,5 @@
 { buildPecl
 , lib
-, stdenv
 }:
 
 buildPecl {
@@ -11,11 +10,11 @@ buildPecl {
 
   doCheck = true;
 
-  meta = with lib; {
-    broken = stdenv.isDarwin; # no inotify support
+  meta = {
     description = "Inotify bindings for PHP";
-    license = licenses.php301;
     homepage = "https://github.com/arnaud-lb/php-inotify";
-    maintainers = teams.php.members;
+    license = lib.licenses.php301;
+    maintainers = lib.teams.php.members;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -204,16 +204,13 @@ lib.makeScope pkgs.newScope (self: with self; {
   # or php.withExtensions to extend the functionality of the PHP
   # interpreter.
   # The extensions attributes is composed of three sections:
-  # 1. The contrib conditional extensions, which are only available on specific versions or system
+  # 1. The contrib conditional extensions, which are only available on specific PHP versions
   # 2. The contrib extensions available
   # 3. The core extensions
   extensions =
   # Contrib conditional extensions
    lib.optionalAttrs (!(lib.versionAtLeast php.version "8.3")) {
     blackfire = callPackage ../development/tools/misc/blackfire/php-probe.nix { inherit php; };
-  } // lib.optionalAttrs (!stdenv.isDarwin) {
-    # Only available on Linux: https://www.php.net/manual/en/inotify.requirements.php
-    inotify = callPackage ../development/php-packages/inotify { };
   } //
   # Contrib extensions
   {
@@ -238,6 +235,8 @@ lib.makeScope pkgs.newScope (self: with self; {
     igbinary = callPackage ../development/php-packages/igbinary { };
 
     imagick = callPackage ../development/php-packages/imagick { };
+
+    inotify = callPackage ../development/php-packages/inotify { };
 
     mailparse = callPackage ../development/php-packages/mailparse { };
 


### PR DESCRIPTION
Follow up of https://github.com/NixOS/nixpkgs/pull/242015

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
