### PR TITLE
fix python relax deps hook

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
@@ -41,6 +41,8 @@
 #
 # Currently unsupported: URL specs (foo @ https://example.com/a.zip).
 
+echo "Sourcing python-relax-deps-hook.sh"
+
 _pythonRelaxDeps() {
     local -r metadata_file="$1"
 

--- a/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
@@ -83,7 +83,7 @@ pythonRelaxDepsHook() {
     local -r metadata_file="$unpack_dir/$pkg_name/$pkg_name.dist-info/METADATA"
 
     # We generally shouldn't have multiple wheel files, but let's be safer here
-    for wheel in "$pkg_name"*".whl"; do
+    while IFS= read -r -d '' wheel; do
         @pythonInterpreter@ -m wheel unpack --dest "$unpack_dir" "$wheel"
         rm -rf "$wheel"
 
@@ -96,7 +96,7 @@ pythonRelaxDepsHook() {
         fi
 
         @pythonInterpreter@ -m wheel pack "$unpack_dir/$pkg_name"
-    done
+    done <   <(find . -type f -name "$pkg_name*.whl" -print0)
 
     # Remove the folder since it will otherwise be in the dist output.
     rm -rf "$unpack_dir"


### PR DESCRIPTION
- python/hooks: fix python-relax-deps-hook
- python/hooks: add sourcing notice to python-relax-deps-hook

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Not notifying the hook was sourced while silently not working implies an unnecessary debugging detour; fix it and notify the hook was sourced.
- Globbing is brittle and stopped working; use proper `find` command [(`shellcheck`ed :heavy_check_mark:)](https://www.shellcheck.net/wiki/SC2044).

###### Things done

- [ ] Tested a private package making use of `pythonRelaxDepsHook` and while it did not work prior to this PR, it now works.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
