### PR TITLE
flake.nix: inject Nixpkgs revision into `lib`

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -119,7 +119,7 @@ in pkgs.stdenv.mkDerivation {
 
     nixos-render-docs manual html \
       --manpage-urls ./manpage-urls.json \
-      --revision ${pkgs.lib.trivial.revisionWithDefault (pkgs.rev or "master")} \
+      --revision ${pkgs.lib.trivial.revisionWithDefault (nixpkgs.rev or "master")} \
       --stylesheet style.css \
       --stylesheet overrides.css \
       --stylesheet highlightjs/mono-blue.css \

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1,6 +1,6 @@
 { lib }:
 
-rec {
+{
 
   ## Simple (higher order) functions
 
@@ -161,7 +161,7 @@ rec {
   ## nixpkgs version strings
 
   /* Returns the current full nixpkgs version number. */
-  version = release + versionSuffix;
+  version = lib.trivial.release + lib.trivial.versionSuffix;
 
   /* Returns the current nixpkgs release number as string. */
   release = lib.strings.fileContents ../.version;
@@ -200,7 +200,7 @@ rec {
   /* Returns the current nixpkgs version suffix as string. */
   versionSuffix =
     let suffixFile = ../.version-suffix;
-    in if pathExists suffixFile
+    in if lib.pathExists suffixFile
     then lib.strings.fileContents suffixFile
     else "pre-git";
 
@@ -220,7 +220,7 @@ rec {
        else if lib.pathExists revisionFile then lib.fileContents revisionFile
        else default;
 
-  nixpkgsVersion = builtins.trace "`lib.nixpkgsVersion` is deprecated, use `lib.version` instead!" version;
+  nixpkgsVersion = builtins.trace "`lib.nixpkgsVersion` is deprecated, use `lib.version` instead!" lib.version;
 
   /* Determine whether the function is being called from inside a Nix
      shell.
@@ -354,14 +354,14 @@ rec {
 
     Type: bool -> string -> a -> a
   */
-  warnIf = cond: msg: if cond then warn msg else x: x;
+  warnIf = cond: msg: if cond then lib.warn msg else x: x;
 
   /*
     Like warnIf, but negated (warn if the first argument is `false`).
 
     Type: bool -> string -> a -> a
   */
-  warnIfNot = cond: msg: if cond then x: x else warn msg;
+  warnIfNot = cond: msg: if cond then x: x else lib.warn msg;
 
   /*
     Like the `assert b; e` expression, but with a custom error message and
@@ -411,7 +411,7 @@ rec {
 
   info = msg: builtins.trace "INFO: ${msg}";
 
-  showWarnings = warnings: res: lib.foldr (w: x: warn w x) res warnings;
+  showWarnings = warnings: res: lib.foldr lib.warn res warnings;
 
   ## Function annotations
 
@@ -446,7 +446,7 @@ rec {
      annotated with function args.
   */
   isFunction = f: builtins.isFunction f ||
-    (f ? __functor && isFunction (f.__functor f));
+    (f ? __functor && lib.isFunction (f.__functor f));
 
   /*
     Turns any non-callable values into constant functions.
@@ -463,7 +463,7 @@ rec {
   toFunction =
     # Any value
     v:
-    if isFunction v
+    if lib.isFunction v
     then v
     else k: v;
 
@@ -491,7 +491,7 @@ rec {
             "15" = "F";
           }.${toString d};
     in
-      lib.concatMapStrings toHexDigit (toBaseDigits 16 i);
+      lib.concatMapStrings toHexDigit (lib.toBaseDigits 16 i);
 
   /* `toBaseDigits base i` converts the positive integer i to a list of its
      digits in the given base. For example:
@@ -514,8 +514,8 @@ rec {
           in
             [r] ++ go q;
     in
-      assert (isInt base);
-      assert (isInt i);
+      assert (lib.isInt base);
+      assert (lib.isInt i);
       assert (base >= 2);
       assert (i >= 0);
       lib.reverseList (go i);

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/options.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/options.py
@@ -59,9 +59,11 @@ class BaseConverter(Converter[md.TR], Generic[md.TR]):
                 if self._revision == 'local':
                     href = f"https://github.com/NixOS/nixpkgs/blob/master/{loc}"
                 else:
-                    href = f"https://github.com/NixOS/nixpkgs/blob/{self._revision}/{loc}"
+                    revision = self._revision.removesuffix("-dirty")
+                    href = f"https://github.com/NixOS/nixpkgs/blob/{revision}/{loc}"
             else:
                 href = f"file://{loc}"
+
             # Print the filename and make it user-friendly by replacing the
             # /nix/store/<hash> prefix by the default location of nixos
             # sources.
@@ -71,6 +73,10 @@ class BaseConverter(Converter[md.TR], Generic[md.TR]):
                 name = f"<nixops/{loc[loc.find('/nix/') + 5:]}>"
             else:
                 name = loc
+
+            if self._revision.endswith("-dirty"):
+                name += " (modified)"
+
             return (href, name)
         else:
             return (loc['url'] if 'url' in loc else None, loc['name'])


### PR DESCRIPTION
###### Description of changes

When using Nixpkgs as a flake, the `lib.nixosSystem` function injects a module to set the revision and version suffix accordingly. However, `lib.trivial.revisionWithDefault default` is always `default` and `lib.trivial.version` always looks like `"YY.MMpre-git"`. That means that e.g. `lib.versionOlder lib.trivial.version "23.05"` is true even on the 23.05 release branch, which is confusing, can break version compatibility checks, makes the `lib` version information inconsistent from the `system.nixos.*` options even inside a NixOS configuration, and just generally means that non-NixOS consumers have to do [complicated](https://github.com/LnL7/nix-darwin/blob/83620edf499ba8033ad43d4f5edc50fdf3eeee5f/modules/system/version.nix#L20-L31) [dances](https://github.com/nix-community/home-manager/pull/4215/commits/832cca945cdcd02b81d535780c49e9f4aa126b19) to try and figure out the Nixpkgs version when using flakes.

These commits inject the revision information into `lib` instead, so all of `nixpkgs.lib.trivial.version`, `nixpkgs.legacyPackages.x86_64-linux.lib.trivial.version`, and `nixpkgs.lib.nixosSystem { modules = [ ({ lib, ... }: ... lib.trivial.version ...) ]; }` yield the correct result. (`(import nixpkgs { ... }).lib.trivial.version` will still be broken by default, unfortunately; I don't see any way to fix that. That's fine as long as you're only importing it for the package set and not for `lib`, though, which thankfully is how NixOS does it.)

Context [from `#dev:nixos.org`](https://matrix.to/#/!kjdutkOsheZdjqYmqp:nixos.org/$kwovKUdWYPw30nGQS_obpbii_4znCLYCUojeoFF-VSw?via=nixos.org&via=matrix.org&via=nixos.dev):

> **<@emilazy>** is there a fundamental reason nixpkgs as a flake has e.g. `lib.version` -> `"23.05pre-git"` even on a release branch (which is `lib.versionOlder` than 23.05!), and `lib.trivial.revisionWithDefault null` -> `null`? that is, I know it doesn't have access to the git repository to compute the revision, but it *does* have access to it via `self.rev` and I don't see why that can't be piped through in the same way that `nixosSystem` uses it - but maybe there's a good reason for it?
> **<@emilazy>** the "23.05 is older than 23.05 if you're using flakes" thing seems particularly unfortunate
> **<@RaitoBezarius>** that sounds like a bug
> **<@RaitoBezarius>** opening the PR would at least create the discussion :)

Marking this for backport to 23.05 as I think the resulting behaviour is strictly better/less buggy and the backwards compatibility risk is small, but I'll remove it if there's disagreement on that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->