### PR TITLE
treewide: allow binding to localhost on darwin

### DIFF
--- a/pkgs/development/python-modules/flower/default.nix
+++ b/pkgs/development/python-modules/flower/default.nix
@@ -33,6 +33,8 @@ buildPythonPackage rec {
     tornado
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/google-nest-sdm/default.nix
+++ b/pkgs/development/python-modules/google-nest-sdm/default.nix
@@ -37,6 +37,8 @@ buildPythonPackage rec {
     requests-oauthlib
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     coreutils
     pytest-aiohttp

--- a/pkgs/development/python-modules/influxdb/default.nix
+++ b/pkgs/development/python-modules/influxdb/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
     msgpack
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
     requests-mock

--- a/pkgs/development/python-modules/mechanicalsoup/default.nix
+++ b/pkgs/development/python-modules/mechanicalsoup/default.nix
@@ -39,6 +39,8 @@ buildPythonPackage rec {
     requests
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytest-httpbin
     pytest-mock

--- a/pkgs/development/python-modules/pyrainbird/default.nix
+++ b/pkgs/development/python-modules/pyrainbird/default.nix
@@ -52,6 +52,8 @@ buildPythonPackage rec {
     requests
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     freezegun
     parameterized

--- a/pkgs/development/python-modules/pytest-base-url/default.nix
+++ b/pkgs/development/python-modules/pytest-base-url/default.nix
@@ -35,6 +35,8 @@ buildPythonPackage rec {
     requests
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
     pytest-localserver

--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -33,6 +33,8 @@ buildPythonPackage rec {
   buildInputs = [ mock ];
   propagatedBuildInputs = [ pbr pyyaml setuptools six multi_key_dict requests ];
 
+  __darwinAllowLocalNetworking = true;
+
    nativeCheckInputs = [ stestr testscenarios requests-mock ];
    checkPhase = ''
      # Skip tests that fail due to setuptools>=66.0.0 rejecting PEP 440

--- a/pkgs/development/python-modules/qcodes/default.nix
+++ b/pkgs/development/python-modules/qcodes/default.nix
@@ -100,6 +100,8 @@ buildPythonPackage rec {
     ];
   };
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
     deepdiff

--- a/pkgs/development/python-modules/softlayer/default.nix
+++ b/pkgs/development/python-modules/softlayer/default.nix
@@ -49,6 +49,8 @@ buildPythonPackage rec {
     urllib3
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     mock
     pytestCheckHook


### PR DESCRIPTION
###### Description of changes

When running nixpkgs-review on macOS with the sandbox enabled, I stumbled across several packages that need to connect to localhost in their tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
