### PR TITLE
jetbrains: add support for plugins on darwin 

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/darwin.nix
+++ b/pkgs/applications/editors/jetbrains/bin/darwin.nix
@@ -19,8 +19,10 @@ let
   loname = lib.toLower productShort;
 in
 stdenvNoCC.mkDerivation {
-  inherit pname meta src version plugins;
+  inherit pname src version plugins;
   passthru.buildNumber = buildNumber;
+  passthru.product = product;
+  meta = meta // { mainProgram = loname; };
   desktopName = product;
   dontFixup = true;
   installPhase = ''

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -90,23 +90,33 @@ in {
       passthru.plugins = plugins ++ (ide.plugins or [ ]);
       newPlugins = plugins;
       disallowedReferences = [ ide ];
-      nativeBuildInputs = [ autoPatchelfHook ] ++ (ide.nativeBuildInputs or [ ]);
+      nativeBuildInputs = (lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook) ++ (ide.nativeBuildInputs or [ ]);
       buildInputs = lib.unique ((ide.buildInputs or [ ]) ++ [ glib ]);
 
       inherit (ide) meta;
 
-      buildPhase = ''
+      buildPhase =
+      let
+        rootDir = if stdenv.hostPlatform.isDarwin then "Applications/${ide.product}.app/Contents" else meta.mainProgram;
+      in
+      ''
         cp -r ${ide} $out
         chmod +w -R $out
-        rm -f $out/${meta.mainProgram}/plugins/plugin-classpath.txt
+        rm -f $out/${rootDir}/plugins/plugin-classpath.txt
         IFS=' ' read -ra pluginArray <<< "$newPlugins"
         for plugin in "''${pluginArray[@]}"
         do
-          ln -s "$plugin" -t $out/${meta.mainProgram}/plugins/
+          ln -s "$plugin" -t "$out/${rootDir}/plugins/"
         done
         sed "s|${ide.outPath}|$out|" \
-          -i $(realpath $out/bin/${meta.mainProgram}) \
-          -i $(realpath $out/bin/${meta.mainProgram}-remote-dev-server)
+          -i $(realpath $out/bin/${meta.mainProgram})
+
+        if test -f "$out/bin/${meta.mainProgram}-remote-dev-server"; then
+          sed "s|${ide.outPath}|$out|" \
+            -i $(realpath $out/bin/${meta.mainProgram}-remote-dev-server)
+        fi
+
+      '' + lib.optionalString stdenv.hostPlatform.isLinux ''
         autoPatchelf $out
       '';
     };

--- a/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
@@ -4,17 +4,17 @@
 {
   "631" = {
     # Python
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
     buildInputs = [ stdenv.cc.cc.lib ];
   };
   "7322" = {
     # Python community edition
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
     buildInputs = [ stdenv.cc.cc.lib ];
   };
   "8182" = {
     # Rust (deprecated)
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
     buildInputs = [ stdenv.cc.cc.lib ];
     buildPhase = ''
       runHook preBuild
@@ -65,7 +65,7 @@
   };
   "22407" = {
     # Rust
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
     buildInputs = [ stdenv.cc.cc.lib ];
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
###### Description of changes
This change fixes up support for installing plugins with JetBrains IDEs on macOS. Presently on master, this falls with the following:
```
error: attribute 'mainProgram' missing

       at /nix/store/apa072dsj782n2r23his9y40nm8nkkrm-source/pkgs/applications/editors/jetbrains/plugins/default.nix:84:15:

           83|     stdenv.mkDerivation rec {
           84|       pname = meta.mainProgram + "-with-plugins";
             |               ^
           85|       version = ide.version;
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
