### PR TITLE
mailpit: init at 1.7.0

### DIFF
--- a/pkgs/servers/mail/mailpit/default.nix
+++ b/pkgs/servers/mail/mailpit/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, fetchurl
+, stdenvNoCC
+}:
+
+let
+  inherit (stdenvNoCC.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  plat = {
+    x86_64-linux = "linux-amd64";
+    x86_64-darwin = "darwin-amd64";
+    aarch64-linux = "linux-arm64";
+    aarch64-darwin = "darwin-arm64";
+  }.${system} or throwSystem;
+
+  hash = {
+    x86_64-linux = "sha256-ChrkpYWCF7zQN2ER0oeArzOSrM2ntt5btuAfyPTxGZE=";
+    x86_64-darwin = "sha256-3L68SXFcc92QjNfkXWsk7eElXCdg0XNe42Dx4WFq6vY=";
+    aarch64-linux = "sha256-BUryu2njZ4ZPCqKInrQDsQHGNRLFRidLy/Qc3LHLJ0c=";
+    aarch64-darwin = "sha256-YyMR2lbCXTspw9TBimTfRpfEKMvYrTl4LrLtn8hEbpw=";
+  }.${system} or throwSystem;
+in stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mailpit";
+  version = "1.7.0";
+
+  setSourceRoot = "sourceRoot=`pwd`";
+
+  src = fetchurl {
+    url = "https://github.com/axllent/mailpit/releases/download/v${finalAttrs.version}/mailpit-${plat}.tar.gz";
+    inherit hash;
+  };
+
+  postInstall = ''
+    mkdir -p $out/bin
+    cp mailpit $out/bin
+  '';
+
+  meta = with lib; {
+    description = "An email and SMTP testing tool with API for developers";
+    homepage = "https://github.com/axllent/mailpit";
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    changelog = "https://github.com/axllent/mailpit/releases/tag/v${version}";
+    maintainers = with maintainers; [ shyim ];
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10201,6 +10201,8 @@ with pkgs;
 
   mailhog = callPackage ../servers/mail/mailhog { };
 
+  mailpit = callPackage ../servers/mail/mailpit { };
+
   mailnag = callPackage ../applications/networking/mailreaders/mailnag {
     availablePlugins = {
       # More are listed here: https://github.com/pulb/mailnag/#desktop-integration


### PR DESCRIPTION
###### Description of changes

[Mailpit](https://github.com/axllent/mailpit) is a modern alternative to mailhog. I could not package it by source as node dependencies require tree-sitter-yaml compiled from source and node-gyp fails with libtool -static on Darwin

###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


