### PR TITLE
jetbrains.plugins: Update plugins when IDEs are being updated

### DIFF
--- a/pkgs/applications/editors/jetbrains/update_ides.py
+++ b/pkgs/applications/editors/jetbrains/update_ides.py
@@ -4,12 +4,14 @@ import json
 import pathlib
 import logging
 import requests
+import subprocess
 import sys
 import xmltodict
 from packaging import version
 
 updates_url = "https://www.jetbrains.com/updates/updates.xml"
-versions_file_path = pathlib.Path(__file__).parent.joinpath("versions.json").resolve()
+current_path = pathlib.Path(__file__).parent
+versions_file_path = current_path.joinpath("versions.json").resolve()
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -98,3 +100,7 @@ for products in versions.values():
 with open(versions_file_path, "w") as versions_file:
     json.dump(versions, versions_file, indent=2)
     versions_file.write("\n")
+
+logging.info("#### Updating plugins ####")
+plugin_script = current_path.joinpath("plugins/update_plugins.py").resolve()
+subprocess.call(plugin_script)


### PR DESCRIPTION
###### Description of changes

Follow up to #242493 : When updating jetbrains IDEs, we need to update the plugins as well. This executes `update_plugins.py` when `update_ides.py` is called.

I'm not a python programmer, so there might be better ways to resolve the path and call the subscript (tagging @GenericNerdyUsername for python expertise).

// cc @Janik-Haag 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
