### PR TITLE
zigHook: init

### DIFF
--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -29,5 +29,6 @@ tetex-tex-live.section.md
 unzip.section.md
 validatePkgConfig.section.md
 waf.section.md
+zig.section.md
 xcbuild.section.md
 ```

--- a/doc/hooks/zig.section.md
+++ b/doc/hooks/zig.section.md
@@ -1,0 +1,59 @@
+# zigHook {#zighook}
+
+[Zig](https://ziglang.org/) is a general-purpose programming language and toolchain for maintaining robust, optimal and reusable software.
+
+In Nixpkgs, `zigHook` overrides the default build, check and install phases.
+
+## Example code snippet {#example-code-snippet}
+
+```nix
+{ lib
+, stdenv
+, zigHook
+}:
+
+stdenv.mkDerivation {
+  # . . .
+
+  nativeBuildInputs = [
+    zigHook
+  ];
+
+  zigBuildFlags = [ "-Dman-pages=true" ];
+
+  dontUseZigCheck = true;
+
+  # . . .
+}
+```
+
+## Variables controlling zigHook {#variables-controlling-zighook}
+
+### `dontUseZigBuild` {#dontUseZigBuild}
+
+Disables using `zigBuildPhase`.
+
+### `zigBuildFlags` {#zigBuildFlags}
+
+Controls the flags passed to the build phase.
+
+### `dontUseZigCheck` {#dontUseZigCheck}
+
+Disables using `zigCheckPhase`.
+
+### `zigCheckFlags` {#zigCheckFlags}
+
+Controls the flags passed to the check phase.
+
+### `dontUseZigInstall` {#dontUseZigInstall}
+
+Disables using `zigInstallPhase`.
+
+### `zigInstallFlags` {#zigInstallFlags}
+
+Controls the flags passed to the install phase.
+
+### Variables honored by zigHook {#variablesHonoredByZigHook}
+
+- `prefixKey`
+- `dontAddPrefix`

--- a/pkgs/development/compilers/zig/hook.nix
+++ b/pkgs/development/compilers/zig/hook.nix
@@ -12,6 +12,6 @@ makeSetupHook {
 
   meta = {
     description = "A setup hook for using the Zig compiler in Nixpkgs";
-    inherit (zig.meta) maintainers platforms badPlatforms broken;
+    inherit (zig.meta) maintainers platforms broken;
   };
 } ./setup-hook.sh

--- a/pkgs/development/compilers/zig/hook.nix
+++ b/pkgs/development/compilers/zig/hook.nix
@@ -1,0 +1,17 @@
+{ lib
+, makeSetupHook
+, zig
+}:
+
+makeSetupHook {
+  name = "zig-hook";
+
+  propagatedBuildInputs = [ zig ];
+
+  passthru = { inherit zig; };
+
+  meta = {
+    description = "A setup hook for using the Zig compiler in Nixpkgs";
+    inherit (zig.meta) maintainers platforms badPlatforms broken;
+  };
+} ./setup-hook.sh

--- a/pkgs/development/compilers/zig/setup-hook.sh
+++ b/pkgs/development/compilers/zig/setup-hook.sh
@@ -1,0 +1,90 @@
+# shellcheck shell=bash disable=SC2154,SC2086
+
+# This readonly zigDefaultBuildFlagsArray below is meant to avoid CPU feature
+# impurity in Nixpkgs. However, this flagset is "unstable": it is specifically
+# meant to be controlled by the upstream development team - being up to that
+# team exposing or not that flags to the outside (especially the package manager
+# teams).
+
+# Because of this hurdle, @andrewrk from Zig Software Foundation proposed some
+# solutions for this issue. Hopefully they will be implemented in future
+# releases of Zig. When this happens, this flagset should be revisited
+# accordingly.
+
+# Below are some useful links describing the discovery process of this 'bug' in
+# Nixpkgs:
+
+# https://github.com/NixOS/nixpkgs/issues/169461
+# https://github.com/NixOS/nixpkgs/issues/185644
+# https://github.com/NixOS/nixpkgs/pull/197046
+# https://github.com/NixOS/nixpkgs/pull/241741#issuecomment-1624227485
+# https://github.com/ziglang/zig/issues/14281#issuecomment-1624220653
+
+readonly zigDefaultFlagsArray=("-Drelease-safe=true" "-Dcpu=baseline")
+
+function zigSetGlobalCacheDir {
+    ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
+    export ZIG_GLOBAL_CACHE_DIR
+}
+
+function zigBuildPhase {
+    runHook preBuild
+
+    local flagsArray=(
+        "${zigDefaultFlagsArray[@]}"
+        $zigBuildFlags "${zigBuildFlagsArray[@]}"
+    )
+
+    echoCmd 'build flags' "${flagsArray[@]}"
+    zig build "${flagsArray[@]}"
+
+    runHook postBuild
+}
+
+function zigCheckPhase {
+    runHook preCheck
+
+    local flagsArray=(
+        "${zigDefaultFlagsArray[@]}"
+        $zigCheckFlags "${zigCheckFlagsArray[@]}"
+    )
+
+    echoCmd 'check flags' "${flagsArray[@]}"
+    zig build test "${flagsArray[@]}"
+
+    runHook postCheck
+}
+
+function zigInstallPhase {
+    runHook preInstall
+
+    local flagsArray=(
+        "${zigDefaultFlagsArray[@]}"
+        $zigBuildFlags "${zigBuildFlagsArray[@]}"
+        $zigInstallFlags "${zigInstallFlagsArray[@]}"
+    )
+
+    if [ -z "${dontAddPrefix-}" ]; then
+        # Zig does not recognize `--prefix=/dir/`, only `--prefix /dir/`
+        flagsArray+=("${prefixKey:---prefix}" "$prefix")
+    fi
+
+    echoCmd 'install flags' "${flagsArray[@]}"
+    zig build install "${flagsArray[@]}"
+
+    runHook postInstall
+}
+
+addEnvHooks "$targetOffset" zigSetGlobalCacheDir
+
+if [ -z "${dontUseZigBuild-}" ] && [ -z "${buildPhase-}" ]; then
+    buildPhase=zigBuildPhase
+fi
+
+if [ -z "${dontUseZigCheck-}" ] && [ -z "${checkPhase-}" ]; then
+    checkPhase=zigCheckPhase
+fi
+
+if [ -z "${dontUseZigInstall-}" ] && [ -z "${installPhase-}" ]; then
+    installPhase=zigInstallPhase
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25429,6 +25429,8 @@ with pkgs;
   };
   zig = zig_0_10;
 
+  zigHook = callPackage ../development/compilers/zig/hook.nix { };
+
   zimlib = callPackage ../development/libraries/zimlib { };
 
   zita-convolver = callPackage ../development/libraries/audio/zita-convolver { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
