### PR TITLE
maubot: init at 0.4.1

### DIFF
--- a/pkgs/tools/networking/maubot/allow-building-plugins-from-nix-store.patch
+++ b/pkgs/tools/networking/maubot/allow-building-plugins-from-nix-store.patch
@@ -1,0 +1,13 @@
+diff --git a/maubot/cli/commands/build.py b/maubot/cli/commands/build.py
+index ec3ac26..4de85f2 100644
+--- a/maubot/cli/commands/build.py
++++ b/maubot/cli/commands/build.py
+@@ -84,7 +84,7 @@ def read_output_path(output: str, meta: PluginMeta) -> str | None:
+ 
+ 
+ def write_plugin(meta: PluginMeta, output: str | IO) -> None:
+-    with zipfile.ZipFile(output, "w") as zip:
++    with zipfile.ZipFile(output, "w", strict_timestamps=False) as zip:
+         meta_dump = BytesIO()
+         yaml.dump(meta.serialize(), meta_dump)
+         zip.writestr("maubot.yaml", meta_dump.getvalue())

--- a/pkgs/tools/networking/maubot/default.nix
+++ b/pkgs/tools/networking/maubot/default.nix
@@ -1,0 +1,137 @@
+{ lib
+, fetchPypi
+, fetchpatch
+, runCommand
+, python3
+, encryptionSupport ? true
+}:
+
+let
+  python = python3.override {
+    packageOverrides = final: prev: {
+      # aiosqlite>=0.16,<0.19
+      aiosqlite = prev.aiosqlite.overridePythonAttrs (old: rec {
+        version = "0.18.0";
+        src = old.src.override {
+          rev = "refs/tags/v${version}";
+          hash = "sha256-yPGSKqjOz1EY5/V0oKz2EiZ90q2O4TINoXdxHuB7Gqk=";
+        };
+      });
+      # mautrix>=0.19.8,<0.20
+      mautrix = prev.mautrix.overridePythonAttrs (old: rec {
+        version = "0.19.16";
+        disabled = final.pythonOlder "3.8";
+        checkInputs = old.checkInputs ++ [ final.sqlalchemy ];
+        SQLALCHEMY_SILENCE_UBER_WARNING = true;
+        src = old.src.override {
+          rev = "refs/tags/v${version}";
+          hash = "sha256-aZlc4+J5Q+N9qEzGUMhsYguPdUy+E5I06wrjVyqvVDk=";
+        };
+      });
+      # mautrix has a runtime error with new ruamel-yaml since 0.17.22 changed the interface
+      ruamel-yaml = prev.ruamel-yaml.overridePythonAttrs (prev: rec {
+        version = "0.17.21";
+        src = prev.src.override {
+          version = version;
+          hash = "sha256-i3zml6LyEnUqNcGsQURx3BbEJMlXO+SSa1b/P10jt68=";
+        };
+      });
+      # SQLAlchemy>=1,<1.4
+      # SQLAlchemy 2.0's derivation is very different, so don't override, just write it from scratch
+      # (see https://github.com/NixOS/nixpkgs/blob/65dbed73949e4c0207e75dcc7271b29f9e457670/pkgs/development/python-modules/sqlalchemy/default.nix)
+      sqlalchemy = final.buildPythonPackage rec {
+        pname = "SQLAlchemy";
+        version = "1.3.24";
+
+        src = fetchPypi {
+          inherit pname version;
+          sha256 = "sha256-67t3fL+TEjWbiXv4G6ANrg9ctp+6KhgmXcwYpvXvdRk=";
+        };
+
+        postInstall = ''
+          sed -e 's:--max-worker-restart=5::g' -i setup.cfg
+        '';
+
+        # tests are pretty annoying to set up for this version, and these dependency overrides are already long enough
+        doCheck = false;
+      };
+    };
+  };
+
+  maubot = python.pkgs.buildPythonPackage rec {
+    pname = "maubot";
+    version = "0.4.1";
+    disabled = python.pythonOlder "3.8";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-Ro2PPgF8818F8JewPZ3AlbfWFNNHKTZkQq+1zpm3kk4=";
+    };
+
+    patches = [
+      # add entry point - https://github.com/maubot/maubot/pull/146
+      (fetchpatch {
+        url = "https://github.com/maubot/maubot/commit/283f0a3ed5dfae13062b6f0fd153fbdc477f4381.patch";
+        sha256 = "0yn5357z346qzy5v5g124mgiah1xsi9yyfq42zg028c8paiw8s8x";
+      })
+      # allow running "mbc build" in a nix derivation
+      ./allow-building-plugins-from-nix-store.patch
+    ];
+
+    propagatedBuildInputs = with python.pkgs; [
+      # requirements.txt
+      mautrix
+      aiohttp
+      yarl
+      sqlalchemy
+      asyncpg
+      aiosqlite
+      commonmark
+      ruamel-yaml
+      attrs
+      bcrypt
+      packaging
+      click
+      colorama
+      questionary
+      jinja2
+    ]
+    # optional-requirements.txt
+    ++ lib.optionals encryptionSupport [
+      python-olm
+      pycryptodome
+      unpaddedbase64
+    ];
+
+    postInstall = ''
+      rm $out/example-config.yaml
+    '';
+
+    passthru.tests = {
+      simple = runCommand "${pname}-tests" { } ''
+        ${maubot}/bin/mbc --help > $out
+      '';
+    };
+
+    # Setuptools is trying to do python -m maubot test
+    dontUseSetuptoolsCheck = true;
+
+    pythonImportsCheck = [
+      "maubot"
+    ];
+
+    meta = with lib; {
+      description = "A plugin-based Matrix bot system written in Python";
+      homepage = "https://maubot.xyz/";
+      changelog = "https://github.com/maubot/maubot/blob/v${version}/CHANGELOG.md";
+      license = licenses.agpl3Plus;
+      # Presumably, people running "nix run nixpkgs#maubot" will want to run the tool
+      # for interacting with Maubot rather than Maubot itself, which should be used as
+      # a NixOS module.
+      mainProgram = "mbc";
+      maintainers = with maintainers; [ chayleaf ];
+    };
+  };
+
+in
+maubot

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10029,6 +10029,8 @@ with pkgs;
 
   matrix-hookshot = callPackage ../servers/matrix-synapse/matrix-hookshot { };
 
+  maubot = with python3Packages; toPythonApplication maubot;
+
   mautrix-discord = callPackage ../servers/mautrix-discord { };
 
   mautrix-facebook = callPackage ../servers/mautrix-facebook { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6485,6 +6485,8 @@ self: super: with self; {
 
   mattermostdriver = callPackage ../development/python-modules/mattermostdriver { };
 
+  maubot = callPackage ../tools/networking/maubot { };
+
   mautrix = callPackage ../development/python-modules/mautrix { };
 
   mautrix-appservice = self.mautrix; # alias 2019-12-28


### PR DESCRIPTION
There's also a NixOS module available [in my flake](https://github.com/chayleaf/maubot.nix) which I am actively using.

###### Description of changes

https://github.com/maubot/maubot/

Maubot is a Matrix bot framework that has a Web UI and a plugin system. I think this PR can pave the way for a service later.

Supersedes #154261 and #123760

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
