### PR TITLE
mawk: 1.3.4-20230203 -> 1.3.4-20230525

### DIFF
--- a/pkgs/tools/text/mawk/default.nix
+++ b/pkgs/tools/text/mawk/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mawk";
-  version = "1.3.4-20230203";
+  version = "1.3.4-20230525";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.invisible-island.net/mawk/mawk-${version}.tgz"
       "https://invisible-mirror.net/archives/mawk/mawk-${version}.tgz"
     ];
-    sha256 = "sha256-bbejKsecURB60xpAfU+SxrhC3eL2inUztOe3sD6JAL4=";
+    sha256 = "sha256-VjnRS7kSQ3Oz1/lX0rklrYrZZW1GISw/I9vKgQzJJp8=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];


### PR DESCRIPTION
###### Description of changes

Upgrade to fix random segfault.

Before:

```
  $ nix-build -A mawk && for i in $(seq 10); do printf "i=$i "; echo PASS | ./result/bin/mawk -W interactive '{ print }'; done
  /nix/store/zyxgmjyb8ii282lx8g64dhd8y9k3rzd6-mawk-1.3.4-20230203
  i=1 PASS
  i=2 PASS
  i=3 Segmentation fault (core dumped)
  i=4 Segmentation fault (core dumped)
  i=5 Segmentation fault (core dumped)
  i=6 Segmentation fault (core dumped)
  i=7 Segmentation fault (core dumped)
  i=8 PASS
  i=9 Segmentation fault (core dumped)
  i=10 PASS
```

After:

```
  $ nix-build -A mawk && for i in $(seq 10); do printf "i=$i "; echo PASS | ./result/bin/mawk -W interactive '{ print }'; done
  /nix/store/dn4mcifn50a6z3g482by0d988zwms0yq-mawk-1.3.4-20230525
  i=1 PASS
  i=2 PASS
  i=3 PASS
  i=4 PASS
  i=5 PASS
  i=6 PASS
  i=7 PASS
  i=8 PASS
  i=9 PASS
  i=10 PASS
```

Upstream changelog: https://invisible-island.net/mawk/CHANGES

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
