### PR TITLE
bootcommander: init at 1.17.00, libopenblt: init at 1.17.00

### DIFF
--- a/pkgs/by-name/bo/bootcommander/package.nix
+++ b/pkgs/by-name/bo/bootcommander/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  libopenblt,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bootcommander";
+  version = "1.15.00";
+
+  src = fetchFromGitHub {
+    owner = "feaser";
+    repo = "openblt";
+    rev = "refs/tags/openblt_v0${lib.replaceStrings [ "." ] [ "" ] finalAttrs.version}"; # will break at version 10.x.x
+    sparseCheckout = [ "Host/Source/" ];
+    hash = "sha256-eO72zVZFFQPoo75pfeqawwYKimoLqUeqnzz/E2YvSYc=";
+  };
+
+  preConfigure = ''
+    export SRCDIRPWD=$(pwd) # to avoid using NIX_BUILD_TOP
+    cd ./Host/Source/BootCommander/
+  '';
+
+  installPhase = ''
+    cd $SRCDIRPWD
+    runHook preInstall
+    install -D "Host/BootCommander" "$out/bin/BootCommander"
+    ln -s "$out/bin/BootCommander" "$out/bin/bootcommander"
+    runHook postInstall
+  '';
+
+  buildInputs = [ libopenblt ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "CLI program to perform firmware updates on microcontrollers that run the OpenBLT bootloader";
+    homepage = "https://www.feaser.com/openblt/doku.php?id=manual:bootcommander";
+    mainProgram = "BootCommander";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ simoneruffini ];
+  };
+})

--- a/pkgs/by-name/li/libopenblt/package.nix
+++ b/pkgs/by-name/li/libopenblt/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  libusb1,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libopenblt";
+  version = "1.17.00";
+
+  src = fetchFromGitHub {
+    owner = "feaser";
+    repo = "openblt";
+    rev = "refs/tags/openblt_v0${lib.replaceStrings [ "." ] [ "" ] finalAttrs.version}"; # will break at version 10.x.x
+    sparseCheckout = [ "Host/Source/" ];
+    hash = "sha256-eO72zVZFFQPoo75pfeqawwYKimoLqUeqnzz/E2YvSYc=";
+  };
+
+  preConfigure = ''
+    export srcDirPwd=$(pwd) # to avoid using NIX_BUILD_TOP
+    cd ./Host/Source/LibOpenBLT/
+  '';
+
+  installPhase = ''
+    cd $srcDirPwd
+    runHook preInstall
+    install -D "Host/libopenblt.so" "$out/lib/libopenblt.so"
+    install -D "Host/Source/LibOpenBLT/openblt.h" "$out/include/openblt.h"
+    runHook postInstall
+  '';
+
+  buildInputs = [ libusb1 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "API for communicating with a microcontrollers running the OpenBLT bootloader";
+    homepage = "https://www.feaser.com/openblt/doku.php?id=manual:libopenblt";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ simoneruffini ];
+  };
+})


### PR DESCRIPTION
###### Description of changes

Added bootcommander flasher utility and it's dynamic library dependency libopenblt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
