### PR TITLE
python310Packages.effdet: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/effdet/default.nix
+++ b/pkgs/development/python-modules/effdet/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+# build inputs
+, torch
+, torchvision
+, timm
+, pycocotools
+, omegaconf
+}:
+let
+  pname = "effdet";
+  version = "0.4.1";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-rFWJ/TBKVlDCAZhrLvX44QwREJOnGxxJ+muIF3EIErU=";
+  };
+
+  propagatedBuildInputs = [
+    torch
+    torchvision
+    timm
+    pycocotools
+    omegaconf
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "effdet" ];
+
+  meta = {
+    description = "A PyTorch implementation of EfficientDet";
+    homepage = "https://pypi.org/project/effdet";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ happysalada ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3216,6 +3216,8 @@ self: super: with self; {
 
   edward = callPackage ../development/python-modules/edward { };
 
+  effdet = callPackage ../development/python-modules/effdet { };
+
   effect = callPackage ../development/python-modules/effect { };
 
   eggdeps = callPackage ../development/python-modules/eggdeps { };


### PR DESCRIPTION
###### Description of changes

This will only be working on linux because of a pending dependency fix and my linux machine is stuck right now, so anyone being able to test this is welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
