### PR TITLE
xcbuild: propagatedBuildInputs should be derivations, not path strings

### DIFF
--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -112,7 +112,13 @@ runCommand "xcodebuild-${xcbuild.version}" {
   inherit (xcbuild) meta;
 
   # ensure that the toolchain goes in PATH
-  propagatedBuildInputs = [ "${toolchains}/XcodeDefault.xctoolchain" ];
+  propagatedBuildInputs = [
+    (runCommand "xcodebuild-xctoolchain-${xcbuild.version}" {} ''
+      mkdir -p $out
+      cp -r "${toolchains}/XcodeDefault.xctoolchain" $out
+    ''
+    )
+  ];
 
   passthru = {
     inherit xcbuild xcrun;

--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -105,6 +105,11 @@ fi
     '';
   };
 
+  default-toolchain = runCommand "xcodebuild-xctoolchain-${xcbuild.version}" {} ''
+    mkdir -p $out
+    cp -r ${toolchains}/XcodeDefault.xctoolchain/* $out
+  '';
+
 in
 
 runCommand "xcodebuild-${xcbuild.version}" {
@@ -112,17 +117,11 @@ runCommand "xcodebuild-${xcbuild.version}" {
   inherit (xcbuild) meta;
 
   # ensure that the toolchain goes in PATH
-  propagatedBuildInputs = [
-    (runCommand "xcodebuild-xctoolchain-${xcbuild.version}" {} ''
-      mkdir -p $out
-      cp -r "${toolchains}/XcodeDefault.xctoolchain" $out
-    ''
-    )
-  ];
+  propagatedBuildInputs = [ default-toolchain ];
 
   passthru = {
     inherit xcbuild xcrun;
-    toolchain = "${toolchains}/XcodeDefault.xctoolchain";
+    toolchain = default-toolchain;
     sdk = "${sdks}/${sdkName}";
     platform = "${platforms}/${xcodePlatform}.platform";
   };


### PR DESCRIPTION
###### Description of changes

This changes `propagatedBuildInputs` from having list of strings of paths to a nix store onto having an actual derivation.

Though other known dependencies seem to work well with the previous approach, this creates confusing behavior with `numtide/devshells`, which trims off `$PATH` more aggressively.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

So far, I've found no PR to fix this issue.

There is also no linked tests, I'm not sure how to proceed with testing and I am leaving these unticked.