### PR TITLE
nixos/trust-dns: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -24,6 +24,8 @@
 
 - [Apache Guacamole](https://guacamole.apache.org/), a cross-platform, clientless remote desktop gateway. Available as [services.guacamole-server](#opt-services.guacamole-server.enable) and [services.guacamole-client](#opt-services.guacamole-client.enable) services.
 
+- [trust-dns](https://trust-dns.org/), a Rust based DNS server built to be safe and secure from the ground up. Available as [services.trust-dns](#opt-services.trust-dns.enable).
+
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 
 - The `boot.loader.raspberryPi` options have been marked deprecated, with intent for removal for NixOS 24.11. They had a limited use-case, and do not work like people expect. They required either very old installs ([before mid-2019](https://github.com/NixOS/nixpkgs/pull/62462)) or customized builds out of scope of the standard and generic AArch64 support. That option set never supported the Raspberry Pi 4 family of devices.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1058,6 +1058,7 @@
   ./services/networking/tox-node.nix
   ./services/networking/toxvpn.nix
   ./services/networking/trickster.nix
+  ./services/networking/trust-dns.nix
   ./services/networking/tvheadend.nix
   ./services/networking/twingate.nix
   ./services/networking/ucarp.nix

--- a/nixos/modules/services/networking/trust-dns.nix
+++ b/nixos/modules/services/networking/trust-dns.nix
@@ -1,0 +1,177 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.trust-dns;
+  toml = pkgs.formats.toml { };
+
+  configFile = toml.generate "trust-dns.toml" (
+    lib.filterAttrsRecursive (_: v: v != null) cfg.settings
+  );
+
+  zoneType = lib.types.submodule ({ config, ... }: {
+    options = with lib; {
+      zone = mkOption {
+        type = types.str;
+        description = mdDoc ''
+          Zone name, like "example.com", "localhost", or "0.0.127.in-addr.arpa".
+        '';
+      };
+      zone_type = mkOption {
+        type = types.enum [ "Primary" "Secondary" "Hint" "Forward" ];
+        default = "Primary";
+        description = mdDoc ''
+          One of:
+          - "Primary" (the master, authority for the zone).
+          - "Secondary" (the slave, replicated from the primary).
+          - "Hint" (a cached zone with recursive resolver abilities).
+          - "Forward" (a cached zone where all requests are forwarded to another resolver).
+
+          For more details about these zone types, consult the documentation for BIND,
+          though note that trust-dns supports only a subset of BIND's zone types:
+          <https://bind9.readthedocs.io/en/v9_18_4/reference.html#type>
+        '';
+      };
+      file = mkOption {
+        type = types.either types.path types.str;
+        default = "${config.zone}.zone";
+        defaultText = literalExpression ''"''${config.zone}.zone"'';
+        description = mdDoc ''
+          Path to the .zone file.
+          If not fully-qualified, this path will be interpreted relative to the `directory` option.
+          If omitted, defaults to the value of the `zone` option suffixed with ".zone".
+        '';
+      };
+    };
+  });
+in
+{
+  meta.maintainers = with lib.maintainers; [ colinsane ];
+  options = {
+    services.trust-dns = with lib; {
+      enable = mkEnableOption (lib.mdDoc "trust-dns");
+      package = mkOption {
+        type = types.package;
+        default = pkgs.trust-dns;
+        defaultText = "pkgs.trust-dns";
+        description = mdDoc ''
+          Trust-dns package to use.
+          Only `bin/named` need be provided: the other trust-dns utilities (client and resolver) are not needed.
+        '';
+      };
+      quiet = mkOption {
+        type = types.bool;
+        default = false;
+        description = mdDoc ''
+          Log ERROR level messages only.
+          This option is mutually exclusive with the `debug` option.
+          If neither `quiet` nor `debug` are enabled, logging defaults to the INFO level.
+        '';
+      };
+      debug = mkOption {
+        type = types.bool;
+        default = false;
+        description = mdDoc ''
+          Log DEBUG, INFO, WARN and ERROR messages.
+          This option is mutually exclusive with the `debug` option.
+          If neither `quiet` nor `debug` are enabled, logging defaults to the INFO level.
+        '';
+      };
+      settings = mkOption {
+        description = lib.mdDoc ''
+          Settings for trust-dns. The options enumerated here are not exhaustive.
+          Refer to upstream documentation for all available options:
+          - [Example settings](https://github.com/bluejekyll/trust-dns/blob/main/tests/test-data/test_configs/example.toml)
+        '';
+        type = types.submodule {
+          freeformType = toml.type;
+          options = {
+            listen_addrs_ipv4 = mkOption {
+              type = types.listOf types.str;
+              default = [ "0.0.0.0" ];
+              description = mdDoc ''
+              List of ipv4 addresses on which to listen for DNS queries.
+              '';
+            };
+            listen_addrs_ipv6 = mkOption {
+              type = types.listOf types.str;
+              default = lib.optional config.networking.enableIPv6 "::0";
+              defaultText = literalExpression ''lib.optional config.networking.enableIPv6 "::0"'';
+              description = mdDoc ''
+                List of ipv6 addresses on which to listen for DNS queries.
+              '';
+            };
+            listen_port = mkOption {
+              type = types.port;
+              default = 53;
+              description = mdDoc ''
+                Port to listen on (applies to all listen addresses).
+              '';
+            };
+            directory = mkOption {
+              type = types.str;
+              default = "/var/lib/trust-dns";
+              description = mdDoc ''
+                The directory in which trust-dns should look for .zone files,
+                whenever zones aren't specified by absolute path.
+              '';
+            };
+            zones = mkOption {
+              description = mdDoc "List of zones to serve.";
+              default = {};
+              type = types.listOf (types.coercedTo types.str (zone: { inherit zone; }) zoneType);
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.trust-dns = {
+      description = "trust-dns Domain Name Server";
+      unitConfig.Documentation = "https://trust-dns.org/";
+      serviceConfig = {
+        ExecStart =
+        let
+          flags =  (lib.optional cfg.debug "--debug") ++ (lib.optional cfg.quiet "--quiet");
+          flagsStr = builtins.concatStringsSep " " flags;
+        in ''
+          ${cfg.package}/bin/named --config ${configFile} ${flagsStr}
+        '';
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = "10s";
+        DynamicUser = true;
+
+        StateDirectory = "trust-dns";
+        ReadWritePaths = [ cfg.settings.directory ];
+
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "full";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [ "AF_INET AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+      };
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

[trust-dns](https://trust-dns.org/) is a DNS server, much like BIND but a more recent effort claimed to be "security first". the trust-dns package was added to nixpkgs in January 2023: <https://github.com/NixOS/nixpkgs/pull/205866>. this PR adds a `services.trust-dns` module to facilitate running trust-dns as a systemd service. management of `.zone` files is left to the user; for those coming from BIND, your zone files _should_ be drop-in compatible with trust-dns.

example config:
```nix
services.trust-dns.enable = true;
services.trust-dns.settings.listen_addrs_ipv4 = [ "127.0.0.1" ];
services.trust-dns.settings.directory = "/var/trust-dns";
services.trust-dns.zones = [ "example.com" ];
# then populate `/var/trust-dns/example.com.zone` with your zone file
# e.g. <https://github.com/bluejekyll/trust-dns/blob/main/tests/test-data/test_configs/example.com.zone>
```

this module tries to be unopinionated, mostly just exposing configuration options as defined and named by upstream. this module as it appears here is the same module which currently serves the `uninsane.org` domain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
