### PR TITLE
ulogd: support postgresql, mysql and sqlite as databases

### DIFF
--- a/pkgs/os-specific/linux/ulogd/default.nix
+++ b/pkgs/os-specific/linux/ulogd/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchurl, gnumake, libnetfilter_acct, libnetfilter_conntrack
 , libnetfilter_log, libmnl, libnfnetlink, automake, autoconf, autogen, libtool
+, postgresql, libmysqlclient, sqlite
 , pkg-config, libpcap, linuxdoc-tools, autoreconfHook, nixosTests }:
 
 stdenv.mkDerivation rec {
@@ -37,6 +38,9 @@ stdenv.mkDerivation rec {
     libmnl
     libnfnetlink
     libpcap
+    postgresql
+    libmysqlclient
+    sqlite
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

The binary weighs ~100KiB more, this is acceptable given that it is very useful to log to proper RDBMS which we do support anyway.

Before:
```
root@zaku:~/ > nix path-info -sh /nix/store/mds4rfd4zssd2zs2bxmq21xs05i86h0v-ulogd-2.0.8/bin/ulogd 
/nix/store/mds4rfd4zssd2zs2bxmq21xs05i86h0v-ulogd-2.0.8	555.2K
```

After:
```
❯ nix path-info -sh /nix/store/17b7m7v2pka1p77h698f5hzhhxb42k82-ulogd-2.0.8                    
/nix/store/17b7m7v2pka1p77h698f5hzhhxb42k82-ulogd-2.0.8	644.2K
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
