### PR TITLE
riemann_c_client: Optional TLS support & other changes

### DIFF
--- a/pkgs/tools/misc/riemann-c-client/default.nix
+++ b/pkgs/tools/misc/riemann-c-client/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchFromGitea, autoreconfHook, pkg-config, file , protobufc }:
+{ lib, stdenv, fetchFromGitea, autoreconfHook, check, pkg-config, file, protobufc
+,withWolfSSL ? false, wolfssl
+,withGnuTLS ? false, gnutls
+,withJSON ? true, json_c
+}:
 
 stdenv.mkDerivation rec {
   pname = "riemann-c-client";
@@ -9,20 +13,30 @@ stdenv.mkDerivation rec {
     owner = "algernon";
     repo = "riemann-c-client";
     rev = "riemann-c-client-${version}";
-    sha256 = "sha256-FIhTT57g2uZBaH3EPNxNUNJn9n+0ZOhI6WMyF+xIr/Q=";
+    hash = "sha256-FIhTT57g2uZBaH3EPNxNUNJn9n+0ZOhI6WMyF+xIr/Q=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ file protobufc ];
+  outputs = [ "bin" "dev" "out" ];
 
-  preBuild = ''
-    make lib/riemann/proto/riemann.pb-c.h
-  '';
+  nativeBuildInputs = [ autoreconfHook check pkg-config ];
+  buildInputs = [ file protobufc ]
+    ++ lib.optional withWolfSSL wolfssl
+    ++ lib.optional withGnuTLS gnutls
+    ++ lib.optional withJSON json_c
+  ;
+
+  configureFlags = []
+    ++ lib.optional withWolfSSL "--with-tls=wolfssl"
+    ++ lib.optional withGnuTLS "--with-tls=gnutls"
+  ;
+
+  doCheck = true;
+  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "https://git.madhouse-project.org/algernon/riemann-c-client";
     description = "A C client library for the Riemann monitoring system";
-    license = licenses.gpl3;
+    license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ pradeepchhetri ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
This is a small update to riemann_c_client to optionally enable features, and correct a few things in the packaging.

###### Description of changes

- Allow building with wolfSSL or GnuTLS (both disabled by default), and with json_c (enabled by default, but can be turned off)
- Split outputs to `bin`, `dev`, and `out`
- Enable parallel building
- Remove the preBuild step, the bug it was working around has been fixed upstream.
- Fix the license: it is LGPL3+, not GPL3.
- Enable the unit tests during build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
