### PR TITLE
yaac: init at 1.0-beta182

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4297,6 +4297,12 @@
     githubId = 10998835;
     name = "Doron Behar";
   };
+  dotemup = {
+    email = "dotemup.designs+nixpkgs@gmail.com";
+    github = "dotemup";
+    githubId = 11077277;
+    name = "Dote";
+  };
   dotlambda = {
     email = "rschuetz17@gmail.com";
     matrix = "@robert:funklause.de";

--- a/pkgs/applications/radio/yaac/default.nix
+++ b/pkgs/applications/radio/yaac/default.nix
@@ -1,0 +1,48 @@
+{ ant, fetchsvn, jdk, jre8, lib, makeWrapper, stdenv, unzip }:
+
+stdenv.mkDerivation rec {
+
+  pname = "yaac";
+  version = "1.0-beta182";
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/yetanotheraprsc/code/trunk/yaac";
+    rev = "r229";
+    sha256 = "sha256-MZxLbIawq+O8paRrLetK6voDRUZSGsIuMF+K+v57izA=";
+  };
+
+  nativeBuildInputs = [ ant jdk makeWrapper unzip ];
+
+  # TODO: Make Desktop Icon
+
+  buildPhase = ''
+    runHook preBuild
+
+    ant
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    unzip /build/*/YAAC.zip -d $out
+
+    makeWrapper ${jre8}/bin/java $out/bin/yaac \
+      --add-flags "-jar $out/YAAC.jar" \
+      --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=on' \
+      --set _JAVA_AWT_WM_NONREPARENTING 1
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Yet Another APRS Client";
+    homepage = "https://www.ka2ddo.org/ka2ddo/YAAC.html";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.dotemup ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36179,6 +36179,8 @@ with pkgs;
 
   xzgv = callPackage ../applications/graphics/xzgv { };
 
+  yaac = callPackage ../applications/radio/yaac { };
+
   yabar = callPackage ../applications/window-managers/yabar { };
 
   yabar-unstable = callPackage ../applications/window-managers/yabar/unstable.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New application YAAC, Yet Another APRS Client. This application is a Radio/Network application for sending and receiving packets through the AX.25 protocol.

Tested in configurations with raw AX.25 I/O, and through assistance with Direwolf, and hamlib rigctld via FLRIG.

Added myself as new maintainer and added new application into top-level call, correctly dist into radio sub-directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
