### PR TITLE
capnproto-java: 0.1.5 -> 0.1.15

### DIFF
--- a/pkgs/development/tools/capnproto-java/default.nix
+++ b/pkgs/development/tools/capnproto-java/default.nix
@@ -2,22 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "capnproto-java";
-  version = "0.1.5";
+  version = "0.1.15";
 
   src = fetchFromGitHub {
     owner = "capnproto";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256:1512x70xa6mlg9dmr84r8xbf0jzysjal51ivhhh2ppl97yiqjgls";
+    hash = "sha256:IcmzI1G0mXOlpzmiyeLD7o1p/eOeVpwkiGsgy5OIjxw=";
   };
-
-  patches = [
-    # Add make install rule
-    (fetchpatch {
-      url = "https://github.com/capnproto/capnproto-java/commit/e96448d3f5737db25e55cd268652712b69db5cc0.diff";
-      sha256 = "0f3vyap1zsxy675900pzg5ngh7bf9icllm1w04q64g8i91sdzljl";
-    })
-  ];
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -30,6 +22,6 @@ stdenv.mkDerivation rec {
     longDescription = "Only includes compiler plugin, the Java runtime/library that the generated code will link to must be built separately with Maven.";
     homepage = "https://dwrensha.github.io/capnproto-java/index.html";
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple ];
+    maintainers = with maintainers; [ bhipple solson ];
   };
 }


### PR DESCRIPTION
###### Description of changes

This updates from a May 2020 version to a Nov 2022 version. However, the changes have not been drastic and my project using this had minimal codegen changes and still functions as expected. The `fetchpatch` is no longer required (long since merged into the project).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
