### PR TITLE
volare: init at 1.8.1.0

### DIFF
--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -17,7 +17,7 @@ with lib;
 
 let
   sway = sway-unwrapped.overrideAttrs (oa: { inherit isNixOS enableXWayland; });
-  baseWrapper = writeShellScriptBin "sway" ''
+  baseWrapper = writeShellScriptBin sway.meta.mainProgram ''
      set -o errexit
      if [ ! "$_SWAY_WRAPPER_ALREADY_EXECUTED" ]; then
        export XDG_CURRENT_DESKTOP=sway
@@ -26,13 +26,13 @@ let
      fi
      if [ "$DBUS_SESSION_BUS_ADDRESS" ]; then
        export DBUS_SESSION_BUS_ADDRESS
-       exec ${sway}/bin/sway "$@"
+       exec ${lib.getExe sway} "$@"
      else
-       exec ${lib.optionalString dbusSupport "${dbus}/bin/dbus-run-session"} ${sway}/bin/sway "$@"
+       exec ${lib.optionalString dbusSupport "${dbus}/bin/dbus-run-session"} ${lib.getExe sway} "$@"
      fi
    '';
 in symlinkJoin {
-  name = "sway-${sway.version}";
+  name = "${sway.meta.mainProgram}-${sway.version}";
 
   paths = (optional withBaseWrapper baseWrapper)
     ++ [ sway ];
@@ -49,14 +49,14 @@ in symlinkJoin {
   postBuild = ''
     ${optionalString withGtkWrapper "gappsWrapperArgsHook"}
 
-    wrapProgram $out/bin/sway \
+    wrapProgram $out/bin/${sway.meta.mainProgram} \
       ${optionalString withGtkWrapper ''"''${gappsWrapperArgs[@]}"''} \
       ${optionalString (extraOptions != []) "${concatMapStrings (x: " --add-flags " + x) extraOptions}"}
   '';
 
   passthru = {
     inherit (sway.passthru) tests;
-    providedSessions = [ "sway" ];
+    providedSessions = [ sway.meta.mainProgram ];
   };
 
   inherit (sway) meta;

--- a/pkgs/applications/window-managers/volare/default.nix
+++ b/pkgs/applications/window-managers/volare/default.nix
@@ -1,0 +1,116 @@
+{ lib
+, stdenv
+, fetchFromGitea
+, fetchpatch
+, substituteAll
+, swaybg
+, sway
+, meson
+, ninja
+, pkg-config
+, wayland-scanner
+, scdoc
+, python3
+, wayland
+, libxkbcommon
+, pcre2
+, json_c
+, libevdev
+, pango
+, cairo
+, libinput
+, gdk-pixbuf
+, librsvg
+, wlroots_0_16
+, wayland-protocols
+, libdrm
+, nixosTests
+# Used by the NixOS module:
+, isNixOS ? false
+, enableXWayland ? true, xorg
+, systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
+, trayEnabled ? systemdSupport
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "volare-unwrapped";
+  version = "1.8.1.0";
+
+  inherit enableXWayland isNixOS systemdSupport trayEnabled;
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "raboof";
+    repo = "volare";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-s2dUgtmcapANituTBaUGN1mPSIftwbVrpoiJgazq9Lk=";
+  };
+
+  patches = [
+    ./load-configuration-from-etc.patch
+
+    (substituteAll {
+      src = ../sway/fix-paths.patch;
+      inherit swaybg;
+    })
+  ] ++ lib.optionals (!finalAttrs.isNixOS) [
+    # References to /nix/store/... will get GC'ed which causes problems when
+    # copying the default configuration
+    ./volare-config-no-nix-store-references.patch
+  ] ++ lib.optionals finalAttrs.isNixOS [
+    # Use /run/current-system/sw/share and /etc instead of /nix/store
+    # references:
+    ../sway/sway-config-nixos-paths.patch
+  ];
+
+  strictDeps = true;
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    meson ninja pkg-config wayland-scanner scdoc
+  ];
+
+  buildInputs = [
+    wayland libxkbcommon pcre2 json_c libevdev
+    pango cairo libinput gdk-pixbuf librsvg
+    wayland-protocols libdrm
+    (wlroots_0_16.override { inherit (finalAttrs) enableXWayland; })
+    sway
+  ] ++ lib.optionals finalAttrs.enableXWayland [
+    xorg.xcbutilwm
+  ];
+
+  mesonFlags = let
+    # The "sd-bus-provider" meson option does not include a "none" option,
+    # but it is silently ignored iff "-Dtray=disabled".  We use "basu"
+    # (which is not in nixpkgs) instead of "none" to alert us if this
+    # changes: https://github.com/swaywm/sway/issues/6843#issuecomment-1047288761
+    # assert trayEnabled -> systemdSupport && dbusSupport;
+
+    sd-bus-provider =  if systemdSupport then "libsystemd" else "basu";
+    in
+    [ "-Dsd-bus-provider=${sd-bus-provider}" ]
+    ++ lib.optional (!finalAttrs.enableXWayland) "-Dxwayland=disabled"
+    ++ lib.optional (!finalAttrs.trayEnabled)    "-Dtray=disabled"
+  ;
+
+  preInstall = ''
+    sed -i "s|#\!/usr/bin/env python3|#\!${python3}/bin/python3|" ../meson_volare_rename.py
+  '';
+
+  meta = with lib; {
+    description = "A tiling, tabbed wayland compositor (based on Sway)";
+    longDescription = ''
+      Volare is a tabbed, tiling Wayland compositor.
+
+      It is a fork of sway, but more static: new windows will show up as new
+      tabs in the current container instead of rearranging the screen layout.
+    '';
+    homepage = "https://codeberg.org/raboof/volare";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ raboof ];
+    mainProgram = "volare";
+  };
+})

--- a/pkgs/applications/window-managers/volare/load-configuration-from-etc.patch
+++ b/pkgs/applications/window-managers/volare/load-configuration-from-etc.patch
@@ -1,0 +1,48 @@
+From 92283df3acbffa5c1bb21f23cdd686113d905114 Mon Sep 17 00:00:00 2001
+From: Patrick Hilhorst <git@hilhorst.be>
+Date: Wed, 31 Mar 2021 21:14:13 +0200
+Subject: [PATCH] Load configs from /etc but fallback to /nix/store
+
+This change will load all configuration files from /etc, to make it easy
+to override them, but fallback to /nix/store/.../etc/sway/config to make
+Sway work out-of-the-box with the default configuration on non NixOS
+systems.
+
+Original patch by Michael Weiss, updated for Sway 1.6 by Patrick Hilhorst,
+adapted for volare by Arnout Engelen
+
+Co-authored-by: Michael Weiss <dev.primeos@gmail.com>
+---
+ meson.build   | 3 ++-
+ sway/config.c | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index b7a29660..8ae8ceb3 100644
+--- a/meson.build
++++ b/meson.build
+@@ -164,7 +164,8 @@ if scdoc.found()
+ 	endforeach
+ endif
+ 
+-add_project_arguments('-DSYSCONFDIR="/@0@"'.format(join_paths(prefix, sysconfdir)), language : 'c')
++add_project_arguments('-DSYSCONFDIR="/@0@"'.format(sysconfdir), language : 'c')
++add_project_arguments('-DNIX_SYSCONFDIR="/@0@"'.format(join_paths(prefix, sysconfdir)), language : 'c')
+ 
+ version = '"@0@"'.format(meson.project_version())
+ git = find_program('git', native: true, required: false)
+diff --git a/sway/config.c b/sway/config.c
+index 76b9ec08..fb5b51aa 100644
+--- a/sway/config.c
++++ b/sway/config.c
+@@ -383,5 +383,6 @@ static char *get_config_path(void) {
+ 		{ .prefix = home, .config_folder = ".volare"},
+ 		{ .prefix = config_home, .config_folder = "volare"},
+-		{ .prefix = SYSCONFDIR, .config_folder = "volare"},
++		{ .prefix = SYSCONFDIR, .config_folder = "volare"},
++		{ .prefix = NIX_SYSCONFDIR, .config_folder = "volare"},
+ 	};
+ 
+ 	size_t num_config_paths = sizeof(config_paths)/sizeof(config_paths[0]);
+-- 
+2.30.1

--- a/pkgs/applications/window-managers/volare/volare-config-no-nix-store-references.patch
+++ b/pkgs/applications/window-managers/volare/volare-config-no-nix-store-references.patch
@@ -1,0 +1,10 @@
+diff --git a/config.in b/config.in
+--- a/config.in
++++ b/config.in
+@@ -213,5 +213,3 @@ client.focused          "#aaaacc" "#666699"    "#eeeeee"  "#aaaacc"    "#000000"
+ client.focused_inactive "#cfcfdf" "#9999bb"    "#000000"  "#000000"    "#000000"
+ client.unfocused        "#e7e7ff" "#b8b8c8"    "#000000"  "#000000"    "#000000"
+ font SourceSansPro, sans 10
+-
+-include @sysconfdir@/volare/config.d/*
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32843,6 +32843,11 @@ with pkgs;
 
   swayest-workstyle = callPackage ../applications/window-managers/sway/swayest-workstyle { };
 
+  volare-unwrapped = callPackage ../applications/window-managers/volare { };
+  volare = (sway.override {
+    sway-unwrapped = volare-unwrapped;
+  });
+
   tiramisu = callPackage ../applications/misc/tiramisu { };
 
   rlaunch = callPackage ../applications/misc/rlaunch { };


### PR DESCRIPTION
Volare is a tabbed, tiling [Wayland](https://wayland.freedesktop.org/) compositor.

This means, compared to other tiling compositors, volare is more static: new windows will show up as tabs in the current frame instead of rearranging the screen layout.

Fixes #240124 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

/cc @primeos @Synthetica9 