### PR TITLE
writeTextFile: support `preInstall`, `postInstall`, `doInstallCheck`, and `installCheckPhase` attributes via `derivationArgs`

### DIFF
--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -226,12 +226,6 @@ Write a text file to the Nix store.
 
   Default: `""`
 
-`checkPhase` (String, _optional_)
-
-: Commands to run after generating the file.
-
-  Default: `""`
-
 `meta` (Attribute set, _optional_)
 
 : Additional metadata for the derivation.
@@ -262,6 +256,10 @@ Write a text file to the Nix store.
 
 : Extra arguments to pass to the underlying call to `stdenv.mkDerivation`.
 
+  Pass `preInstall`/`postInstall` to run commands before/after generating the file, or `installCheckPhase` to test the generated file.
+
+  `doInstallCheck` defaults to `true`. Disable the test commands by setting it to `false`.
+
   Default: `{}`
 
 The resulting store path will include some variation of the name, and it will be a file unless `destination` is used, in which case it will be a directory.
@@ -281,9 +279,11 @@ writeTextFile {
   '';
   executable = true;
   destination = "/some/subpath/my-cool-script";
-  checkPhase = ''
-    ${pkgs.shellcheck}/bin/shellcheck $out/some/subpath/my-cool-script
-  '';
+  derivationArgs = {
+    installCheckPhase = ''
+      ${pkgs.shellcheck}/bin/shellcheck $out/some/subpath/my-cool-script
+    '';
+  };
   meta = {
     license = pkgs.lib.licenses.cc0;
   };

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -228,6 +228,14 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   The list in `nixos/modules/virtualisation/amazon-ec2-amis.nix` will stop
   being updated and will be removed in the future.
 
+- Change `writeTextFile`'s input arguments as follows:
+  - Support `preInstall`, `postInstall`, `doInstallCheck` and `installCheckPhase` inside `derivationArgs` to specify commands to run before/after text file generation and to test the generated file.
+  - Deprecate `checkPhase` argument in favour of `derivationArgs.installCheckPhase`, as the latter emphasize the execution order (`echo ... > "$out"` -> `postInstall` -> `installCheckPhase`).
+  - Redirect `checkPhase` to `installCheckPhase` when only the former is specefied for backward compatibility, with an evaluation-time warning about the rename.
+
+  Apply these changes to the derived build helper `writeShellApplication`.
+  - Redirect `preCheck`/`postCheck` attributes specification to `preInstallCheck`/`postInstallCheck` when only the former is specified for backward compatibility, with an evaluation-time warning about the rename.
+
 - The option `services.postgresql.ensureUsers._.ensurePermissions` has been removed as it's
   not declarative and is broken with newer postgresql versions. Consider using
   [](#opt-services.postgresql.ensureUsers._.ensureDBOwnership)

--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -112,7 +112,7 @@ let
         ${mkKeyValuePairs (filterAttrs (key: value: isExtra key) cfg.settings)}
         ${cfg.extraOptions}
       '';
-      checkPhase = lib.optionalString cfg.checkConfig (
+      derivationArgs.installCheckPhase = lib.optionalString cfg.checkConfig (
         if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform then ''
           echo "Ignoring validation for cross-compilation"
         ''

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -73,7 +73,7 @@ let
   mkConfigFile = name: settings: pkgs.writeTextFile {
     name = "btrbk-${name}.conf";
     text = genConfig' (addDefaults settings);
-    checkPhase = ''
+    derivationArgs.installCheckPhase = ''
       set +e
       ${pkgs.btrbk}/bin/btrbk -c $out dryrun
       # According to btrbk(1), exit status 2 means parse error

--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -46,7 +46,7 @@ let
     text = concatStringsSep "\n" (
       map mkConf settings
     );
-    checkPhase = optionalString cfg.checkConfig ''
+    derivationArgs.installCheckPhase = optionalString cfg.checkConfig ''
       # logrotate --debug also checks that users specified in config
       # file exist, but we only have sandboxed users here so brown these
       # out. according to man page that means su, create and createolddir.

--- a/nixos/modules/services/networking/adguardhome.nix
+++ b/nixos/modules/services/networking/adguardhome.nix
@@ -15,7 +15,7 @@ let
   configFile = pkgs.writeTextFile {
     name = "AdGuardHome.yaml";
     text = builtins.toJSON cfg.settings;
-    checkPhase = "${pkgs.adguardhome}/bin/adguardhome -c $out --check-config";
+    derivationArgs.installCheckPhase = "${pkgs.adguardhome}/bin/adguardhome -c $out --check-config";
   };
   defaultBindPort = 3000;
 

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -65,7 +65,7 @@ in
     environment.etc."bird/bird2.conf".source = pkgs.writeTextFile {
       name = "bird2";
       text = cfg.config;
-      checkPhase = optionalString cfg.checkConfig ''
+      derivationArgs.installCheckPhase = optionalString cfg.checkConfig ''
         ln -s $out bird2.conf
         ${cfg.preCheckConfig}
         ${pkgs.buildPackages.bird}/bin/bird -d -p -c bird2.conf

--- a/nixos/modules/services/networking/knot.nix
+++ b/nixos/modules/services/networking/knot.nix
@@ -141,7 +141,7 @@ let
   mkConfigFile = configString: pkgs.writeTextFile {
     name = "knot.conf";
     text = (concatMapStringsSep "\n" (file: "include: ${file}") cfg.keyFiles) + "\n" + configString;
-    checkPhase = lib.optionalString cfg.checkConfig ''
+    derivationArgs.installCheckPhase = lib.optionalString cfg.checkConfig ''
       ${cfg.package}/bin/knotc --config=$out conf-check
     '';
   };

--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -312,7 +312,7 @@ in
                 ''
               else ""}
           '';
-          checkPhase = lib.optionalString cfg.checkRuleset ''
+          installCheckPhase = lib.optionalString cfg.checkRuleset ''
             cp $out ruleset.conf
             sed 's|include "${deletionsScriptVar}"||' -i ruleset.conf
             ${cfg.preCheckRuleset}

--- a/nixos/modules/services/networking/v2ray.nix
+++ b/nixos/modules/services/networking/v2ray.nix
@@ -63,7 +63,7 @@ with lib;
       else pkgs.writeTextFile {
         name = "v2ray.json";
         text = builtins.toJSON cfg.config;
-        checkPhase = ''
+        derivationArgs.installCheckPhase = ''
           ${cfg.package}/bin/v2ray test -c $out
         '';
       };

--- a/nixos/modules/services/networking/xray.nix
+++ b/nixos/modules/services/networking/xray.nix
@@ -63,7 +63,7 @@ with lib;
       else pkgs.writeTextFile {
         name = "xray.json";
         text = builtins.toJSON cfg.settings;
-        checkPhase = ''
+        derivationArgs.installCheckPhase = ''
           ${cfg.package}/bin/xray -test -config $out
         '';
       };

--- a/nixos/modules/services/printing/cups-pdf.nix
+++ b/nixos/modules/services/printing/cups-pdf.nix
@@ -13,7 +13,7 @@ let
     name = "${pkgs.cups-pdf-to-pdf.name}-wrapper.sh";
     executable = true;
     destination = "/lib/cups/backend/cups-pdf";
-    checkPhase = ''
+    derivationArgs.installCheckPhase = ''
       ${pkgs.stdenv.shellDryRun} "$target"
       ${lib.getExe pkgs.shellcheck} "$target"
     '';

--- a/nixos/modules/services/search/hound.nix
+++ b/nixos/modules/services/search/hound.nix
@@ -93,7 +93,7 @@ in {
       configFile = pkgs.writeTextFile {
         name = "hound.json";
         text = cfg.config;
-        checkPhase = ''
+        derivationArgs.installCheckPhase = ''
           # check if the supplied text is valid json
           ${lib.getExe pkgs.jq} . $target > /dev/null
         '';

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -37,7 +37,7 @@ let
   writePhpFile = name: text: pkgs.writeTextFile {
     inherit name;
     text = "<?php\n${text}";
-    checkPhase = "${pkgs.php81}/bin/php --syntax-check $target";
+    derivationArgs.installCheckPhase = "${pkgs.php81}/bin/php --syntax-check $target";
   };
 
   mkPhpValue = v: let

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -70,7 +70,7 @@ let
         require_once(ABSPATH . 'wp-settings.php');
       ?>
     '';
-    checkPhase = "${pkgs.php81}/bin/php --syntax-check $target";
+    derivationArgs.installCheckPhase = "${pkgs.php81}/bin/php --syntax-check $target";
   };
 
   mkPhpValue = v: let

--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -114,5 +114,5 @@ writeTextFile {
   name = "${name}.desktop";
   destination = "/share/applications/${name}.desktop";
   text = builtins.concatStringsSep "\n" content;
-  checkPhase = ''${buildPackages.desktop-file-utils}/bin/desktop-file-validate "$target"'';
+  derivationArgs.installCheckPhase = ''${buildPackages.desktop-file-utils}/bin/desktop-file-validate "$target"'';
 })

--- a/pkgs/build-support/make-pkgconfigitem/default.nix
+++ b/pkgs/build-support/make-pkgconfigitem/default.nix
@@ -65,5 +65,5 @@ writeTextFile {
   name = "${name}.pc";
   destination = "/lib/pkgconfig/${name}.pc";
   text = builtins.concatStringsSep "\n" content;
-  checkPhase = ''${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config --validate "$target"'';
+  derivationArgs.Phase = ''${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config --validate "$target"'';
 }

--- a/pkgs/build-support/trivial-builders/test-overriding.nix
+++ b/pkgs/build-support/trivial-builders/test-overriding.nix
@@ -36,7 +36,7 @@ let
   # building this derivation would fail without overriding
   textFileCase = writeTextFile {
     name = "test-trivial-overriding-text-file";
-    checkPhase = "false";
+    derivationArgs.installCheckPhase = "false";
     text = ''
       #!${runtimeShell}
       echo success
@@ -55,7 +55,7 @@ let
     # in nix: With `assertFail` we want to make sure that the default
     # `checkPhase` would fail if extglob was used in the script.
     assertFail = x: x.overrideAttrs (old: {
-      checkPhase = ''
+      installCheckPhase = ''
         if
           ${old.checkPhase}
         then exit 1; fi
@@ -81,7 +81,7 @@ let
     binFail = mkCase binCase "fail" true;
     # Check that we can also override plain writeTextFile
     textFileSuccess = textFileCase.overrideAttrs (_: {
-      checkPhase = "true";
+      installCheckPhase = "true";
     });
   };
 

--- a/pkgs/build-support/trivial-builders/test/write-shell-script.nix
+++ b/pkgs/build-support/trivial-builders/test/write-shell-script.nix
@@ -3,7 +3,7 @@
 in (writeShellScript "test-script" ''
   echo ${lib.escapeShellArg output}
 '').overrideAttrs (old: {
-  checkPhase = old.checkPhase or "" + ''
+  installCheckPhase = old.installCheckPhase or "" + ''
     expected=${lib.escapeShellArg output}
     got=$("$target")
     if [[ "$got" != "$expected" ]]; then

--- a/pkgs/build-support/trivial-builders/test/write-text-file.nix
+++ b/pkgs/build-support/trivial-builders/test/write-text-file.nix
@@ -41,7 +41,10 @@ lib.recurseIntoAttrs {
     name = "weird-names";
     destination = "/etc/${veryWeirdName}";
     text = ''passed!'';
-    checkPhase = ''
+    derivationArgs.postInstall = ''
+      echo -n '!!' >> "$target"
+    '';
+    derivationArgs.installCheckPhase = ''
       # intentionally hardcode everything here, to make sure
       # Nix does not mess with file paths
 
@@ -56,7 +59,7 @@ lib.recurseIntoAttrs {
       fi
 
       content=$(<"$fullPath")
-      expected="passed!"
+      expected="passed!!!"
 
       if [ "$content" = "$expected" ]; then
         echo "[PASS] Contents match!"

--- a/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
+++ b/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
@@ -78,11 +78,26 @@ linkFarm "writeShellApplication-tests" {
       '';
     };
 
-  test-check-phase =
+  test-post-install =
     checkShellApplication {
-      name = "test-check-phase";
+      name = "test-post-install";
+      text = ''
+        hello
+      '';
+      derivationArgs.postInstall = ''
+        echo "world" >> "$target"
+      '';
+      expected = ''
+        hello
+        world
+      '';
+    };
+
+  test-install-check-phase =
+    checkShellApplication {
+      name = "test-install-check-phase";
       text = "";
-      checkPhase = ''
+      derivationArgs.installCheckPhase = ''
         echo "echo -n hello" > $target
       '';
       expected = "hello";
@@ -93,7 +108,7 @@ linkFarm "writeShellApplication-tests" {
       name = "test-argument-forwarding";
       text = "";
       derivationArgs.MY_BUILD_TIME_VARIABLE = "puppy";
-      derivationArgs.postCheck = ''
+      derivationArgs.postInstallCheck = ''
         if [[ "$MY_BUILD_TIME_VARIABLE" != puppy ]]; then
           echo "\$MY_BUILD_TIME_VARIABLE is not set to 'puppy'!"
           exit 1

--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -120,7 +120,7 @@ rec {
     writeTextFile {
       inherit name text;
       executable = true;
-      checkPhase = ''
+      derivationArgs.installCheckPhase = ''
          ${(phraseContextForPWD (
              phraseInvocation name (
                partialSolution // {
@@ -138,7 +138,7 @@ rec {
       inherit name text;
       executable = true;
       destination = "/bin/${name}";
-      checkPhase = ''
+      derivationArgs.installCheckPhase = ''
         ${phraseContextForOut (
             phraseInvocation name (
               partialSolution // {

--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -100,7 +100,7 @@ if ! [[ -z "$@" ]]; then
    exec "$@"
 fi
     '';
-    checkPhase = ''
+    derivationArgs.installCheckPhase = ''
       ${stdenv.shellDryRun} "$target"
     '';
   };


### PR DESCRIPTION
###### Description of changes

Change `writeTextFile`'s input arguments as follows:
- Support `preInstall`, `postInstall`, `doInstallCheck` and `installCheckPhase` inside `derivationArgs` to specify commands to run before/after text file generation and to test the generated file.
- Deprecate `checkPhase` argument in favour of `derivationArgs.installCheckPhase`, as the latter emphasize the execution order (`echo ... > "$out"` -> `postInstall` -> `installCheckPhase`).
- Redirect `checkPhase` to `installCheckPhase` when only the former is specefied for backward compatibility, with an evaluation-time warning about the rename.

Apply these changes to the derived build helper `writeShellApplication`.
- Redirect `preCheck`/`postCheck` attributes specification to `preInstallCheck`/`postInstallCheck` when only the former is specified for backward compatibility, with an evaluation-time warning about the rename.

Initial effort for #223144

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
