### PR TITLE
jabref: fix gapps wrapper

### DIFF
--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -38,12 +38,12 @@ stdenv.mkDerivation rec {
   desktopItems = [
     (makeDesktopItem {
       comment = meta.description;
-      name = "JabRef %U";
+      name = "JabRef";
       desktopName = "JabRef";
       genericName = "Bibliography manager";
       categories = [ "Office" ];
       icon = "jabref";
-      exec = "JabRef";
+      exec = "JabRef %U";
       startupWMClass = "org.jabref.gui.JabRefMain";
       mimeTypes = [ "text/x-bibtex" ];
     })
@@ -144,8 +144,14 @@ stdenv.mkDerivation rec {
     unzip $out/lib/javafx-web-*.jar libjfxwebkit.so -d $out/lib/
 
     DEFAULT_JVM_OPTS=$(sed -n -E "s/^DEFAULT_JVM_OPTS='(.*)'$/\1/p" $out/bin/JabRef | sed -e "s|\$APP_HOME|$out|g" -e 's/"//g')
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
     rm $out/bin/*
 
+    # put this in postFixup because some gappsWrapperArgs are generated in gappsWrapperArgsHook in preFixup
     makeWrapper ${jdk}/bin/java $out/bin/JabRef \
       "''${gappsWrapperArgs[@]}" \
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
@@ -154,8 +160,6 @@ stdenv.mkDerivation rec {
 
     # lowercase alias (for convenience and required for browser extensions)
     ln -sf $out/bin/JabRef $out/bin/jabref
-
-    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/242505

I switched the wrapper from gappsWrapper to makeWrapper to avoid double wrapping. Howere the gappsWrapperArgsHook is run in preFixup. So some args are not added in postInstall. I fix it by running the hook in postInstall manully. Also fix a typo in the desktop item.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
