### PR TITLE
drawterm: enable strict deps and parallel builds

### DIFF
--- a/pkgs/tools/admin/drawterm/default.nix
+++ b/pkgs/tools/admin/drawterm/default.nix
@@ -15,7 +15,7 @@
 , config
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "drawterm";
   version = "unstable-2023-06-27";
 
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     sha256 = "ebqw1jqeRC0FWeUIO/HaEovuwzU6+B48TjZbVJXByvA=";
   };
 
+  enableParallelBuilding = true;
+  strictDeps = true;
   nativeBuildInputs = [ installShellFiles ] ++ {
     linux = [ pkg-config wayland-scanner ];
     unix = [ makeWrapper ];
@@ -47,11 +49,10 @@ stdenv.mkDerivation rec {
       mv drawterm drawterm.bin
       install -Dm755 -t $out/bin/ drawterm.bin
       makeWrapper ${pulseaudio}/bin/padsp $out/bin/drawterm --add-flags $out/bin/drawterm.bin
-     '';
-  }."${config}" or (throw "unsupported CONF")  + ''
-      installManPage drawterm.1
+    '';
+  }."${config}" or (throw "unsupported CONF") + ''
+    installManPage drawterm.1
   '';
-
 
   meta = with lib; {
     description = "Connect to Plan 9 CPU servers from other operating systems.";


### PR DESCRIPTION
###### Description of changes

Turn on strictDeps and enableParallelBuilding. This ends up being quite a large speedup for building drawterm specifically.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
