### PR TITLE
linuxPackages.kvmfr: fix for linux 6.4

### DIFF
--- a/pkgs/os-specific/linux/kvmfr/default.nix
+++ b/pkgs/os-specific/linux/kvmfr/default.nix
@@ -1,11 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, kernel, kmod, looking-glass-client }:
+{ lib, stdenv, kernel, looking-glass-client }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "kvmfr";
   version = looking-glass-client.version;
 
   src = looking-glass-client.src;
   sourceRoot = "source/module";
+  patches = lib.optional (kernel.kernelAtLeast "6.4") [
+    ./linux-6-4-compat.patch
+  ];
   hardeningDisable = [ "pic" "format" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/kvmfr/linux-6-4-compat.patch
+++ b/pkgs/os-specific/linux/kvmfr/linux-6-4-compat.patch
@@ -1,0 +1,16 @@
+diff --git a/kvmfr.c b/kvmfr.c
+index 121aae5b..2f4c9e1a 100644
+--- a/kvmfr.c
++++ b/kvmfr.c
+@@ -539,7 +539,11 @@ static int __init kvmfr_module_init(void)
+   if (kvmfr->major < 0)
+     goto out_free;
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+   kvmfr->pClass = class_create(THIS_MODULE, KVMFR_DEV_NAME);
++#else
++  kvmfr->pClass = class_create(KVMFR_DEV_NAME);
++#endif
+   if (IS_ERR(kvmfr->pClass))
+     goto out_unreg;
+ 


### PR DESCRIPTION
I can't use fetchpatch here because the upstream code has changed quite a bit since the last release

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
