### PR TITLE
pppd: add systemd support and waitUntilReady option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -100,6 +100,11 @@ The module update takes care of the new config syntax and the data itself (user 
 
 - `programs.gnupg.agent.pinentryFlavor` is now set in `/etc/gnupg/gpg-agent.conf`, and will no longer take precedence over a `pinentry-program` set in `~/.gnupg/gpg-agent.conf`.
 
+- `PPP` links configured via `services.pppd.*` can now be configured to
+  `waitUntilReady`. This prevents the associated systemd service from reporting
+  readiness until the network interface is ready and a link is established.
+  This can be used to better order service dependencies on startup.
+
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 
 - The `qemu-vm.nix` module by default now identifies block devices via

--- a/nixos/tests/pppd.nix
+++ b/nixos/tests/pppd.nix
@@ -50,6 +50,7 @@ import ./make-test-python.nix (
               noauth
               debug
             '';
+            waitUntilReady = true;
           };
         };
         environment.etc."ppp/chap-secrets" = chap-secrets;

--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -7,6 +7,7 @@
 , autoreconfHook
 , openssl
 , bash
+, systemd
 , nixosTests
 , writeTextDir
 }:
@@ -26,6 +27,7 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--with-openssl=${openssl.dev}"
+    "--enable-systemd"
   ];
 
   nativeBuildInputs = [
@@ -38,6 +40,7 @@ stdenv.mkDerivation rec {
     libxcrypt
     openssl
     bash
+    systemd
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Fixes #215814. This allows more useful dependencies with the systemd units for pppd: they can now be made to be ready only when a connection is established. This is not made the default behavior, since there are scenarios when this might not be wanted and might be a backwards-incompatible / breaking change.

cc @poscat0x04 for testing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
