### PR TITLE
viber: 16.1.0.37 -> 20.3.0.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/viber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/default.nix
@@ -1,17 +1,22 @@
 {fetchurl, lib, stdenv, dpkg, makeWrapper,
- alsa-lib, cups, curl, dbus, expat, fontconfig, freetype, glib, gst_all_1,
- harfbuzz, libcap, libGL, libGLU, libpulseaudio, libxkbcommon, libxml2, libxslt,
- nspr, nss, openssl_1_1, systemd, wayland, xorg, zlib, ...
+ alsa-lib, brotli, cups, curl, dbus, expat,
+ fontconfig, freetype, glib, gst_all_1,
+ harfbuzz, krb5, libcap, libGL, libGLU,
+ libpulseaudio, libxkbcommon, libxml2,
+ libxslt, libopus, libwebp, lcms, nspr, nss,
+ snappy, openssl_1_1, systemd, wayland, xorg,
+ zlib, zstd, ...
 }:
 
 stdenv.mkDerivation {
   pname = "viber";
-  version = "16.1.0.37";
+  version = "20.3.0.1";
 
   src = fetchurl {
     # Official link: https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb
-    url = "https://web.archive.org/web/20211119123858/https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
-    sha256 = "sha256-hOz+EQc2OOlLTPa2kOefPJMUyWvSvrgqgPgBKjWE3p8=";
+    # To update this URL use the WaybackMachine extension for your browser
+    url = "https://web.archive.org/web/20230711214652/https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
+    sha256 = "sha256-YDh6YZCBa6aS2SlzZjOxNtPwGkcfcT5bu8/SssaZCA4=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -21,6 +26,7 @@ stdenv.mkDerivation {
 
   libPath = lib.makeLibraryPath [
       alsa-lib
+      brotli
       cups
       curl
       dbus
@@ -30,13 +36,19 @@ stdenv.mkDerivation {
       glib
       gst_all_1.gst-plugins-base
       gst_all_1.gstreamer
+      gst_all_1.gst-plugins-bad
       harfbuzz
+      krb5
       libcap
       libGLU libGL
       libpulseaudio
       libxkbcommon
       libxml2
       libxslt
+      libopus
+      libwebp
+      lcms
+      snappy
       nspr
       nss
       openssl_1_1
@@ -44,6 +56,7 @@ stdenv.mkDerivation {
       systemd
       wayland
       zlib
+      zstd
 
       xorg.libICE
       xorg.libSM
@@ -59,12 +72,13 @@ stdenv.mkDerivation {
       xorg.libXrender
       xorg.libXScrnSaver
       xorg.libXtst
+      xorg.libxshmfence
+      xorg.libxkbfile
       xorg.xcbutilimage
       xorg.xcbutilkeysyms
       xorg.xcbutilrenderutil
       xorg.xcbutilwm
-  ]
-  ;
+  ];
 
   installPhase = ''
     dpkg-deb -x $src $out


### PR DESCRIPTION
###### Description of changes

Updates to a new version of Viber which mostly adds UI refinements, afair.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).