### PR TITLE
mullvad.openvpn-mullvad: 2.5.3 -> 2.6.0

### DIFF
--- a/pkgs/applications/networking/mullvad/openvpn.nix
+++ b/pkgs/applications/networking/mullvad/openvpn.nix
@@ -90,7 +90,9 @@ openvpn.overrideAttrs (oldAttrs:
         sha256 = "sha256-Via62wKVfMWHTmO7xIXXO7b5k0KYHs1D0JVg3qnXkeM=";
       })
     ];
-    postPatch = oldAttrs.postPatch or [ ] ++ [ "rm ./configure" ];
+    postPatch = oldAttrs.postPatch or "" + ''
+      rm ./configure
+    '';
 
     meta = oldAttrs.meta or { } // {
       description = "OpenVPN with Mullvad-specific patches applied";

--- a/pkgs/applications/networking/mullvad/openvpn.nix
+++ b/pkgs/applications/networking/mullvad/openvpn.nix
@@ -3,8 +3,7 @@
 , fetchpatch
 , fetchurl
 , iproute2
-, autoconf
-, automake
+, autoreconfHook
 }:
 
 openvpn.overrideAttrs (oldAttrs:
@@ -16,68 +15,82 @@ openvpn.overrideAttrs (oldAttrs:
   in
   rec {
     pname = "openvpn-mullvad";
-    version = "2.5.3";
+    version = "2.6.0";
 
     src = fetchurl {
       url = "https://swupdate.openvpn.net/community/releases/openvpn-${version}.tar.gz";
-      sha256 = "sha256-dfAETfRJQwVVynuZWit3qyTylG/cNmgwG47cI5hqX34=";
+      sha256 = "sha256-6+yTMmPJhQ72984SXi8iIUvmCxy7jM/xiJJkP+CDro8=";
     };
 
     buildInputs = oldAttrs.buildInputs or [ ] ++ [
+      autoreconfHook
       iproute2
     ];
 
     configureFlags = oldAttrs.configureFlags  or [ ] ++ [
+      # Flags are based on https://github.com/mullvad/mullvadvpn-app-binaries/blob/main/Makefile#L17
+      "--enable-static"
+      "--disable-shared"
+      "--disable-debug"
+      "--disable-plugin-down-root"
+      "--disable-management"
+      "--disable-port-share"
+      "--disable-systemd"
+      "--disable-dependency-tracking"
+      "--disable-pkcs11"
+      "--disable-plugin-auth-pam"
+      "--enable-plugins"
+      "--disable-lzo"
+      "--disable-lz4"
+      "--enable-comp-stub"
+
+      # TODO: Use '--enable-dco --disable-iproute2' on Linux, see https://github.com/mullvad/mullvadvpn-app-binaries/blob/main/Makefile#L35
       "--enable-iproute2"
       "IPROUTE=${iproute2}/sbin/ip"
     ];
 
-    nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [
-      autoconf
-      automake
-    ];
-
     patches = oldAttrs.patches or [ ] ++ [
       # look at compare to find the relevant commits
-      # https://github.com/OpenVPN/openvpn/compare/release/2.5...mullvad:mullvad-patches
+      # https://github.com/OpenVPN/openvpn/compare/release/2.6...mullvad:mullvad-patches
       # used openvpn version is the latest tag ending with -mullvad
       # https://github.com/mullvad/openvpn/tags
       (fetchMullvadPatch {
         # "Reduce PUSH_REQUEST_INTERVAL to one second"
-        commit = "41e44158fc71bb6cc8cc6edb6ada3307765a12e8";
-        sha256 = "sha256-UoH0V6gTPdEuybFkWxdaB4zomt7rZeEUyXs9hVPbLb4=";
-      })
-      (fetchMullvadPatch {
-        # "Allow auth plugins to set a failure reason"
-        commit = "f51781c601e8c72ae107deaf25bf66f7c193e9cd";
-        sha256 = "sha256-+kwG0YElL16T0e+avHlI8gNQdAxneRS6fylv7QXvC1s=";
+        commit = "4084b49de84e64c56584a378e85faf37973b6d6d";
+        sha256 = "sha256-MmYeFSw6c/QJh0LqLgkx+UxrbtTVv6zEFcnYEqznR1c=";
       })
       (fetchMullvadPatch {
         # "Send an event to any plugins when authentication fails"
-        commit = "c2f810f966f2ffd68564d940b5b8946ea6007d5a";
-        sha256 = "sha256-PsKIxYwpLD66YaIpntXJM8OGcObyWBSAJsQ60ojvj30=";
+        commit = "f24de7922d70c6e1ae06acf18bce1f62d9fa6b07";
+        sha256 = "sha256-RvlQbR6/s4NorYeA6FL7tE6geg6MIoZJtHeYxkVbdwA=";
       })
       (fetchMullvadPatch {
         # "Shutdown when STDIN is closed"
-        commit = "879d6a3c0288b5443bbe1b94261655c329fc2e0e";
-        sha256 = "sha256-pRFY4r+b91/xAKXx6u5GLzouQySXuO5gH0kMGm77a3c=";
-      })
-      (fetchMullvadPatch {
-        # "Update TAP hardware ID"
-        commit = "7f71b37a3b25bec0b33a0e29780c222aef869e9d";
-        sha256 = "sha256-RF/GvD/ZvhLdt34wDdUT/yxa+IVWx0eY6WRdNWXxXeQ=";
+        commit = "81ae84271c044359b67991b15ebfb0cf9a32b3ad";
+        sha256 = "sha256-ilKMyU97ha2m0p1FD64aNQncnKo4Tyi/nATuD5yPmVw=";
       })
       (fetchMullvadPatch {
         # "Undo dependency on Python docutils"
-        commit = "abd3c6214529d9f4143cc92dd874d8743abea17c";
-        sha256 = "sha256-SC2RlpWHUDMAEKap1t60dC4hmalk3vok6xY+/xhC2U0=";
+        commit = "a5064b4b6c598b68d8cabc3f4006e5addef1ec1e";
+        sha256 = "sha256-+B6jxL0M+W5LzeukXkir26hn1OaYnycVNBwMYFq6gsE=";
       })
       (fetchMullvadPatch {
         # "Prevent signal when stdin is closed from being cleared (#10)"
-        commit = "b45b090c81e7b4f2dc938642af7a1e12f699f5c5";
-        sha256 = "sha256-KPTFmbuJhMI+AvaRuu30CPPLQAXiE/VApxlUCqbZFls=";
+        commit = "abe529e6d7f71228a036007c6c02624ec98ad6c1";
+        sha256 = "sha256-qJQeEtZO/+8kenXTKv4Bx6NltUYe8AwzXQtJcyhrjfc=";
+      })
+      (fetchMullvadPatch {
+        # "Disable libcap-ng"
+        commit = "598014de7c063fa4e8ba1fffa01434229faafd04";
+        sha256 = "sha256-+cFX5gmMuG6XFkTs6IV7utiKRF9E47F5Pgo93c+zBXo=";
+      })
+      (fetchMullvadPatch {
+        # "Remove libnsl dep"
+        commit = "845727e01ab3ec9bd58fcedb31b3cf2ebe2d5226";
+        sha256 = "sha256-Via62wKVfMWHTmO7xIXXO7b5k0KYHs1D0JVg3qnXkeM=";
       })
     ];
+    postPatch = oldAttrs.postPatch or [ ] ++ [ "rm ./configure" ];
 
     meta = oldAttrs.meta or { } // {
       description = "OpenVPN with Mullvad-specific patches applied";

--- a/pkgs/applications/networking/mullvad/openvpn.nix
+++ b/pkgs/applications/networking/mullvad/openvpn.nix
@@ -22,9 +22,12 @@ openvpn.overrideAttrs (oldAttrs:
       sha256 = "sha256-6+yTMmPJhQ72984SXi8iIUvmCxy7jM/xiJJkP+CDro8=";
     };
 
-    buildInputs = oldAttrs.buildInputs or [ ] ++ [
+    nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [
       autoreconfHook
-      iproute2
+    ];
+
+    buildInputs = oldAttrs.buildInputs or [ ] ++ [
+       iproute2
     ];
 
     configureFlags = oldAttrs.configureFlags  or [ ] ++ [


### PR DESCRIPTION
###### Description of changes
Update OpenVPN inside Mullvad package to the version (2.6.0) required by the current Mullvad. Fixes #232794 

Also I've copied configure flags from Makefile ([1](https://github.com/mullvad/mullvadvpn-app-binaries/blob/main/Makefile#L17-L20) [2](https://github.com/mullvad/mullvadvpn-app-binaries/blob/main/Makefile#L35)) - as I understand it, Mullvad uses them when compiling their builds.
~~There are also additional flags they add only on Linux, not sure how to add them correctly (see https://github.com/mullvad/mullvadvpn-app-binaries/blob/main/Makefile#L35 ).~~
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
    **Tested against NixOS 23.05 I'm running on my system (510d721ce097150ae3b80f84b04b13b039186571)** 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
