### PR TITLE
python310Packages.pytest-pudb: init at 0.7.0

### DIFF
--- a/pkgs/development/python-modules/pytest-pudb/default.nix
+++ b/pkgs/development/python-modules/pytest-pudb/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pytest
+, pudb
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-pudb";
+  version = "0.7.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "wronglink";
+    repo = "pytest-pudb";
+    # Repo missing tags for releases https://github.com/wronglink/pytest-pudb/issues/24
+    rev = "a6b3d2f4d35e558d72bccff472ecde9c9d9c69e5";
+    hash = "sha256-gI9p6sXCQaQjWBXaHJCFli6lBh8+pr+KPhz50fv1F7A=";
+  };
+
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ pudb ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pytest_pudb" ];
+
+  meta = with lib; {
+    description = "Pytest PuDB debugger integration";
+    homepage = "https://github.com/wronglink/pytest-pudb";
+    license = licenses.mit;
+    maintainers = with maintainers; [ thornycrackers ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7945,6 +7945,8 @@ self: super: with self; {
 
   pytest-mockito = callPackage ../development/python-modules/pytest-mockito { };
 
+  pytest-pudb = callPackage ../development/python-modules/pytest-pudb { };
+
   python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };
 
   python-creole = callPackage ../development/python-modules/python-creole { };


### PR DESCRIPTION
###### Description of changes

This is for https://github.com/NixOS/nixpkgs/issues/241678. But I have a couple of questions.

1. When packaging something like this should `pytest` and `pudb` be in `nativeBuildInputs` or `propagatedBuildInputs`?
2. This package has tests that are on the github repo but the author doesn't use tags for the release so I would have to hard code the rev to `a6b3d2f`. Is it ok to use the direct ref? If so I'll update to pull from there and add `pytestCheckHook`

I built this and tested it in an environment with `pytest --pudb` to make sure it was activated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).