### PR TITLE
gex: 0.4.0 -> 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12945,6 +12945,12 @@
     githubId = 1830959;
     name = "Piper McCorkle";
   };
+  piturnah = {
+    email = "peterhebden6@gmail.com";
+    github = "piturnah";
+    githubId = 20472367;
+    name = "Peter Hebden";
+  };
   pjbarnoy = {
     email = "pjbarnoy@gmail.com";
     github = "pjbarnoy";

--- a/pkgs/applications/version-management/gex/default.nix
+++ b/pkgs/applications/version-management/gex/default.nix
@@ -25,6 +25,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "Git Explorer: cross-platform git workflow improvement tool inspired by Magit";
     homepage = "https://github.com/Piturnah/gex";
+    changelog = "https://github.com/Piturnah/gex/releases/tag/${src.rev}";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ azd325 Br1ght0ne evanrichter ];
   };

--- a/pkgs/applications/version-management/gex/default.nix
+++ b/pkgs/applications/version-management/gex/default.nix
@@ -8,19 +8,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gex";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "Piturnah";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-eRforLvRVSrFWnI5UZEWr1L4UM3ABjAIvui1E1hzk5s=";
+    hash = "sha256-//sQ0s8bBQzuu5aO3RjPRjFuVYiGW6BwSPoCWKAx9DQ=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libgit2 ];
 
-  cargoHash = "sha256-OEaNERozmJL8gYe33V/m4HQNHi2I4KHpI6PTwFQkPSs=";
+  cargoHash = "sha256-rkhkFnRDtMTWFM+E5C4jR7TWtHdy3WUtIzvGDDLHqtE=";
 
   meta = with lib; {
     description = "Git Explorer: cross-platform git workflow improvement tool inspired by Magit";

--- a/pkgs/applications/version-management/gex/default.nix
+++ b/pkgs/applications/version-management/gex/default.nix
@@ -27,6 +27,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Piturnah/gex";
     changelog = "https://github.com/Piturnah/gex/releases/tag/${src.rev}";
     license = with licenses; [ asl20 /* or */ mit ];
-    maintainers = with maintainers; [ azd325 evanrichter ];
+    maintainers = with maintainers; [ azd325 evanrichter piturnah ];
   };
 }

--- a/pkgs/applications/version-management/gex/default.nix
+++ b/pkgs/applications/version-management/gex/default.nix
@@ -27,6 +27,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Piturnah/gex";
     changelog = "https://github.com/Piturnah/gex/releases/tag/${src.rev}";
     license = with licenses; [ asl20 /* or */ mit ];
-    maintainers = with maintainers; [ azd325 Br1ght0ne evanrichter ];
+    maintainers = with maintainers; [ azd325 evanrichter ];
   };
 }

--- a/pkgs/applications/version-management/gex/default.nix
+++ b/pkgs/applications/version-management/gex/default.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage rec {
     description = "Git Explorer: cross-platform git workflow improvement tool inspired by Magit";
     homepage = "https://github.com/Piturnah/gex";
     license = with licenses; [ asl20 /* or */ mit ];
-    maintainers = with maintainers; [ azd325 Br1ght0ne ];
+    maintainers = with maintainers; [ azd325 Br1ght0ne evanrichter ];
   };
 }


### PR DESCRIPTION
###### Description of changes

simple updates, but closing a few cleanup items suggested by reviewers:
 - closes #241326 by adding piturnah to maintainers of gex
 - remove Br1ght0ne as maintainer of gex
 - add changelog url to derivation

###### Things done

used gex 0.5.0 to stage and commit this very PR :)

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

ping @Azd325 @Br1ght0ne
