### PR TITLE
libredirect: Fix segfault handling null paths

### DIFF
--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -70,9 +70,12 @@ static void init()
 
 }
 
-static const char * rewrite(const char * path, char * buf)
+static const char * rewrite(const char * volatile path, char * buf)
 {
+    // Marking the path volatile is needed so the the following check isn't
+    // optimized away by the compiler.
     if (path == NULL) return path;
+
     for (int n = 0; n < nrRedirects; ++n) {
         int len = strlen(from[n]);
         if (strncmp(path, from[n], len) != 0) continue;

--- a/pkgs/build-support/libredirect/test.c
+++ b/pkgs/build-support/libredirect/test.c
@@ -45,6 +45,17 @@ void test_subprocess(void) {
     assert(system(SUBTEST) == 0);
 }
 
+void test_stat_with_null_path(void) {
+    // This checks whether the compiler optimizes away the null pointer check
+    // on the path passed to stat(). If that's the case, the following code
+    // should segfault.
+    struct stat buf;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
+    stat(NULL, &buf);
+#pragma GCC diagnostic pop
+}
+
 void assert_mktemp_path(
     const char * orig_prefix,
     const char * orig_suffix,
@@ -147,6 +158,7 @@ int main(int argc, char *argv[])
 
     test_spawn();
     test_system();
+    test_stat_with_null_path();
 
     // Only run subprocess if no arguments are given
     // as the subprocess will be called without argument


### PR DESCRIPTION
###### Description of changes

While using libredirect in conjunction with geckodriver, I stumbled on odd segfaults that happened when running the wrapped statx() call from libredirect:

```backtrace
  0x00007ffff7ddd541 in __strncmp_avx2 () from .../lib/libc.so.6
  0x00007ffff7f6fe57 in statx () from .../lib/libredirect.so
  0x00005555558d35bd in std::sys::unix::fs::try_statx::h2045d39b0c66d4e8 ()
  0x00005555558d2230 in std::sys::unix::fs::stat::ha063998dfb361520 ()
  0x0000555555714019 in mozversion::firefox_version::hdc3b57eb04947426 ()
  0x00005555556a603c in geckodriver::capabilities::FirefoxCapabilities::version::h58e289917bd3c721 ()
  0x00005555556a77f5 in <geckodriver::capabilities::FirefoxCapabilities as webdriver::capabilities::BrowserCapabilities>::validate_custom::h62d23cf9fd63b719 ()
  0x000055555562a7c8 in webdriver::capabilities::SpecNewSessionParameters::validate::h60da250d33f0989f ()
  0x00005555556d7a13 in <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold::h9427a360a3d0bf8f ()
  0x0000555555669d85 in <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter::hd274d536ea29bb33 ()
  0x00005555555c05ef in core::iter::adapters::try_process::hdf96a01ec1f9b8bd ()
  0x000055555561768d in <webdriver::capabilities::SpecNewSessionParameters as webdriver::capabilities::CapabilitiesMatching>::match_browser::hfbd8c38f6db17e9f ()
  0x00005555555ca6ef in <geckodriver::marionette::MarionetteHandler as webdriver::server::WebDriverHandler<geckodriver::command::GeckoExtensionRoute>>::handle_command::h13b98b9cb87a69d6 ()
  0x00005555555e859e in webdriver::server::Dispatcher<T,U>::run::h746a8bf2f0bc24fd ()
  0x000055555569ff0f in std::sys_common::backtrace::__rust_begin_short_backtrace::h3b920773bd467d2a ()
  0x00005555555dbc99 in core::ops::function::FnOnce::call_once{{vtable.shim}}::h81ba7228877515f7 ()
  0x00005555558d31a3 in std::sys::unix::thread::Thread::new::thread_start::h4514580219a899c5 ()
  0x00007ffff7d0ce24 in start_thread () from .../lib/libc.so.6
  0x00007ffff7d8e9b0 in clone3 () from .../lib/libc.so.6
```

The reason why I found this odd was because it happens in the following piece of code (shortened a bit):

```c
static const char * rewrite(const char * path, char * buf)
{
  if (path == NULL) return path;
  for (int n = 0; n < nrRedirects; ++n) {
    int len = strlen(from[n]);
    if (strncmp(path, from[n], len) != 0) continue;
    if (snprintf(buf, PATH_MAX, "%s%s", to[n], path + len) >= PATH_MAX)
      abort();
    return buf;
  }
  return path;
}
```

When inspecting the assembly, I found that the check for the null pointer in line 3 was completely missing and the code was directly entering the loop and then eventually segfault when running `strncmp()` with a null pointer as its first argument.

I confirmed that indeed that check was missing by compiling libredirect with `-O0` and comparing the generated assembly with the optimized one. The one compiled with `-O0` had that check while the optimized one did not and indeed when running geckodriver with the unoptimized version it worked fine.

Digging in the Git history, I found 5677ce200831a83a7b3d37f2cfc4ec00c10, which actually introduced the null pointer check. Going back to that commit however, the check actually was still in the generated assembly.

So I bisected between that commit and the most recent one and ended up with commit ca8aa5dc877344082864cf75512e59c7a1d0ad8c, which moved everything to use GCC 7.

I haven't found out why *exactly* GCC was optimizing the check away, but playing around on Godbolt with various other compilers seems that other compilers such as Clang are doing it as well. Additionally, given that passing `NULL` to `stat()` is UB, my guess is that compilers tend to assume that such an argument can't be `NULL`. My assumption is based on the fact that GCC warns with "argument 1 null where non-null expected" when passing `NULL` to eg. `stat()`.

To address this for now, I marked the path argument of the `rewrite()` volatile and also added a test that should cause a segfault in case this would regress again as it already did.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).