### PR TITLE
apparmor: add some policies and improve abstractions and utils

### DIFF
--- a/nixos/modules/security/apparmor/includes.nix
+++ b/nixos/modules/security/apparmor/includes.nix
@@ -279,6 +279,8 @@ config.security.apparmor.includes = {
     r /var/lib/acme/*/chain.pem,
     r /var/lib/acme/*/fullchain.pem,
 
+    r /etc/pki/tls/certs/,
+
     '' + lib.concatMapStringsSep "\n" etcRule [
       "ssl/certs/ca-certificates.crt"
       "ssl/certs/ca-bundle.crt"

--- a/nixos/modules/security/apparmor/includes.nix
+++ b/nixos/modules/security/apparmor/includes.nix
@@ -72,7 +72,7 @@ config.security.apparmor.includes = {
 
     # bash inspects filesystems at startup
     # and /etc/mtab is linked to /proc/mounts
-    @{PROC}/mounts
+    r @{PROC}/mounts,
 
     # system-wide bash configuration
     '' + lib.concatMapStringsSep "\n" etcRule [

--- a/nixos/modules/security/apparmor/includes.nix
+++ b/nixos/modules/security/apparmor/includes.nix
@@ -62,7 +62,7 @@ config.security.apparmor.includes = {
     include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/base"
     r ${pkgs.stdenv.cc.libc}/share/locale/**,
     r ${pkgs.stdenv.cc.libc}/share/locale.alias,
-    ${lib.optionalString (pkgs.glibcLocales != null) "r ${pkgs.glibcLocales}/lib/locale/locale-archive,"}
+    r ${config.i18n.glibcLocales}/lib/locale/locale-archive,
     ${etcRule "localtime"}
     r ${pkgs.tzdata}/share/zoneinfo/**,
     r ${pkgs.stdenv.cc.libc}/share/i18n/**,

--- a/nixos/modules/security/apparmor/includes.nix
+++ b/nixos/modules/security/apparmor/includes.nix
@@ -211,6 +211,9 @@ config.security.apparmor.includes = {
   "abstractions/nis" = ''
     include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/nis"
   '';
+  "abstractions/nss-systemd" = ''
+    include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/nss-systemd"
+  '';
   "abstractions/nvidia" = ''
     include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/nvidia"
     ${etcRule "vdpau_wrapper.cfg"}

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -355,5 +355,37 @@ in
       '';
       destination = "/share/dbus-1/system.d/murmur.conf";
     })];
+
+    security.apparmor.policies."bin.mumble-server".profile = ''
+      include <tunables/global>
+
+      ${cfg.package}/bin/{mumble-server,.mumble-server-wrapped} {
+        include <abstractions/base>
+        include <abstractions/nameservice>
+        include <abstractions/ssl_certs>
+        include "${pkgs.apparmorRulesFromClosure { name = "mumble-server"; } cfg.package}"
+        pix ${cfg.package}/bin/.mumble-server-wrapped,
+
+        r ${config.environment.etc."os-release".source},
+        r ${config.environment.etc."lsb-release".source},
+        owner rwk /var/lib/murmur/murmur.sqlite,
+        owner rw /var/lib/murmur/murmur.sqlite-journal,
+        owner r /var/lib/murmur/,
+        r /run/murmur/murmurd.pid,
+        r /run/murmur/murmurd.ini,
+        r ${configFile},
+      '' + optionalString (cfg.logFile != null) ''
+        rw ${cfg.logFile},
+      '' + optionalString (cfg.sslCert != "") ''
+        r ${cfg.sslCert},
+      '' + optionalString (cfg.sslKey != "") ''
+        r ${cfg.sslKey},
+      '' + optionalString (cfg.sslCa != "") ''
+        r ${cfg.sslCa},
+      '' + optionalString (cfg.dbus != null) ''
+        dbus bus=${cfg.dbus}
+      '' + ''
+      }
+    '';
   };
 }

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -130,5 +130,17 @@ in
       environment = cfg.config;
     };
     environment.systemPackages = [ cfg.package ];
+
+    security.apparmor.policies."bin.miniflux".profile = ''
+      include <tunables/global>
+      ${cfg.package}/bin/miniflux {
+        include <abstractions/base>
+        include <abstractions/nameservice>
+        include <abstractions/ssl_certs>
+        include "${pkgs.apparmorRulesFromClosure { name = "miniflux"; } cfg.package}"
+        r ${cfg.package}/bin/miniflux,
+        r @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size,
+      }
+    '';
   };
 }

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -25,6 +25,7 @@ in
     default =
       { ... }:
       {
+        security.apparmor.enable = true;
         services.miniflux = {
           enable = true;
           inherit adminCredentialsFile;
@@ -34,6 +35,7 @@ in
     withoutSudo =
       { ... }:
       {
+        security.apparmor.enable = true;
         services.miniflux = {
           enable = true;
           inherit adminCredentialsFile;
@@ -44,6 +46,7 @@ in
     customized =
       { ... }:
       {
+        security.apparmor.enable = true;
         services.miniflux = {
           enable = true;
           config = {
@@ -63,6 +66,7 @@ in
     default.succeed(
         "curl 'http://localhost:${toString defaultPort}/v1/me' -u '${defaultUsername}:${defaultPassword}' -H Content-Type:application/json | grep '\"is_admin\":true'"
     )
+    default.fail('journalctl -b --no-pager --grep "^audit: .*apparmor=\\"DENIED\\""')
 
     withoutSudo.wait_for_unit("miniflux.service")
     withoutSudo.wait_for_open_port(${toString defaultPort})
@@ -70,6 +74,7 @@ in
     withoutSudo.succeed(
         "curl 'http://localhost:${toString defaultPort}/v1/me' -u '${defaultUsername}:${defaultPassword}' -H Content-Type:application/json | grep '\"is_admin\":true'"
     )
+    withoutSudo.fail('journalctl -b --no-pager --grep "^audit: .*apparmor=\\"DENIED\\""')
 
     customized.wait_for_unit("miniflux.service")
     customized.wait_for_open_port(${toString port})
@@ -77,5 +82,6 @@ in
     customized.succeed(
         "curl 'http://localhost:${toString port}/v1/me' -u '${username}:${password}' -H Content-Type:application/json | grep '\"is_admin\":true'"
     )
+    customized.fail('journalctl -b --no-pager --grep "^audit: .*apparmor=\\"DENIED\\""')
   '';
 })

--- a/nixos/tests/mumble.nix
+++ b/nixos/tests/mumble.nix
@@ -20,6 +20,7 @@ in
 
   nodes = {
     server = { config, ... }: {
+      security.apparmor.enable = true;
       services.murmur.enable = true;
       services.murmur.registerName = "NixOS tests";
       services.murmur.password = "$MURMURD_PASSWORD";
@@ -81,5 +82,8 @@ in
     server.sleep(5)  # wait to get screenshot
     client1.screenshot("screen1")
     client2.screenshot("screen2")
+
+    # check if apparmor denied anything
+    server.fail('journalctl -b --no-pager --grep "^audit: .*apparmor=\\"DENIED\\""')
   '';
 })

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -128,9 +128,10 @@ let
     meta = apparmor-meta "library";
   };
 
-  apparmor-utils = stdenv.mkDerivation {
+  apparmor-utils = python.pkgs.buildPythonApplication {
     pname = "apparmor-utils";
     version = apparmor-version;
+    format = "other";
 
     src = apparmor-sources;
 
@@ -146,14 +147,25 @@ let
       libapparmor.python
     ];
 
+    propagatedBuildInputs = [
+      libapparmor.python
+
+      # Used by aa-notify
+      python.pkgs.notify2
+      python.pkgs.psutil
+    ];
+
     prePatch = prePatchCommon +
       # Do not build vim file
       lib.optionalString stdenv.hostPlatform.isMusl ''
         sed -i ./utils/Makefile -e "/\<vim\>/d"
       '' + ''
-      for file in utils/apparmor/easyprof.py utils/apparmor/aa.py utils/logprof.conf; do
-        substituteInPlace $file --replace "/sbin/apparmor_parser" "${apparmor-parser}/bin/apparmor_parser"
-      done
+      sed -i -E 's/^(DESTDIR|BINDIR|PYPREFIX)=.*//g' ./utils/Makefile
+
+      sed -i utils/aa-unconfined -e "/my_env\['PATH'\]/d"
+
+      substituteInPlace utils/aa-remove-unknown \
+       --replace "/lib/apparmor/rc.apparmor.functions" "${apparmor-parser}/lib/apparmor/rc.apparmor.functions"
     '';
     inherit patches;
     postPatch = "cd ./utils";
@@ -161,17 +173,6 @@ let
     installFlags = [ "DESTDIR=$(out)" "BINDIR=$(out)/bin" "VIM_INSTALL_PATH=$(out)/share" "PYPREFIX=" ];
 
     postInstall = ''
-      sed -i $out/bin/aa-unconfined -e "/my_env\['PATH'\]/d"
-      for prog in aa-audit aa-autodep aa-cleanprof aa-complain aa-disable aa-enforce aa-genprof aa-logprof aa-mergeprof aa-unconfined ; do
-        wrapProgram $out/bin/$prog --prefix PYTHONPATH : "$out/lib/${python.sitePackages}:$PYTHONPATH"
-      done
-
-      substituteInPlace $out/bin/aa-notify \
-        --replace /usr/bin/notify-send ${libnotify}/bin/notify-send \
-        --replace /usr/bin/perl "${perl}/bin/perl -I ${libapparmor}/${perl.libPrefix}"
-
-      substituteInPlace $out/bin/aa-remove-unknown \
-       --replace "/lib/apparmor/rc.apparmor.functions" "${apparmor-parser}/lib/apparmor/rc.apparmor.functions"
       wrapProgram $out/bin/aa-remove-unknown \
        --prefix PATH : ${lib.makeBinPath [ gawk ]}
 


### PR DESCRIPTION
###### Description of changes

Initially I wanted to understand how apparmor works and use it to add sandboxing to miniflux.

There are not yet many applications/services with apparmor policies in nixpkgs and there are a few rough edges around using apparmor on nixos. I hope this PR makes it easier to add more policies in the future.

What is in this PR?
- Fix issues encountered in the abstractions. They can be found in nixos/modules/security/apparmor/includes.nix
- Make the tools mentioned in https://github.com/NixOS/nixpkgs/issues/169056 not crash with import errors. Because of differences in filesystem hirachy (ubuntu <-> nixos) their usefulness might still be limited, but it is an improvement.
- Add apparmor policies for miniflux and murmur and enable apparmor in their nixosTests

I ran the relevant nixosTests and am using the policies on my server.

Should this PR be too big, please let me know, so I can break it up.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
