### PR TITLE
libopus: increase test timeouts

### DIFF
--- a/pkgs/development/libraries/libopus/default.nix
+++ b/pkgs/development/libraries/libopus/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix-pkg-config-paths.patch
+    # Some tests time out easily on slower machines
+    ./test-timeout.patch
     # Fix meson build for arm64. Remove with next release
     # https://gitlab.xiph.org/xiph/opus/-/merge_requests/59
     (fetchpatch {

--- a/pkgs/development/libraries/libopus/test-timeout.patch
+++ b/pkgs/development/libraries/libopus/test-timeout.patch
@@ -1,0 +1,16 @@
+diff --git a/tests/meson.build b/tests/meson.build
+index 5f3ac9d..74b2de7 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -1,8 +1,8 @@
+ # Tests that link to libopus
+ opus_tests = [
+-  ['test_opus_api'],
+-  ['test_opus_decode', [], 60],
+-  ['test_opus_encode', 'opus_encode_regressions.c', 120],
++  ['test_opus_api', [], 60],
++  ['test_opus_decode', [], 120],
++  ['test_opus_encode', 'opus_encode_regressions.c', 240],
+   ['test_opus_padding'],
+   ['test_opus_projection'],
+ ]


### PR DESCRIPTION

###### Description of changes

Some tests time out easily on slower machines.
Tested on a pine64 star64.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] riscv64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
