### PR TITLE
qrca: init at unstable-2023-07-08

### DIFF
--- a/pkgs/applications/misc/qrca/default.nix
+++ b/pkgs/applications/misc/qrca/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, qtquickcontrols2
+, wrapQtAppsHook
+, extra-cmake-modules
+, kirigami2
+, prison
+, networkmanager-qt
+, ki18n
+, kcontacts
+, knotifications
+, kpurpose
+, kio
+, kservice
+, unstableGitUpdater
+, gst_all_1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qrca";
+  version = "unstable-2023-07-08";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "utilities";
+    repo = "qrca";
+    rev = "c1024e9c6de76b42d4359db8b0e9e9af2e95052b";
+    hash = "sha256-f6mliSJ+0Vmp2jTcIdytQ6IcSe0eEzuhjGS36QiqGFk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    qtquickcontrols2
+    kirigami2
+    prison
+    ki18n
+    kcontacts
+    knotifications
+    kpurpose
+    kio
+    kservice
+    networkmanager-qt
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+  ]);
+
+  preFixup = ''
+    # add gstreamer plugins path to the wrapper
+    qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+  '';
+
+  passthru.updateScript = unstableGitUpdater {};
+
+  meta = with lib; {
+    description = "QR code scanner for Plasma Mobile";
+    homepage = "https://invent.kde.org/utilities/qrca";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ squalus ];
+    platforms = platforms.linux;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41303,4 +41303,6 @@ with pkgs;
   waylyrics = callPackage ../applications/audio/waylyrics { };
 
   gitrs = callPackage ../tools/misc/gitrs { };
+
+  qrca = libsForQt5.callPackage ../applications/misc/qrca { };
 }


### PR DESCRIPTION
###### Description of changes

Add the qrca package.

qrca is a QR code scanner for Plasma Mobile.

Manually tested functionality on NixOS x86-64-linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
