### PR TITLE
conntrack-tools: fixup systemd support

### DIFF
--- a/pkgs/os-specific/linux/conntrack-tools/default.nix
+++ b/pkgs/os-specific/linux/conntrack-tools/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, lib, stdenv, flex, bison, pkg-config, libmnl, libnfnetlink
 , libnetfilter_conntrack, libnetfilter_queue, libnetfilter_cttimeout
-, libnetfilter_cthelper, systemd
-, libtirpc
+, libnetfilter_cthelper, libtirpc
+, systemdSupport ? true, systemd
 }:
 
 stdenv.mkDerivation rec {
@@ -15,9 +15,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libmnl libnfnetlink libnetfilter_conntrack libnetfilter_queue
-    libnetfilter_cttimeout libnetfilter_cthelper systemd libtirpc
+    libnetfilter_cttimeout libnetfilter_cthelper libtirpc
+  ] ++ lib.optionals systemdSupport [
+    systemd
   ];
   nativeBuildInputs = [ flex bison pkg-config ];
+
+  configureFlags = [
+    (lib.enableFeature systemdSupport "systemd")
+  ];
 
   meta = with lib; {
     homepage = "http://conntrack-tools.netfilter.org/";


### PR DESCRIPTION
###### Description of changes

Conntrack-tools was previously not compiled with systemd support, this also make the support optional

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
