### PR TITLE
openafs: 1.8.9 → 1.8.10

### DIFF
--- a/pkgs/servers/openafs/1.8/cross-build.patch
+++ b/pkgs/servers/openafs/1.8/cross-build.patch
@@ -144,7 +144,7 @@ diff -Nur --unidirectional-new-file openafs-1.8.2/src/comerr/Makefile.in openafs
 @@ -38,11 +38,14 @@
  compile_et:	compile_et.o error_table.o
  	$(Q)case $(SYS_NAME) in \
- 	*_linux* | *_umlinux* | *_darwin* ) \
+ 	*_linux* | *_umlinux* | *_darwin* | rs_aix72 | rs_aix73 ) \
 -	$(LT_LDRULE_static_NOQ) compile_et.o error_table.o -L${TOP_LIBDIR} -lopr $(buildtool_roken) $(MT_LIBS);; \
 +	$(LT_LDRULE_static_NOQ) compile_et.o error_table.o -L${TOP_LIBDIR} -lopr_build $(buildtool_roken) $(MT_LIBS);; \
  	* ) \

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -37,54 +37,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ libkrb5 ];
 
-  patches = [
-    # LINUX: Run the 'sparse' checker if available
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=2cf76b31ce4c912b1151c141818f6e8c5cddcab2";
-      hash = "sha256-//7HSlotx70vWDEMB8P8or4ZmmXZthgioUOkvOcJpgk=";
-    })
-    # cf: Detect how to pass CFLAGS to linux kbuild
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=57df4dff496ca9bea04510759b8fdd9cd2cc0009";
-      hash = "sha256-pJnW9bVz2ZQZUvZ+PcZ5gEgCL5kcbTGxsyMNvM2IseU=";
-    })
-    # cf: Handle autoconf linux checks with -Werror
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=b17625959386459059f6f43875d8817383554481";
-      hash = "sha256-Kqx5QEX1p4UoIsWxqvJVX4IyCQFiWxtAOgvAtk+ULuQ=";
-    })
-    # Linux: Fix functions without prototypes
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=3084117f10bd62acb1182cb54fc85b1d96738f70";
-      hash = "sha256-nNyqDQfS9zzlS2i3dbfud2tQOaTQ1x/rZcQEsaLu3qc=";
-    })
-    # Linux: Check for block_dirty_folio
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=f0fee2c7752d18ff183d60bcfba4c98c3348cd5f";
-      hash = "sha256-tnNlVjZ5exC+jo78HC/y8yp0L8KQroFvVRzTC+O6vlY=";
-    })
-    # Linux: Replace lru_cache_add with folio_add_lru
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=b885159cc2bc6c746aec1d54cdd8a515d1115d14";
-      hash = "sha256-ptPALSbZPSGu8PMmZiOkHUd5x0UItqIM7U7wJlxtSL8=";
-    })
-    # LINUX 5.13: set .proc_lseek in proc_ops
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=cba2b88851c3ae0ab1b18ea3ce77f7f5e8200b2f";
-      hash = "sha256-suj7n0U0odHXZHLPqeB/k96gyBh52uoS3AuHvOzPyd8=";
-    })
-    # Linux 6.3: Include linux/filelock.h if available
-    (fetchBase64Patch {
-      url = "https://gerrit.openafs.org/changes/15388/revisions/ddb99d32012c43c76ae37f6a7563f1ca32f0e964/patch";
-      hash = "sha256-0Cql4+0ISfW4J4D7PhlSYNfIKAeDVWEz57PHOu5TRXg=";
-    })
-    # Linux 6.3: Use mnt_idmap for inode op functions
-    (fetchBase64Patch {
-      url = "https://gerrit.openafs.org/changes/15389/revisions/ff0d53d2fb38fc3b262f02fb1c5f49b286ff13dd/patch";
-      hash = "sha256-KyVAI/A+/lNrLyKY6O8DgMKzgnF6P5sOfSq3qcs6Qq0=";
-    })
-  ];
-
   hardeningDisable = [ "pic" ];
 
   configureFlags = [

--- a/pkgs/servers/openafs/1.8/srcs.nix
+++ b/pkgs/servers/openafs/1.8/srcs.nix
@@ -1,16 +1,16 @@
 { fetchurl }:
 rec {
-  version = "1.8.9";
+  version = "1.8.10";
   src = fetchurl {
     url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    hash = "sha256-0SYXi+H0LMoYy3wMJpGsNUUY43kBcBUKdrvSX00VHwY=";
+    hash = "sha256-n+wRNkYjVJ6NtzdAcvXI8BuEH2v+foVnPLzjX/Q/+wc=";
   };
 
   srcs = [
     src
     (fetchurl {
       url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      hash = "sha256-75HoVOq0qnQmhSWVSkHCoq0KLq9TDqoiu55L9FOxWTk=";
+      hash = "sha256-nDgJ6K/qAX2K8lKPYM8OD5+oRU+shlM6PmciHy61+10=";
     })
   ];
 }


### PR DESCRIPTION
###### Description of changes

Update OpenAFS from 1.8.9 to 1.8.10, which is required for Linux kernel 6.4 support.

https://openafs.org/dl/openafs/1.8.10/RELNOTES-1.8.10
https://github.com/openafs/openafs/compare/openafs-stable-1_8_9...openafs-stable-1_8_10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
