### PR TITLE
python310Packages.shap: 0.41.0 -> 0.42.0; fix build

### DIFF
--- a/pkgs/development/python-modules/shap/default.nix
+++ b/pkgs/development/python-modules/shap/default.nix
@@ -1,39 +1,43 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, writeText
 , fetchpatch
-, isPy27
 , pytestCheckHook
-, pytest-mpl
-, numpy
-, scipy
-, scikit-learn
-, pandas
-, transformers
-, opencv4
-, lightgbm
+, pythonOlder
+, writeText
 , catboost
-, pyspark
-, sentencepiece
-, tqdm
-, slicer
-, numba
-, matplotlib
-, nose
-, lime
 , cloudpickle
 , ipython
+, lightgbm
+, lime
+, matplotlib
+, nose
+, numba
+, numpy
+, opencv4
+, pandas
+, pyspark
+, pytest-mpl
+, scikit-learn
+, scipy
+, sentencepiece
+, setuptools
+, slicer
+, tqdm
+, transformers
+, xgboost
 }:
 
 buildPythonPackage rec {
   pname = "shap";
   version = "0.42.0";
-  disabled = isPy27;
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "slundberg";
-    repo = pname;
+    repo = "shap";
     rev = "refs/tags/v${version}";
     hash = "sha256-VGlswr9ywHk4oKSmmAzEC7+E0V2XEFlg19zXVktUdhc=";
   };
@@ -46,15 +50,19 @@ buildPythonPackage rec {
     })
   ];
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [
-    numpy
-    scipy
-    scikit-learn
-    pandas
-    tqdm
-    slicer
-    numba
     cloudpickle
+    numba
+    numpy
+    pandas
+    scikit-learn
+    scipy
+    slicer
+    tqdm
   ];
 
   passthru.optional-dependencies = {
@@ -97,26 +105,28 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
-    pytestCheckHook
-    pytest-mpl
+    ipython
     matplotlib
     nose
-    ipython
+    pytest-mpl
+    pytestCheckHook
     # optional dependencies, which only serve to enable more tests:
-    opencv4
-    #pytorch # we already skip all its tests due to slowness, adding it does nothing
-    transformers
-    #xgboost # numerically unstable? xgboost tests randomly fails pending on nixpkgs revision
-    lightgbm
     catboost
+    lightgbm
+    opencv4
     pyspark
     sentencepiece
+    #torch # we already skip all its tests due to slowness, adding it does nothing
+    transformers
+    xgboost
   ];
+
   disabledTestPaths = [
     # The resulting plots look sane, but does not match pixel-perfectly with the baseline.
     # Likely due to a matplotlib version mismatch, different backend, or due to missing fonts.
     "tests/plots/test_summary.py" # FIXME: enable
   ];
+
   disabledTests = [
     # The same reason as above test_summary.py
     "test_simple_bar_with_cohorts_dict"
@@ -143,6 +153,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/slundberg/shap/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ evax ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/shap/default.nix
+++ b/pkgs/development/python-modules/shap/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , writeText
+, fetchpatch
 , isPy27
 , pytestCheckHook
 , pytest-mpl
@@ -27,15 +28,23 @@
 
 buildPythonPackage rec {
   pname = "shap";
-  version = "0.41.0";
+  version = "0.42.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "slundberg";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-rYVWQ3VRvIObSQPwDRsxhTOGOKNkYkLtiHzVwoB3iJ0=";
+    hash = "sha256-VGlswr9ywHk4oKSmmAzEC7+E0V2XEFlg19zXVktUdhc=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-circular-import-error.patch";
+      url = "https://github.com/slundberg/shap/commit/ce118526b19b4a206cf8b496c2cd2b215ef7a91b.patch";
+      hash = "sha256-n2yFjFgc2VSFKb4ZJx775HblULWfnQSEnqjfPa8AOt0=";
+    })
+  ];
 
   propagatedBuildInputs = [
     numpy
@@ -58,7 +67,7 @@ buildPythonPackage rec {
     # tests that try to access the network will raise, get caught, be marked as skipped and tagged as xfailed.
     conftestSkipNetworkErrors = writeText "conftest.py" ''
       from _pytest.runner import pytest_runtest_makereport as orig_pytest_runtest_makereport
-      import urllib, requests
+      import urllib, requests, transformers
 
       class NetworkAccessDeniedError(RuntimeError): pass
       def deny_network_access(*a, **kw):
@@ -68,6 +77,7 @@ buildPythonPackage rec {
       requests.get  = deny_network_access
       urllib.request.urlopen = deny_network_access
       urllib.request.Request = deny_network_access
+      transformers.AutoTokenizer.from_pretrained = deny_network_access
 
       def pytest_runtest_makereport(item, call):
         tr = orig_pytest_runtest_makereport(item, call)
@@ -81,14 +91,11 @@ buildPythonPackage rec {
     # when importing the local copy the extension is not found
     rm -r shap
 
-    # coverage testing is a waste considering how much we have to skip
-    substituteInPlace pytest.ini \
-      --replace "--cov=shap --cov-report=term-missing" ""
-
     # Add pytest hook skipping tests that access network.
     # These tests are marked as "Expected fail" (xfail)
     cat ${conftestSkipNetworkErrors} >> tests/conftest.py
   '';
+
   nativeCheckInputs = [
     pytestCheckHook
     pytest-mpl
@@ -106,29 +113,16 @@ buildPythonPackage rec {
     sentencepiece
   ];
   disabledTestPaths = [
-    # takes forever without GPU acceleration
-    "tests/explainers/test_deep.py"
-    "tests/explainers/test_gradient.py"
-    # requires GPU. We skip here instead of having pytest repeatedly check for GPU
-    "tests/explainers/test_gpu_tree.py"
     # The resulting plots look sane, but does not match pixel-perfectly with the baseline.
     # Likely due to a matplotlib version mismatch, different backend, or due to missing fonts.
     "tests/plots/test_summary.py" # FIXME: enable
-    # 100% of the tests in these paths require network
-    "tests/explainers/test_explainer.py"
-    "tests/explainers/test_exact.py"
-    "tests/explainers/test_partition.py"
-    "tests/maskers/test_fixed_composite.py"
-    "tests/maskers/test_text.py"
-    "tests/models/test_teacher_forcing_logits.py"
-    "tests/models/test_text_generation.py"
   ];
   disabledTests = [
-    # unstable. A xgboost-enabled test. possibly related: https://github.com/slundberg/shap/issues/2480
-    "test_provided_background_tree_path_dependent"
+    # The same reason as above test_summary.py
+    "test_simple_bar_with_cohorts_dict"
+    "test_random_summary_violin_with_data2"
+    "test_random_summary_layered_violin_with_data2"
   ];
-
-  #pytestFlagsArray = ["-x" "-W" "ignore"]; # uncomment this to debug
 
   pythonImportsCheck = [
     "shap"
@@ -150,8 +144,5 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ evax ];
     platforms = platforms.unix;
-    # No support for scikit-learn > 1.2
-    # https://github.com/slundberg/shap/issues/2866
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/slicer/default.nix
+++ b/pkgs/development/python-modules/slicer/default.nix
@@ -3,8 +3,8 @@
 , dos2unix
 , fetchpatch
 , fetchPypi
-, isPy27
 , pytestCheckHook
+, pythonOlder
 , pandas
 , torch
 , scipy
@@ -13,11 +13,12 @@
 buildPythonPackage rec {
   pname = "slicer";
   version = "0.0.7";
-  disabled = isPy27;
+  format = "setuptools";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f5d5f7b45f98d155b9c0ba6554fa9770c6b26d5793a3e77a1030fb56910ebeec";
+    hash = "sha256-9dX3tF+Y0VW5wLplVPqXcMaybVeTo+d6EDD7VpEOvuw=";
   };
 
   prePatch = ''

--- a/pkgs/development/python-modules/slicer/default.nix
+++ b/pkgs/development/python-modules/slicer/default.nix
@@ -1,5 +1,7 @@
 { lib
 , buildPythonPackage
+, dos2unix
+, fetchpatch
 , fetchPypi
 , isPy27
 , pytestCheckHook
@@ -17,6 +19,30 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "f5d5f7b45f98d155b9c0ba6554fa9770c6b26d5793a3e77a1030fb56910ebeec";
   };
+
+  prePatch = ''
+    dos2unix slicer/*
+  '';
+
+  patches = [
+    # these patches add support for numpy>=1.24
+    (fetchpatch {
+      url = "https://github.com/interpretml/slicer/commit/028e09e639c4a3c99abe1d537cce30af2eebb081.patch";
+      hash = "sha256-jh/cbz7cx2ks6jMNh1gI1n5RS/OHBtSIDZRxUGyrl/I=";
+    })
+    (fetchpatch {
+      url = "https://github.com/interpretml/slicer/commit/d4bb09f136d7e1f64711633c16a37e7bee738696.patch";
+      hash = "sha256-9rh99s4JWF4iKClZ19jvqSeRulL32xB5Use8PGkh/SA=";
+    })
+    (fetchpatch {
+      url = "https://github.com/interpretml/slicer/commit/74b3683a5a7bd982f9eaaf8d8d665dfdaf2c6604.patch";
+      hash = "sha256-R3zsC3udYPFUT93eRhb6wyc9S5n2wceiOunWJ8K+648=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    dos2unix
+  ];
 
   nativeCheckInputs = [ pytestCheckHook pandas torch scipy ];
 


### PR DESCRIPTION
###### Description of changes

Diff: https://github.com/slundberg/shap/compare/refs/tags/v0.41.0...v0.42.0
Changelog: https://github.com/slundberg/shap/releases/tag/v0.42.0

- fix a dependency `python310Packages.slicer`
- refactor these packages

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
