### PR TITLE
k3s_1_26: 1.26.5+k3s1 -> 1.26.6+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_26/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_26/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.26.5+k3s1";
-  k3sCommit = "7cefebeaac7dbdd0bfec131ea7a43a45cb125354";
-  k3sRepoSha256 = "0iz8w24lhb3mgwnks79ky4nypdqbjn91zm4nrj1ar3abkb5i8bg3";
-  k3sVendorSha256 = "sha256-yPzpt9OZfW7qY9gFgrRVgmk2l9OSMMF85OY79MDCKTs=";
+  k3sVersion = "1.26.6+k3s1";
+  k3sCommit = "3b1919b0d55811707bd1168f0abf11cccc656c26";
+  k3sRepoSha256 = "1g82bkq4w0jpfn1fanj1d24bj46rw908wk50p3cm47rqiqlys72y";
+  k3sVendorSha256 = "sha256-+a9/q5a28zA9SmAdp2IItHR1MdJvlbMW5796bHTfKBw=";
   chartVersions = import ./chart-versions.nix;
   k3sRootVersion = "0.12.2";
   k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";


### PR DESCRIPTION
###### Description of changes

This update was made via `nix-shell maintainers/scripts/update.nix --argstr package k3s_1_26 `, and no additional changes were needed beyond what the script did.

Upstream release notes: https://github.com/k3s-io/k3s/releases/tag/v1.26.6%2Bk3s1

This also fixes [CVE-2023-2728](https://nvd.nist.gov/vuln/detail/CVE-2023-2728).
The upstream k3s notes don't mention it, but the [k8s ones](https://github.com/kubernetes/kubernetes/blob/19a25bac052e9d3bbfe6961867207ef98cfa0f06/CHANGELOG/CHANGELOG-1.26.md#changelog-since-v1265) do


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
    NixOS tests:
    ```
    $ nix build '.#k3s_1_26.tests.multi-node' 
    $ nix build '.#k3s_1_26.tests.single-node' 
    ```
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
