### PR TITLE
nickel: fix darwin build

### DIFF
--- a/pkgs/development/interpreters/nickel/default.nix
+++ b/pkgs/development/interpreters/nickel/default.nix
@@ -1,7 +1,10 @@
 { lib
+, stdenv
 , rustPlatform
 , fetchFromGitHub
 , python3
+, libiconv
+, darwin
 , nix-update-script
 }:
 
@@ -22,6 +25,12 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     python3
+  ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+  ];
+
+  buildInputs = [ ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/development/tools/language-servers/nls/default.nix
+++ b/pkgs/development/tools/language-servers/nls/default.nix
@@ -6,7 +6,7 @@
 rustPlatform.buildRustPackage {
   pname = "nls";
 
-  inherit (nickel) src version nativeBuildInputs;
+  inherit (nickel) src version nativeBuildInputs buildInputs;
 
   cargoHash = "sha256-UGfc5cr6vl10aCVihOEEZktF8MzT56C9/wSvSQhCiVs=";
 


### PR DESCRIPTION
###### Description of changes
Tries to fix the darwin build issue noticed in https://github.com/NixOS/nixpkgs/pull/242686#issuecomment-1631662785.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).