### PR TITLE
gegl: 0.4.44 → 0.4.46

### DIFF
--- a/pkgs/development/libraries/gegl/default.nix
+++ b/pkgs/development/libraries/gegl/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch2
 , pkg-config
 , vala
 , gobject-introspection
@@ -37,15 +38,24 @@
 
 stdenv.mkDerivation rec {
   pname = "gegl";
-  version = "0.4.44";
+  version = "0.4.46";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
   src = fetchurl {
-    url = "https://download.gimp.org/pub/gegl/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "CkzbQWNeQGoISc0NPwPK99l8q4qhPShwfVMtAInVYSY=";
+    url = "https://download.gimp.org/pub/gegl/${lib.versions.majorMinor version}/gegl-${version}.tar.xz";
+    hash = "sha256-0LOySBvId0xfPQpIdhGRAWbRju+COoWfuR54Grex6JI=";
   };
+
+  patches = [
+    # https://gitlab.gnome.org/GNOME/gegl/-/merge_requests/136
+    # Fix missing libm dependency.
+    (fetchpatch2 {
+      url = "https://gitlab.gnome.org/GNOME/gegl/-/commit/ee970f10f4fe442cbf8a4f5cb94049deab33e786.patch";
+      hash = "sha256-0LLKH+Gg+1H83kN7hJGK2u+oLrw7Hxed7R4tTwT3C5s=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -103,10 +113,6 @@ stdenv.mkDerivation rec {
     # https://github.com/NixOS/nixpkgs/pull/73586
     "-Djasper=disabled"
   ];
-
-  # TODO: Fix missing math symbols in gegl seamless clone.
-  # It only appears when we use packaged poly2tri-c instead of vendored one.
-  env.NIX_CFLAGS_COMPILE = "-lm";
 
   postPatch = ''
     chmod +x tests/opencl/opencl_test.sh


### PR DESCRIPTION
###### Description of changes

Waiting on upstream: https://gitlab.gnome.org/GNOME/gegl/-/merge_requests/136

https://gitlab.gnome.org/GNOME/gegl/-/compare/GEGL_0_4_44...GEGL_0_4_46

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
