### PR TITLE
nixos/openvpn3: Add support for systemd-resolved

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -320,6 +320,8 @@
 
 - The `fonts.fonts` and `fonts.enableDefaultFonts` options have been renamed to `fonts.packages` and `fonts.enableDefaultPackages` respectively.
 
+- `pkgs.openvpn3` now optionally supports systemd-resolved. `programs.openvpn3` will automatically enable systemd-resolved support if `config.services.resolved.enable` is enabled.
+
 - `services.fail2ban.jails` can now be configured with attribute sets defining settings and filters instead of lines. The stringed options `daemonConfig` and `extraSettings` have respectively been replaced by `daemonSettings` and `jails.DEFAULT.settings` which use attribute sets.
 
 - The application firewall `opensnitch` now uses the process monitor method eBPF as default as recommended by upstream. The method can be changed with the setting [services.opensnitch.settings.ProcMonitorMethod](#opt-services.opensnitch.settings.ProcMonitorMethod).

--- a/nixos/modules/programs/openvpn3.nix
+++ b/nixos/modules/programs/openvpn3.nix
@@ -8,11 +8,23 @@ in
 {
   options.programs.openvpn3 = {
     enable = mkEnableOption (lib.mdDoc "the openvpn3 client");
+    package = mkOption {
+      type = types.package;
+      default = pkgs.openvpn3.override {
+        enableSystemdResolved = config.services.resolved.enable;
+      };
+      defaultText = literalExpression ''pkgs.openvpn3.override {
+        enableSystemdResolved = config.services.resolved.enable;
+      }'';
+      description = lib.mdDoc ''
+        Which package to use for `openvpn3`.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
-    services.dbus.packages = with pkgs; [
-      openvpn3
+    services.dbus.packages = [
+      cfg.package
     ];
 
     users.users.openvpn = {
@@ -25,8 +37,8 @@ in
       gid = config.ids.gids.openvpn;
     };
 
-    environment.systemPackages = with pkgs; [
-      openvpn3
+    environment.systemPackages = [
+      cfg.package
     ];
   };
 

--- a/pkgs/tools/networking/openvpn3/default.nix
+++ b/pkgs/tools/networking/openvpn3/default.nix
@@ -15,6 +15,8 @@
 , pkg-config
 , protobuf
 , python3
+, systemd
+, enableSystemdResolved ? false
 , tinyxml-2
 , wrapGAppsHook
 }:
@@ -80,6 +82,8 @@ stdenv.mkDerivation rec {
     openssl
     protobuf
     tinyxml-2
+  ] ++ lib.optionals enableSystemdResolved [
+    systemd
   ];
 
   # runtime deps
@@ -101,6 +105,10 @@ stdenv.mkDerivation rec {
     "--enable-addons-aws"
     "--disable-selinux-build"
     "--disable-build-test-progs"
+  ] ++ lib.optionals enableSystemdResolved [
+    # This defaults to --resolv-conf /etc/resolv.conf. See
+    # https://github.com/OpenVPN/openvpn3-linux/blob/v20/configure.ac#L434
+    "DEFAULT_DNS_RESOLVER=--systemd-resolved"
   ];
 
   NIX_LDFLAGS = "-lpthread";


### PR DESCRIPTION
###### Description of changes

I noticed that openvpn3 is been clobbering my `/etc/resolv.conf` file. I dug around a bit, and it turns out that upstream actually does have support for systemd-resolved. I think it makes sense for us to automatically enable that feature if the system is configured to use systemd-resolved.

I opted to not change the default behavior of `pkgs.openvpn3`, but can easily be convinced to change that if folks think I should.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
