### PR TITLE
wildmidi: Enable on Darwin & refactor config, gst-plugins-bad: enable wildmidi on Darwin

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -192,6 +192,7 @@ stdenv.mkDerivation rec {
     libfreeaptx
     zxing-cpp
     usrsctp
+    wildmidi
   ] ++ lib.optionals opencvSupport [
     opencv4
   ] ++ lib.optionals enableZbar [
@@ -212,9 +213,6 @@ stdenv.mkDerivation rec {
     wayland
     wayland-protocols
   ] ++ lib.optionals (!stdenv.isDarwin) [
-    # wildmidi requires apple's OpenAL
-    # TODO: package apple's OpenAL, fix wildmidi, include on Darwin
-    wildmidi
     # TODO: mjpegtools uint64_t is not compatible with guint64 on Darwin
     mjpegtools
 
@@ -318,7 +316,6 @@ stdenv.mkDerivation rec {
     "-Duvch264=disabled" # requires gudev
     "-Dv4l2codecs=disabled" # requires gudev
     "-Dladspa=disabled" # requires lrdf
-    "-Dwildmidi=disabled" # see dependencies above
   ] ++ lib.optionals (!stdenv.isLinux || !stdenv.isx86_64) [
     "-Dqsv=disabled" # Linux (and Windows) x86 only
   ] ++ lib.optionals (!gst-plugins-base.glEnabled) [

--- a/pkgs/development/libraries/wildmidi/default.nix
+++ b/pkgs/development/libraries/wildmidi/default.nix
@@ -1,5 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, cmake, alsa-lib, freepats }:
+{ lib, stdenv, fetchFromGitHub, writeTextFile, cmake, alsa-lib, OpenAL, freepats }:
 
+let
+  defaultCfgPath = "${placeholder "out"}/etc/wildmidi/wildmidi.cfg";
+in
 stdenv.mkDerivation rec {
   pname = "wildmidi";
   version = "0.4.5";
@@ -13,21 +16,34 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ alsa-lib stdenv.cc.libc/*couldn't find libm*/ ];
+  buildInputs = lib.optionals stdenv.buildPlatform.isLinux [
+    alsa-lib stdenv.cc.libc/*couldn't find libm*/
+  ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
+    OpenAL
+  ];
 
   preConfigure = ''
-    substituteInPlace CMakeLists.txt \
-      --replace /etc/wildmidi $out/etc
     # https://github.com/Mindwerks/wildmidi/issues/236
     substituteInPlace src/wildmidi.pc.in \
       --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
       --replace '$'{exec_prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
-  postInstall = ''
-    mkdir "$out"/etc
-    echo "dir ${freepats}" > "$out"/etc/wildmidi.cfg
-    echo "source ${freepats}/freepats.cfg" >> "$out"/etc/wildmidi.cfg
+  cmakeFlags = [
+    "-DWILDMIDI_CFG=${defaultCfgPath}"
+  ];
+
+  postInstall = let
+    defaultCfg = writeTextFile {
+      name = "wildmidi.cfg";
+      text = ''
+        dir ${freepats}
+        source ${freepats}/freepats.cfg
+      '';
+    };
+  in ''
+    mkdir -p "$(dirname ${defaultCfgPath})"
+    ln -s ${defaultCfg} ${defaultCfgPath}
   '';
 
   meta = with lib; {
@@ -39,7 +55,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wildmidi.sourceforge.net/";
     # The library is LGPLv3, the wildmidi executable is GPLv3
     license = licenses.lgpl3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25059,7 +25059,9 @@ with pkgs;
 
   whereami = callPackage ../development/libraries/whereami { };
 
-  wildmidi = callPackage ../development/libraries/wildmidi { };
+  wildmidi = callPackage ../development/libraries/wildmidi {
+    inherit (darwin.apple_sdk.frameworks) OpenAL;
+  };
 
   wiredtiger = callPackage ../development/libraries/wiredtiger { };
 


### PR DESCRIPTION
###### Description of changes

wildmidi:
- enable on Darwin (uses OpenAL framework there)
- refactor default config
  - use `WriteTextFile` and symlink instead of echoing together
  - set `WILDMIDI_CFG` cmake variable instead of patching its default value
  - correct config location
    - default (and now explicitly-set) location is actually /etc/wildmidi/wildmidi.cfg

gst-plugins-bad:
- enable wildmidi on Darwin
  - had comments explaining why wildmidi is Linux-only, which don't apply anymore

![Screenshot_macOS_2023-07-10_11:03:00](https://github.com/NixOS/nixpkgs/assets/23431373/651c08aa-3b9e-405e-96e2-5eb5fe628fe2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
