### PR TITLE
bzip2, zstd: Add enableStatic option

### DIFF
--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -29,7 +29,7 @@ in rec {
   cctools_ = darwin.cctools;
 
   # Avoid debugging larger changes for now.
-  bzip2_ = bzip2.override (args: { linkStatic = true; });
+  bzip2_ = bzip2.override (args: { enableStatic = true; enableShared = false; });
 
   # Avoid messing with libkrb5 and libnghttp2.
   curl_ = curlMinimal.override (args: { gssSupport = false; http2Support = false; });

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl
-, linkStatic ? with stdenv.hostPlatform; isStatic || isCygwin
+, enableStatic ? with stdenv.hostPlatform; isStatic || isCygwin
+, enableShared ? true
 , autoreconfHook
 , testers
 }:
@@ -47,8 +48,12 @@ in {
 
   outputs = [ "bin" "dev" "out" "man" ];
 
-  configureFlags =
-    lib.optionals linkStatic [ "--enable-static" "--disable-shared" ];
+  configureFlags = lib.concatLists [
+    (lib.optional enableStatic "--enable-static")
+    (lib.optional (!enableShared) "--disable-shared")
+  ];
+
+  dontDisableStatic = enableStatic;
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -3,7 +3,8 @@
 , file
 , fetchpatch
 , legacySupport ? false
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.hostPlatform.isStatic # generates static libraries *only*
+, enableStatic ? static
 # these need to be ran on the host, thus disable when cross-compiling
 , buildContrib ? stdenv.hostPlatform == stdenv.buildPlatform
 , doCheck ? stdenv.hostPlatform == stdenv.buildPlatform
@@ -55,7 +56,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = lib.attrsets.mapAttrsToList
     (name: value: "-DZSTD_${name}:BOOL=${if value then "ON" else "OFF"}") {
       BUILD_SHARED = !static;
-      BUILD_STATIC = static;
+      BUILD_STATIC = enableStatic;
       BUILD_CONTRIB = buildContrib;
       PROGRAMS_LINK_SHARED = !static;
       LEGACY_SUPPORT = legacySupport;


### PR DESCRIPTION
Re-open of #237563 for `staging` instead of `master`.

###### Description of changes

Supports #61575.

The fact that these libs currently force-disable shared libraries when static ones are enabled was found during working on https://github.com/nh2/static-haskell-nix/pull/116.

FYI @jonathanlking @aherrmann 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC from #237563: @l0b0 @SuperSandro2000 @wegank 