### PR TITLE
module system: Clean up and improve an error message

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -540,34 +540,26 @@ let
   mergeModules' = prefix: options: configs:
     let
       # an attrset 'name' => list of submodules that declare ‘name’.
-      declsByName = (attr: f: modules:
+      declsByName = (f: modules:
         zipAttrsWith (n: concatLists)
-          (map (module: let subtree = module.${attr}; in
+          (map (module: let subtree = module.options; in
               if !(builtins.isAttrs subtree) then
-                throw (if attr == "config" then ''
-                  You're trying to define a value of type `${builtins.typeOf subtree}'
-                  rather than an attribute set for the option
-                  `${builtins.concatStringsSep "." prefix}'!
-
-                  This usually happens if `${builtins.concatStringsSep "." prefix}' has option
-                  definitions inside that are not matched. Please check how to properly define
-                  this option by e.g. referring to `man 5 configuration.nix'!
-                '' else ''
+                throw ''
                   An option declaration for `${builtins.concatStringsSep "." prefix}' has type
                   `${builtins.typeOf subtree}' rather than an attribute set.
                   Did you mean to define this outside of `options'?
-                '')
+                ''
               else
                 mapAttrs (n: f module) subtree
-              ) modules)) "options" (module: option:
+              ) modules)) (module: option:
           [{ inherit (module) _file; options = option; }]
         ) options;
       # an attrset 'name' => list of submodules that define ‘name’.
-      defnsByName = (attr: f: modules:
+      defnsByName = (f: modules:
         zipAttrsWith (n: concatLists)
-          (map (module: let subtree = module.${attr}; in
+          (map (module: let subtree = module.config; in
               if !(builtins.isAttrs subtree) then
-                throw (if attr == "config" then ''
+                throw ''
                   You're trying to define a value of type `${builtins.typeOf subtree}'
                   rather than an attribute set for the option
                   `${builtins.concatStringsSep "." prefix}'!
@@ -575,22 +567,18 @@ let
                   This usually happens if `${builtins.concatStringsSep "." prefix}' has option
                   definitions inside that are not matched. Please check how to properly define
                   this option by e.g. referring to `man 5 configuration.nix'!
-                '' else ''
-                  An option declaration for `${builtins.concatStringsSep "." prefix}' has type
-                  `${builtins.typeOf subtree}' rather than an attribute set.
-                  Did you mean to define this outside of `options'?
-                '')
+                ''
               else
                 mapAttrs (n: f module) subtree
-              ) modules)) "config" (module: value:
+              ) modules)) (module: value:
           map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
         ) configs;
       # extract the definitions for each loc
-      defnsByName' = (attr: f: modules:
+      defnsByName' = (f: modules:
         zipAttrsWith (n: concatLists)
-          (map (module: let subtree = module.${attr}; in
+          (map (module: let subtree = module.config; in
               if !(builtins.isAttrs subtree) then
-                throw (if attr == "config" then ''
+                throw ''
                   You're trying to define a value of type `${builtins.typeOf subtree}'
                   rather than an attribute set for the option
                   `${builtins.concatStringsSep "." prefix}'!
@@ -598,14 +586,10 @@ let
                   This usually happens if `${builtins.concatStringsSep "." prefix}' has option
                   definitions inside that are not matched. Please check how to properly define
                   this option by e.g. referring to `man 5 configuration.nix'!
-                '' else ''
-                  An option declaration for `${builtins.concatStringsSep "." prefix}' has type
-                  `${builtins.typeOf subtree}' rather than an attribute set.
-                  Did you mean to define this outside of `options'?
-                '')
+                ''
               else
                 mapAttrs (n: f module) subtree
-              ) modules)) "config" (module: value:
+              ) modules)) (module: value:
           [{ inherit (module) file; inherit value; }]
         ) configs;
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -565,8 +565,11 @@ let
         assert
           lib.all
             (c:
+              # TODO: I have my doubts that this error would occur when option definitions are not matched.
+              #       The implementation of this check used to be tied to a superficially similar check for
+              #       options, so maybe that's why this is here.
               isAttrs c.config || throw ''
-                You're trying to define a value of type `${builtins.typeOf c.config}'
+                In module `${c.file}', you're trying to define a value of type `${builtins.typeOf c.config}'
                 rather than an attribute set for the option
                 `${builtins.concatStringsSep "." prefix}'!
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -541,8 +541,10 @@ let
     let
       # an attrset 'name' => list of submodules that declare ‘name’.
       declsByName =
-        zipAttrsWith (n: concatLists)
-          (map (module: let subtree = module.options; in
+        zipAttrsWith
+          (n: concatLists)
+          (map
+            (module: let subtree = module.options; in
               if !(builtins.isAttrs subtree) then
                 throw ''
                   An option declaration for `${builtins.concatStringsSep "." prefix}' has type
@@ -555,7 +557,8 @@ let
                     [{ inherit (module) _file; options = option; }]
                   )
                   subtree
-              ) options);
+              )
+            options);
 
       # The root of any module definition must be an attrset.
       checkedConfigs =
@@ -577,24 +580,30 @@ let
 
       # an attrset 'name' => list of submodules that define ‘name’.
       pushedDownDefinitionsByName =
-        zipAttrsWith (n: concatLists)
-          (map (module:
-                mapAttrs
-                  (n: value:
-                    map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
-                  )
-                  module.config
-              ) checkedConfigs);
+        zipAttrsWith
+          (n: concatLists)
+          (map
+            (module:
+              mapAttrs
+                (n: value:
+                  map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
+                )
+              module.config
+            )
+            checkedConfigs);
       # extract the definitions for each loc
       rawDefinitionsByName =
-        zipAttrsWith (n: concatLists)
-          (map (module:
-                mapAttrs
-                  (n: value:
-                    [{ inherit (module) file; inherit value; }]
-                  )
-                  module.config
-              ) checkedConfigs);
+        zipAttrsWith
+          (n: concatLists)
+          (map
+            (module:
+              mapAttrs
+                (n: value:
+                  [{ inherit (module) file; inherit value; }]
+                )
+                module.config
+            )
+            checkedConfigs);
 
       # Convert an option tree decl to a submodule option decl
       optionTreeToOption = decl:

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -551,9 +551,9 @@ let
                 ''
               else
                 mapAttrs
-                  (n: (module: option:
-                        [{ inherit (module) _file; options = option; }]
-                      ) module)
+                  (n: option:
+                    [{ inherit (module) _file; options = option; }]
+                  )
                   subtree
               ) options);
       # an attrset 'name' => list of submodules that define ‘name’.
@@ -572,9 +572,9 @@ let
                 ''
               else
                 mapAttrs
-                  (n: (module: value:
-                        map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
-                      ) module)
+                  (n: value:
+                    map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
+                  )
                   subtree
               ) configs);
       # extract the definitions for each loc
@@ -593,9 +593,9 @@ let
                 ''
               else
                 mapAttrs
-                  (n: (module: value:
-                        [{ inherit (module) file; inherit value; }]
-                      ) module)
+                  (n: value:
+                    [{ inherit (module) file; inherit value; }]
+                  )
                 subtree
               ) configs);
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -578,7 +578,7 @@ let
                   subtree
               ) configs);
       # extract the definitions for each loc
-      defnsByName' =
+      rawDefinitionsByName =
         zipAttrsWith (n: concatLists)
           (map (module: let subtree = module.config; in
               if !(builtins.isAttrs subtree) then
@@ -620,7 +620,7 @@ let
         let
           loc = prefix ++ [name];
           defns = defnsByName.${name} or [];
-          defns' = defnsByName'.${name} or [];
+          defns' = rawDefinitionsByName.${name} or [];
           optionDecls = filter (m: isOption m.options) decls;
         in
           if length optionDecls == length decls then
@@ -663,7 +663,7 @@ let
         # Propagate all unmatched definitions from nested option sets
         mapAttrs (n: v: v.unmatchedDefns) resultsByName
         # Plus the definitions for the current prefix that don't have a matching option
-        // removeAttrs defnsByName' (attrNames matchedOptions);
+        // removeAttrs rawDefinitionsByName (attrNames matchedOptions);
     in {
       inherit matchedOptions;
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -557,7 +557,7 @@ let
                   subtree
               ) options);
       # an attrset 'name' => list of submodules that define ‘name’.
-      defnsByName =
+      pushedDownDefinitionsByName =
         zipAttrsWith (n: concatLists)
           (map (module: let subtree = module.config; in
               if !(builtins.isAttrs subtree) then
@@ -619,7 +619,7 @@ let
         # We're descending into attribute ‘name’.
         let
           loc = prefix ++ [name];
-          defns = defnsByName.${name} or [];
+          defns = pushedDownDefinitionsByName.${name} or [];
           defns' = rawDefinitionsByName.${name} or [];
           optionDecls = filter (m: isOption m.options) decls;
         in

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -578,22 +578,22 @@ let
       # an attrset 'name' => list of submodules that define ‘name’.
       pushedDownDefinitionsByName =
         zipAttrsWith (n: concatLists)
-          (map (module: let subtree = module.config; in
+          (map (module:
                 mapAttrs
                   (n: value:
                     map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
                   )
-                  subtree
+                  module.config
               ) checkedConfigs);
       # extract the definitions for each loc
       rawDefinitionsByName =
         zipAttrsWith (n: concatLists)
-          (map (module: let subtree = module.config; in
+          (map (module:
                 mapAttrs
                   (n: value:
                     [{ inherit (module) file; inherit value; }]
                   )
-                subtree
+                  module.config
               ) checkedConfigs);
 
       # Convert an option tree decl to a submodule option decl

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -540,7 +540,7 @@ let
   mergeModules' = prefix: options: configs:
     let
       # an attrset 'name' => list of submodules that declare ‘name’.
-      declsByName = (modules:
+      declsByName =
         zipAttrsWith (n: concatLists)
           (map (module: let subtree = module.options; in
               if !(builtins.isAttrs subtree) then
@@ -555,9 +555,9 @@ let
                         [{ inherit (module) _file; options = option; }]
                       ) module)
                   subtree
-              ) modules))  options;
+              ) options);
       # an attrset 'name' => list of submodules that define ‘name’.
-      defnsByName = (modules:
+      defnsByName =
         zipAttrsWith (n: concatLists)
           (map (module: let subtree = module.config; in
               if !(builtins.isAttrs subtree) then
@@ -576,9 +576,9 @@ let
                         map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
                       ) module)
                   subtree
-              ) modules)) configs;
+              ) configs);
       # extract the definitions for each loc
-      defnsByName' = (modules:
+      defnsByName' =
         zipAttrsWith (n: concatLists)
           (map (module: let subtree = module.config; in
               if !(builtins.isAttrs subtree) then
@@ -597,7 +597,7 @@ let
                         [{ inherit (module) file; inherit value; }]
                       ) module)
                 subtree
-              ) modules))  configs;
+              ) configs);
 
       # Convert an option tree decl to a submodule option decl
       optionTreeToOption = decl:

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -540,7 +540,7 @@ let
   mergeModules' = prefix: options: configs:
     let
       # an attrset 'name' => list of submodules that declare ‘name’.
-      declsByName = (f: modules:
+      declsByName = (modules:
         zipAttrsWith (n: concatLists)
           (map (module: let subtree = module.options; in
               if !(builtins.isAttrs subtree) then
@@ -550,12 +550,14 @@ let
                   Did you mean to define this outside of `options'?
                 ''
               else
-                mapAttrs (n: f module) subtree
-              ) modules)) (module: option:
-          [{ inherit (module) _file; options = option; }]
-        ) options;
+                mapAttrs
+                  (n: (module: option:
+                        [{ inherit (module) _file; options = option; }]
+                      ) module)
+                  subtree
+              ) modules))  options;
       # an attrset 'name' => list of submodules that define ‘name’.
-      defnsByName = (f: modules:
+      defnsByName = (modules:
         zipAttrsWith (n: concatLists)
           (map (module: let subtree = module.config; in
               if !(builtins.isAttrs subtree) then
@@ -569,12 +571,14 @@ let
                   this option by e.g. referring to `man 5 configuration.nix'!
                 ''
               else
-                mapAttrs (n: f module) subtree
-              ) modules)) (module: value:
-          map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
-        ) configs;
+                mapAttrs
+                  (n: (module: value:
+                        map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
+                      ) module)
+                  subtree
+              ) modules)) configs;
       # extract the definitions for each loc
-      defnsByName' = (f: modules:
+      defnsByName' = (modules:
         zipAttrsWith (n: concatLists)
           (map (module: let subtree = module.config; in
               if !(builtins.isAttrs subtree) then
@@ -588,10 +592,12 @@ let
                   this option by e.g. referring to `man 5 configuration.nix'!
                 ''
               else
-                mapAttrs (n: f module) subtree
-              ) modules)) (module: value:
-          [{ inherit (module) file; inherit value; }]
-        ) configs;
+                mapAttrs
+                  (n: (module: value:
+                        [{ inherit (module) file; inherit value; }]
+                      ) module)
+                subtree
+              ) modules))  configs;
 
       # Convert an option tree decl to a submodule option decl
       optionTreeToOption = decl:

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -207,7 +207,7 @@ checkConfigOutput '^"foo"$' config.submodule.foo ./declare-submoduleWith-special
 ## shorthandOnlyDefines config behaves as expected
 checkConfigOutput '^true$' config.submodule.config ./declare-submoduleWith-shorthand.nix ./define-submoduleWith-shorthand.nix
 checkConfigError 'is not of type `boolean' config.submodule.config ./declare-submoduleWith-shorthand.nix ./define-submoduleWith-noshorthand.nix
-checkConfigError "You're trying to define a value of type \`bool'\n\s*rather than an attribute set for the option" config.submodule.config ./declare-submoduleWith-noshorthand.nix ./define-submoduleWith-shorthand.nix
+checkConfigError "In module ..*define-submoduleWith-shorthand.nix., you're trying to define a value of type \`bool'\n\s*rather than an attribute set for the option" config.submodule.config ./declare-submoduleWith-noshorthand.nix ./define-submoduleWith-shorthand.nix
 checkConfigOutput '^true$' config.submodule.config ./declare-submoduleWith-noshorthand.nix ./define-submoduleWith-noshorthand.nix
 
 ## submoduleWith should merge all modules in one swoop


### PR DESCRIPTION
###### Description of changes

This is mostly about refactoring away `byName` which was a non-abstraction.

Most of the commits are the small refactoring steps, separated out so they can be followed and checked.

The only commits that aren't pure refactoring are the ones titled

- lib/modules.nix: Make entire definition list strict in config check
   - see commit message for argumentation why this is fine
- lib.mergeModules: Add context to error message
   - an incremental improvement; see todo comment. I don't want to increase the scope of this PR.

These changes were motivated by https://github.com/NixOS/nixpkgs/pull/242339#discussion_r1258599252

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
