### PR TITLE
hwdata: 0.371 -> 0.372

### DIFF
--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hwdata";
-  version = "0.371";
+  version = "0.372";
 
   src = fetchFromGitHub {
     owner = "vcrhonek";
     repo = "hwdata";
     rev = "v${version}";
-    sha256 = "sha256-bK61nvuzm8LTotVSBtGyBMELZPqoENkPM4NKtgEx9qw=";
+    hash = "sha256-XC0U5UsOjTveRj1b0e1TBlYv/tKebSOu/YEGt/rmAHw=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Diff: https://github.com/vcrhonek/hwdata/compare/v0.371...v0.372

As one can see in the diff, there are some new Makefiles, but it does not seem they affect our build:

```console
╰─λ find ./result/
./result/
./result/share
./result/share/pkgconfig
./result/share/pkgconfig/hwdata.pc
./result/share/hwdata
./result/share/hwdata/pci.ids
./result/share/hwdata/usb.ids
./result/share/hwdata/pnp.ids
./result/share/hwdata/iab.txt
./result/share/hwdata/oui.txt
./result/lib
./result/lib/modprobe.d
./result/lib/modprobe.d/dist-blacklist.conf
╰─λ find /nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/lib
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/lib/modprobe.d
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/lib/modprobe.d/dist-blacklist.conf
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/share
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/share/pkgconfig
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/share/pkgconfig/hwdata.pc
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/share/hwdata
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/share/hwdata/iab.txt
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/share/hwdata/pnp.ids
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/share/hwdata/oui.txt
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/share/hwdata/pci.ids
/nix/store/f1qhx09f0gvl408k4l97f93m7ybic0dy-hwdata-0.371/share/hwdata/usb.ids
```

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
