### PR TITLE
nixos/libretranslate: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -34,7 +34,9 @@
 
 - Auto-scrub support for Bcachefs filesystems can now be enabled through [services.bcachefs.autoScrub.enable](#opt-services.bcachefs.autoScrub.enable) to periodically check for data corruption. If there's a correct copy available, it will automatically repair corrupted blocks.
 
-- [tlsrpt-reporter], an application suite to generate and deliver TLSRPT reports. Available as [services.tlsrpt](#opt-services.tlsrpt.enable).
+- [LibreTranslate](https://libretranslate.com), a free and open source machine translation API. Available as [services.libretranslate](#opt-services.libretranslate.enable).
+
+- [tlsrpt-reporter](https://github.com/sys4/tlsrpt-reporter), an application suite to generate and deliver TLSRPT reports. Available as [services.tlsrpt](#opt-services.tlsrpt.enable).
 
 - [Chhoto URL](https://github.com/SinTan1729/chhoto-url), a simple, blazingly fast, selfhosted URL shortener with no unnecessary features, written in Rust. Available as [services.chhoto-url](#opt-services.chhoto-url.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1611,6 +1611,7 @@
   ./services/web-apps/lasuite-docs.nix
   ./services/web-apps/lasuite-meet.nix
   ./services/web-apps/lemmy.nix
+  ./services/web-apps/libretranslate.nix
   ./services/web-apps/limesurvey.nix
   ./services/web-apps/mainsail.nix
   ./services/web-apps/mastodon.nix

--- a/nixos/modules/services/web-apps/libretranslate.nix
+++ b/nixos/modules/services/web-apps/libretranslate.nix
@@ -1,0 +1,233 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.libretranslate;
+  ltmanageKeysCli = pkgs.writeShellScriptBin "ltmanage-keys" ''
+    set -a
+    export HOME="/var/lib/libretranslate"
+    sudo=exec
+    if [[ "$USER" != ${cfg.user} ]]; then
+      sudo='exec /run/wrappers/bin/sudo -u ${cfg.user} --preserve-env'
+    fi
+    $sudo ${cfg.package}/bin/ltmanage keys --api-keys-db-path ${cfg.dataDir}/db/api_keys.db "$@"
+  '';
+
+in
+{
+  options = {
+    services.libretranslate = {
+      enable = lib.mkEnableOption "LibreTranslate service";
+
+      package = lib.mkPackageOption pkgs "libretranslate" { };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "libretranslate";
+        description = "User account under which libretranslate runs.";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "libretranslate";
+        description = "Group account under which libretranslate runs.";
+      };
+
+      host = lib.mkOption {
+        description = "The address the application should listen on.";
+        type = lib.types.str;
+        default = "127.0.0.1";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 5000;
+        description = "The the application should listen on.";
+      };
+
+      dataDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/libretranslate";
+        example = "/srv/data/libretranslate";
+        description = "The data directory.";
+      };
+
+      threads = lib.mkOption {
+        type = lib.types.nullOr lib.types.ints.positive;
+        default = null;
+        example = 8;
+        description = "Set number of threads.";
+      };
+
+      enableApiKeys = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable the API keys database.";
+      };
+
+      disableWebUI = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        example = true;
+        description = "Whether to disable the Web UI.";
+      };
+
+      updateModels = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        example = true;
+        description = "Update language models at startup";
+      };
+
+      domain = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        example = "libretranslate.example.com";
+        description = ''
+          The domain serving your LibreTranslate instance.
+          Required for configure nginx as a reverse proxy.
+        '';
+      };
+
+      configureNginx = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Configure nginx as a reverse proxy for LibreTranslate.";
+      };
+
+      extraArgs = lib.mkOption {
+        type =
+          with lib.types;
+          attrsOf (
+            nullOr (oneOf [
+              bool
+              str
+              int
+              (listOf (oneOf [
+                bool
+                str
+                int
+              ]))
+            ])
+          );
+        default = { };
+        example = {
+          debug = true;
+          disable-files-translation = true;
+          url-prefix = "translate";
+        };
+        description = "Extra arguments passed to the LibreTranslate.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = lib.mkIf cfg.enableApiKeys [ ltmanageKeysCli ];
+
+    systemd.tmpfiles.rules = lib.mkIf (cfg.dataDir != "/var/lib/libretranslate") [
+      "d '${cfg.dataDir}' 0750 ${cfg.user} ${cfg.group} - -"
+      "z '${cfg.dataDir}' 0750 ${cfg.user} ${cfg.group} - -"
+    ];
+
+    systemd.services.libretranslate = {
+      description = "LibreTranslate service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        HOME = cfg.dataDir;
+      };
+      serviceConfig = lib.mkMerge [
+        {
+          Type = "simple";
+          ExecStart = ''
+            ${cfg.package}/bin/libretranslate ${
+              lib.cli.toGNUCommandLineShell { } (
+                cfg.extraArgs
+                // {
+                  inherit (cfg) host port threads;
+                  api-keys = cfg.enableApiKeys;
+                  disable-web-ui = cfg.disableWebUI;
+                  update-models = cfg.updateModels;
+                }
+              )
+            }
+          '';
+          WorkingDirectory = cfg.dataDir;
+          User = cfg.user;
+          Group = cfg.group;
+          ProcSubset = "all";
+          ProtectProc = "invisible";
+          UMask = "0027";
+          CapabilityBoundingSet = "";
+          NoNewPrivileges = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProtectHostname = true;
+          ProtectClock = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+          ];
+          RestrictNamespaces = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = false;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          PrivateMounts = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [ "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @setuid" ];
+        }
+        (lib.mkIf (cfg.dataDir == "/var/lib/libretranslate") {
+          StateDirectory = "libretranslate";
+          StateDirectoryMode = "0750";
+        })
+        (lib.mkIf (cfg.dataDir != "/var/lib/libretranslate") {
+          ReadWritePaths = cfg.dataDir;
+        })
+      ];
+    };
+
+    services.nginx = lib.mkIf cfg.configureNginx {
+      enable = true;
+      virtualHosts."${cfg.domain}" = {
+        root = "/var/empty";
+
+        locations."/" = {
+          proxyPass = "http://127.0.0.1:${toString cfg.port}";
+        };
+
+        locations."= /favicon.ico" = {
+          alias = "${cfg.package.static-compressed}/share/libretranslate/static/favicon.ico";
+        };
+
+        locations."^~ /static/" = {
+          alias = "${cfg.package.static-compressed}/share/libretranslate/static/";
+        };
+      };
+    };
+
+    users.users = lib.optionalAttrs (cfg.user == "libretranslate") {
+      libretranslate = {
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = lib.optionalAttrs (cfg.group == "libretranslate") {
+      libretranslate = { };
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes
Add LibreTranslate service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
