### PR TITLE
mailpit: init at 1.7.1

### DIFF
--- a/pkgs/servers/mail/mailpit/default.nix
+++ b/pkgs/servers/mail/mailpit/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildGoModule
+, nodejs
+, python3
+, libtool
+, npmHooks
+, fetchFromGitHub
+, fetchNpmDeps
+}:
+
+buildGoModule rec {
+  pname = "mailpit";
+  version = "1.7.1";
+
+  src = fetchFromGitHub {
+    owner = "axllent";
+    repo = "mailpit";
+    rev = "v${version}";
+    hash = "sha256-jT9QE0ikp9cJlT8qtfPPjKOUuqWyQk94D3UbkyaGXa8=";
+  };
+
+  vendorHash = "sha256-XBYIO7fdo5EahJB7EcAuY9SGKZb8dsvoJHp/D5LO5Qo=";
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    hash = "sha256-6VCs8125fTJkZW+eZgK56j7ccK8tcGhIXiq2HkYp4XM=";
+  };
+
+  nativeBuildInputs = [ nodejs python3 libtool npmHooks.npmConfigHook ];
+
+  preBuild = ''
+    npm run package
+  '';
+
+  CGO_ENABLED = 0;
+
+  ldflags = [ "-s" "-w" "-X github.com/axllent/mailpit/config.Version=${version}" ];
+
+  meta = with lib; {
+    description = "An email and SMTP testing tool with API for developers";
+    homepage = "https://github.com/axllent/mailpit";
+    changelog = "https://github.com/axllent/mailpit/releases/tag/v${version}";
+    maintainers = with maintainers; [ stephank ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10213,6 +10213,10 @@ with pkgs;
   );
   bubblemail = callPackage ../applications/networking/mailreaders/bubblemail { };
 
+  mailpit = callPackage ../servers/mail/mailpit {
+    libtool = if stdenv.isDarwin then darwin.cctools else libtool;
+  };
+
   mailsend = callPackage ../tools/networking/mailsend { };
 
   mailutils = callPackage ../tools/networking/mailutils {


### PR DESCRIPTION
###### Description of changes

Packages [mailpit](https://github.com/axllent/mailpit)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
