### PR TITLE
treewide: disable fortify3 hardening flag on more packages

### DIFF
--- a/pkgs/applications/audio/alsa-scarlett-gui/default.nix
+++ b/pkgs/applications/audio/alsa-scarlett-gui/default.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config wrapGAppsHook4 ];
   buildInputs = [ gtk4 alsa-lib ];
 
+  # causes redefinition of _FORTIFY_SOURCE
+  hardeningDisable = [ "fortify3" ];
+
   meta = with lib; {
     description = "GUI for alsa controls presented by Focusrite Scarlett Gen 2/3 Mixer Driver";
     homepage = "https://github.com/geoffreybennett/alsa-scarlett-gui";

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -722,6 +722,10 @@ in
       # remove ccache
       substituteInPlace CMakeLists.txt --replace "ccache" ""
     '';
+
+    # causes redefinition of _FORTIFY_SOURCE
+    hardeningDisable = [ "fortify3" ];
+
     postBuild = "cd /build/source/build/pcsx2";
     meta = {
       description = "Port of PCSX2 to libretro";

--- a/pkgs/applications/graphics/foxotron/default.nix
+++ b/pkgs/applications/graphics/foxotron/default.nix
@@ -51,6 +51,9 @@ stdenv.mkDerivation rec {
     "-Wno-error=array-bounds"
   ];
 
+  # error: writing 1 byte into a region of size 0
+  hardeningDisable = [ "fortify3" ];
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/science/chemistry/ergoscf/default.nix
+++ b/pkgs/applications/science/chemistry/ergoscf/default.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation rec {
 
   OMP_NUM_THREADS = 2; # required for check phase
 
+  # With "fortify3", there are test failures, such as:
+  # Testing cnof CAMB3LYP/6-31G using FMM
+  # *** buffer overflow detected ***: terminated
+  # ./test_fmm_camb3lyp.sh: line 81: 1061289 Aborted                 (core dumped) ./ergo <<EOINPUT > /dev/null
+  hardeningDisable = [ "fortify3" ];
+
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -94,8 +94,13 @@ buildPythonApplication rec {
     ./disable-test_ssh_bootstrap_with_different_launchers.patch
   ];
 
-  # Causes build failure due to warning
-  hardeningDisable = lib.optional stdenv.cc.isClang "strictoverflow";
+  hardeningDisable = [
+    # causes redefinition of _FORTIFY_SOURCE
+    "fortify3"
+  ] ++ lib.optionals stdenv.cc.isClang [
+    # Causes build failure due to warning
+    "strictoverflow"
+  ];
 
   CGO_ENABLED = 0;
   GOFLAGS = "-trimpath";

--- a/pkgs/development/libraries/libffi/3.3.nix
+++ b/pkgs/development/libraries/libffi/3.3.nix
@@ -29,6 +29,9 @@ stdenv.mkDerivation rec {
     "--disable-exec-static-tramp"
   ];
 
+  # with fortify3, tests fail for some reason
+  hardeningDisable = [ "fortify3" ];
+
   preCheck = ''
     # The tests use -O0 which is not compatible with -D_FORTIFY_SOURCE.
     NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}

--- a/pkgs/development/libraries/libxlsxwriter/default.nix
+++ b/pkgs/development/libraries/libxlsxwriter/default.nix
@@ -31,6 +31,9 @@ stdenv.mkDerivation rec {
     "USE_SYSTEM_MINIZIP=1"
   ];
 
+  # TEST 428/429 worksheet:worksheet_table15 *** buffer overflow detected ***: terminated
+  hardeningDisable = [ "fortify3" ];
+
   doCheck = true;
 
   checkTarget = "test";

--- a/pkgs/development/tools/analysis/sparse/default.nix
+++ b/pkgs/development/tools/analysis/sparse/default.nix
@@ -22,6 +22,14 @@ in stdenv.mkDerivation rec {
   doCheck = true;
   buildFlags = [ "GCC_BASE:=${GCC_BASE}" ];
 
+  # Test failures with "fortify3" on, such as:
+  # +*** buffer overflow detected ***: terminated
+  # +Aborted (core dumped)
+  # error: Actual exit value does not match the expected one.
+  # error: expected 0, got 134.
+  # error: FAIL: test 'bool-float.c' failed
+  hardeningDisable = [ "fortify3" ];
+
   passthru.tests = {
     simple-execution = callPackage ./tests.nix { };
   };

--- a/pkgs/games/cdogs-sdl/default.nix
+++ b/pkgs/games/cdogs-sdl/default.nix
@@ -50,6 +50,9 @@ stdenv.mkDerivation rec {
     protobuf
   ];
 
+  # inlining failed in call to 'tinydir_open': --param max-inline-insns-single limit reached
+  hardeningDisable = [ "fortify3" ];
+
   meta = with lib; {
     homepage = "https://cxong.github.io/cdogs-sdl";
     description = "Open source classic overhead run-and-gun game";

--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -12,6 +12,9 @@ stdenv.mkDerivation {
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "prefix=$(out)" ];
 
+  # causes redefinition of _FORTIFY_SOURCE
+  hardeningDisable = [ "fortify3" ];
+
   postInstall = ''
     mkdir -p $out/share/man/man1
     cp man/mmc.1 $out/share/man/man1/

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -59,7 +59,10 @@ stdenv.mkDerivation rec {
     protobuf
   ];
 
-  hardeningDisable = lib.optionals debug [
+  hardeningDisable = [
+    # causes redefinition of _FORTIFY_SOURCE
+    "fortify3"
+  ] ++ lib.optionals debug [
     "fortify"
   ];
 

--- a/pkgs/os-specific/linux/x86info/default.nix
+++ b/pkgs/os-specific/linux/x86info/default.nix
@@ -26,6 +26,9 @@ stdenv.mkDerivation rec {
     pciutils
   ];
 
+  # causes redefinition of _FORTIFY_SOURCE
+  hardeningDisable = [ "fortify3" ];
+
   postBuild = ''
     patchShebangs lsmsr/createheader.py
     make -C lsmsr

--- a/pkgs/tools/networking/tgt/default.nix
+++ b/pkgs/tools/networking/tgt/default.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation rec {
     "-Wno-error=maybe-uninitialized"
   ];
 
+  hardeningDisable = lib.optionals stdenv.isAarch64 [
+    # error: 'read' writing 1 byte into a region of size 0 overflows the destination
+    "fortify3"
+  ];
+
   installFlags = [
     "sysconfdir=${placeholder "out"}/etc"
   ];


### PR DESCRIPTION
###### Description of changes

This is a follow-on of https://github.com/NixOS/nixpkgs/pull/242466 after comparing [the latest staging-next](https://hydra.nixos.org/eval/1797520) run on Hydra against master looking for more failures that might be due to fortify3. I'm not knowledgeable about hardening but, for the packages this PR addresses, I either verified that they fail with fortify3 and pass without it or the error signature made it obvious.

Targeting staging-next right now as it is relevant for https://github.com/NixOS/nixpkgs/pull/241951.

/cc @risicle @collares 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
