### PR TITLE
Update std2 and pynvim-pp python packages

### DIFF
--- a/pkgs/development/python-modules/pynvim-pp/default.nix
+++ b/pkgs/development/python-modules/pynvim-pp/default.nix
@@ -7,15 +7,15 @@
 
 buildPythonPackage {
   pname = "pynvim-pp";
-  version = "unstable-2023-07-05";
+  version = "unstable-2023-07-09";
 
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "ms-jpq";
     repo = "pynvim_pp";
-    rev = "e9ac3171c7edcc0be020d63840d6af4222b69540";
-    hash = "sha256-H1sCwU2wl9HO92LNkvkCb1iLbZrTNMmYA/8qy9uCgyU=";
+    rev = "93aa25bf3ee039c4eb85f402d6adf6977033013b";
+    hash = "sha256-gZvIiFpP+eMLD8/xodY7ywWxhWXtethXviVRedW/bgo=";
   };
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/std2/default.nix
+++ b/pkgs/development/python-modules/std2/default.nix
@@ -6,15 +6,15 @@
 
 buildPythonPackage {
   pname = "std2";
-  version = "unstable-2023-07-05";
+  version = "unstable-2023-07-09";
 
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "ms-jpq";
     repo = "std2";
-    rev = "1080b7b657f75352481808a906939d16b6d956a1";
-    hash = "sha256-shAuCZvyFGrW26uTnNeyvlAIABb1d9oeKpk9hQbtuEQ=";
+    rev = "2d5594b40585ecae60ce5175bee68cc8b3085ee6";
+    hash = "sha256-phGIWow7PGOtS1Pre1Gz0Xg6izGp6BiUTmze5jI/BwY=";
   };
 
   nativeBuildInputs = [ setuptools ];


### PR DESCRIPTION
###### Description of changes

Update ms-jpq's plugins `pynvim-pp` and `std2`.
This is necessary for the vim plugins `chadtree` and `coq_nvim` to work well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
