### PR TITLE
anilibria-winmaclinux: init at 1.2.9

### DIFF
--- a/pkgs/applications/video/anilibria-winmaclinux/0001-fix-instalation-paths.patch
+++ b/pkgs/applications/video/anilibria-winmaclinux/0001-fix-instalation-paths.patch
@@ -1,0 +1,24 @@
+diff --git a/AniLibria.pro b/AniLibria.pro
+index 3eb7213..ea571ff 100644
+--- a/AniLibria.pro
++++ b/AniLibria.pro
+@@ -271,17 +271,8 @@ QML_IMPORT_PATH =
+ # Additional import path used to resolve QML modules just for Qt Quick Designer
+ QML_DESIGNER_IMPORT_PATH =
+ 
+-# Default rules for deployment.
+-!flatpak{
+-    qnx: target.path = /tmp/$${TARGET}/bin
+-    else: unix:!android: target.path = /opt/$${TARGET}/bin
+-}else{
+-    target.path = $$PREFIX/bin
+-}
+-!isEmpty(target.path) {
+-    unix: INSTALLS += target desktop $${UNIX_ICONS}
+-    else:macx: INSTALLS += target
+-}
++target.path = $$PREFIX/bin
++INSTALLS += target $${UNIX_ICONS}
+ 
+ flatpak {
+     metadata.path = $$PREFIX/share/metainfo

--- a/pkgs/applications/video/anilibria-winmaclinux/0002-disable-version-check.patch
+++ b/pkgs/applications/video/anilibria-winmaclinux/0002-disable-version-check.patch
@@ -1,0 +1,12 @@
+diff --git a/AniLibria.pro b/AniLibria.pro
+index 3eb7213..3d39ec9 100644
+--- a/AniLibria.pro
++++ b/AniLibria.pro
+@@ -174,7 +174,6 @@ unix {
+ DEFINES += QT_DEPRECATED_WARNINGS
+ 
+ # If you need not check version remove or comment this line
+-DEFINES += USE_VERSION_CHECK
+ 
+ # You can also make your code fail to compile if it uses deprecated APIs.
+ # In order to do so, uncomment the following line.

--- a/pkgs/applications/video/anilibria-winmaclinux/default.nix
+++ b/pkgs/applications/video/anilibria-winmaclinux/default.nix
@@ -1,0 +1,91 @@
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, qmake
+, qtbase
+, qtquickcontrols2
+, qtwebsockets
+, qtmultimedia
+, gst_all_1
+, wrapQtAppsHook
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+mkDerivation rec {
+  pname = "anilibria-winmaclinux";
+  version = "1.2.9";
+
+  src = fetchFromGitHub {
+    owner = "anilibria";
+    repo = "anilibria-winmaclinux";
+    rev = version;
+    sha256 = "sha256-Fdj7i4jpKIDwaIBAch7SjIV/WnqMDnCfNYSiZLsamx8=";
+  };
+
+  sourceRoot = "source/src";
+
+  qmakeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  patches = [
+    ./0001-fix-instalation-paths.patch
+    ./0002-disable-version-check.patch
+  ];
+
+  preConfigure = ''
+    substituteInPlace AniLibria.pro \
+      --replace "\$\$PREFIX" '${placeholder "out"}'
+  '';
+
+  qtWrapperArgs = [
+    "--prefix GST_PLUGIN_PATH : ${(with gst_all_1; lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
+      gst-plugins-bad
+      gst-plugins-good
+      gst-plugins-base
+      gst-libav
+      gstreamer
+    ])}"
+  ];
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    qtbase
+    qtquickcontrols2
+    qtwebsockets
+    qtmultimedia
+  ] ++ (with gst_all_1; [
+    gst-plugins-bad
+    gst-plugins-good
+    gst-plugins-base
+    gst-libav
+    gstreamer
+  ]);
+
+  desktopItems = [
+    (makeDesktopItem (rec {
+      name = "AniLibria";
+      desktopName = name;
+      icon = "anilibria";
+      comment = meta.description;
+      genericName = "AniLibria desktop client";
+      categories = [ "Qt" "AudioVideo" "Player" ];
+      keywords = [ "anime" ];
+      exec = name;
+      terminal = false;
+    }))
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/anilibria/anilibria-winmaclinux";
+    description = "AniLibria cross platform desktop client";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ _3JlOy-PYCCKUi ];
+    inherit (qtbase.meta) platforms;
+    mainProgram = "AniLibria";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30145,6 +30145,8 @@ with pkgs;
 
   appvm = callPackage ../applications/virtualization/appvm { };
 
+  anilibria-winmaclinux = libsForQt5.callPackage ../applications/video/anilibria-winmaclinux { };
+
   yggdrasil = callPackage ../tools/networking/yggdrasil { };
 
   masterpdfeditor = libsForQt5.callPackage ../applications/misc/masterpdfeditor { };


### PR DESCRIPTION
###### Description of changes

https://github.com/anilibria/anilibria-winmaclinux is official desktop client for anilibria.tv

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>anilibria-winmaclinux</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
