### PR TITLE
python310Packages.prophet: init at 1.1.4

### DIFF
--- a/pkgs/development/python-modules/cmdstanpy/default.nix
+++ b/pkgs/development/python-modules/cmdstanpy/default.nix
@@ -1,0 +1,82 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, substituteAll
+
+, cmdstan
+
+, pandas
+, numpy
+, tqdm
+, xarray
+
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "cmdstanpy";
+  version = "1.1.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "stan-dev";
+    repo = "cmdstanpy";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-9kAd3rbSctWEhAzB6RiQlbg5/uVxGIghYLus8hWzBFQ=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./use-nix-cmdstan-path.patch;
+      cmdstan = "${cmdstan}/opt/cmdstan";
+    })
+  ];
+
+  postPatch = ''
+    # conftest.py would have used git to clean up, which is unnecessary here
+    rm test/conftest.py
+  '';
+
+  propagatedBuildInputs = [
+    pandas
+    numpy
+    tqdm
+  ];
+
+  passthru.optional-dependencies = {
+    all = [ xarray ];
+  };
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ] ++ passthru.optional-dependencies.all;
+
+  disabledTestPaths = [
+    # No need to test these when using Nix
+    "test/test_install_cmdstan.py"
+    "test/test_cxx_installation.py"
+  ];
+
+  disabledTests = [
+    "test_lp_good" # Fails for some reason
+    "test_serialization" # Pickle class mismatch errors
+    # These tests use the flag -DSTAN_THREADS which doesn't work in cmdstan (missing file)
+    "test_multi_proc_threads"
+    "test_compile_force"
+  ];
+
+  pythonImportsCheck = [ "cmdstanpy" ];
+
+  meta = {
+    homepage = "https://github.com/stan-dev/cmdstanpy";
+    description = "A lightweight interface to Stan for Python users";
+    changelog = "https://github.com/stan-dev/cmdstanpy/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/development/python-modules/cmdstanpy/use-nix-cmdstan-path.patch
+++ b/pkgs/development/python-modules/cmdstanpy/use-nix-cmdstan-path.patch
@@ -1,0 +1,25 @@
+diff --git a/cmdstanpy/utils/cmdstan.py b/cmdstanpy/utils/cmdstan.py
+index 227d97a..27c3ccc 100644
+--- a/cmdstanpy/utils/cmdstan.py
++++ b/cmdstanpy/utils/cmdstan.py
+@@ -163,19 +163,7 @@ def cmdstan_path() -> str:
+     if 'CMDSTAN' in os.environ and len(os.environ['CMDSTAN']) > 0:
+         cmdstan = os.environ['CMDSTAN']
+     else:
+-        cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+-        if not os.path.exists(cmdstan_dir):
+-            raise ValueError(
+-                'No CmdStan installation found, run command "install_cmdstan"'
+-                'or (re)activate your conda environment!'
+-            )
+-        latest_cmdstan = get_latest_cmdstan(cmdstan_dir)
+-        if latest_cmdstan is None:
+-            raise ValueError(
+-                'No CmdStan installation found, run command "install_cmdstan"'
+-                'or (re)activate your conda environment!'
+-            )
+-        cmdstan = os.path.join(cmdstan_dir, latest_cmdstan)
++        cmdstan = '@cmdstan@'
+         os.environ['CMDSTAN'] = cmdstan
+     validate_cmdstan_path(cmdstan)
+     return os.path.normpath(cmdstan)

--- a/pkgs/development/python-modules/lunarcalendar/default.nix
+++ b/pkgs/development/python-modules/lunarcalendar/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+, python-dateutil
+, ephem
+, pytz
+
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "lunarcalendar";
+  version = "0.0.9";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "wolfhong";
+    repo = "LunarCalendar";
+    rev = "885418ea1a2a90b7e0bbe758919af9987fb2863b";
+    hash = "sha256-AhxCWWqCjlOroqs4pOSZTWoIQT8a1l/D2Rxuw1XUoU8=";
+  };
+
+  propagatedBuildInputs = [
+    python-dateutil
+    ephem
+    pytz
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "lunarcalendar" ];
+
+  meta = {
+    homepage = "https://github.com/wolfhong/LunarCalendar";
+    description = "A Lunar-Solar Converter, containing a number of lunar and solar festivals in China";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/development/python-modules/prophet/default.nix
+++ b/pkgs/development/python-modules/prophet/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, fetchpatch
+
+, setuptools
+
+, cmdstanpy
+, numpy
+, matplotlib
+, pandas
+, lunarcalendar
+, convertdate
+, holidays
+, python-dateutil
+, tqdm
+, importlib-resources
+
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "prophet";
+  version = "1.1.4";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "prophet";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-pbJ0xL5wDZ+rKgtQQTJPsB1Mu2QXo3S9MMpiYkURsz0=";
+  };
+
+  patches = [
+    # TODO: remove when bumping version from 1.1.4
+    (fetchpatch {
+      name = "fix-stan-file-temp-dest.patch";
+      url = "https://github.com/facebook/prophet/commit/374676500795aec9d5cbc7fe5f7a96bf00489809.patch";
+      hash = "sha256-sfiQ2V3ZEF0WM9oM1FkL/fhZesQJ1i2EUPYJMdDA2UM=";
+      relative = "python";
+    })
+  ];
+
+  sourceRoot = "source/python";
+
+  env.PROPHET_REPACKAGE_CMDSTAN = "false";
+
+  nativeBuildInputs = [ setuptools ];
+
+  # TODO: update when bumping version from 1.1.4
+  propagatedBuildInputs = [
+    cmdstanpy
+    numpy
+    matplotlib
+    pandas
+    lunarcalendar
+    convertdate
+    holidays
+    python-dateutil
+    tqdm
+    importlib-resources
+  ];
+
+  preCheck = ''
+    # the generated stan_model directory only exists in build/lib*
+      cd build/lib*
+  '';
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "prophet" ];
+
+  meta = {
+    homepage = "https://facebook.github.io/prophet/";
+    description = "A tool for producing high quality forecasts for time series data that has multiple seasonality with linear or non-linear growth";
+    changelog = "https://github.com/facebook/prophet/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2001,6 +2001,8 @@ self: super: with self; {
 
   cmdline = callPackage ../development/python-modules/cmdline { };
 
+  cmdstanpy = callPackage ../development/python-modules/cmdstanpy { };
+
   cmigemo = callPackage ../development/python-modules/cmigemo {
     inherit (pkgs) cmigemo;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7827,6 +7827,8 @@ self: super: with self; {
 
   prodict = callPackage ../development/python-modules/prodict { };
 
+  prophet = callPackage ../development/python-modules/prophet { };
+
   propka = callPackage ../development/python-modules/propka { };
 
   proxy_tools = callPackage ../development/python-modules/proxy_tools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6023,6 +6023,8 @@ self: super: with self; {
 
   luhn = callPackage ../development/python-modules/luhn { };
 
+  lunarcalendar = callPackage ../development/python-modules/lunarcalendar { };
+
   luqum = callPackage ../development/python-modules/luqum { };
 
   luxor = callPackage ../development/python-modules/luxor { };


### PR DESCRIPTION
###### Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/164974

This PR adds 3 python packages `prophet` `cmdstanpy` and `LunarCalendar`.

---
###### Notes:

For `cmdstanpy` I created a patch, which makes it so that if no `CMDSTAN` env-var is set, it will use the `cmdstan` package from nixpkgs. This eliminates the need to call `install_cmdstan(...)`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
