### PR TITLE
dxvk: 2.1 -> 2.2

### DIFF
--- a/pkgs/misc/dxvk/default.nix
+++ b/pkgs/misc/dxvk/default.nix
@@ -8,8 +8,12 @@
 
 stdenvNoCC.mkDerivation (finalAttrs:
   let
-    dxvk32 = if stdenv.isDarwin then pkgsCross.mingw32.dxvk_1 else pkgsCross.mingw32.dxvk_2;
-    dxvk64 = if stdenv.isDarwin then pkgsCross.mingwW64.dxvk_1 else pkgsCross.mingwW64.dxvk_2;
+    dxvk32 = if stdenv.isDarwin
+      then pkgsCross.mingw32.dxvk_1.override { enableMoltenVKCompat = true; }
+      else pkgsCross.mingw32.dxvk_2;
+    dxvk64 = if stdenv.isDarwin
+      then pkgsCross.mingwW64.dxvk_1.override { enableMoltenVKCompat = true; }
+      else pkgsCross.mingwW64.dxvk_2;
   in
   {
     pname = "dxvk";

--- a/pkgs/misc/dxvk/dxvk.nix
+++ b/pkgs/misc/dxvk/dxvk.nix
@@ -45,12 +45,12 @@ let
       ];
     };
     "default" = rec {
-      version = "2.1";
+      version = "2.2";
       src = fetchFromGitHub {
         owner = "doitsujin";
         repo = "dxvk";
         rev = "v${version}";
-        hash = "sha256-A4KR11brfQbR56dGt371MRwMN/H6HFAU8TlFC97/bRs=";
+        hash = "sha256-GKRd66DvcA+7p3/wDqAUi02ZLRSVZ/fvJM0PQDEKVMA=";
         fetchSubmodules = true; # Needed for the DirectX headers and libdisplay-info
       };
       patches = [ ];

--- a/pkgs/misc/dxvk/dxvk.nix
+++ b/pkgs/misc/dxvk/dxvk.nix
@@ -14,6 +14,7 @@
 , gitUpdater
 , sdl2Support ? true
 , glfwSupport ? false
+, enableMoltenVKCompat ? false
 }:
 
 # SDL2 and GLFW support are mutually exclusive.
@@ -35,7 +36,7 @@ let
         hash = "sha256-T93ZylxzJGprrP+j6axZwl2d3hJowMCUOKNjIyNzkmE=";
       };
       # These patches are required when using DXVK with Wine on Darwin.
-      patches = lib.optionals stdenv.buildPlatform.isDarwin [
+      patches = lib.optionals enableMoltenVKCompat [
         # Patch DXVK to work with MoltenVK even though it doesn’t support some required features.
         # Some games work poorly (particularly Unreal Engine 4 games), but others work pretty well.
         ./darwin-dxvk-compat.patch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39521,7 +39521,7 @@ with pkgs;
 
   dxvk = callPackage ../misc/dxvk { };
   dxvk_1 = callPackage ../misc/dxvk/dxvk.nix { dxvkVersion = "1.10"; };
-  dxvk_2 = callPackage ../misc/dxvk/dxvk.nix { dxvkVersion = "2.1"; };
+  dxvk_2 = callPackage ../misc/dxvk/dxvk.nix { };
 
   ec2stepshell = callPackage ../tools/security/ec2stepshell { };
 


### PR DESCRIPTION
###### Description of changes

https://github.com/doitsujin/dxvk/releases/tag/v2.2

This PR also adds an update script and cleans up Darwin support a bit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
