### PR TITLE
quark-goldleaf: init at 0.10.1

### DIFF
--- a/pkgs/applications/misc/quark-goldleaf/default.nix
+++ b/pkgs/applications/misc/quark-goldleaf/default.nix
@@ -1,0 +1,83 @@
+{ lib
+, stdenv
+, maven
+, fetchFromGitHub
+, wrapGAppsHook
+, makeWrapper
+, jre
+, libXtst
+}:
+let
+  pname = "quark-goldleaf";
+  version = "0.10.1";
+
+  mvnHashes = {
+    x86_64-linux = "sha256-Yt39Lj1LGpobXepa8S3gvhphU1fE1gWSPB+k/bgc9wk=";
+    aarch64-linux = "sha256-Yt39Lj1LGpobXepa8S3gvhphU1fE1gWSPB+k/bgc9wk=";
+    x86_64-darwin = "sha256-Yt39Lj1LGpobXepa8S3gvhphU1fE1gWSPB+k/bgc9wk=";
+    aarch64-darwin = "sha256-Yt39Lj1LGpobXepa8S3gvhphU1fE1gWSPB+k/bgc9wk=";
+  };
+
+  quarkUnwrapped = maven.buildMavenPackage {
+    pname = "${pname}-half-wrapped";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "XorTroll";
+      repo = "Goldleaf";
+      rev = "refs/tags/${version}";
+      sha256 = "sha256-Kq9IkkPJgPCdTBWlpqz2AexYqp6auFnsy/hV/n980VQ=";
+    };
+    sourceRoot = "source/Quark";
+
+    mvnHash = mvnHashes.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+
+    nativeBuildInputs = [
+      wrapGAppsHook
+      makeWrapper
+    ];
+
+    installPhase = ''
+      install -D target/Quark.jar $out/share/java/${pname}.jar
+      makeWrapper ${jre}/bin/java $out/bin/${pname} \
+            --add-flags "-jar $out/share/java/${pname}.jar" \
+            --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXtst ]}"
+    '';
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ${./switch.rules} $out/etc/udev/rules.d/99-switch.rules
+    # If wrapGAppsHook was used here, ~ wouldn't work properly
+    makeWrapper ${quarkUnwrapped}/bin/${pname} $out/bin/${pname} \
+    --append-flags "-cfgfile ~/.quark.cfg"
+
+    runHook postInstall
+  '';
+
+  meta = rec {
+    homepage = "https://github.com/XorTroll/Goldleaf/blob/master/Quark.md";
+    changelog = "https://github.com/XorTroll/Goldleaf/releases/tag/${version}";
+    description = "A GUI tool to help Goldleaf with file-transfer between the Nintendo Switch and the PC";
+    longDescription = ''
+      ${description}
+
+      For it to work properly, you need to install the Nintendo Switch udev rules.
+
+      On NixOS you can do this by adding the following to your configuration:
+
+      `services.udev.packages = [ pkgs.${pname} ]`
+    '';
+    license = lib.licenses.gpl3Only;
+    platforms = lib.attrNames mvnHashes;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/applications/misc/quark-goldleaf/switch.rules
+++ b/pkgs/applications/misc/quark-goldleaf/switch.rules
@@ -1,0 +1,2 @@
+# Nintendo Switch (for Goldleaf+Quark connection)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="3000", MODE="0666"

--- a/pkgs/development/tools/build-managers/apache-maven/build-package.nix
+++ b/pkgs/development/tools/build-managers/apache-maven/build-package.nix
@@ -4,6 +4,7 @@
 }:
 
 { src
+, sourceRoot ? "source"
 , patches ? [ ]
 , pname
 , version
@@ -19,7 +20,7 @@
 let
   fetchedMavenDeps = stdenv.mkDerivation ({
     name = "${pname}-${version}-maven-deps";
-    inherit src patches;
+    inherit src sourceRoot patches;
 
     nativeBuildInputs = [
       maven

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12178,6 +12178,8 @@ with pkgs;
 
   pystring = callPackage ../development/libraries/pystring { };
 
+  quark-goldleaf = callPackage ../applications/misc/quark-goldleaf { };
+
   raysession = python3Packages.callPackage ../applications/audio/raysession {
     inherit (qt5) qttools;
   };


### PR DESCRIPTION
###### Description of changes

This PR adds 1 package: `quark-goldleaf`.

---

The actual program is called Quark, however, there already exists a package named `quark` so this was called `quark-goldleaf` because the project is only together used with the program called Goldleaf, running on the Nintendo Switch.

The PR also adds a `udev` rule which allows the Nintendo Switch to be detected by Quark.
I found that if you disconnect and then reconnect the Nintendo Switch, only by using `MODE="0666"` will it work without rebooting the PC.

Link to Goldleaf's repo: https://github.com/XorTroll/Goldleaf/
Inside the repo, the `/Quark` directory contains the project and `/Quark.md` contains the install instructions.

---

I also added inheriting of `sourceRoot` to `buildMavenPackage`. This did not cause a rebuild of the other packages.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>quark-goldleaf</li>
  </ul>
</details>

---

###### Notes:
I had to wrap the program twice:
- firstly, only the built `.jar` file , with its dependencies, applying `wrapGAppsHook`
- secondly, supplying the default `-cfgfile` flag

The reason for this double wrapping is that `wrapGAppsHook` changes the `makeWrapper` implementation, replacing it with `makeCWrapper`. The problem is that, for some reason, it can't resolve a path beginning with `~` correctly (no idea why).

Also, not sure whether this should be in application/misc or tools/misc. This is a really simple GUI so maybe it's better to put it into tools/misc

---

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).