### PR TITLE
riemann-c-client: fix sources location

### DIFF
--- a/pkgs/tools/misc/riemann-c-client/default.nix
+++ b/pkgs/tools/misc/riemann-c-client/default.nix
@@ -1,14 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, file , protobufc }:
+{ lib, stdenv, fetchFromGitea, autoreconfHook, pkg-config, file , protobufc }:
 
 stdenv.mkDerivation rec {
   pname = "riemann-c-client";
   version = "1.10.5";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "git.madhouse-project.org";
     owner = "algernon";
     repo = "riemann-c-client";
     rev = "riemann-c-client-${version}";
-    sha256 = "sha256-LuI9XFDPx0qw/+kkpXd0FOMESERAp31R1+ttkGuJnPA=";
+    sha256 = "1w4wi5mr0vgbsx8pv9s08i409qqlfivsa979zyq4miyga1f3vqif";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/algernon/riemann-c-client";
+    homepage = "https://git.madhouse-project.org/algernon/riemann-c-client";
     description = "A C client library for the Riemann monitoring system";
     license = licenses.gpl3;
     maintainers = with maintainers; [ pradeepchhetri ];


### PR DESCRIPTION
###### Description of changes

The algernon repo in github is no longer avilable, so switching it to one of the mirrors which contains the same archive

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
