### PR TITLE
plasma-desktop: add missing gsettings schemas on kaccess

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-desktop/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-desktop/default.nix
@@ -58,7 +58,14 @@
 , runCommandLocal
 , makeWrapper
 }:
-
+let
+  # run gsettings with desktop schemas for using in "kcm_access" kcm
+  # and in kaccess
+  gsettings-wrapper = runCommandLocal "gsettings-wrapper" { nativeBuildInputs = [ makeWrapper ]; } ''
+    mkdir -p $out/bin
+    makeWrapper ${glib}/bin/gsettings $out/bin/gsettings --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas.out}/share/gsettings-schemas/${gsettings-desktop-schemas.name}
+  '';
+in
 mkDerivation {
   pname = "plasma-desktop";
   nativeBuildInputs = [ extra-cmake-modules kdoctools wayland-scanner ];
@@ -122,19 +129,16 @@ mkDerivation {
     ./kcm-access.patch
   ];
   CXXFLAGS =
-    let
-      # run gsettings with desktop schemas for using in kcm_accces kcm
-      gsettings-wrapper = runCommandLocal "gsettings-wrapper" { nativeBuildInputs = [ makeWrapper ]; } ''
-        makeWrapper ${glib}/bin/gsettings $out --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas.out}/share/gsettings-schemas/${gsettings-desktop-schemas.name}
-      '';
-    in
     [
       ''-DNIXPKGS_HWCLOCK=\"${lib.getBin util-linux}/bin/hwclock\"''
-      ''-DNIXPKGS_GSETTINGS=\"${gsettings-wrapper}\"''
+      ''-DNIXPKGS_GSETTINGS=\"${gsettings-wrapper}/bin/gsettings\"''
     ];
   postInstall = ''
     # Display ~/Desktop contents on the desktop by default.
     sed -i "''${!outputBin}/share/plasma/shells/org.kde.plasma.desktop/contents/defaults" \
         -e 's/Containment=org.kde.desktopcontainment/Containment=org.kde.plasma.folder/'
   '';
+
+  # wrap kaccess with wrapped gsettings so it can access accessibility schemas
+  qtWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ gsettings-wrapper ]}" ];
 }


### PR DESCRIPTION
this commit lets kaccess to read screen reader settings[1] using gsettings by adding required gsettings schemas dirs to the $XDG_DATA_DIRS

this commit also refactors previus gsettings schemas fix of kcm_access for allowing reuse of wrapped gsettings between kaccess and kcm_access

[1]gsettings get org.gnome.desktop.a11y.applications screen-reader-enabled

~~note: enabling screen reader doesn't work directly because
mismatch of default values in [kcm_access](https://invent.kde.org/plasma/plasma-desktop/-/blob/master/kaccess/kaccess.cpp#L320) and [kaccess](https://invent.kde.org/plasma/plasma-desktop/-/blob/master/kaccess/kaccess.cpp#L320) this
can be workaround by disabling screen reader from kcm_access
and enbling it from $XDG_CONFIG_HOME/kaccessrc file
this bug fixed in https://invent.kde.org/plasma/plasma-desktop/-/merge_requests/1050 but this mr doesnt seem to be in Plasma/5.27 branch yet but it is backported in https://invent.kde.org/plasma/plasma-desktop/-/merge_requests/1607~~
edit: this issue is fixed and now current version of plasma desktop in nixpkgs doesn't have this bug
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
