### PR TITLE
python3.pkgs.pylion: init at 0.5.3

### DIFF
--- a/pkgs/development/python-modules/pylion/default.nix
+++ b/pkgs/development/python-modules/pylion/default.nix
@@ -11,15 +11,15 @@
 
 buildPythonPackage {
   pname = "pylion";
-  version = "0.5.2";
+  version = "0.5.3";
   format = "setuptools";
 
   src = fetchFromBitbucket {
     owner = "dtrypogeorgos";
     repo = "pylion";
     # Version is set in setup.cfg, but not in a git tag / bitbucket release
-    rev = "8945a7b6f1912ae6b9c705f8a2bd521101f5ba59";
-    hash = "sha256-4AdJkoQ1hAssDUpgmARGmN+ihQqRPPOncWJ5ErQyWII=";
+    rev = "3e6b96b542b97107c622d66b0be0551c3bd9f948";
+    hash = "sha256-c0UOv2Vlv9wJ6YW+QdHinhpdaclUh3As5TDvyoRhpSI=";
   };
 
   # Docs are not available online, besides the article:


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
