### PR TITLE
liquibase: include all jars from internal/lib instead of just a few

### DIFF
--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -70,9 +70,8 @@ stdenv.mkDerivation rec {
       ${addJars "$out/lib"}
       ${addJars "$out"}
       ${lib.concatStringsSep "\n" (map (p: addJars "${p}/share/java") extraJars)}
-
       ${lib.getBin jre}/bin/java -cp "\$CP" \$JAVA_OPTS \
-        liquibase.integration.commandline.LiquibaseCommandLine \''${1+"\$@"}
+      liquibase.integration.commandline.LiquibaseCommandLine \''${1+"\$@"}
       EOF
       chmod +x $out/bin/liquibase
     '';

--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -48,7 +48,10 @@ stdenv.mkDerivation rec {
     in
     ''
       mkdir -p $out
-      mv ./{lib,licenses,internal/lib/*.jar} $out/
+      mv ./{lib,licenses} $out/
+
+      mkdir -p $out/internal/lib
+      mv ./internal/lib/*.jar $out/internal/lib/
 
       mkdir -p $out/share/doc/${pname}-${version}
       mv LICENSE.txt \
@@ -63,6 +66,7 @@ stdenv.mkDerivation rec {
       #!/usr/bin/env bash
       # taken from the executable script in the source
       CP=""
+      ${addJars "$out/internal/lib"}
       ${addJars "$out/lib"}
       ${addJars "$out"}
       ${lib.concatStringsSep "\n" (map (p: addJars "${p}/share/java") extraJars)}

--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     in
     ''
       mkdir -p $out
-      mv ./{lib,licenses,internal/lib/liquibase-core.jar,internal/lib/postgresql.jar,internal/lib/picocli.jar} $out/
+      mv ./{lib,licenses,internal/lib/*.jar} $out/
 
       mkdir -p $out/share/doc/${pname}-${version}
       mv LICENSE.txt \


### PR DESCRIPTION
###### Description of changes

The official installer installs more jars by default than this nix installer. Multiple commands don't work as intended because of that. In fact even `liquibase init project` - a command everyone would start with is broken. Furthermore since the `snakeyaml.jar` is not included it is impossible to parse `root.yml` files.

This PR adds all jars and also moves them into the `internal/lib` directory - the same as the default installer would.

I also tried aligning the output of the `liquibase --version` command, but even though I moved the jars into the `internal/lib` folder they are not listed. They are on the classpath though, which is also why the aforementioned commands work as intended. It's just that they are not listed when calling the `liquibase --version` command. I can live with that...

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
