### PR TITLE
python3Packages.spacy-lookups-data: init at 1.0.3

### DIFF
--- a/pkgs/development/python-modules/spacy/lookups-data.nix
+++ b/pkgs/development/python-modules/spacy/lookups-data.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, spacy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "spacy-lookups-data";
+  version = "1.0.3";
+  format = "setuptools";
+
+  src = fetchPypi {
+    pname = "spacy_lookups_data";
+    inherit version;
+    hash = "sha256-q2hlVI+4ZtR5CQ4xEIp+Je0ZKhH8sJiW5xFjKM3FK+E=";
+  };
+
+  nativeCheckInputs = [
+    spacy
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "spacy_lookups_data" ];
+
+  meta = with lib; {
+    description = "Additional lookup tables and data resources for spaCy";
+    homepage = "https://pypi.org/project/spacy-lookups-data";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jboy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10964,6 +10964,8 @@ self: super: with self; {
 
   spacy-loggers = callPackage ../development/python-modules/spacy-loggers { };
 
+  spacy-lookups-data = callPackage ../development/python-modules/spacy/lookups-data.nix { };
+
   spacy_models = callPackage ../development/python-modules/spacy/models.nix {
       inherit (pkgs) jq;
   };


### PR DESCRIPTION
###### Description of changes

This package installs additional data files to be used with [spaCy](https://spacy.io/). When installed in the same environment as spaCy, this package makes the resources for each language available as an entry point, which spaCy checks when setting up the Vocab and Lookups. This makes it possible to work with languages for which no pre-trained models are available (e.g., Turkish).

- Release notes for 1.0.3: https://github.com/explosion/spacy-lookups-data/releases/tag/v1.0.3
- Repository: https://github.com/explosion/spacy-lookups-data
- PyPI: https://pypi.org/project/spacy-lookups-data/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
