### PR TITLE
python311Packages.python-arango: Add setuptools to propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/python-arango/default.nix
+++ b/pkgs/development/python-modules/python-arango/default.nix
@@ -9,6 +9,7 @@
 , mock
 , requests
 , requests-toolbelt
+, setuptools
 }:
 
 let
@@ -38,6 +39,7 @@ buildPythonPackage rec {
     requests
     requests-toolbelt
     pyjwt
+    setuptools
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
###### Description of changes

I was trying to use `python-arango` in one of my experiments with NixOS (23.05). I got the following error:

```console
[rm_me] λ nix-shell -p python311Packages.python-arango

[nix-shell:/data/rm_me]$ python -c 'import arango'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/nix/store/4n18qmv3dfx8gja79rvrlmrxzv1acmx9-python3.11-python-arango-7.5.7/lib/python3.11/site-packages/arango/__init__.py", line 2, in <module>
    from arango.client import ArangoClient  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/4n18qmv3dfx8gja79rvrlmrxzv1acmx9-python3.11-python-arango-7.5.7/lib/python3.11/site-packages/arango/client.py", line 6, in <module>
    from pkg_resources import get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
```

To fix it, I have to pass an additional package to the nix shell:

```console
[rm_me] λ nix-shell -p python311Packages.python-arango python311Packages.setuptools 

[nix-shell:/data/rm_me]$ python -c 'import arango'

[nix-shell:/data/rm_me]$ 
```

I found a similar issue with `pwndbg` in the past has been resolved in #71219. But I think in this case, we only need to change the Python side, not everything.

This is my first nixpkgs PR, apologies if it is not correct. Will try to make it work :)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions

Signed-off-by: Mihai Maruseac <mihai.maruseac@gmail.com>
-->
