### PR TITLE
[Backport release-23.05] standardnotes: use nixpkgs electron

### DIFF
--- a/pkgs/applications/editors/standardnotes/default.nix
+++ b/pkgs/applications/editors/standardnotes/default.nix
@@ -1,38 +1,45 @@
-{ callPackage, lib, stdenv, appimageTools, autoPatchelfHook, desktop-file-utils
-, fetchurl, libsecret  }:
+{ lib, stdenv, fetchurl, dpkg, makeWrapper, electron, libsecret
+, desktop-file-utils , callPackage }:
 
 let
+
   srcjson = builtins.fromJSON (builtins.readFile ./src.json);
-  version = srcjson.version;
-  pname = "standardnotes";
-  name = "${pname}-${version}";
+
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
-  src = fetchurl (srcjson.appimage.${stdenv.hostPlatform.system} or throwSystem);
+in
 
-  appimageContents = appimageTools.extract {
-    inherit name src;
-  };
+stdenv.mkDerivation rec {
 
-  nativeBuildInputs = [ autoPatchelfHook desktop-file-utils ];
+  pname = "standardnotes";
 
-in appimageTools.wrapType2 rec {
-  inherit name src;
+  src = fetchurl (srcjson.deb.${stdenv.hostPlatform.system} or throwSystem);
 
-  extraPkgs = pkgs: with pkgs; [
-    libsecret
-  ];
+  inherit (srcjson) version;
 
-  extraInstallCommands = ''
-    # directory in /nix/store so readonly
-    cd $out
-    chmod -R +w $out
-    mv $out/bin/${name} $out/bin/${pname}
+  dontConfigure = true;
 
-    # fixup and install desktop file
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper dpkg desktop-file-utils ];
+
+  unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/standardnotes
+    cp -R usr/share/{applications,icons} $out/share
+    cp -R opt/Standard\ Notes/resources/app.asar $out/share/standardnotes/
+
+    makeWrapper ${electron}/bin/electron $out/bin/standardnotes \
+      --add-flags $out/share/standardnotes/app.asar \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret stdenv.cc.cc.lib ]}
+
     ${desktop-file-utils}/bin/desktop-file-install --dir $out/share/applications \
-      --set-key Exec --set-value ${pname} ${appimageContents}/standard-notes.desktop
-    ln -s ${appimageContents}/usr/share/icons share
+      --set-key Exec --set-value standardnotes usr/share/applications/standard-notes.desktop
+
+    runHook postInstall
   '';
 
   passthru.updateScript = callPackage ./update.nix {};
@@ -47,6 +54,6 @@ in appimageTools.wrapType2 rec {
     license = licenses.agpl3;
     maintainers = with maintainers; [ mgregoire chuangzhu squalus ];
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
-    platforms = builtins.attrNames srcjson.appimage;
+    platforms = builtins.attrNames srcjson.deb;
   };
 }

--- a/pkgs/applications/editors/standardnotes/src.json
+++ b/pkgs/applications/editors/standardnotes/src.json
@@ -1,13 +1,13 @@
 {
-  "version": "3.154.1",
-  "appimage": {
+  "version": "3.162.8",
+  "deb": {
     "x86_64-linux": {
-      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.154.1/standard-notes-3.154.1-linux-x86_64.AppImage",
-      "hash": "sha512-eMKrRCMVEpgtKLuLTIIOkwDVKmkFFWqlAg2UXs+h8axQwKyEnnA6dGaWfQvE/NSQwgWvmZRJZNMUE2atTc9AAw=="
+      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.162.8/standard-notes-3.162.8-linux-amd64.deb",
+      "hash": "sha512-XxSz1ZXCVzNBqX5BQ4nytFla1igEttV/pQ40r3HW6BQfy6yprQqmQ94OMJSx7kpfeQpxnwBMOUsA58QM3W7y1w=="
     },
     "aarch64-linux": {
-      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.154.1/standard-notes-3.154.1-linux-arm64.AppImage",
-      "hash": "sha512-6EllhNEaLPL/5Nmt1NxtU6x6wi7DnU+k7oyr1HaLWMmkE673vQTyYW+fyFRrxnyBUlmjG4i+ztWYEzxN8CBlqg=="
+      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.162.8/standard-notes-3.162.8-linux-arm64.deb",
+      "hash": "sha512-Y1+89UaPfB+UKiVg3JWo3zwH1rFnjdKuU1CBwIjMblzf1775gEMXicU0n+6FpWTphcVmEeah9VISoq0oBHNHtg=="
     }
   }
 }

--- a/pkgs/applications/editors/standardnotes/update.nix
+++ b/pkgs/applications/editors/standardnotes/update.nix
@@ -31,7 +31,7 @@ writeScript "update-standardnotes" ''
   fi
 
   function getDownloadUrl() {
-    jq -r ".assets[] | select(.name==\"standard-notes-$newVersion-$1.AppImage\") | .browser_download_url" < "$jsonPath"
+    jq -r ".assets[] | select(.name==\"standard-notes-$newVersion-$1.deb\") | .browser_download_url" < "$jsonPath"
   }
 
   function setJsonKey() {
@@ -44,11 +44,11 @@ writeScript "update-standardnotes" ''
     url=$(getDownloadUrl "$upstreamPlatform")
     hash=$(nix-prefetch-url "$url" --type sha512)
     sriHash=$(nix hash to-sri --type sha512 $hash)
-    setJsonKey .appimage[\""$nixPlatform"\"].url "$url"
-    setJsonKey .appimage[\""$nixPlatform"\"].hash "$sriHash"
+    setJsonKey .deb[\""$nixPlatform"\"].url "$url"
+    setJsonKey .deb[\""$nixPlatform"\"].hash "$sriHash"
   }
 
-  updatePlatform x86_64-linux linux-x86_64
+  updatePlatform x86_64-linux linux-amd64
   updatePlatform aarch64-linux linux-arm64
   setJsonKey .version "$newVersion"
 ''


### PR DESCRIPTION
###### Description of changes
Backport of https://github.com/NixOS/nixpkgs/pull/241831

- Use electron from nixpkgs instead of upstream's binaries
- Pull web assets from upstream deb package
- Continue using architecture specific packages, since the web assets still contain some native binaries
- Reduce closure size from 2.8GB to 775MB on x86_64-linux
- Update to 3.162.8

(cherry picked from commit 4a0670748e47459476a67ee343a361ea5a6f6146)

Manual functionality tests pass on NixOS x86_64-linux

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
