### PR TITLE
nixos-rebuild: Add `nixos-rebuild repl`

### DIFF
--- a/nixos/doc/manual/installation/changing-config.chapter.md
+++ b/nixos/doc/manual/installation/changing-config.chapter.md
@@ -55,6 +55,14 @@ which causes the new configuration (and previous ones created using
 This can be useful to separate test configurations from "stable"
 configurations.
 
+A repl, or read-eval-print loop, is also available. You can inspect your configuration and use the Nix language with
+
+```ShellSession
+# nixos-rebuild repl
+```
+
+Your configuration is loaded into the `config` variable. Use tab for autocompletion, use the `:r` command to reload the configuration files. See `:?` or [`nix repl` in the Nix manual](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-repl.html) to learn more.
+
 Finally, you can do
 
 ```ShellSession

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -10,7 +10,7 @@
 .Sh SYNOPSIS
 .Nm
 .Bro
-.Cm switch | boot | test | build | dry-build | dry-activate | edit | build-vm | build-vm-with-bootloader | list-generations Op Fl -json
+.Cm switch | boot | test | build | dry-build | dry-activate | edit | repl | build-vm | build-vm-with-bootloader | list-generations Op Fl -json
 .Brc
 .br
 .Op Fl -upgrade | -upgrade-all
@@ -142,6 +142,10 @@ The list of changes is not guaranteed to be complete.
 Opens
 .Pa configuration.nix
 in the default editor.
+.
+.It Cm repl
+Opens the configuration in
+.Ic nix repl Ns .
 .
 .It Cm build-vm
 Build a script that starts a NixOS virtual machine with the desired

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -49,7 +49,7 @@ while [ "$#" -gt 0 ]; do
       --help)
         showSyntax
         ;;
-      switch|boot|test|build|edit|dry-build|dry-run|dry-activate|build-vm|build-vm-with-bootloader|list-generations)
+      switch|boot|test|build|edit|repl|dry-build|dry-run|dry-activate|build-vm|build-vm-with-bootloader|list-generations)
         if [ "$i" = dry-run ]; then i=dry-build; fi
         # exactly one action mandatory, bail out if multiple are given
         if [ -n "$action" ]; then showSyntax; fi
@@ -509,6 +509,68 @@ fi
 
 if [ "$action" = dry-build ]; then
     extraBuildFlags+=(--dry-run)
+fi
+
+if [ "$action" = repl ]; then
+    # This is a very end user command, implemented using sub-optimal means.
+    # You should feel free to improve its behavior, as well as resolve tech
+    # debt in "breaking" ways. Humans adapt quite well.
+    if [[ -z $flake ]]; then
+        exec nix repl '<nixpkgs/nixos>' "${extraBuildFlags[@]}"
+    else
+        if [[ -n "${lockFlags[0]}" ]]; then
+            # nix repl itself does not support locking flags
+            log "nixos-rebuild repl does not support locking flags yet"
+            exit 1
+        fi
+        d='$'
+        q='"'
+        bold="$(echo -e '\033[1m')"
+        blue="$(echo -e '\033[34;1m')"
+        attention="$(echo -e '\033[35;1m')"
+        reset="$(echo -e '\033[0m')"
+        # This nix repl invocation is impure, because usually the flakeref is.
+        # For a solution that preserves the motd and custom scope, we need
+        # something like https://github.com/NixOS/nix/issues/8679.
+        exec nix repl --impure --expr "
+          let flake = builtins.getFlake ''$flake'';
+              configuration = flake.$flakeAttr;
+              motd = ''
+                $d{$q\n$q}
+                Hello and welcome to the NixOS configuration
+                    $flakeAttr
+                    in $flake
+
+                The following is loaded into nix repl's scope:
+
+                    - ${blue}config${reset}   All option values
+                    - ${blue}options${reset}  Option data and metadata
+                    - ${blue}pkgs${reset}     Nixpkgs package set
+                    - other module arguments
+
+                    - ${blue}flake${reset}    Flake outputs, inputs and source info of $flake
+
+                Use tab completion to browse around ${blue}config${reset}.
+
+                Use ${bold}:r${reset} to ${bold}reload${reset} everything after making a change in the flake.
+                  (assuming $flake is a mutable flake ref)
+
+                See ${bold}:?${reset} for more repl commands.
+
+                ${attention}warning:${reset} nixos-rebuild repl does not currently enforce pure evaluation.
+              '';
+              scope =
+                assert configuration._type or null == ''configuration'';
+                assert configuration.class or ''nixos'' == ''nixos'';
+                configuration._module.args //
+                configuration._module.specialArgs //
+                {
+                  inherit (configuration) config options;
+                  inherit flake;
+                };
+          in builtins.seq scope builtins.trace motd scope
+        " "${extraBuildFlags[@]}"
+    fi
 fi
 
 if [ "$action" = list-generations ]; then


### PR DESCRIPTION
###### Description of changes

Add `nixos-rebuild repl`, which loads a `nix repl` for you.

If you use flakes, brings the flake itself into scope as well.

Apologies to the non-flake users; your repl isn't quite as fancy, but at least evaluates your config exactly as you would expect, unlike flakes which are only evaluated impurely for now.

Tested by hand, as evaluating in the sandbox is tricky.

**Try it**

Flake in `~/config`

```console
nix run github:hercules-ci/nixpkgs/nixos-rebuild-repl#nixos-rebuild -- repl --flake ~/config
```

Non-flake

```console
nix --extra-experimental-features flakes\ nix-command run github:hercules-ci/nixpkgs/nixos-rebuild-repl#nixos-rebuild -- repl
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
