### PR TITLE
treewide: go-modules -> goModules

### DIFF
--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -20,7 +20,7 @@ In the following is an example expression using `buildGoModule`, the following a
 
   To obtain the actual hash, set `vendorHash = lib.fakeSha256;` and run the build ([more details here](#sec-source-hashes)).
 - `proxyVendor`: Fetches (go mod download) and proxies the vendor directory. This is useful if your code depends on c code and go mod tidy does not include the needed sources to build or if any dependency has case-insensitive conflicts which will produce platform-dependent `vendorHash` checksums.
-- `modPostBuild`: Shell commands to run after the build of the go-modules executes `go mod vendor`, and before calculating fixed output derivation's `vendorHash` (or `vendorSha256`). Note that if you change this attribute, you need to update `vendorHash` (or `vendorSha256`) attribute.
+- `modPostBuild`: Shell commands to run after the build of the goModules executes `go mod vendor`, and before calculating fixed output derivation's `vendorHash` (or `vendorSha256`). Note that if you change this attribute, you need to update `vendorHash` (or `vendorSha256`) attribute.
 
 ```nix
 pet = buildGoModule rec {
@@ -115,7 +115,7 @@ done
 
 ## Attributes used by the builders {#ssec-go-common-attributes}
 
-Many attributes [controlling the build phase](#variables-controlling-the-build-phase) are respected by both `buildGoModule` and `buildGoPackage`. Note that `buildGoModule` reads the following attributes also when building the `vendor/` go-modules fixed output derivation as well:
+Many attributes [controlling the build phase](#variables-controlling-the-build-phase) are respected by both `buildGoModule` and `buildGoPackage`. Note that `buildGoModule` reads the following attributes also when building the `vendor/` goModules fixed output derivation as well:
 
 - [`sourceRoot`](#var-stdenv-sourceRoot)
 - [`prePatch`](#var-stdenv-prePatch)

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -98,6 +98,8 @@
 
 - DocBook option documentation is no longer supported, all module documentation now uses markdown.
 
+- `buildGoModule` `go-modules` attrs have been renamed to `goModules`.
+
 - `services.fail2ban.jails` can now be configured with attribute sets defining settings and filters instead of lines. The stringed options `daemonConfig` and `extraSettings` have respectively been replaced by `daemonSettings` and `jails.DEFAULT.settings` which use attribute sets.
 
 - The module [services.ankisyncd](#opt-services.ankisyncd.package) has been switched to [anki-sync-server-rs](https://github.com/ankicommunity/anki-sync-server-rs) from the old python version, which was difficult to update, had not been updated in a while, and did not support recent versions of anki.

--- a/pkgs/applications/networking/cluster/k3s/update-script.sh
+++ b/pkgs/applications/networking/cluster/k3s/update-script.sh
@@ -114,7 +114,7 @@ cat >versions.nix <<EOF
 EOF
 
 set +e
-K3S_VENDOR_SHA256=$(nix-prefetch -I nixpkgs=${NIXPKGS_ROOT} "{ sha256 }: (import ${NIXPKGS_ROOT}. {}).k3s_1_${MINOR_VERSION}.go-modules.overrideAttrs (_: { vendorSha256 = sha256; })")
+K3S_VENDOR_SHA256=$(nix-prefetch -I nixpkgs=${NIXPKGS_ROOT} "{ sha256 }: (import ${NIXPKGS_ROOT}. {}).k3s_1_${MINOR_VERSION}.goModules.overrideAttrs (_: { vendorSha256 = sha256; })")
 set -e
 
 if [ -n "${K3S_VENDOR_SHA256:-}" ]; then

--- a/pkgs/applications/networking/cluster/kfctl/default.nix
+++ b/pkgs/applications/networking/cluster/kfctl/default.nix
@@ -28,6 +28,6 @@ buildGoModule rec {
     homepage = "https://github.com/kubeflow/kfctl";
     license = licenses.asl20;
     maintainers = with maintainers; [ mvnetbiz ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/applications/networking/cluster/kubemqctl/default.nix
+++ b/pkgs/applications/networking/cluster/kubemqctl/default.nix
@@ -21,6 +21,6 @@ buildGoModule rec {
     description = "Kubemqctl is a command line interface (CLI) for Kubemq Kubernetes Message Broker.";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ brianmcgee ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/applications/networking/cluster/terraform-providers/update-provider
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-provider
@@ -151,7 +151,7 @@ update_attr hash "${hash}"
 old_vendor_hash="$(read_attr vendorHash)"
 if [[ ${old_vendor_hash} != null ]]; then
   echo_provider "calculating vendorHash"
-  vendorHash=$(generate_hash go-modules)
+  vendorHash=$(generate_hash goModules)
   update_attr vendorHash "${vendorHash}"
 fi
 

--- a/pkgs/applications/system/mgmt/default.nix
+++ b/pkgs/applications/system/mgmt/default.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
     hash = "sha256-jurZvEtiaTjWeDkmCJDIFlTzR5EVglfoDxkFgOilo8s=";
   };
 
-  # patching must be done in prebuild, so it is shared with go-modules
+  # patching must be done in prebuild, so it is shared with goModules
   # see https://github.com/NixOS/nixpkgs/issues/208036
   preBuild = ''
     for file in `find -name Makefile -type f`; do

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -43,7 +43,7 @@ buildPythonApplication rec {
     pname = "kitty-go-modules";
     inherit src version;
     vendorHash = "sha256-jk2EcYVuhV/UQfHAIfpnn8ZIZnwjA/o8YRXmpoC85Vc=";
-  }).go-modules;
+  }).goModules;
 
   buildInputs = [
     harfbuzz
@@ -224,7 +224,6 @@ buildPythonApplication rec {
   '';
 
   passthru = {
-    go-modules = goModules; # allow for updateScript to handle vendorHash
     tests.test = nixosTests.terminal-emulators.kitty;
     updateScript = nix-update-script {};
   };

--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -88,7 +88,7 @@ buildGoModule rec {
       --prefix PATH : ${lib.makeBinPath [ bash git gzip openssh ]}
   '';
 
-  # $data is not available in go-modules.drv and preBuild isn't needed
+  # $data is not available in goModules.drv and preBuild isn't needed
   overrideModAttrs = (_: {
     postPatch = null;
     preBuild = null;

--- a/pkgs/applications/version-management/git-hound/default.nix
+++ b/pkgs/applications/version-management/git-hound/default.nix
@@ -26,6 +26,6 @@ buildGoModule rec {
     homepage = "https://github.com/tillson/git-hound";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/applications/version-management/sourcehut/fix-gqlgen-trimpath.nix
+++ b/pkgs/applications/version-management/sourcehut/fix-gqlgen-trimpath.nix
@@ -3,7 +3,7 @@
 }:
 {
   overrideModAttrs = (_: {
-    # No need to workaround -trimpath: it's not used in go-modules,
+    # No need to workaround -trimpath: it's not used in goModules,
     # but do download `go generate`'s dependencies nonetheless.
     preBuild = ''
       go generate ./loaders

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -93,7 +93,7 @@ in
   inherit pname version src;
 
   # Override vendorHash with the output got from
-  # nix-prefetch -E "{ sha256 }: ((import ./. { }).apptainer.override { vendorHash = sha256; }).go-modules"
+  # nix-prefetch -E "{ sha256 }: ((import ./. { }).apptainer.override { vendorHash = sha256; }).goModules"
   # or with `null` when using vendored source tarball.
   inherit vendorHash deleteVendor proxyVendor;
 

--- a/pkgs/applications/virtualization/singularity/packages.nix
+++ b/pkgs/applications/virtualization/singularity/packages.nix
@@ -18,7 +18,7 @@ let
       };
 
       # Update by running
-      # nix-prefetch -E "{ sha256 }: ((import ./. { }).apptainer.override { vendorHash = sha256; }).go-modules"
+      # nix-prefetch -E "{ sha256 }: ((import ./. { }).apptainer.override { vendorHash = sha256; }).goModules"
       # at the root directory of the Nixpkgs repository
       vendorHash = "sha256-PfFubgR/W1WBXIsRO+Kg7hA6ebeAcRiJlTlAZbnl19A=";
 
@@ -49,7 +49,7 @@ let
       };
 
       # Update by running
-      # nix-prefetch -E "{ sha256 }: ((import ./. { }).singularity.override { vendorHash = sha256; }).go-modules"
+      # nix-prefetch -E "{ sha256 }: ((import ./. { }).singularity.override { vendorHash = sha256; }).goModules"
       # at the root directory of the Nixpkgs repository
       vendorHash = "sha256-mBhlH6LSmcJuc6HbU/3Q9ii7vJkW9jcikBWCl8oeMOk=";
 

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -6,7 +6,7 @@
 , passthru ? { }
 , patches ? [ ]
 
-  # A function to override the go-modules derivation
+  # A function to override the goModules derivation
 , overrideModAttrs ? (_oldAttrs: { })
 
   # path to go.mod and go.sum directory
@@ -52,9 +52,9 @@ assert (args' ? vendorHash && args' ? vendorSha256) -> throw "both `vendorHash` 
 let
   args = removeAttrs args' [ "overrideModAttrs" "vendorSha256" "vendorHash" ];
 
-  go-modules = if (vendorHash == null) then "" else
+  goModules = if (vendorHash == null) then "" else
   (stdenv.mkDerivation {
-    name = "${name}-go-modules";
+    name = "${name}-goModules";
 
     nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ go git cacert ];
 
@@ -163,10 +163,10 @@ let
       cd "$modRoot"
     '' + lib.optionalString (vendorHash != null) ''
       ${if proxyVendor then ''
-        export GOPROXY=file://${go-modules}
+        export GOPROXY=file://${goModules}
       '' else ''
         rm -rf vendor
-        cp -r --reflink=auto ${go-modules} vendor
+        cp -r --reflink=auto ${goModules} vendor
       ''}
     '' + ''
 
@@ -288,7 +288,7 @@ let
 
     disallowedReferences = lib.optional (!allowGoReference) go;
 
-    passthru = passthru // { inherit go go-modules vendorHash; } // { inherit (args') vendorSha256; };
+    passthru = passthru // { inherit go goModules vendorHash; } // { inherit (args') vendorSha256; };
 
     meta = {
       # Add default meta information

--- a/pkgs/development/tools/kcli/default.nix
+++ b/pkgs/development/tools/kcli/default.nix
@@ -20,6 +20,6 @@ buildGoModule rec {
     homepage = "https://github.com/cswank/kcli";
     license = licenses.mit;
     maintainers = with maintainers; [ cswank ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/servers/authelia/update.sh
+++ b/pkgs/servers/authelia/update.sh
@@ -80,6 +80,6 @@ clean_up
 OLD_GO_VENDOR_HASH="$(instantiateClean authelia.vendorHash)"
 echo "Old go vendor hash $OLD_GO_VENDOR_HASH"
 replace "$OLD_GO_VENDOR_HASH" "$TMP_HASH" "$DRV_DIR/sources.nix"
-NEW_GO_VENDOR_HASH="$(fetchNewSha authelia.go-modules)"
+NEW_GO_VENDOR_HASH="$(fetchNewSha authelia.goModules)"
 echo "New go vendor hash $NEW_GO_VENDOR_HASH"
 replace "$TMP_HASH" "$NEW_GO_VENDOR_HASH" "$DRV_DIR/sources.nix"

--- a/pkgs/servers/dns/ncdns/default.nix
+++ b/pkgs/servers/dns/ncdns/default.nix
@@ -37,7 +37,7 @@ buildGoModule {
 
   vendorSha256 = "sha256-ENtTnDsz5WhRz1kiqnWQ5vyEpZtgi7ZeYvksffgW78k=";
 
-  # Override the go-modules fetcher derivation to apply
+  # Override the goModules fetcher derivation to apply
   # upstream's patch of the crypto/x509 library.
   modBuildPhase = ''
     go mod init github.com/namecoin/x509-compressed

--- a/pkgs/servers/geospatial/pg_featureserv/default.nix
+++ b/pkgs/servers/geospatial/pg_featureserv/default.nix
@@ -20,6 +20,6 @@ buildGoModule rec {
     homepage = "https://github.com/CrunchyData/pg_featureserv";
     license = licenses.asl20;
     maintainers = with maintainers; [ sikmir ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/servers/gobetween/default.nix
+++ b/pkgs/servers/gobetween/default.nix
@@ -35,6 +35,6 @@ buildGoModule rec {
     homepage = "https://gobetween.io";
     license = licenses.mit;
     maintainers = with maintainers; [ tomberek ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/servers/memos/update.sh
+++ b/pkgs/servers/memos/update.sh
@@ -13,7 +13,7 @@ fi
 
 extractVendorHash() {
   original="${1?original hash missing}"
-  result="$(nix-build -A memos.go-modules 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+  result="$(nix-build -A memos.goModules 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
   [ -z "$result" ] && { echo "$original"; } || { echo "$result"; }
 }
 

--- a/pkgs/servers/monitoring/alertmanager-bot/default.nix
+++ b/pkgs/servers/monitoring/alertmanager-bot/default.nix
@@ -30,6 +30,6 @@ buildGoModule rec {
     homepage = "https://github.com/metalmatze/alertmanager-bot";
     license = licenses.mit;
     maintainers = with maintainers; [ mmahut ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/servers/monitoring/grafana/update.sh
+++ b/pkgs/servers/monitoring/grafana/update.sh
@@ -16,7 +16,7 @@ replaceHash() {
 }
 extractVendorHash() {
   original="${1?original hash missing}"
-  result="$(nix-build -A grafana.go-modules 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+  result="$(nix-build -A grafana.goModules 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
   [ -z "$result" ] && { echo "$original"; } || { echo "$result"; }
 }
 

--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -46,11 +46,11 @@ let
     })
   ];
 
-  netfilter-go-modules = (buildGoModule {
+  netfilter-goModules = (buildGoModule {
     inherit pname version src patches;
     modRoot = "linux/netfilter";
     vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
-  }).go-modules;
+  }).goModules;
 
   extensionBridgeDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
@@ -132,7 +132,7 @@ stdenv.mkDerivation {
     substituteInPlace extension/CMakeLists.txt \
       --replace '/etc' "$out/etc"
 
-    ln -s '${netfilter-go-modules}' linux/netfilter/vendor
+    ln -s '${netfilter-goModules}' linux/netfilter/vendor
 
     pushd extension/bridge
     cargoDepsCopy="$extensionBridgeDepsCopy" cargoSetupPostPatchHook

--- a/pkgs/tools/networking/shadowfox/default.nix
+++ b/pkgs/tools/networking/shadowfox/default.nix
@@ -27,6 +27,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = with maintainers; [ infinisil ];
     mainProgram = "shadowfox-updater";
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/tools/networking/waitron/default.nix
+++ b/pkgs/tools/networking/waitron/default.nix
@@ -34,6 +34,6 @@ buildGoModule rec {
     license =  licenses.asl20;
     maintainers = with maintainers; [ guibert ];
     platforms = platforms.linux;
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/tools/networking/wuzz/default.nix
+++ b/pkgs/tools/networking/wuzz/default.nix
@@ -18,6 +18,6 @@ buildGoModule rec {
     description = "Interactive cli tool for HTTP inspection";
     license = licenses.agpl3;
     maintainers = with maintainers; [ pradeepchhetri ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/tools/security/deepsea/default.nix
+++ b/pkgs/tools/security/deepsea/default.nix
@@ -26,6 +26,6 @@ buildGoModule rec {
     homepage = "https://github.com/dsnezhkov/deepsea";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ fab ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/tools/security/shhgit/default.nix
+++ b/pkgs/tools/security/shhgit/default.nix
@@ -22,6 +22,6 @@ buildGoModule rec {
     homepage = "https://github.com/eth0izzle/shhgit";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/tools/security/ssb/default.nix
+++ b/pkgs/tools/security/ssb/default.nix
@@ -21,6 +21,6 @@ buildGoModule rec {
     homepage = "https://github.com/kitabisa/ssb";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ fab ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }

--- a/pkgs/tools/text/wrap/default.nix
+++ b/pkgs/tools/text/wrap/default.nix
@@ -32,6 +32,6 @@ buildGoModule rec {
     homepage = "https://github.com/Wraparound/wrap";
     license = licenses.gpl3Only;
     maintainers = [ maintainers.austinbutler ];
-    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.go-modules --check
+    broken = true; # vendor isn't reproducible with go > 1.17: nix-build -A $name.goModules --check
   };
 }


### PR DESCRIPTION
In 787af0f79f128cb21b113d2eb37e64d913f18aae https://github.com/NixOS/nixpkgs/pull/241707
I had to change ${go-modules} to $goModules to allow overrideAttrs to work; However, env vars cannot contain -, so  i had to change go-modules too. This in turn broke nix-update because it uses the go-modules attr.

Instead of making nix-update more complicated, make go-modules naming match cargoDeps.

`fd --type f | xargs sd '\bgo-modules\b' 'goModules'` and revert change to pkgs/applications/misc/dstask/default.nix

release note added

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
