### PR TITLE
indi: 1.9.8 -> 2.0.2, fix udev and libraw linking, enable Atik, Pentax and SX driver

### DIFF
--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , perl
 , wrapGAppsHook
@@ -29,6 +30,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-8Iheb/9wjf0u10ZQRkLMLNN2s7P++Fqcr26iatiKcTo=";
   };
+
+  patches = [
+    # Compatibility with INDI 2.0 series from https://github.com/Stellarium/stellarium/pull/3269
+    (fetchpatch {
+      url = "https://github.com/Stellarium/stellarium/commit/31fd7bebf33fa710ce53ac8375238a24758312bc.patch";
+      hash = "sha256-eJEqqitZgtV6noeCi8pDBYMVTFIVWXZU1fiEvoilX8o=";
+    })
+  ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace CMakeLists.txt \

--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -12,17 +12,18 @@
 , libjpeg
 , gsl
 , fftw
+, gtest
 }:
 
 stdenv.mkDerivation rec {
   pname = "indilib";
-  version = "1.9.8";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "indilib";
     repo = "indi";
     rev = "v${version}";
-    sha256 = "sha256-+KFuZgM/Bl6Oezq3WXjWCHefc1wvR3wOKXejmT0pw1U=";
+    hash = "sha256-GoEvWzGT3Ckv9Syif6Z2kAlnvg/Kt5I8SpGFG9kFTJo=";
   };
 
   nativeBuildInputs = [
@@ -45,14 +46,24 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DUDEVRULES_INSTALL_DIR=lib/udev/rules.d"
+  ] ++ lib.optional doCheck [
+    "-DINDI_BUILD_UNITTESTS=ON"
+    "-DINDI_BUILD_INTEGTESTS=ON"
   ];
+
+  checkInputs = [ gtest ];
+
+  doCheck = true;
+
+  # Socket address collisions between tests
+  enableParallelChecking = false;
 
   meta = with lib; {
     homepage = "https://www.indilib.org/";
     description = "Implementation of the INDI protocol for POSIX operating systems";
     changelog = "https://github.com/indilib/indi/releases/tag/v${version}";
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ hjones2199 ];
+    maintainers = with maintainers; [ hjones2199 sheepforce ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-firmware.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-firmware.nix
@@ -19,6 +19,7 @@
 , ffmpeg
 , version
 , src
+, autoPatchelfHook
 }:
 
 stdenv.mkDerivation rec {
@@ -26,7 +27,7 @@ stdenv.mkDerivation rec {
 
   inherit version src;
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake autoPatchelfHook ];
 
   buildInputs = [
     indilib libnova curl cfitsio libusb1 zlib boost gsl gpsd
@@ -60,7 +61,7 @@ stdenv.mkDerivation rec {
     description = "Third party firmware for the INDI astronomical software suite";
     changelog = "https://github.com/indilib/indi-3rdparty/releases/tag/v${version}";
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ hjones2199 ];
+    maintainers = with maintainers; [ hjones2199 sheepforce ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-full.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-full.nix
@@ -1,30 +1,29 @@
 { stdenv, lib, callPackage, fetchFromGitHub, indilib }:
 
 let
-  indi-version = "1.9.8";
+  inherit (indilib) version;
   indi-3rdparty-src = fetchFromGitHub {
     owner = "indilib";
     repo = "indi-3rdparty";
-    rev = "v${indi-version}";
-    sha256 = "sha256-ZFbMyjMvAWcdsl+1TyX5/v5nY1DqvhZ2ckFBDe8gdQg=";
+    rev = "v${version}";
+    hash = "sha256-xAGSFTOfO9P8JldzY59OnQULzf2Mlx3vWjoP+IDdEFE=";
   };
   indi-firmware = callPackage ./indi-firmware.nix {
-    version = indi-version;
+    inherit version;
     src = indi-3rdparty-src;
   };
   indi-3rdparty = callPackage ./indi-3rdparty.nix {
-    version = indi-version;
+    inherit version;
     src = indi-3rdparty-src;
-    withFirmware = stdenv.isx86_64;
+    withFirmware = stdenv.isx86_64 || stdenv.isAarch64;
     firmware = indi-firmware;
   };
 in
 callPackage ./indi-with-drivers.nix {
   pname = "indi-full";
-  version = indi-version;
+  inherit version;
   extraDrivers = [
     indi-3rdparty
-  ] ++ lib.optionals stdenv.isx86_64 [
-    indi-firmware
-  ];
+  ] ++ lib.optional (stdenv.isx86_64 || stdenv.isAarch64) indi-firmware
+  ;
 }


### PR DESCRIPTION
###### Description of changes

This is updates the INDI drivers and software, used to control of telescopes and cameras, to 2.0.2. The KStars and Ekos versions in nixpkgs require at least INDI 2.0.0 to work properly.

I've fixed some CMake linking errors against libudev and libraw1394 and also fixed compilation of the Atik, Pentax and SX drivers in INDI (I am using an Atik camera myself).

@hjones2199 I've also added myself as a second maintainer of INDI as I am actually using it myself and INDI is probably a rather rarely used piece of software in Nixpkgs. I hope this is okay for you? :slightly_smiling_face: 

Closes #242725

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

