### PR TITLE
{nickel,nls}: 1.0.0 -> 1.1.1

### DIFF
--- a/pkgs/development/interpreters/nickel/default.nix
+++ b/pkgs/development/interpreters/nickel/default.nix
@@ -1,21 +1,28 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, python3
 , nix-update-script
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nickel";
-  version = "1.0.0";
+  version = "1.1.1";
 
   src  = fetchFromGitHub {
     owner = "tweag";
     repo = pname;
-    rev = "refs/tags/${version}"; # because pure ${version} doesn't work
-    hash = "sha256-8peoO3B5LHKiTUyDLpe0A2xg82LPI7l2vuGdyNhV478=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-bG0vNfKQpFQHDBfokvTpfXgVmKg6u/BcIz139pLwwsE=";
   };
 
-  cargoHash = "sha256-lrRCc5kUekUHrJTznR8xRiLVgQLJ/PsMP967PS41UJU=";
+  cargoHash = "sha256-qPKAozFXv94wgY99ugjsSuaN92SXZGgZwI2+7UlerHQ=";
+
+  cargoBuildFlags = [ "-p nickel-lang-cli" ];
+
+  nativeBuildInputs = [
+    python3
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/tools/language-servers/nls/default.nix
+++ b/pkgs/development/tools/language-servers/nls/default.nix
@@ -6,9 +6,9 @@
 rustPlatform.buildRustPackage {
   pname = "nls";
 
-  inherit (nickel) src version;
+  inherit (nickel) src version nativeBuildInputs;
 
-  cargoHash = "sha256-tahSuSc16oUUjeBBAnTDAiSaLr0zMKgN/XvypXqvvxw=";
+  cargoHash = "sha256-UGfc5cr6vl10aCVihOEEZktF8MzT56C9/wSvSQhCiVs=";
 
   cargoBuildFlags = [ "-p nickel-lang-lsp" ];
 


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/tweag/nickel/releases/tag/1.1.1)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).