### PR TITLE
bloodhound: init at 4.3.1

### DIFF
--- a/pkgs/applications/misc/bloodhound/default.nix
+++ b/pkgs/applications/misc/bloodhound/default.nix
@@ -1,0 +1,127 @@
+{ lib
+, stdenv
+, fetchzip
+, makeWrapper
+, alsa-lib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gtk3
+, libGL
+, libappindicator-gtk3
+, libdrm
+, libnotify
+, libpulseaudio
+, libuuid
+, libxcb
+, libxkbcommon
+, libxshmfence
+, mesa
+, nspr
+, nss
+, pango
+, systemd
+, udev
+, unzip
+, xdg-utils
+, xorg
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bloodhound";
+  version = "4.3.1";
+
+  src = fetchzip {
+    url = "https://github.com/BloodHoundAD/BloodHound/releases/download/v${finalAttrs.version}/BloodHound-linux-x64.zip";
+    hash = "sha256-gGfZ5Mj8rmz3dwKyOitRExkgOmSVDOqKpPxvGlE4izw=";
+  };
+
+  rpath = lib.makeLibraryPath [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libGL
+    libappindicator-gtk3
+    libdrm
+    libnotify
+    libpulseaudio
+    libuuid
+    libxcb
+    libxkbcommon
+    mesa
+    nspr
+    nss
+    pango
+    systemd
+    stdenv.cc.cc.lib
+    udev
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libxkbfile
+    xorg.libxshmfence
+  ];
+
+  buildInputs = [
+    gtk3 # needed for GSETTINGS_SCHEMAS_PATH
+  ];
+
+  nativeBuildInputs = [ makeWrapper unzip ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,/lib/BloodHound}
+    mv * $out/lib/BloodHound
+    chmod +x $out/lib/BloodHound/BloodHound
+
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+       $out/lib/BloodHound/BloodHound --set-rpath ${finalAttrs.rpath}:$out/lib/BloodHound \
+       --add-needed libudev.so # Needed to fix trace trap (core dump)
+
+    makeWrapper $out/lib/BloodHound/BloodHound $out/bin/BloodHound \
+      --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH \
+      --suffix PATH : ${lib.makeBinPath [xdg-utils]} \
+      --append-flags "--in-process-gpu" # fix for sandbox issues
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Active Directory reconnaissance and attack path management tool";
+    homepage = "https://github.com/BloodHoundAD/BloodHound";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    changelog = "https://github.com/BloodHoundAD/BloodHound/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/BloodHoundAD/BloodHound/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ akechishiro ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "BloodHound";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30313,6 +30313,8 @@ with pkgs;
 
   blogc = callPackage ../applications/misc/blogc { };
 
+  bloodhound = callPackage ../applications/misc/bloodhound { };
+
   blucontrol = callPackage ../applications/misc/blucontrol/wrapper.nix {
     inherit (haskellPackages) ghcWithPackages;
   };


### PR DESCRIPTION
###### Description of changes
Continuation of #164043, bumped version to 4.3.1 (latest stable release) and rebase on Nixpkgs.

Change maintainer to myself as I'll be using this package, previous maintainer, looked like he was missing and not responding.

This latest stable release is affected by this bug : https://github.com/BloodHoundAD/BloodHound/issues/590
Version 4.2.0 is not affected.

> **Note**
A workaround mentioned here works for 4.3.1 : https://github.com/Automattic/simplenote-electron/issues/3044#issuecomment-1333893363, when launching the binary use `--in-gpu-process`, if it fails use `--disable-gpu-sandbox` and if all else fails, then use `--no-sandbox`, these option have negative security impact.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
