### PR TITLE
Draft: oneVPL for intel gpu

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -52,7 +52,6 @@
 , withLadspa ? withFullDeps # LADSPA audio filtering
 , withLibplacebo ? withFullDeps && !stdenv.isDarwin # libplacebo video processing library
 , withLzma ? withHeadlessDeps # xz-utils
-, withMfx ? withFullDeps && (with stdenv.targetPlatform; isLinux && !isAarch) # Hardware acceleration via intel-media-sdk/libmfx
 , withModplug ? withFullDeps && !stdenv.isDarwin # ModPlug support
 , withMp3lame ? withHeadlessDeps # LAME MP3 encoder
 , withMysofa ? withFullDeps # HRTF support via SOFAlizer
@@ -88,6 +87,7 @@
 , withVmaf ? withFullDeps && withGPLv3 && !stdenv.isAarch64 # Netflix's VMAF (Video Multi-Method Assessment Fusion)
 , withVoAmrwbenc ? withFullDeps # AMR-WB encoder
 , withVorbis ? withHeadlessDeps # Vorbis de/encoding, native encoder exists
+, withVpl ? withFullDeps && (with stdenv.targetPlatform; isLinux) # Hardware acceleration via intel-media-sdk/libvpl
 , withVpx ? withHeadlessDeps && stdenv.buildPlatform == stdenv.hostPlatform # VP8 & VP9 de/encoding
 , withVulkan ? withFullDeps && !stdenv.isDarwin
 , withWebp ? withFullDeps # WebP encoder
@@ -202,7 +202,6 @@
 , libraw1394
 , libdrm
 , libiconv
-, intel-media-sdk
 , libmodplug
 , libmysofa
 , libogg
@@ -229,6 +228,7 @@
 , xz
 , nv-codec-headers
 , nv-codec-headers-11
+, oneVPL
 , openal
 , ocl-icd # OpenCL ICD
 , opencl-headers  # OpenCL headers
@@ -465,7 +465,6 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withDrm "libdrm")
     (enableFeature withIconv "iconv")
     (enableFeature withJack "libjack")
-    (enableFeature withMfx "libmfx")
     (enableFeature withModplug "libmodplug")
     (enableFeature withMysofa "libmysofa")
     (enableFeature withOpus "libopus")
@@ -482,6 +481,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withVorbis "libvorbis")
     (enableFeature withVmaf "libvmaf")
     (enableFeature withVpx "libvpx")
+    (optionalString withVpl "--enable-libvpl")
     (enableFeature withWebp "libwebp")
     (enableFeature withXlib "xlib")
     (enableFeature withXcb "libxcb")
@@ -578,7 +578,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withLadspa [ ladspaH ]
   ++ optionals withLibplacebo [ libplacebo vulkan-headers ]
   ++ optionals withLzma [ xz ]
-  ++ optionals withMfx [ intel-media-sdk ]
   ++ optionals withModplug [ libmodplug ]
   ++ optionals withMp3lame [ lame ]
   ++ optionals withMysofa [ libmysofa ]
@@ -610,6 +609,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withVmaf [ libvmaf ]
   ++ optionals withVoAmrwbenc [ vo-amrwbenc ]
   ++ optionals withVorbis [ libvorbis ]
+  ++ optionals withVpl [ oneVPL ]
   ++ optionals withVpx [ libvpx ]
   ++ optionals withV4l2 [ libv4l ]
   ++ optionals withVulkan [ vulkan-headers vulkan-loader ]

--- a/pkgs/development/libraries/intel-media-sdk/default.nix
+++ b/pkgs/development/libraries/intel-media-sdk/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config, gtest, libdrm, libpciaccess, libva, libX11
-, libXau, libXdmcp, libpthreadstubs }:
+, libXau, libXdmcp, libpthreadstubs, oneVPL }:
 
 stdenv.mkDerivation rec {
   pname = "intel-media-sdk";
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
     libdrm libva libpciaccess libX11 libXau libXdmcp libpthreadstubs
   ];
   nativeCheckInputs = [ gtest ];
+
+  # For forward compatibility with oneVPL.
+  # To ensure the VPL backend is dispatched at runtime, export INTEL_MEDIA_RUNTIME=ONEVPL
+  # See https://github.com/Intel-Media-SDK/MediaSDK#media-sdk-support-matrix
+  runtimeInputs = [ oneVPL ];
 
   cmakeFlags = [
     "-DBUILD_SAMPLES=OFF"

--- a/pkgs/development/libraries/oneVPL-intel-gpu/default.nix
+++ b/pkgs/development/libraries/oneVPL-intel-gpu/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libdrm
+, libva
+}:
+
+stdenv.mkDerivation rec {
+  pname = "onevpl-intel-gpu";
+  version = "23.2.4";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "oneapi-src";
+    repo = "oneVPL-intel-gpu";
+    rev = "intel-onevpl-${version}";
+    sha256 = "sha256-v6SMAFI2bYmn0jz5Tb9fjg+/KXpaEXqur+2FoCa7pAk=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ libdrm libva ];
+
+  meta = {
+    description = "oneAPI Video Processing Library Intel GPU implementation";
+    homepage = "https://github.com/oneapi-src/oneVPL-intel-gpu";
+    changelog = "";
+    license = [ lib.licenses.mit ];
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.evanrichter ];
+  };
+}

--- a/pkgs/development/libraries/oneVPL/default.nix
+++ b/pkgs/development/libraries/oneVPL/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libdrm
+, libffi
+, libpciaccess
+, libva
+, libX11
+, libXau
+, libXdmcp
+, wayland
+, wayland-protocols
+}:
+
+stdenv.mkDerivation rec {
+  pname = "onevpl";
+  version = "2023.3.1";
+
+  outputs = [ "out" "bin" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "oneapi-src";
+    repo = "oneVPL";
+    rev = "v${version}";
+    sha256 = "sha256-kFW5n3uGTS+7ATKAuVff5fK3LwEKdCQVgGElgypmrG4=";
+  };
+
+  cmakeFlags = [
+    "-DVPL_INSTALL_PKGCONFIGDIR=${placeholder "dev"}"
+    "-DVPL_INSTALL_ENVDIR=${placeholder "dev"}"
+    "-DBUILD_TESTS=OFF"
+    "-DENABLE_DRI3=ON"
+    "-DENABLE_DRM=ON"
+    "-DENABLE_VA=ON"
+    "-DENABLE_WAYLAND=ON"
+    "-DENABLE_X11=ON"
+    "-DINSTALL_EXAMPLE_CODE=OFF"
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    libdrm
+    libffi
+    libpciaccess
+    libva
+    libX11
+    libXau
+    libXdmcp
+    wayland
+    wayland-protocols
+  ];
+
+  meta = {
+    description = "oneAPI Video Processing Library, dispatcher, tools, and examples";
+    homepage = "https://github.com/oneapi-src/oneVPL";
+    changelog = "https://github.com/oneapi-src/oneVPL/releases/tag/v${version}";
+    license = [ lib.licenses.mit ];
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.evanrichter ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24300,6 +24300,8 @@ with pkgs;
 
   oneko = callPackage ../applications/misc/oneko { };
 
+  oneVPL = callPackage ../development/libraries/oneVPL { };
+
   oniguruma = callPackage ../development/libraries/oniguruma { };
 
   oobicpl = callPackage ../development/libraries/science/biology/oobicpl { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24302,6 +24302,8 @@ with pkgs;
 
   oneVPL = callPackage ../development/libraries/oneVPL { };
 
+  oneVPL-intel-gpu = callPackage ../development/libraries/oneVPL-intel-gpu { };
+
   oniguruma = callPackage ../development/libraries/oniguruma { };
 
   oobicpl = callPackage ../development/libraries/science/biology/oobicpl { };


### PR DESCRIPTION
###### Description of changes

I got an Intel Arc dedicated gpu and want to test hardware decoding with ffmpeg. This requires using `libvpl` instead of `libmfx` to interface with hardware, and is a configure flag in ffmpeg (newer sources than currently in nixpkgs).

This PR:
- adds oneVPL
- adds oneVPL-intel-gpu
- modifies ffmpeg-full configure flags to build with oneVPL
- now that intel-media-sdk is [deprecated](https://github.com/Intel-Media-SDK/MediaSDK), intel is recommending developers switch to depending on oneVPL, but at runtime, end-users can dispatch to newer hardware by setting an environment variable. I added oneVPL to the runtimeInputs of intel-media-sdk so that this can actually happen

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).