### PR TITLE
sage: refresh patches

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -52,32 +52,32 @@ stdenv.mkDerivation rec {
   # should come from or be proposed to upstream. This list will probably never
   # be empty since dependencies update all the time.
   packageUpgradePatches = [
-    # https://github.com/sagemath/sage/pull/35584, positively reviewed
+    # https://github.com/sagemath/sage/pull/35584, landed in 10.1.beta1
     (fetchpatch {
       name = "networkx-3.1-upgrade.patch";
-      url = "https://github.com/sagemath/sage/compare/10.0.rc2..e599562cf5fdfb9799a5412fac40c2f8e9f97341.diff";
-      sha256 = "sha256-3A90kXqNR0c7+k8xrZXAt5wqWg/VFAPNhQujwTdOyhI=";
+      url = "https://github.com/sagemath/sage/commit/be0aab74fd7e399e146988ef27260d2837baebae.diff";
+      sha256 = "sha256-xBGrylNaiF7CpfmX9/4lTioP2LSYKoRCkKlKSGZuv9U=";
     })
 
-    # https://github.com/sagemath/sage/pull/35612, positively reviewed
+    # https://github.com/sagemath/sage/pull/35612, landed in 10.1.beta1
     (fetchpatch {
       name = "linbox-1.7-upgrade.patch";
-      url = "https://github.com/sagemath/sage/compare/10.0.rc2..9c8796c7b677e3a056348e3510331ea8b8c3c42e.diff";
+      url = "https://github.com/sagemath/sage/commit/35cbd2f2a2c4c355455d39b1424f05ea0aa4349b.diff";
       sha256 = "sha256-/TpvIQZUqmbUuz6wvp3ni9oRir5LBA2FKDJcmnHI1r4=";
     })
 
-    # https://github.com/sagemath/sage/pull/35619
+    # https://github.com/sagemath/sage/pull/35619, landed in 10.1.beta1
     (fetchpatch {
       name = "maxima-5.46.0-upgrade.patch";
-      url = "https://github.com/sagemath/sage/compare/10.0.rc3..7e86af5dae8f89868b25a6f57189bb5ca618da89.diff";
-      sha256 = "sha256-pxSxdJ2lyHoMUIxhlIn1nTHaddRxGvvTj9IbwFCTBFU=";
+      url = "https://github.com/sagemath/sage/commit/4ddf9328e7598284d4bc03cd2ed890f0be6b6399.diff";
+      sha256 = "sha256-f6YaZiLSj+E0LJMsMZHDt6vecWffSAuUHYVkegBEhno=";
     })
 
-    # https://github.com/sagemath/sage/pull/35635, positively reviewed
+    # https://github.com/sagemath/sage/pull/35635, landed in 10.1.beta1
     (fetchpatch {
       name = "sympy-1.12-upgrade.patch";
-      url = "https://github.com/sagemath/sage/compare/10.0.rc2..aa4193cdc8ec9fb7bd7c49696b7f914668f7913a.diff";
-      sha256 = "sha256-UAmYCxHvnE5p+H2DySNZTPFVm915jHtOEoG+tZz5n7I=";
+      url = "https://github.com/sagemath/sage/commit/1a73b3bbbfa0f4a297e05d49305070e1ed5ae598.diff";
+      sha256 = "sha256-k8Oam+EiRcfXC7qCdLacCx+7vpUAw2K1wsjKcQbeGb4=";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

Some of the hashes changed due to fuzz or Sage-the-distro (`build/pkgs`) changes, but I've verified that the patches are still effectively the same.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
