### PR TITLE
haskell.compiler.{ghc962,ghcHEAD}: no rendered src on aarch64-linux

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -154,6 +154,8 @@
     ghcSrc = ghcSrc;
     ghcVersion = version;
     userSettings = hadrianUserSettings;
+    # Disable haddock generating pretty source listings to stay under 3GB on aarch64-linux
+    enableHyperlinkedSource = !(stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux);
   }
 
 , #  Whether to build sphinx documentation.

--- a/pkgs/development/tools/haskell/hadrian/default.nix
+++ b/pkgs/development/tools/haskell/hadrian/default.nix
@@ -4,6 +4,10 @@
 , extra, filepath, lib, mtl, parsec, shake, text, transformers
 , unordered-containers, cryptohash-sha256, base16-bytestring
 , userSettings ? null
+# Whether to pass --hyperlinked-source to haddock or not. This is a custom
+# workaround as we wait for this to be configurable via userSettings or similar.
+# https://gitlab.haskell.org/ghc/ghc/-/issues/23625
+, enableHyperlinkedSource ? true
 , writeText
 }:
 
@@ -18,6 +22,9 @@ mkDerivation {
   postUnpack = ''
     sourceRoot="$sourceRoot/hadrian"
   '';
+  patches = lib.optionals (!enableHyperlinkedSource) [
+    ./disable-hyperlinked-source.patch
+  ];
   # Overwrite UserSettings.hs with a provided custom one
   postPatch = lib.optionalString (userSettings != null) ''
     install -m644 "${writeText "UserSettings.hs" userSettings}" src/UserSettings.hs

--- a/pkgs/development/tools/haskell/hadrian/disable-hyperlinked-source.patch
+++ b/pkgs/development/tools/haskell/hadrian/disable-hyperlinked-source.patch
@@ -1,0 +1,12 @@
+diff --git a/hadrian/src/Settings/Builders/Haddock.hs b/hadrian/src/Settings/Builders/Haddock.hs
+index 902b2f85e2..429a441c3b 100644
+--- a/src/Settings/Builders/Haddock.hs
++++ b/src/Settings/Builders/Haddock.hs
+@@ -57,7 +57,6 @@ haddockBuilderArgs = mconcat
+             , arg $ "--odir=" ++ takeDirectory output
+             , arg $ "--dump-interface=" ++ output
+             , arg "--html"
+-            , arg "--hyperlinked-source"
+             , arg "--hoogle"
+             , arg "--quickjump"
+             , arg $ "--title=" ++ pkgName pkg ++ "-" ++ version


### PR DESCRIPTION
This saves just enough space on aarch64-linux so that the hadrian built GHCs are under the 3GB Hydra output limit:

| compiler | before     | after      | Δ          |
|----------|------------|------------|------------|
| ghc962   | 3241234736 | 2810740560 | -430494176 |
| ghcHEAD  | 3341288328 | 2902760872 | -438527456 |

The total output size can be calculated using (don't forget to use aarch64-linux):

```
nix-build -A <compiler> | xargs nix path-info -s | awk '{ s += $2 }; END { print s }'
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
