### PR TITLE
jsonnet: fix linking issue with libjsonnet++

### DIFF
--- a/pkgs/development/compilers/jsonnet/default.nix
+++ b/pkgs/development/compilers/jsonnet/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "jsonnet";
   version = "0.20.0";
-  outputs = ["out" "doc"];
+  outputs = [ "out" "doc" ];
 
   src = fetchFromGitHub {
     rev = "v${version}";
@@ -15,7 +15,16 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ jekyll cmake ];
   buildInputs = [ gtest ];
 
-  cmakeFlags = ["-DBUILD_STATIC_LIBS=ON" "-DUSE_SYSTEM_GTEST=ON" ];
+  cmakeFlags = [
+    "-DUSE_SYSTEM_GTEST=ON"
+    "-DBUILD_STATIC_LIBS=${if stdenv.hostPlatform.isStatic then "ON" else "OFF"}"
+    "-DBUILD_SHARED_BINARIES=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
+
+  # https://github.com/google/jsonnet/issues/778
+  patches = [
+    ./fix-cpp-unresolved-symbols.patch
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/jsonnet/fix-cpp-unresolved-symbols.patch
+++ b/pkgs/development/compilers/jsonnet/fix-cpp-unresolved-symbols.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
+index 3a52458..872e6c6 100644
+--- a/cpp/CMakeLists.txt
++++ b/cpp/CMakeLists.txt
+@@ -10,6 +10,7 @@ set(LIBJSONNETPP_SOURCE
+
+ add_library(libjsonnet++ SHARED ${LIBJSONNETPP_HEADERS} ${LIBJSONNETPP_SOURCE})
+ add_dependencies(libjsonnet++ jsonnet)
++target_link_libraries(libjsonnet++ libjsonnet)
+ # target_link_libraries(libjsonnet libjsonnet)
+
+ # CMake prepends CMAKE_SHARED_LIBRARY_PREFIX to shared libraries, so without


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/239912

Note: the static build still doesn't work because it tries to build a shared library. I tried patching CMakeLists.txt to wrap this in an `if` but then one of the vendored dependencies wasn't linked properly and I gave up. See also: https://github.com/google/jsonnet/issues/908

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
