### PR TITLE
 nixos/networkd: add networkd-global useDHCP option

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -2634,6 +2634,23 @@ let
       '';
     };
 
+    useDHCP = mkOption {
+      default = config.networking.useDHCP;
+      defaultText = literalExpression "config.networking.useDHCP";
+      example = true;
+      visible = initrd;
+      type = types.bool;
+      description = lib.mdDoc ''
+        Whether to configure networkd to use DHCP to obtain an IP address and
+        other configuration for network interfaces that are not manually
+        configured.
+
+        This option is a duplicate of the primary systemd networking config, but
+        is necessary when using the networkd in initrd while managing the
+        primary (stage-2) using a different solution (e.g. NetworkManager)
+      '';
+    };
+
     links = mkOption {
       default = {};
       inherit visible;

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -2624,7 +2624,7 @@ let
     value.source = "${cfg.units.${name}.unit}/${name}";
   }) (attrNames cfg.units));
 
-  commonOptions = visible: {
+  commonOptions = { initrd ? false }: let visible = if initrd then "shallow" else true; in {
 
     enable = mkOption {
       default = false;
@@ -2925,8 +2925,8 @@ in
 
 {
   options = {
-    systemd.network = commonOptions true;
-    boot.initrd.systemd.network = commonOptions "shallow";
+    systemd.network = commonOptions {};
+    boot.initrd.systemd.network = commonOptions { initrd = true; };
   };
 
   config = mkMerge [

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -44,47 +44,51 @@ let
       domains = override domains;
     };
 
-  genericDhcpNetworks = { initrd }: mkIf cfg.useDHCP {
-    networks."99-ethernet-default-dhcp" = {
-      # We want to match physical ethernet interfaces as commonly
-      # found on laptops, desktops and servers, to provide an
-      # "out-of-the-box" setup that works for common cases.  This
-      # heuristic isn't perfect (it could match interfaces with
-      # custom names that _happen_ to start with en or eth), but
-      # should be good enough to make the common case easy and can
-      # be overridden on a case-by-case basis using
-      # higher-priority networks or by disabling useDHCP.
+  genericDhcpNetworks = { initrd }:
+    let
+      networkCfg =
+        if initrd
+        then config.boot.initrd.systemd.network
+        else config.systemd.network;
+    in
+    mkIf networkCfg.useDHCP {
+      networks."99-ethernet-default-dhcp" = {
+        # We want to match physical ethernet interfaces as commonly
+        # found on laptops, desktops and servers, to provide an
+        # "out-of-the-box" setup that works for common cases.  This
+        # heuristic isn't perfect (it could match interfaces with
+        # custom names that _happen_ to start with en or eth), but
+        # should be good enough to make the common case easy and can
+        # be overridden on a case-by-case basis using
+        # higher-priority networks or by disabling useDHCP.
 
-      # Type=ether matches veth interfaces as well, and this is
-      # more likely to result in interfaces being configured to
-      # use DHCP when they shouldn't.
+        # Type=ether matches veth interfaces as well, and this is
+        # more likely to result in interfaces being configured to
+        # use DHCP when they shouldn't.
 
-      # When wait-online.anyInterface is enabled, RequiredForOnline really
-      # means "sufficient for online", so we can enable it.
-      # Otherwise, don't block the network coming online because of default networks.
-      matchConfig.Name = ["en*" "eth*"];
-      DHCP = "yes";
-      linkConfig.RequiredForOnline =
-        lib.mkDefault (if initrd
-        then config.boot.initrd.systemd.network.wait-online.anyInterface
-        else config.systemd.network.wait-online.anyInterface);
-      networkConfig.IPv6PrivacyExtensions = "kernel";
+        # When wait-online.anyInterface is enabled, RequiredForOnline really
+        # means "sufficient for online", so we can enable it.
+        # Otherwise, don't block the network coming online because of default networks.
+        matchConfig.Name = [ "en*" "eth*" ];
+        DHCP = "yes";
+        linkConfig.RequiredForOnline =
+          lib.mkDefault networkCfg.wait-online.anyInterface;
+        networkConfig.IPv6PrivacyExtensions = "kernel";
+      };
+      networks."99-wireless-client-dhcp" = {
+        # Like above, but this is much more likely to be correct.
+        matchConfig.WLANInterfaceType = "station";
+        DHCP = "yes";
+        linkConfig.RequiredForOnline =
+          lib.mkDefault networkCfg.wait-online.anyInterface;
+        networkConfig.IPv6PrivacyExtensions = "kernel";
+        # We also set the route metric to one more than the default
+        # of 1024, so that Ethernet is preferred if both are
+        # available.
+        dhcpV4Config.RouteMetric = 1025;
+        ipv6AcceptRAConfig.RouteMetric = 1025;
+      };
     };
-    networks."99-wireless-client-dhcp" = {
-      # Like above, but this is much more likely to be correct.
-      matchConfig.WLANInterfaceType = "station";
-      DHCP = "yes";
-      linkConfig.RequiredForOnline =
-        lib.mkDefault config.systemd.network.wait-online.anyInterface;
-      networkConfig.IPv6PrivacyExtensions = "kernel";
-      # We also set the route metric to one more than the default
-      # of 1024, so that Ethernet is preferred if both are
-      # available.
-      dhcpV4Config.RouteMetric = 1025;
-      ipv6AcceptRAConfig.RouteMetric = 1025;
-    };
-  };
-
 
   interfaceNetworks = mkMerge (forEach interfaces (i: {
     netdevs = mkIf i.virtual ({

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -44,7 +44,7 @@ let
       domains = override domains;
     };
 
-  genericDhcpNetworks = initrd: mkIf cfg.useDHCP {
+  genericDhcpNetworks = { initrd }: mkIf cfg.useDHCP {
     networks."99-ethernet-default-dhcp" = {
       # We want to match physical ethernet interfaces as commonly
       # found on laptops, desktops and servers, to provide an
@@ -182,7 +182,7 @@ in
     # Note this is if initrd.network.enable, not if
     # initrd.systemd.network.enable. By setting the latter and not the
     # former, the user retains full control over the configuration.
-    boot.initrd.systemd.network = mkMerge [(genericDhcpNetworks true) interfaceNetworks];
+    boot.initrd.systemd.network = mkMerge [(genericDhcpNetworks { initrd = true; }) interfaceNetworks];
   })
 
   (mkIf cfg.useNetworkd {
@@ -210,7 +210,7 @@ in
       mkMerge [ {
         enable = true;
       }
-      (genericDhcpNetworks false)
+      (genericDhcpNetworks { initrd = false; })
       interfaceNetworks
       (mkMerge (flip mapAttrsToList cfg.bridges (name: bridge: {
         netdevs."40-${name}" = {


### PR DESCRIPTION
###### Description of changes

This PR allows a NixOS system's stage-2 to be configured with something like NetworkManager, while also using systemd-networkd in the stage-1 systemd-initrd. 

Previously, systemd-initrd didn't autoconfigure the network when using NetworkManager.

Additionally, this PR hurt my brain *a lot*, but here it is. It comes with a NixOS test to verify correctness.

[matrix chat ref](https://matrix.to/#/!kjdutkOsheZdjqYmqp:nixos.org/$_WIefLVRUETZXsFip3gbnY0LXYQFeIh2MTO7AKvraEQ?via=nixos.org&via=matrix.org&via=nixos.dev)

- [x] Test changes on my live NixOS system — works!!
- [ ] Contemplate a more nuanced default for `boot.initrd.systemd.network.useDHCP` (check for `NetworkManager`)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
