### PR TITLE
darwin.rewrite-tbd: 20201114 -> unstable-2023-03-27

### DIFF
--- a/pkgs/os-specific/darwin/rewrite-tbd/default.nix
+++ b/pkgs/os-specific/darwin/rewrite-tbd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "rewrite-tbd";
-  version = "20201114";
+  version = "unstable-2023-03-27";
 
   src = fetchFromGitHub {
     owner = "thefloweringash";
     repo = "rewrite-tbd";
-    rev = "988f29c6ccbca9b883966225263d8d78676da6a3";
-    sha256 = "08sk91zwj6n9x2ymwid2k7y0rwv5b7p6h1b25ipx1dv0i43p6v1a";
+    rev = "d7852691762635028d237b7d00c3dc6a6613de79";
+    hash = "sha256-syxioFiGvEv4Ypk5hlIjLQth5YmdFdr+NC+aXSXzG4k=";
   };
 
   # Nix takes care of these paths. Avoiding the use of `pkg-config` prevents an infinite recursion.
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://github.com/thefloweringash/rewrite-tbd/";
     description = "Rewrite filepath in .tbd to Nix applicable format";
-    platforms = platforms.darwin;
+    platforms = platforms.unix;
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
