### PR TITLE
fluidsynth: Fix CMake config

### DIFF
--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, buildPackages, pkg-config, cmake
+{ stdenv, lib, fetchFromGitHub, fetchpatch, buildPackages, pkg-config, cmake
 , alsa-lib, glib, libjack2, libsndfile, libpulseaudio
 , AppKit, AudioUnit, CoreAudio, CoreMIDI, CoreServices
 }:
@@ -14,6 +14,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-BSJu3jB7b5G2ThXBUHUNnBGl55EXe3nIzdBdgfOWDSM=";
   };
 
+  patches = [
+    # Fixes bad CMAKE_INSTALL_PREFIX + CMAKE_INSTALL_LIBDIR concatenation for Darwin install name dir
+    # Remove when PR merged & in release
+    (fetchpatch {
+      name = "0001-Fix-incorrect-way-of-turning-CMAKE_INSTALL_LIBDIR-absolute.patch";
+      url = "https://github.com/FluidSynth/fluidsynth/pull/1261/commits/03cd38dd909fc24aa39553d869afbb4024416de8.patch";
+      hash = "sha256-nV+MbFttnbNBO4zWnPLpnnEuoiESkV9BGFlUS9tQQfk=";
+    })
+  ];
+
   outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ buildPackages.stdenv.cc pkg-config cmake ];
@@ -24,8 +34,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-Denable-framework=off"
-    # set CMAKE_INSTALL_NAME_DIR to correct value on darwin
-    "-DCMAKE_INSTALL_LIBDIR=lib"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Closes #242623

Upstream is concatenating `CMAKE_INSTALL_LIBDIR` onto `CMAKE_INSTALL_PREFIX` to get a directory to use for the install_name on Darwin. This is not the right way of making `CMAKE_INSTALL_LIBDIR` absolute.

The config was first set up for breakage when the `CMAKE_INSTALL_LIBDIR` was made relative, in order to work around the wrong concatenation. This caused the `_IMPORT_PREFIX` to be computed by walking up the directory tree from the config file, instead of using the absolute `CMAKE_INSTALL_PREFIX`.

Then outputs were introduced to the derivation and the config was moved to a different output. Now the prefix it walks up to is the wrong prefix, and the config is busted.

Fix by reverting the original workaround so we have an absolute `CMAKE_INSTALL_LIBDIR`, and pulling a patch that fixes the bad concatenation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
