### PR TITLE
bup: don't error out on implicit-function-declaration on darwin

### DIFF
--- a/pkgs/tools/backup/bup/default.nix
+++ b/pkgs/tools/backup/bup/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation {
     "LIBDIR=$(out)/lib/bup"
   ];
 
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-Wno-error=implicit-function-declaration";
+
   postInstall = ''
     wrapProgram $out/bin/bup \
       --prefix PATH : ${lib.makeBinPath [ git par2cmdline ]} \


### PR DESCRIPTION
Upstream should fix that but this fixes the build on Darwin for now:

```
building
build flags: SHELL=/nix/store/mxvgjwzdvrl81plvgqnzbrqb14ccnji6-bash-5.2-p15/bin/bash MANDIR=\$\(out\)/share/man DOCDIR=\$\(out\)/share/doc/bup BINDIR=\$\(out\)/bin LIBDIR=\$\(out\)/lib/bup
fatal: not a git repository (or any of the parent directories): .git
clang -I/nix/store/2rrfpkq6cr8ppip9szl0z1qfdlskdinq-python3-3.10.12/include/python3.10 -I/nix/store/2rrfpkq6cr8ppip9szl0z1qfdlskdinq-python3-3.10.12/include/python3.10 -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/nix/store/vnn3dp5cyjlknkqxmi29vbg812ml5m7r-libxcrypt-4.4.35/include -Wno-unused-command-line-argument -D_FILE_OFFSET_BITS=64 -Wno-unknown-pragmas -Wsign-compare -O2 -Wall -Werror -Wformat=2 -MMD -MP -D BUP_DEV_BUP_EXEC=1 -I/private/tmp/nix-build-bup-0.33.2.drv-0/source/src -I src  -g lib/cmd/bup.c src/bup/compat.c src/bup/io.c -lpython3.10 -lcrypt -ldl -L/nix/store/vnn3dp5cyjlknkqxmi29vbg812ml5m7r-libxcrypt-4.4.35/lib -framework CoreFoundation  -g -fPIE -o dev/bup-exec
lib/cmd/bup.c:153:14: error: implicit declaration of function '_NSGetExecutablePath' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    int rc = _NSGetExecutablePath(spath, &size);
             ^
1 error generated.
make: *** [GNUmakefile:185: dev/bup-exec] Error 1
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
