### PR TITLE
buck2: init at unstable-2023-07-11

### DIFF
--- a/pkgs/development/tools/build-managers/buck2/default.nix
+++ b/pkgs/development/tools/build-managers/buck2/default.nix
@@ -1,0 +1,79 @@
+{ fetchurl, lib, stdenv, zstd
+, autoPatchelfHook, gcc-unwrapped
+}:
+
+let
+  # NOTE (aseipp): buck2 uses a precompiled binary build for good reason — the
+  # upstream codebase extensively uses unstable `rustc` nightly features, and as
+  # a result can't be built upstream in any sane manner. it is only ever tested
+  # and integrated against a single version of the compiler, which produces all
+  # usable binaries. you shouldn't try to workaround this or get clever and
+  # think you can patch it to work; just accept it for now. it is extremely
+  # unlikely buck2 will build with a stable compiler anytime soon; see related
+  # upstream issues:
+  #
+  #   - NixOS/nixpkgs#226677
+  #   - NixOS/nixpkgs#232471
+  #   - facebook/buck2#265
+  #   - facebook/buck2#322
+  #
+  # worth noting: it *is* possible to build buck2 from source using
+  # buildRustPackage, and it works fine, but only if you are using flakes and
+  # can import `rust-overlay` from somewhere else to vendor your compiler. See
+  # nixos/nixpkgs#226677 for more information about that.
+
+  # map our platform name to the rust toolchain suffix
+  suffix = {
+    x86_64-darwin  = "x86_64-apple-darwin";
+    aarch64-darwin = "aarch64-apple-darwin";
+    # TODO (aseipp): there's an aarch64-linux musl build of buck2, but not a
+    # x86_64-linux musl build. keep things consistent for now and use glibc
+    # builds for both; but we should fix this in the future to be less fragile;
+    # we can then remove autoPatchelfHook.
+    x86_64-linux   = "x86_64-unknown-linux-gnu";
+    aarch64-linux  = "aarch64-unknown-linux-gnu";
+  }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  buck2-version = "2023-07-11";
+  src =
+    let
+      hashes = builtins.fromJSON (builtins.readFile ./hashes.json);
+      sha256 = hashes."${stdenv.hostPlatform.system}";
+      url = "https://github.com/facebook/buck2/releases/download/${buck2-version}/buck2-${suffix}.zst";
+    in fetchurl { inherit url sha256; };
+in
+stdenv.mkDerivation {
+  pname = "buck2";
+  version = "unstable-${buck2-version}"; # TODO (aseipp): kill 'unstable' once a non-prerelease is made
+  inherit src;
+
+  buildInputs = lib.optionals stdenv.isLinux [ gcc-unwrapped ]; # need libgcc_s.so.1 for patchelf
+  nativeBuildInputs = [ zstd ]
+    # TODO (aseipp): move to musl build and nuke this?
+    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  dontConfigure = true;
+  unpackPhase = "unzstd ${src} -o ./buck2";
+  buildPhase = "chmod +x ./buck2";
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D buck2 $out/bin/buck2
+  '';
+
+  # NOTE (aseipp): use installCheckPhase instead of checkPhase so that
+  # autoPatchelfHook kicks in first.
+  doInstallCheck = true;
+  installCheckPhase = "$out/bin/buck2 --version";
+
+  passthru.updateScript = ./update.sh;
+  meta = with lib; {
+    description = "Fast, hermetic, multi-language build system";
+    homepage = "https://buck2.build";
+    license = with licenses; [ asl20 /* or */ mit ];
+    platforms = [
+      "x86_64-linux" "aarch64-linux"
+      "x86_64-darwin" "aarch64-darwin"
+    ];
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/development/tools/build-managers/buck2/hashes.json
+++ b/pkgs/development/tools/build-managers/buck2/hashes.json
@@ -1,0 +1,5 @@
+{ "x86_64-linux": "sha256-dVOshrjpsFomstnJsZMPBDfakXOkU+ORbv//fq8Oxss="
+, "x86_64-darwin": "sha256-BuzA8irlqLWnv5fGUdIHu0grz9smTBdOs5yTUBZLUKg="
+, "aarch64-linux": "sha256-Thr9RsI7AkumBeraq08KoxDAXYKv63bZUTrTYN0GAss="
+, "aarch64-darwin": "sha256-vRu0ra6YN7+o1AId6+v0ZLQucO84KwS3Ila6Ksmp1J0="
+}

--- a/pkgs/development/tools/build-managers/buck2/update.sh
+++ b/pkgs/development/tools/build-managers/buck2/update.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq nix-prefetch common-updater-scripts nix coreutils
+# shellcheck shell=bash
+set -euo pipefail
+
+VERSION=$(curl -s https://api.github.com/repos/facebook/buck2/releases \
+  | jq -r '. |
+           sort_by(.created_at) | .[] |
+           select ((.prerelease == true) and (.name != "latest")) |
+           .name')
+echo "Latest buck2 prerelease: $VERSION"
+
+ARCHS=(
+    "x86_64-linux:x86_64-unknown-linux-gnu"
+    "x86_64-darwin:x86_64-apple-darwin"
+    "aarch64-linux:aarch64-unknown-linux-gnu"
+    "aarch64-darwin:aarch64-apple-darwin"
+)
+
+NFILE=pkgs/development/tools/build-managers/buck2/default.nix
+HFILE=pkgs/development/tools/build-managers/buck2/hashes.json
+rm -f "$HFILE" && touch "$HFILE"
+
+marker="{"
+for arch in "${ARCHS[@]}"; do
+    IFS=: read -r arch_name arch_target <<< "$arch"
+    sha256hash="$(nix-prefetch-url --type sha256 "https://github.com/facebook/buck2/releases/download/${VERSION}/buck2-${arch_target}.zst")"
+    srihash="$(nix hash to-sri --type sha256 "$sha256hash")"
+
+    echo "${marker} \"$arch_name\": \"$srihash\"" >> "$HFILE"
+    marker=","
+done
+
+echo "}" >> "$HFILE"
+
+sed -i \
+  's/buck2-version\s*=\s*".*";/buck2-version = "'"$VERSION"'";/' \
+  "$NFILE"
+
+echo "Done; wrote $HFILE and updated version"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18372,6 +18372,8 @@ with pkgs;
 
   buck = callPackage ../development/tools/build-managers/buck { };
 
+  buck2 = callPackage ../development/tools/build-managers/buck2 { };
+
   build2 = callPackage ../development/tools/build-managers/build2 {
     # Break cycle by using self-contained toolchain for bootstrapping
     build2 = buildPackages.callPackage ../development/tools/build-managers/build2/bootstrap.nix { };


### PR DESCRIPTION
The Buck2 team has (rather unexpectedly!) done its first binary prerelease, with an actual version tag; this binary is (still) built with the unstable rust compiler, which blocked #232471 from being merged. But the binary should run fine with a little `patchelf` magic, and, is at least built and deployed directly from GitHub Actions.

This adds binaries for all 4 major Unix platforms and just makes the patchelf hook succeeds. It adds myself as the maintainer, as I already am doing a bunch of work on/with buck2. New updates will happen every 2 weeks; the included `update.sh` script can helpfully dump out the hashes for you.

This should help alleviate #226677; though a source build is of course ideal. That's going to probably be a very far ways off, though. It might explode. Handle with care.

I've only tested this on `x86_64-linux`, so we're going to hand off to borg to try it elsewhere. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
