### PR TITLE
VictoriaMetrics: 1.91.0 -> 1.91.3

### DIFF
--- a/pkgs/servers/nosql/victoriametrics/default.nix
+++ b/pkgs/servers/nosql/victoriametrics/default.nix
@@ -34,6 +34,8 @@ buildGoModule rec {
     export ldflags=''${ldflags//=${version}/=}
   '';
 
+  __darwinAllowLocalNetworking = true;
+
   passthru.tests = { inherit (nixosTests) victoriametrics; };
 
   meta = with lib; {

--- a/pkgs/servers/nosql/victoriametrics/default.nix
+++ b/pkgs/servers/nosql/victoriametrics/default.nix
@@ -1,30 +1,17 @@
-{ lib, buildGoModule, fetchFromGitHub, fetchpatch, nixosTests }:
+{ lib, buildGoModule, fetchFromGitHub, nixosTests }:
 
 buildGoModule rec {
   pname = "VictoriaMetrics";
-  version = "1.91.0";
+  version = "1.91.3";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-ZGUJfziqQCCv/9p+z8UJpvHkg6fKOIMv1tJ679f9NTo=";
+    hash = "sha256-xW31Lm+WiJ1quMaIDa7tbZuKhILTMdUviIDTRJT1Cqg=";
   };
 
   vendorHash = null;
-
-  patches = [
-    (fetchpatch {
-      name = "vmctl-fix-tests.patch";
-      url = "https://github.com/VictoriaMetrics/VictoriaMetrics/commit/4060f3f261cb41d97df719e6c60b71be19829301.patch";
-      hash = "sha256-SCeSdSLzZZodMiL7Kts0L8R5XD7TbOc5+/oidmithCY=";
-    })
-    (fetchpatch {
-      name = "graphite-fixes-tests-for-arm.patch";
-      url = "https://github.com/VictoriaMetrics/VictoriaMetrics/commit/228ea03bda0eda3507d782cb627d946843f29c30.patch";
-      hash = "sha256-FnN5O9H1tNtBs5Fr4tXrnyted8SZwX82ZdBmeHlIQ2Y=";
-    })
-  ];
 
   postPatch = ''
     # main module (github.com/VictoriaMetrics/VictoriaMetrics) does not contain package


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.1
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.2
https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
