### PR TITLE
Added missing wgo entry to all-packages.nix

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27923,6 +27923,8 @@ with pkgs;
 
   quicktemplate = callPackage ../development/tools/quicktemplate { };
 
+  wgo = callPackage ../development/tools/wgo { };
+
   linux_logo = callPackage ../tools/misc/linux-logo { };
 
   linux-pam = callPackage ../os-specific/linux/pam { };


### PR DESCRIPTION
###### Description of changes

The all-packages.nix entry for `wgo` was missing from #216141. This PR adds  it.
