### PR TITLE
starruler2: init at 2022-08-30

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -282,6 +282,12 @@ in mkLicense lset) ({
     free = false;
   };
 
+  cc-by-nc-20 = {
+    spdxId = "CC-BY-NC-2.0";
+    fullName = "Creative Commons Attribution Non Commercial 2.0 Unported";
+    free = false;
+  };
+
   cc-by-nc-30 = {
     spdxId = "CC-BY-NC-3.0";
     fullName = "Creative Commons Attribution Non Commercial 3.0 Unported";

--- a/pkgs/games/starruler2/data.nix
+++ b/pkgs/games/starruler2/data.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "starruler2-data";
+  version = "2022-08-30";
+
+  src = fetchFromGitHub {
+    owner = "OpenSRProject";
+    repo = "OpenStarRuler-Data";
+    rev = "681d87467f7e6bbdc3dddbbe4c6ab7a77fe0a781";
+    hash = "sha256-MaGPbfSv3/j98seR+p2mVOf2zJ4A6Fc+W03SesgnPpU=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    dir="$out/share/games/starruler2"
+    mkdir -p $dir
+    mv data locales maps mods scripts credits.txt sr2.icns sr2.ico "$dir"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A massive-scale 4X/RTS game set in space -- data files";
+    homepage = "https://github.com/OpenSRProject/OpenStarRuler-Data";
+    license = with licenses; [mit cc-by-nc-20]; # Art assets are licensed as CC-BY-NC 2.0.
+    maintainers = with maintainers; [justinlovinger];
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/games/starruler2/default.nix
+++ b/pkgs/games/starruler2/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  makeWrapper,
+  # Path to directory containing music for the game,
+  # such as `data/music` from the commercial version.
+  musicPath ? null,
+  # Paths of mods to add.
+  modPaths ? [],
+}: let
+  data = callPackage ./data.nix {};
+  engine = callPackage ./engine.nix {};
+in
+  # The game is mostly implemented in Angelscript,
+  # a scripting language.
+  # For security,
+  # the Angelscript runtime refuses to load files outside particular directories.
+  # If we symlink `data` files,
+  # such as by using `buildEnv`,
+  # Angelscript will not load those files,
+  # and the game will not run.
+  # We must instead `cp` files.
+  stdenv.mkDerivation {
+    pname = "starruler2";
+    version = lib.trivial.max data.version engine.version;
+
+    phases = ["installPhase"];
+
+    nativeBuildInputs = [makeWrapper];
+
+    installPhase = ''
+      runHook preInstall
+
+      game="$out/share/games/starruler2"
+      mkdir -p "$out/bin"
+
+      cp -r "${data}/share" "$out/share"
+
+      ${
+        lib.optionalString (musicPath != null) ''
+          cp -r "${musicPath}" "$game/data/music"
+        ''
+      }
+
+      ${
+        lib.optionalString (modPaths != []) ''
+          cp -r ${lib.concatStringsSep " " (map (path: ''"${path}"'') modPaths)} "$game/mods"
+        ''
+      }
+
+      makeWrapper "${engine}/bin/starruler2" "$out/bin/starruler2" --chdir "$game"
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "A massive-scale 4X/RTS game set in space";
+      homepage = "https://github.com/OpenSRProject";
+      license = lib.unique (lib.toList engine.meta.license ++ lib.toList data.meta.license);
+      platforms = engine.meta.platforms;
+      maintainers = with maintainers; [justinlovinger];
+      hydraPlatforms = [];
+    };
+  }

--- a/pkgs/games/starruler2/engine.nix
+++ b/pkgs/games/starruler2/engine.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bzip2,
+  cmake,
+  curl,
+  freetype,
+  glew,
+  libGLU,
+  libogg,
+  libpng,
+  libvorbis,
+  libXi,
+  libXrandr,
+  libXxf86vm,
+  openal,
+  which,
+  zlib,
+}:
+stdenv.mkDerivation {
+  pname = "starruler2-engine";
+  version = "2022-05-27";
+
+  src = fetchFromGitHub {
+    owner = "OpenSRProject";
+    repo = "OpenStarRuler";
+    rev = "db86ab0c173abf4b5fba2a4acd8704b5fd9dfec5";
+    hash = "sha256-FH2hWTdL1wNYjcsZ5kVD5qkJZ71BVtjg8QIiVY49K/A=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    which
+  ];
+
+  buildInputs = [
+    bzip2
+    curl
+    freetype
+    glew
+    libGLU
+    libogg
+    libpng
+    libvorbis
+    libXi
+    libXrandr
+    libXxf86vm
+    openal
+    zlib
+  ];
+
+  NLTO = 1; # LTO fails in Nix.
+
+  # CMake is only used for the nested GLFW build,
+  # not the top-level build.
+  dontUseCmakeConfigure = true;
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    mv bin/lin64/StarRuler2.bin "$out/bin/starruler2"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A massive-scale 4X/RTS game set in space -- engine";
+    homepage = "https://github.com/OpenSRProject/OpenStarRuler";
+    license = licenses.mit;
+    # 32-bit Linux may be supported,
+    # but will require testing
+    # and changes to `installPhase`,
+    # at the least.
+    # Darwin may require upstream changes.
+    platforms = ["x86_64-linux"];
+    maintainers = with maintainers; [justinlovinger];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37556,6 +37556,8 @@ with pkgs;
 
   shipwright = callPackage ../games/shipwright { };
 
+  starruler2 = callPackage ../games/starruler2 { };
+
   wipeout-rewrite = callPackage ../games/wipeout-rewrite {
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };


### PR DESCRIPTION
###### Description of changes

I went with the latest commit for the engine and data repository because neither have had releases since 1.0.0, and it has been years.

For the name of the package, I tried to stay consistent with existing package names. Most existing packages I saw concatenated words without dashes, but not all.

Note, the music for the game was not released with the source-code, hence the `musicPath` argument. `musicPath` and `modPaths` can be used like,

```nix
(pkgs.starruler2.override {
  musicPath = inputs.star-ruler-2-music;
  modPaths = [(inputs.star-ruler-2-mod-ce + "/colonisation-expansion")];
})
```

with Flakes like,

```nix
star-ruler-2-music = {
  url = "file:///path/to/star-ruler-2-music.tar.gz";
  flake = false;
};

star-ruler-2-mod-ce = {
  url = "github:Skeletonxf/star-ruler-2-mod-ce/master";
  flake = false;
};
```

Without Flakes, fetchers can be used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
