### PR TITLE
ipmicfg: fix broken pkg: 1.34.0 -> 1.34.2

### DIFF
--- a/pkgs/applications/misc/ipmicfg/default.nix
+++ b/pkgs/applications/misc/ipmicfg/default.nix
@@ -2,12 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ipmicfg";
-  version = "1.34.0";
-  buildVersion = "220906";
+  version = "1.34.2";
+  buildVersion = "230224";
 
   src = fetchzip {
-    url = "https://www.supermicro.com/wftp/utility/IPMICFG/IPMICFG_${version}_build.${buildVersion}.zip";
-    sha256 = "ZumCXuR7M2Ep7maBOBFk0UsxyRo4fBkf+9AVmkz4AF0=";
+    url =
+      "https://www.supermicro.com/wdl/utility/IPMICFG/IPMICFG_${version}_build.${buildVersion}.zip";
+    sha256 = "1s924y6f0lvmd2m0na1nh0vyqf8qpp34wc6ndi8fwga4ynj66l63";
   };
 
   installPhase = ''
@@ -22,14 +23,15 @@ stdenv.mkDerivation rec {
     ln -s "$out/opt/ipmicfg/IPMICFG-Linux.x86_64" "$out/bin/ipmicfg"
   '';
 
-   dontPatchShebangs = true; # There are no scripts and it complains about null bytes.
+  # There are no scripts and it complains about null bytes.
+  dontPatchShebangs = true;
 
-   meta = with lib; {
-     description = "Supermicro IPMI configuration tool";
-     homepage = "http://www.supermicro.com/products/nfo/ipmi.cfm";
-     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-     license = licenses.unfree;
-     platforms = [ "x86_64-linux" ];
-     maintainers = with maintainers; [ sorki ];
-   };
+  meta = with lib; {
+    description = "Supermicro IPMI configuration tool";
+    homepage = "http://www.supermicro.com/products/nfo/ipmi.cfm";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ sorki ];
+  };
 }


### PR DESCRIPTION
Summary
===

ipmicfg looks to be broken due to a broken supermicro download link. I found a minor version upgrade link that works and upgraded this nix pkg with it.

Detailed reproduction / literate change
===

Adding `ipmicfg` to my `configuration.nix`

```

  environment.systemPackages = with pkgs; [
    ipmicfg
  ];
```

breaks the `nixos-rebuild switch`:

```
~ λ sudo nixos-rebuild switch
trying https://www.supermicro.com/wftp/utility/IPMICFG/IPMICFG_1.34.0_build.220906.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   201  100   201    0     0    897      0 --:--:-- --:--:-- --:--:--   901
100   150  100   150    0     0    254      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  163k    0  163k    0     0   234k      0 --:--:-- --:--:-- --:--:--  234k
unpacking source archive /build/IPMICFG_1.34.0_build.220906.zip
[/build/IPMICFG_1.34.0_build.220906.zip]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /build/IPMICFG_1.34.0_build.220906.zip or
        /build/IPMICFG_1.34.0_build.220906.zip.zip, and cannot find /build/IPMICFG_1.34.0_build.220906.zip.ZIP, period.
do not know how to unpack source archive /build/IPMICFG_1.34.0_build.220906.zip
error: builder for '/nix/store/0l6h8gbvynn0fpl1gfnj0hhv6hj5nc8h-source.drv' failed with exit code 1
error: 1 dependencies of derivation '/nix/store/0gv1k3zpgj2dkdfxzfv5dl0wlb0flk7p-ipmicfg-1.34.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/s9h4j6yfmyjp312vy55ya5qdh7z630cy-system-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/5fw4wznnvwr7gjglv5pxx8m15nma0k27-nixos-system-nixos-23.05.1784.d8bb6c681cf.drv' failed to build
```

curling that URL shows it has been moved:

```

~ λ  curl https://www.supermicro.com/wftp/utility/IPMICFG/IPMICFG_1.34.0_build.220906.zip
<head><title>Document Moved</title></head>
<body><h1>Object Moved</h1>This document may be found <a HREF="https://www.supermicro.com/wdl/utility/IPMICFG/IPMICFG_1.34.0_build.220906.zip">here</a></body>
```

following the 301 goes to the homepage:

```

~ λ curl https://www.supermicro.com/wdl/utility/IPMICFG/IPMICFG_1.34.0_build.220906.zip
<head><title>Document Moved</title></head>
<body><h1>Object Moved</h1>This document may be found <a HREF="https://www.supermicro.com/">here</a></body>
```

In other words, it looks like this link is broken now.

On the bright side, I found an upgrade:

```
curl https://www.supermicro.com/wdl/utility/IPMICFG/
www.supermicro.com - /wdl/utility/IPMICFG/
[To Parent Directory]

 3/24/2023  9:34 AM         1000 CheckSum.txt
 3/24/2023  9:34 AM          512 IPMICFG_1.34.2_build.230224.sig
 3/24/2023  9:34 AM      2381414 IPMICFG_1.34.2_build.230224.zip
 3/24/2023  9:34 AM          512 IPMICFG_1.34.2_build.230224_ESXi.sig
 3/24/2023  9:34 AM      1643195 IPMICFG_1.34.2_build.230224_ESXi.zip
 3/24/2023  9:34 AM       839705 IPMICFG_UserGuide.pdf
 3/24/2023  9:34 AM        <dir> Previous Releases
```

wgetting the `IPMICFG_1.34.2_build.230224.zip` file works as expected.

```
/tmp λ wget https://www.supermicro.com/wdl/utility/IPMICFG/IPMICFG_1.34.2_build.230224.zip
--2023-07-09 18:04:53--  https://www.supermicro.com/wdl/utility/IPMICFG/IPMICFG_1.34.2_build.230224.zip
Resolving www.supermicro.com (www.supermicro.com)... 23.44.174.154, 23.44.174.120
Connecting to www.supermicro.com (www.supermicro.com)|23.44.174.154|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2381414 (2.3M) [application/x-zip-compressed]
Saving to: ‘IPMICFG_1.34.2_build.230224.zip’

IPMICFG_1.34.2_buil 100%[===================>]   2.27M  --.-KB/s    in 0.08s

2023-07-09 18:04:53 (27.5 MB/s) - ‘IPMICFG_1.34.2_build.230224.zip’ saved [2381414/2381414]
```

cross-referencing the provided `CheckSum.txt` file:

```
/tmp λ curl https://www.supermicro.com/wdl/utility/IPMICFG/CheckSum.txt
IPMICFG_1.34.2_build.230224.sig
  CRC32 CheckSum : D32AD874
  MD5 CheckSum : 7D74C33E34584CE01895486B71D042DF
  SHA-256 CheckSum : BF783BFE0DD0FE54A995873BCF8118CFC2C0E15C8A15D691BB721ED170B5AE8F
IPMICFG_1.34.2_build.230224.zip
  CRC32 CheckSum : DD3EA812
  MD5 CheckSum : 0F1C7B0528A3C6CE93488B9964AEDBED
  SHA-256 CheckSum : FADD6CDDE37427313620CD894B041A6CF298E76277093B5EE5BF6D4A20780AA3
IPMICFG_1.34.2_build.230224_ESXi.sig
  CRC32 CheckSum : CDDAC198
  MD5 CheckSum : 7AB98B5150418B815D2B740C5661565B
  SHA-256 CheckSum : A0CD49060A8EA77A5B0E0B1BF63D60B2512354A2F15EB32E884B14602A9A6B81
IPMICFG_1.34.2_build.230224_ESXi.zip
  CRC32 CheckSum : 0D3DA053
  MD5 CheckSum : 262D3D6B4A27D8ED93D5941DD217EEC6
  SHA-256 CheckSum : A896E52811B7333D55BF72E2133ABF8F07951752899172C4C5131F4919CDB7FA
IPMICFG_UserGuide.pdf
  CRC32 CheckSum : 7A6FF7C1
  MD5 CheckSum : 00C09CC09036830000AC1348C9024832
  SHA-256 CheckSum : 6CB4986DA00627030A73154A436CCE06309ED3DC55D26097AF2ED0DBB97259A5
```

```
/tmp λ sha256sum IPMICFG_1.34.2_build.230224.zip
fadd6cdde37427313620cd894b041a6cf298e76277093b5ee5bf6d4a20780aa3  IPMICFG_1.34.2_build.230224.zip
```

We find that it is the same as the downloaded build zip.

To get the nix sha256:

```
/tmp λ nix-prefetch-url --unpack https://www.supermicro.com/wdl/utility/IPMICFG/IPMICFG_1.34.2_build.230224.zip
path is '/nix/store/4l050cmkki5l926d4zqn269532f193mh-IPMICFG_1.34.2_build.230224.zip'
1s924y6f0lvmd2m0na1nh0vyqf8qpp34wc6ndi8fwga4ynj66l63
```

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

