### PR TITLE
postgresqlPackages.pg_embedding: init at 0.3.1

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_embedding.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_embedding.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "pg_embedding";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "neondatabase";
+    repo = pname;
+    rev = version;
+    hash = "sha256-dpwBwomUPzxnBVnnK4IWYlP+c8Z/EKerXhgrLcQj8Gk=";
+  };
+
+  buildInputs = [ postgresql ];
+
+  installPhase = ''
+    install -D -t $out/lib *.so
+    install -D -t $out/share/postgresql/extension *.sql
+    install -D -t $out/share/postgresql/extension *.control
+  '';
+
+  meta = with lib; {
+    description = "PostgreSQL extension implementing the HNSW algorithm for vector similarity search";
+    homepage = "https://github.com/neondatabase/pg_embedding";
+    maintainers = with maintainers; [ ivan ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.postgresql;
+    broken = versionOlder postgresql.version "14";
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -16,6 +16,8 @@ self: super: {
 
     pg_ed25519 = super.callPackage ./ext/pg_ed25519.nix { };
 
+    pg_embedding = super.callPackage ./ext/pg_embedding.nix { };
+
     pg_hint_plan = super.callPackage ./ext/pg_hint_plan.nix { };
 
     pg_ivm = super.callPackage ./ext/pg_ivm.nix { };


### PR DESCRIPTION
###### Description of changes

This adds https://github.com/neondatabase/pg_embedding to nixpkgs. See also https://neon.tech/blog/pg-embedding-extension-for-vector-search

No minimum PostgreSQL version is documented, but it fails to build with PostgreSQL 13:

```
embedding.c:543:18: error: 'IndexAmRoutine' has no member named 'amadjustmembers'
  543 |         amroutine->amadjustmembers = NULL;
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested that the basic querying documented in https://github.com/neondatabase/pg_embedding#usage-summary works on PostgreSQL 15.3 on x86_64 NixOS 23.05.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
