### PR TITLE
johnny-reborn: init at unstable-2020-12-06

### DIFF
--- a/pkgs/applications/misc/johnny-reborn/default.nix
+++ b/pkgs/applications/misc/johnny-reborn/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, SDL2
+}:
+
+stdenv.mkDerivation {
+  pname = "johnny-reborn-engine";
+  version = "unstable-2020-12-06";
+
+  src = fetchFromGitHub {
+    owner = "jno6809";
+    repo = "jc_reborn";
+    rev = "524a5803e4fa65f840379c781f40ce39a927032e";
+    hash = "sha256-YKAOCgdRnvNMzL6LJVXN0pLvjyJk4Zv/RCqGtDPFR90=";
+  };
+
+  makefile = "Makefile.linux";
+
+  buildInputs = [ SDL2 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp jc_reborn $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "An open-source engine for the classic \"Johnny Castaway\" screensaver (engine only)";
+    homepage = "https://github.com/jno6809/jc_reborn";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ pedrohlc ];
+    inherit (SDL2.meta) platforms;
+  };
+}

--- a/pkgs/applications/misc/johnny-reborn/with-data.nix
+++ b/pkgs/applications/misc/johnny-reborn/with-data.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, fetchzip
+, johnny-reborn-engine
+, makeWrapper
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "johnny-reborn";
+  inherit (johnny-reborn-engine) version;
+
+  srcs =
+    let
+      sounds = fetchFromGitHub {
+        owner = "nivs1978";
+        repo = "Johnny-Castaway-Open-Source";
+        rev = "be6afefd43a3334acc66fc9d777c162c8bfb9558";
+        hash = "sha256-rtZVCn4KbEBVwaSQ4HZhMoDEI5Q9IPj9SZywgAx0MPY=";
+      };
+
+      resources = fetchzip {
+        name = "scrantic-source";
+        url = "https://archive.org/download/johnny-castaway-screensaver/scrantic-run.zip";
+        hash = "sha256-Q9chCYReOQEmkTyIkYo+D+OXYUqxPNOOEEmiFh8yaw4=";
+        stripRoot = false;
+      };
+    in
+    [
+      sounds
+      resources
+    ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  sourceRoot = "source";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -t $out/ \
+      ../scrantic-source/RESOURCE.* \
+      JCOS/Resources/sound*.wav
+
+    makeWrapper \
+      ${johnny-reborn-engine}/jc_reborn \
+      $out/jc_reborn \
+      --chdir $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "An open-source engine for the classic \"Johnny Castaway\" screensaver (ready to use, with resources)";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ pedrohlc ];
+    inherit (johnny-reborn-engine.meta) homepage platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2740,6 +2740,10 @@ with pkgs;
 
   ytree = callPackage ../applications/file-managers/ytree { };
 
+  johnny-reborn-engine = callPackage ../applications/misc/johnny-reborn { };
+
+  johnny-reborn = callPackage ../applications/misc/johnny-reborn/with-data.nix { };
+
   ### APPLICATIONS/TERMINAL-EMULATORS
 
   alacritty = callPackage ../applications/terminal-emulators/alacritty {


### PR DESCRIPTION
###### Description of changes

This is a classic screensaver from Sierra, "Johnny Castaway".

The engine is reimplementation is licensed as GPL3+. I can't track whoever is entitled to the resources to ask for redistribution, so I kept the final package as unfree. At least there is nothing for the final user to build.

![Screenshot stretched on my 4K display](https://github.com/NixOS/nixpkgs/assets/1368952/53863199-baa6-4464-bcbe-415108e2b65b)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
