### PR TITLE
darwin.stdenv: clean up portable libsystem hook

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -105,6 +105,7 @@ rec {
             name = "darwin-portable-libSystem-hook";
             substitutions = {
               libsystem = "${stdenv.cc.libc}/lib/libSystem.B.dylib";
+              targetPrefix = stdenv.cc.bintools.targetPrefix;
             };
           } ./darwin/portable-libsystem.sh)
         ];

--- a/pkgs/stdenv/darwin/portable-libsystem.sh
+++ b/pkgs/stdenv/darwin/portable-libsystem.sh
@@ -7,6 +7,6 @@ fixupOutputHooks+=('fixLibsystemRefs $prefix')
 fixLibsystemRefs() {
   if [ -d "$1/bin" ]; then
       find "$1/bin" -exec \
-        install_name_tool -change @libsystem@ /usr/lib/libSystem.B.dylib {} \;
+        @targetPrefix@install_name_tool -change @libsystem@ /usr/lib/libSystem.B.dylib {} \;
   fi
 }

--- a/pkgs/stdenv/darwin/portable-libsystem.sh
+++ b/pkgs/stdenv/darwin/portable-libsystem.sh
@@ -6,7 +6,7 @@ fixupOutputHooks+=('fixLibsystemRefs $prefix')
 
 fixLibsystemRefs() {
   if [ -d "$1/bin" ]; then
-      find "$1/bin" -exec \
+      find "$1/bin" -type f -exec \
         @targetPrefix@install_name_tool -change @libsystem@ /usr/lib/libSystem.B.dylib {} \;
   fi
 }


### PR DESCRIPTION
###### Description of changes

I noticed this while building #242316. The hook fails to find `install_name_tool` when sandboxing is enabled. I also cleaned up an `install_name_tool` failure due to trying to run it on `$out/bin` itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
