### PR TITLE
bespokesynth: update to latest commit

### DIFF
--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -36,6 +36,7 @@
 , CoreServices
 , CoreAudioKit
 , IOBluetooth
+, MetalKit
   # It is not allowed to distribute binaries with the VST2 SDK plugin without a license
   # (the author of Bespoke has such a licence but not Nix). VST3 should work out of the box.
   # Read more in https://github.com/NixOS/nixpkgs/issues/145607
@@ -58,19 +59,15 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bespokesynth";
-  version = "1.1.0";
+  version = "unstable-2023-08-17";
 
   src = fetchFromGitHub {
     owner = "BespokeSynth";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-PN0Q6/gI1PeMaF/8EZFGJdLR8JVHQZfWunAhOIQxkHw=";
+    rev = "c6b1410afefc8b0b9aeb4aa11ad5c32651879c9f";
+    hash = "sha256-MLHlHSszD2jEN4/f2jC4vjAidr3gVOSK606qs5bq+Sc=";
     fetchSubmodules = true;
   };
-
-  postPatch = ''
-    sed '1i#include <memory>' -i Source/TitleBar.h # gcc12
-  '';
 
   cmakeBuildType = "Release";
 
@@ -79,7 +76,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ python3 makeWrapper cmake pkg-config ninja ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    # List obtained in https://github.com/BespokeSynth/BespokeSynth/blob/main/azure-pipelines.yml
+    # List obtained from https://github.com/BespokeSynth/BespokeSynth/blob/main/azure-pipelines.yml
     libX11
     libXrandr
     libXinerama
@@ -110,6 +107,7 @@ stdenv.mkDerivation rec {
     CoreServices
     CoreAudioKit
     IOBluetooth
+    MetalKit
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin (toString [
@@ -133,23 +131,27 @@ stdenv.mkDerivation rec {
         --prefix PATH : '${lib.makeBinPath [
           gnome.zenity
           (python3.withPackages (ps: with ps; [ jedi ]))
-        ]}' \
-        --prefix LD_LIBRARY_PATH : '${lib.makeLibraryPath [
-          libXrandr
-          libXinerama
-          libXcursor
-          libXScrnSaver
         ]}'
     '';
+
+  env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux "-rpath ${lib.makeLibraryPath ([
+    libX11
+    libXrandr
+    libXinerama
+    libXext
+    libXcursor
+    libXScrnSaver
+  ])}";
+  dontPatchELF = true; # needed or nix will try to optimize the binary by removing "useless" rpath
 
   meta = with lib; {
     description =
       "Software modular synth with controllers support, scripting and VST";
-    homepage = "https://github.com/awwbees/BespokeSynth";
+    homepage = "https://www.bespokesynth.com/";
     license = with licenses; [
       gpl3Plus
     ] ++ lib.optional enableVST2 unfree;
-    maintainers = with maintainers; [ astro tobiasBora OPNA2608 ];
+    maintainers = with maintainers; [ astro tobiasBora OPNA2608 PowerUser64 ];
     mainProgram = "BespokeSynth";
     platforms = platforms.all;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30035,8 +30035,8 @@ with pkgs;
 
   berry = callPackage ../applications/window-managers/berry { };
 
-  bespokesynth = callPackage ../applications/audio/bespokesynth {
-    inherit (darwin.apple_sdk.frameworks) Accelerate Cocoa WebKit CoreServices CoreAudioKit IOBluetooth;
+  bespokesynth = darwin.apple_sdk_11_0.callPackage ../applications/audio/bespokesynth {
+    inherit (darwin.apple_sdk_11_0.frameworks) Accelerate Cocoa WebKit CoreServices CoreAudioKit IOBluetooth MetalKit;
   };
 
   bespokesynth-with-vst2 = bespokesynth.override {


### PR DESCRIPTION
###### Description of changes

The developer of bespoke synth unfortunately doesn't have much time to devote to creating version number releases for the project, so the current "stable" release has gone untouched for quite some time. Currently, the latest commit/nightly release is far more stable and featureful than the current stable release. This PR updates the BespokeSynth package to the latest commit.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
