### PR TITLE
circus: 0.16.1 -> 0.18.0; reintroduce as python-modules

### DIFF
--- a/pkgs/development/python-modules/circus/default.nix
+++ b/pkgs/development/python-modules/circus/default.nix
@@ -1,4 +1,12 @@
-{ lib, buildPythonPackage, fetchPypi, psutil, pyzmq, tornado }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, psutil
+, pytestCheckHook
+, pyyaml
+, pyzmq
+, tornado
+}:
 
 buildPythonPackage rec {
   pname = "circus";
@@ -10,9 +18,56 @@ buildPythonPackage rec {
     hash = "sha256-GTzoIk4GjO1mckz0gxBvtmdLUaV1g6waDn7Xp+6Mcas=";
   };
 
-  doCheck = false; # weird error
+  propagatedBuildInputs = [
+    psutil
+    pyzmq
+    tornado
+  ];
 
-  propagatedBuildInputs = [ psutil pyzmq tornado ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pyyaml
+  ];
+
+  disabledTests = [
+    # these tests raise circus.tests.support.TimeoutException
+    "test_reload1"
+    "test_reload2"
+    "test_reload_sequential"
+    "test_reload_uppercase"
+    "test_reload_wid_1_worker"
+    "test_reload_wid_4_workers"
+    "test_add"
+    "test_add_start"
+    "test_command_already_running"
+    "test_launch_cli"
+    "test_handler"
+    "test_resource_watcher_max_cpu"
+    "test_resource_watcher_max_mem"
+    "test_resource_watcher_max_mem_abs"
+    "test_resource_watcher_min_cpu"
+    "test_resource_watcher_min_mem"
+    "test_resource_watcher_min_mem_abs"
+    "test_full_stats"
+    "test_watchdog_discovery_found"
+    "test_watchdog_discovery_not_found"
+    "test_dummy"
+    "test_handler"
+    "test_stdin_socket"
+    "test_stop_and_restart"
+    "test_stream"
+    "test_inherited"
+    "test_set_before_launch"
+    "test_set_by_arbiter"
+    "test_max_age"
+    "test_signal"
+    "test_exits_within_graceful_timeout"
+    "test_kills_after_graceful_timeout"
+    # this test requires socket communication
+    "test_plugins"
+  ];
+
+  pythonImportsCheck = [ "circus" ];
 
   meta = with lib; {
     description = "A process and socket manager";

--- a/pkgs/development/python-modules/circus/default.nix
+++ b/pkgs/development/python-modules/circus/default.nix
@@ -1,10 +1,6 @@
-{ lib, python3, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, psutil, pyzmq, tornado }:
 
-let
-  inherit (python3.pkgs) buildPythonApplication psutil pyzmq tornado;
-in
-
-buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "circus";
   version = "0.18.0";
   format = "flit";

--- a/pkgs/tools/networking/circus/default.nix
+++ b/pkgs/tools/networking/circus/default.nix
@@ -1,36 +1,22 @@
 { lib, python3, fetchPypi }:
 
 let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: {
-      tornado = super.tornado_4;
-    };
-  };
-
-  inherit (python.pkgs) buildPythonApplication iowait psutil pyzmq tornado mock six;
+  inherit (python3.pkgs) buildPythonApplication psutil pyzmq tornado;
 in
 
 buildPythonApplication rec {
   pname = "circus";
-  version = "0.16.1";
+  version = "0.18.0";
+  format = "flit";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0paccmqwgard2l0z7swcc3nwc418l9b4mfaddb4s31bpnqg02z6x";
+    hash = "sha256-GTzoIk4GjO1mckz0gxBvtmdLUaV1g6waDn7Xp+6Mcas=";
   };
-
-  postPatch = ''
-    # relax version restrictions to fix build
-    substituteInPlace setup.py \
-      --replace "pyzmq>=13.1.0,<17.0" "pyzmq>13.1.0"
-  '';
-
-  nativeCheckInputs = [ mock ];
 
   doCheck = false; # weird error
 
-  propagatedBuildInputs = [ iowait psutil pyzmq tornado six ];
+  propagatedBuildInputs = [ psutil pyzmq tornado ];
 
   meta = with lib; {
     description = "A process and socket manager";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6485,7 +6485,7 @@ with pkgs;
 
   circleci-cli = callPackage ../development/tools/misc/circleci-cli { };
 
-  circus = callPackage ../tools/networking/circus { };
+  circus = with python3Packages; toPythonApplication circus;
 
   cirrus-cli = callPackage ../development/tools/continuous-integration/cirrus-cli { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1859,6 +1859,8 @@ self: super: with self; {
 
   circuitbreaker = callPackage ../development/python-modules/circuitbreaker { };
 
+  circus = callPackage ../development/python-modules/circus { };
+
   cirq = callPackage ../development/python-modules/cirq { };
 
   cirq-aqt = callPackage ../development/python-modules/cirq-aqt { };


### PR DESCRIPTION
###### Description of changes

Diff: https://github.com/circus-tent/circus/compare/0.16.1...0.18.0

We changed circus to application in #73199, but later updates have removed the bottleneck library version restriction.

I would also like to revert to python-modules, as this package is required for [bentoml](https://github.com/bentoml/BentoML).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
