### PR TITLE
streamlit: 1.24.0 -> 1.24.1; move to python-modules

### DIFF
--- a/pkgs/development/python-modules/streamlit/default.nix
+++ b/pkgs/development/python-modules/streamlit/default.nix
@@ -27,12 +27,12 @@
 
 buildPythonPackage rec {
   pname = "streamlit";
-  version = "1.24.0";
+  version = "1.24.1";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version format;
-    hash = "sha256-NSX6zpTHh5JzPFbWOja0iEUVDjume7UKGa20xZdagiU=";
+    hash = "sha256-/V8LZHmOlwY2RAj7WJt3WVMUpjFdE7LXULljx66X82I=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/streamlit/default.nix
+++ b/pkgs/development/python-modules/streamlit/default.nix
@@ -1,7 +1,7 @@
 { lib
 , altair
 , blinker
-, buildPythonApplication
+, buildPythonPackage
 , cachetools
 , click
 , fetchPypi
@@ -25,7 +25,7 @@
 , watchdog
 }:
 
-buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "streamlit";
   version = "1.24.0";
   format = "setuptools";

--- a/pkgs/development/python-modules/streamlit/default.nix
+++ b/pkgs/development/python-modules/streamlit/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , altair
 , blinker
 , buildPythonPackage
@@ -7,19 +8,21 @@
 , fetchPypi
 , gitpython
 , importlib-metadata
-, jinja2
+, numpy
+, packaging
+, pandas
 , pillow
 , protobuf3
 , pyarrow
 , pydeck
 , pympler
+, python-dateutil
+, pythonOlder
 , requests
 , rich
-, semver
-, setuptools
 , tenacity
 , toml
-, tornado
+, typing-extensions
 , tzlocal
 , validators
 , watchdog
@@ -29,6 +32,8 @@ buildPythonPackage rec {
   pname = "streamlit";
   version = "1.24.1";
   format = "setuptools";
+
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version format;
@@ -42,21 +47,23 @@ buildPythonPackage rec {
     click
     gitpython
     importlib-metadata
-    jinja2
+    numpy
+    packaging
+    pandas
     pillow
     protobuf3
     pyarrow
     pydeck
     pympler
+    python-dateutil
     requests
     rich
-    semver
-    setuptools
     tenacity
     toml
-    tornado
+    typing-extensions
     tzlocal
     validators
+  ] ++ lib.optionals (!stdenv.isDarwin) [
     watchdog
   ];
 

--- a/pkgs/development/python-modules/streamlit/default.nix
+++ b/pkgs/development/python-modules/streamlit/default.nix
@@ -82,7 +82,7 @@ buildPythonPackage rec {
     homepage = "https://streamlit.io/";
     changelog = "https://github.com/streamlit/streamlit/releases/tag/${version}";
     description = "The fastest way to build custom ML tools";
-    maintainers = with maintainers; [ yrashk ];
+    maintainers = with maintainers; [ natsukium yrashk ];
     license = licenses.asl20;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38022,8 +38022,6 @@ with pkgs;
 
   stone-kingdoms = callPackage ../games/stone-kingdoms { };
 
-  streamlit = python3Packages.callPackage ../applications/science/machine-learning/streamlit { };
-
   stt = callPackage ../tools/audio/stt { };
 
   stuntrally = callPackage ../games/stuntrally
@@ -38757,6 +38755,8 @@ with pkgs;
   nengo-gui = callPackage ../applications/science/machine-learning/nengo-gui { };
 
   sc2-headless = callPackage ../applications/science/machine-learning/sc2-headless { };
+
+  streamlit = with python3Packages; toPythonApplication streamlit;
 
   uarmsolver = callPackage ../applications/science/machine-learning/uarmsolver { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12170,6 +12170,8 @@ self: super: with self; {
 
   streamlabswater = callPackage ../development/python-modules/streamlabswater { };
 
+  streamlit = callPackage ../development/python-modules/streamlit { };
+
   streamz = callPackage ../development/python-modules/streamz { };
 
   strenum =  callPackage ../development/python-modules/strenum { };


### PR DESCRIPTION
###### Description of changes

Changelog: https://github.com/streamlit/streamlit/releases/tag/1.24.1

As [this comment](https://github.com/NixOS/nixpkgs/pull/226329#issue-1669545038) suggests, streamlit is more valuable as a library than a standalone application.

I decided to keep streamlit at the top-level and manage it as python-modules.

The concern in [this comment](https://github.com/NixOS/nixpkgs/pull/226329#issuecomment-1513629805) was addressed by running the following tutorial.
https://docs.streamlit.io/library/get-started/create-an-app#lets-put-it-all-together

cc @risicle @felschr 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
