### PR TITLE
mprime-primenet: init at 30.19

### DIFF
--- a/pkgs/by-name/mp/mprime-primenet/package.nix
+++ b/pkgs/by-name/mp/mprime-primenet/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  gmp,
+}:
+
+# This package provides patched versions of release builds instead of building
+# from source because mprime can only be used to run workers for primenet
+# using the official mprime release builds. Binaries of mprime built from
+# source are only capable of local operation.
+
+let
+
+  throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  version = "30.19b14";
+
+  target =
+    {
+      "x86_64-linux" = "linux64";
+      "x86_64-darwin" = "MacOSX";
+    }
+    ."${stdenv.hostPlatform.system}" or throwSystem;
+
+  sha256 =
+    {
+      "x86_64-linux" = "ccd48d2ceebfe583003dbf8ff1dca8d744e98bf7ed4124e482bd6a3a06eaf507";
+      "x86_64-darwin" = "520dbf6e6dbd6184626bfae02e8e2d8ba4d4ab081d138a73a3852f08ece1ea6a";
+    }
+    ."${stdenv.hostPlatform.system}" or throwSystem;
+
+  tarballName = "p95v${lib.replaceStrings [ "." ] [ "" ] version}.${target}.tar.gz";
+
+  tarball = fetchurl {
+    url = "https://www.mersenne.org/download/software/v30/30.19/${tarballName}";
+    inherit sha256;
+  };
+
+in
+
+stdenv.mkDerivation {
+  pname = "mprime-primenet";
+  inherit version;
+
+  # src handled in non-standard way to allow for the hashes for fetchurl of the
+  # tarballs to match the checksums published on mersenne.org
+  src = tarball;
+  unpackPhase = ''
+    cp $src $(echo $src | cut --delimiter=- --fields=2-)
+  '';
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    gmp
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    tar -xf ${tarballName}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m755 -D mprime $out/bin/mprime
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Mersenne prime search / System stability tester";
+    longDescription = ''
+      MPrime is the Linux command-line interface version of Prime95, to be run
+      in a text terminal or in a terminal emulator window as a remote shell
+      client. It is identical to Prime95 in functionality, except it lacks a
+      graphical user interface.
+    '';
+    homepage = "https://www.mersenne.org/";
+    # Unfree, because of a license requirement to share prize money if you find
+    # a suitable prime. http://www.mersenne.org/legal/#EULA
+    license = licenses.unfree;
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
+    maintainers = with maintainers; [ cameronfyfe ];
+    mainProgram = "mprime";
+  };
+}


### PR DESCRIPTION
###### Description of changes

This package adds official release builds for `mprime`. `mprime` is already packaged on nixpkgs but the existing package builds from source which prevents the binary from running workers connected to primenet, which is the easiest way to participate in GIMPS (Great Internet Mersenne Prime Search). I've tested running this with workers connected to primenet on both x86-linux and x86-macos with no issues so far.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
