### PR TITLE
spotify: 1.1.97.962.g24733a46 -> 1.2.15.828.g79f41970

### DIFF
--- a/pkgs/applications/audio/spotify/darwin.nix
+++ b/pkgs/applications/audio/spotify/darwin.nix
@@ -9,17 +9,17 @@
 stdenv.mkDerivation {
   inherit pname;
 
-  version = "1.1.97.962.g24733a46";
+  version = "1.2.15.828.g79f41970";
 
   src = if stdenv.isAarch64 then (
     fetchurl {
-      url = "https://web.archive.org/web/20221101120432/https://download.scdn.co/SpotifyARM64.dmg";
-      sha256 = "sha256-8WDeVRgaZXuUa95PNa15Cuul95ynklBaZpuq+U1eGTU=";
+      url = "https://web.archive.org/web/20230710021420/https://download.scdn.co/SpotifyARM64.dmg";
+      sha256 = "sha256-1X0Mln47uYs5l1t+5BFBk5lLnXZgnSqZLX41yA91I0s=";
     })
   else (
     fetchurl {
-      url = "https://web.archive.org/web/20221101120647/https://download.scdn.co/Spotify.dmg";
-      sha256 = "sha256-uPpD8Hv70FlaSjtt9rq5ntI64agxG8+/LNEvRe4ocJ4=";
+      url = "https://web.archive.org/web/20230710021726/https://download.scdn.co/Spotify.dmg";
+      sha256 = "sha256-CmKZx8Ad0w6STBN0O4Sc4XqidOM6fCl74u2sI8w+Swk=";
     });
 
   nativeBuildInputs = [ undmg ];


### PR DESCRIPTION
###### Description of changes
Updates Spotify to 1.2.15.828.g79f41970 for Darwin.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
