### PR TITLE
pforth: allow cross-compile

### DIFF
--- a/pkgs/development/compilers/pforth/default.nix
+++ b/pkgs/development/compilers/pforth/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, buildPackages
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -14,14 +15,26 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-vEjFeHSJl+yAtatYJEnu+r9hmOr/kZOgIbSUXR/c8WU=";
   };
 
-  dontConfigure = true;
-
-  preBuild = ''
-    cd platforms/unix
+  # We build the dictionary in a cross-compile compatible way.
+  # For that, we perform steps, that the Makefile would otherwise do.
+  buildPhase = ''
+    runHook preBuild
+    make -C platforms/unix pfdicapp
+    pushd fth/
+    ${stdenv.hostPlatform.emulator buildPackages} ../platforms/unix/pforth -i system.fth
+    ${stdenv.hostPlatform.emulator buildPackages} ../platforms/unix/pforth -d pforth.dic <<< "include savedicd.fth sdad bye"
+    mv pforth.dic pfdicdat.h ../platforms/unix/
+    popd
+    make -C platforms/unix pforthapp
+    runHook postBuild
   '';
 
   installPhase = ''
-    install -Dm755 pforth_standalone $out/bin/pforth
+    runHook preInstall
+    install -Dm755 platforms/unix/pforth_standalone $out/bin/pforth
+    mkdir -p $out/share/pforth
+    cp -r fth/* $out/share/pforth/
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
###### Description of changes

This allows to build, for example, the attributes `pkgsCross.raspberryPi.pkgsStatic.pforth` and `pkgsCross.aarch64-multiplatform.pkgsStatic.pforth`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).