### PR TITLE
openldap: 2.6.4 -> 2.6.5

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation rec {
   pname = "openldap";
-  version = "2.6.4";
+  version = "2.6.5";
 
   src = fetchurl {
     url = "https://www.openldap.org/software/download/OpenLDAP/openldap-release/${pname}-${version}.tgz";
-    hash = "sha256-1RcE5QF4QwwGzz2KoXTaZrrfVZdHpH2SC7VLLUqkCZE=";
+    hash = "sha256-Lieo1PTCr4/oQLVzJxwgqhY+JJh/l2UhRkQpD1vrONk=";
   };
 
   # TODO: separate "out" and "bin"


### PR DESCRIPTION
###### Description of changes

```
OpenLDAP 2.6.5 Release (2023/07/10)
	Fixed libldap handling of TCP KEEPALIVE options (ITS#10015)
	Fixed libldap with async connections (ITS#10023)
	Fixed libldap openssl TLSv1.3 cipher suite handling (ITS#10035)
	Fixed slapd callback handling with overlays that do extended operations (ITS#9990)
	Fixed slapd conversion of pcache configurations (ITS#10031)
	Fixed slapd cn=config modification handling with abandon (ITS#10045)
	Fixed slapd-mdb online indexer termination and cleanup (ITS#9993)
	Fixed slapd-mdb online indexer when interrupted (ITS#10047)
	Fixed slapd-monitor connection cleanup (ITS#10042)
	Fixed slapo-constraint handling of push replication (ITS#9953)
	Fixed slapo-dynlist filter evaluation efficiency (ITS#10041)
	Fixed slapo-pcache handling of invalid schema (ITS#10032)
	Fixed slapo-ppolicy handling of push replication (ITS#9953)
	Fixed slapo-ppolicy handling of pwdMinDelay (ITS#10028)
	Fixed slapo-syncprov abandon handling (ITS#10016)
	Fixed slapo-translucent handling of invalid schema (ITS#10032)
	Fixed slapo-unique handling of push replication (ITS#9953)
	Fixed slapo-variant to improve regex handling (ITS#10048)
	Build Environment
		Fixed compatibility with stricter C99 compilers (ITS#10011)
		Keep .pc files during make clean (ITS#9989)
	Contrib
		Fixed slapo-variant handling of push replication (ITS#9953)
	Minor Cleanup
		ITS#9855
		ITS#9995
		ITS#9996
		ITS#9997
		ITS#9998
		ITS#9999
		ITS#10000
		ITS#10003
		ITS#10004
		ITS#10033
		ITS#10037
		ITS#10039
		ITS#10046
		ITS#10063
```

https://www.openldap.org/software/release/changes.html



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
