### PR TITLE
nixos/cgit: rework to virtualHost and location, add locationConfig for nginx configuration

### DIFF
--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  cfgs = config.services.cgit;
+  cfg = config.services.cgit;
 
   settingType =
     with lib.types;
@@ -21,7 +21,87 @@ let
       (listOf settingType)
     ];
 
-  genAttrs' = names: f: lib.listToAttrs (map f names);
+  vhostOptions = {
+    options = {
+      package = lib.mkPackageOption pkgs "cgit" {
+        extraDescription = "The cgit package cannot be overwritten per location because cgit expects its static files to be available at `/cgit.css` and so forth.";
+      };
+
+      locations = lib.mkOption {
+        description = "Declarative configuration of cgit locations";
+        type = with lib.types; attrsOf (submodule locationOptions);
+        default = { };
+        example = lib.literalExpression ''
+          {
+            "/git/" = {
+              scanPath = "/var/lib/git";
+            };
+          }
+        '';
+      };
+    };
+  };
+
+  locationOptions = {
+    options = {
+      repos = lib.mkOption {
+        description = "cgit repository settings, see {manpage}`cgitrc(5)`";
+        type = with lib.types; attrsOf (attrsOf settingType);
+        default = { };
+        example = {
+          blah = {
+            path = "/var/lib/git/example";
+            desc = "An example repository";
+          };
+        };
+      };
+
+      scanPath = lib.mkOption {
+        description = "A path which will be scanned for repositories.";
+        type = with lib.types; nullOr path;
+        default = null;
+        example = "/var/lib/git";
+      };
+
+      user = lib.mkOption {
+        description = ''
+          User to run the cgit service, or rather its fcgiwrap instance, as.
+
+          fcgiwrap instances are reused if they share the same user and group.
+        '';
+        type = lib.types.str;
+        default = "cgit";
+      };
+
+      group = lib.mkOption {
+        description = ''
+          Group to run the cgit service, or rather its fcgiwrap instance, as.
+
+          fcgiwrap instances are reused if they share the same user and group.
+        '';
+        type = lib.types.str;
+        default = "cgit";
+      };
+
+      settings = lib.mkOption {
+        description = "cgit configuration, see cgitrc(5)";
+        type = lib.types.attrsOf settingType;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            enable-follow-links = true;
+            source-filter = "''${pkgs.cgit}/lib/cgit/filters/syntax-highlighting.py";
+          }
+        '';
+      };
+
+      extraConfig = lib.mkOption {
+        description = "These lines go to the end of cgitrc verbatim.";
+        type = lib.types.lines;
+        default = "";
+      };
+    };
+  };
 
   regexEscape =
     let
@@ -55,23 +135,32 @@ let
     in
     lib.replaceStrings special (map (c: "\\${c}") special);
 
-  stripLocation = cfg: lib.removeSuffix "/" cfg.nginx.location;
+  stripLocation = lib.removeSuffix "/";
 
-  regexLocation = cfg: regexEscape (stripLocation cfg);
+  regexLocation = loc: regexEscape (stripLocation loc);
 
-  mkFastcgiPass = name: cfg: ''
-    ${
-      if cfg.nginx.location == "/" then
-        ''
-          fastcgi_param PATH_INFO $uri;
-        ''
-      else
-        ''
-          fastcgi_split_path_info ^(${regexLocation cfg})(/.+)$;
-          fastcgi_param PATH_INFO $fastcgi_path_info;
-        ''
-    }fastcgi_pass unix:${config.services.fcgiwrap.instances."cgit-${name}".socket.address};
-  '';
+  mkFastcgiPass =
+    { loc, locCfg }:
+    let
+      inherit
+        (config.services.fcgiwrap.instances.${fcgiwrapInstanceName { inherit (locCfg) user group; }})
+        socket
+        ;
+    in
+    assert socket.type == "unix";
+    ''
+      ${
+        if loc == "/" then
+          ''
+            fastcgi_param PATH_INFO $uri;
+          ''
+        else
+          ''
+            fastcgi_split_path_info ^(${regexLocation loc})(/.+)$;
+            fastcgi_param PATH_INFO $fastcgi_path_info;
+          ''
+      }fastcgi_pass unix:${socket.address};
+    '';
 
   cgitrcLine =
     name: value:
@@ -84,203 +173,183 @@ let
         toString value
     }";
 
-  # list value as multiple lines (for "readme" for example)
-  cgitrcEntry =
-    name: value: if lib.isList value then map (cgitrcLine name) value else [ (cgitrcLine name value) ];
-
   mkCgitrc =
-    cfg:
+    loc: locCfg:
     pkgs.writeText "cgitrc" ''
       # global settings
       ${lib.concatStringsSep "\n" (
-        lib.flatten (
-          lib.mapAttrsToList cgitrcEntry ({ virtual-root = cfg.nginx.location; } // cfg.settings)
-        )
+        lib.mapAttrsToList cgitrcLine ({ virtual-root = loc; } // locCfg.settings)
       )}
-      ${lib.optionalString (cfg.scanPath != null) (cgitrcLine "scan-path" cfg.scanPath)}
+      ${lib.optionalString (locCfg.scanPath != null) (cgitrcLine "scan-path" locCfg.scanPath)}
 
       # repository settings
       ${lib.concatStrings (
         lib.mapAttrsToList (url: settings: ''
           ${cgitrcLine "repo.url" url}
           ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: cgitrcLine "repo.${name}") settings)}
-        '') cfg.repos
+        '') locCfg.repos
       )}
 
       # extra config
-      ${cfg.extraConfig}
+      ${locCfg.extraConfig}
     '';
 
-  fcgiwrapUnitName = name: "fcgiwrap-cgit-${name}";
-  fcgiwrapRuntimeDir = name: "/run/${fcgiwrapUnitName name}";
+  fcgiwrapInstanceName = { user, group }: "cgit-${user}:${group}";
+  fcgiwrapUnitName = { user, group }: "fcgiwrap-${fcgiwrapInstanceName { inherit user group; }}";
+
   gitProjectRoot =
-    name: cfg: if cfg.scanPath != null then cfg.scanPath else "${fcgiwrapRuntimeDir name}/repos";
+    locCfg:
+    if locCfg.scanPath != null then
+      locCfg.scanPath
+    else
+      pkgs.runCommandLocal "cgit-repos" { } ''
+        mkdir -p "$out"
+        ${lib.concatStrings (
+          lib.mapAttrsToList (name: value: ''
+            ln -s ${lib.escapeShellArg value.path} "$out"/${lib.escapeShellArg name}
+          '') locCfg.repos
+        )}
+      '';
 
 in
 {
   options = {
-    services.cgit = lib.mkOption {
-      description = "Configure cgit instances.";
-      default = { };
-      type = lib.types.attrsOf (
-        lib.types.submodule (
-          { config, ... }:
+    services.cgit = {
+      enable = lib.mkEnableOption "cgit";
+
+      virtualHosts = lib.mkOption {
+        description = "Declarative configuration of cgit virtual hosts";
+        type = with lib.types; attrsOf (submodule vhostOptions);
+        default = { };
+        example = lib.literalExpression ''
           {
-            options = {
-              enable = lib.mkEnableOption "cgit";
-
-              package = lib.mkPackageOption pkgs "cgit" { };
-
-              nginx.virtualHost = lib.mkOption {
-                description = "VirtualHost to serve cgit on, defaults to the attribute name.";
-                type = lib.types.str;
-                default = config._module.args.name;
-                example = "git.example.com";
-              };
-
-              nginx.location = lib.mkOption {
-                description = "Location to serve cgit under.";
-                type = lib.types.str;
-                default = "/";
-                example = "/git/";
-              };
-
-              repos = lib.mkOption {
-                description = "cgit repository settings, see {manpage}`cgitrc(5)`";
-                type = with lib.types; attrsOf (attrsOf settingType);
-                default = { };
-                example = {
-                  blah = {
-                    path = "/var/lib/git/example";
-                    desc = "An example repository";
-                  };
-                };
-              };
-
-              scanPath = lib.mkOption {
-                description = "A path which will be scanned for repositories.";
-                type = lib.types.nullOr lib.types.path;
-                default = null;
-                example = "/var/lib/git";
-              };
-
-              settings = lib.mkOption {
-                description = "cgit configuration, see {manpage}`cgitrc(5)`";
-                type = lib.types.attrsOf repeatedSettingType;
-                default = { };
-                example = lib.literalExpression ''
-                  {
-                    enable-follow-links = true;
-                    source-filter = "''${pkgs.cgit}/lib/cgit/filters/syntax-highlighting.py";
-                  }
-                '';
-              };
-
-              extraConfig = lib.mkOption {
-                description = "These lines go to the end of cgitrc verbatim.";
-                type = lib.types.lines;
-                default = "";
-              };
-
-              user = lib.mkOption {
-                description = "User to run the cgit service as.";
-                type = lib.types.str;
-                default = "cgit";
-              };
-
-              group = lib.mkOption {
-                description = "Group to run the cgit service as.";
-                type = lib.types.str;
-                default = "cgit";
+            "localhost" = {
+              locations."/git" = {
+                scanPath = "/var/lib/git";
               };
             };
           }
-        )
-      );
+        '';
+      };
     };
   };
 
-  config = lib.mkIf (lib.any (cfg: cfg.enable) (lib.attrValues cfgs)) {
-    assertions = lib.mapAttrsToList (vhost: cfg: {
-      assertion = !cfg.enable || (cfg.scanPath == null) != (cfg.repos == { });
-      message = "Exactly one of services.cgit.${vhost}.scanPath or services.cgit.${vhost}.repos must be set.";
-    }) cfgs;
+  config = lib.mkIf cfg.enable {
+    assertions = lib.concatLists (
+      lib.mapAttrsToList (
+        vhost: vhostCfg:
+        lib.mapAttrsToList (loc: locCfg: {
+          assertion = (locCfg.scanPath == null) != (locCfg.repos == { });
+          message = ''
+            Exactly one of services.cgit.virtualHosts.${vhost}.locations.${loc}.scanPath
+            or services.cgit.virtualHosts.${vhost}.locations.${loc}.repos must be set.
+          '';
+        }) vhostCfg.locations
+      ) cfg.virtualHosts
+    );
 
     users = lib.mkMerge (
-      lib.flip lib.mapAttrsToList cfgs (
-        _: cfg: {
-          users.${cfg.user} = {
-            isSystemUser = true;
-            inherit (cfg) group;
-          };
-          groups.${cfg.group} = { };
-        }
-      )
-    );
-
-    services.fcgiwrap.instances = lib.flip lib.mapAttrs' cfgs (
-      name: cfg:
-      lib.nameValuePair "cgit-${name}" {
-        process = { inherit (cfg) user group; };
-        socket = { inherit (config.services.nginx) user group; };
-      }
-    );
-
-    systemd.services = lib.flip lib.mapAttrs' cfgs (
-      name: cfg:
-      lib.nameValuePair (fcgiwrapUnitName name) (
-        lib.mkIf (cfg.repos != { }) {
-          serviceConfig.RuntimeDirectory = fcgiwrapUnitName name;
-          preStart = ''
-            GIT_PROJECT_ROOT=${lib.escapeShellArg (gitProjectRoot name cfg)}
-            mkdir -p "$GIT_PROJECT_ROOT"
-            cd "$GIT_PROJECT_ROOT"
-            ${lib.concatLines (
-              lib.flip lib.mapAttrsToList cfg.repos (
-                name: repo: ''
-                  ln -s ${lib.escapeShellArg repo.path} ${lib.escapeShellArg name}
-                ''
-              )
-            )}
-          '';
-        }
-      )
-    );
-
-    services.nginx.enable = true;
-
-    services.nginx.virtualHosts = lib.mkMerge (
-      lib.mapAttrsToList (name: cfg: {
-        ${cfg.nginx.virtualHost} = {
-          locations =
-            (genAttrs' [ "cgit.css" "cgit.png" "favicon.ico" "robots.txt" ] (
-              fileName:
-              lib.nameValuePair "= ${stripLocation cfg}/${fileName}" {
-                alias = lib.mkDefault "${cfg.package}/cgit/${fileName}";
-              }
-            ))
-            // {
-              "~ ${regexLocation cfg}/.+/(info/refs|git-upload-pack)" = {
-                fastcgiParams = rec {
-                  SCRIPT_FILENAME = "${pkgs.git}/libexec/git-core/git-http-backend";
-                  GIT_HTTP_EXPORT_ALL = "1";
-                  GIT_PROJECT_ROOT = gitProjectRoot name cfg;
-                  HOME = GIT_PROJECT_ROOT;
-                };
-                extraConfig = mkFastcgiPass name cfg;
-              };
-              "${stripLocation cfg}/" = {
-                fastcgiParams = {
-                  SCRIPT_FILENAME = "${cfg.package}/cgit/cgit.cgi";
-                  QUERY_STRING = "$args";
-                  HTTP_HOST = "$server_name";
-                  CGIT_CONFIG = mkCgitrc cfg;
-                };
-                extraConfig = mkFastcgiPass name cfg;
-              };
+      lib.concatMap (
+        vhostCfg:
+        lib.flip lib.mapAttrsToList vhostCfg.locations (
+          _: locCfg: {
+            users.${locCfg.user} = {
+              isSystemUser = true;
+              inherit (locCfg) group;
             };
-        };
-      }) cfgs
+            groups.${locCfg.group} = { };
+          }
+        )
+      ) (lib.attrValues cfg.virtualHosts)
     );
+
+    services.fcgiwrap.instances = lib.mkMerge (
+      lib.flip lib.mapAttrsToList cfg.virtualHosts (
+        _: vhostCfg:
+        lib.flip lib.mapAttrs' vhostCfg.locations (
+          loc: locCfg:
+          lib.nameValuePair (fcgiwrapInstanceName { inherit (locCfg) user group; }) {
+            process = { inherit (locCfg) user group; };
+            socket = { inherit (config.services.nginx) user group; };
+          }
+        )
+      )
+    );
+
+    systemd.services =
+      let
+        safeDirectoriesByUnit = lib.zipAttrsWith (_: lib.concatLists) (
+          lib.concatMap (
+            vhostCfg:
+            map (locCfg: {
+              ${fcgiwrapUnitName { inherit (locCfg) user group; }} =
+                # safe.directory supports trailing /*, use it for scanPath
+                # https://git-scm.com/docs/git-config/2.36.0#Documentation/git-config.txt-safedirectory
+                lib.optional (locCfg.scanPath != null) "${locCfg.scanPath}/*"
+                ++ map (name: "${gitProjectRoot locCfg}/${name}") (lib.attrNames locCfg.repos);
+            }) (lib.attrValues vhostCfg.locations)
+          ) (lib.attrValues cfg.virtualHosts)
+        );
+      in
+      lib.mapAttrs (_: safeDirectories: {
+        # see https://git-scm.com/docs/git-config/2.36.0#Documentation/git-config.txt-GITCONFIGCOUNT
+        environment = (
+          {
+            GIT_CONFIG_COUNT = toString (lib.length safeDirectories);
+          }
+          // lib.mergeAttrsList (
+            lib.imap0 (i: directory: {
+              "GIT_CONFIG_KEY_${toString i}" = "safe.directory";
+              "GIT_CONFIG_VALUE_${toString i}" = directory;
+            }) safeDirectories
+          )
+        );
+        serviceConfig.ExecStartPre = [
+          "${lib.getExe pkgs.git} config get --all --show-names safe.directory"
+        ];
+      }) safeDirectoriesByUnit;
+
+    services.nginx = {
+      enable = true;
+      virtualHosts = lib.mapAttrs (_: vhostCfg: {
+        locations = lib.mkMerge (
+          lib.optionals (vhostCfg.locations != { }) (
+            map
+              (name: {
+                "= /${name}".extraConfig = ''
+                  alias ${vhostCfg.package}/cgit/${name};
+                  auth_basic off;
+                '';
+              })
+              [
+                "cgit.css"
+                "cgit.png"
+                "favicon.ico"
+                "robots.txt"
+              ]
+          )
+          ++ (lib.mapAttrsToList (loc: locCfg: {
+            "~ ${regexLocation loc}/.+/(info/refs|git-upload-pack)" = {
+              fastcgiParams = rec {
+                SCRIPT_FILENAME = "${pkgs.git}/libexec/git-core/git-http-backend";
+                GIT_HTTP_EXPORT_ALL = "1";
+                GIT_PROJECT_ROOT = gitProjectRoot locCfg;
+                HOME = GIT_PROJECT_ROOT;
+              };
+              extraConfig = mkFastcgiPass { inherit loc locCfg; };
+            };
+            "${stripLocation loc}/" = {
+              fastcgiParams = {
+                SCRIPT_FILENAME = "${vhostCfg.package}/cgit/cgit.cgi";
+                QUERY_STRING = "$args";
+                HTTP_HOST = "$server_name";
+                CGIT_CONFIG = mkCgitrc loc locCfg;
+              };
+              extraConfig = mkFastcgiPass { inherit loc locCfg; };
+            };
+          }) vhostCfg.locations)
+        );
+      }) cfg.virtualHosts;
+    };
   };
 }

--- a/nixos/tests/cgit.nix
+++ b/nixos/tests/cgit.nix
@@ -35,6 +35,11 @@ in
                     desc = "some-repo description";
                   };
                 };
+                locationConfig = {
+                  basicAuth = {
+                    git = "password";
+                  };
+                };
               };
               "/scan-path/" = {
                 scanPath = "/var/lib/git/scan-path";
@@ -58,7 +63,7 @@ in
       from typing import Optional
 
       locations = {
-          "(c)git": None,
+          "(c)git": "git:password",
           "scan-path": None,
       }
 
@@ -88,7 +93,8 @@ in
 
       server.succeed("curl -fsS http://localhost/robots.txt | diff -u - ${robotsTxt}")
 
-      server.succeed(f"curl -fsS {curl_url('(c)git')} | grep -F 'some-repo description'")
+      server.fail(f"curl -fsS {curl_url('(c)git')}")
+      server.succeed(f"curl -fsS {curl_url('(c)git', auth=locations['(c)git'])} | grep -F 'some-repo description'")
 
       for location, auth in locations.items():
           server.succeed("${pkgs.writeShellScript "setup-cgit-test-repo" ''
@@ -111,5 +117,8 @@ in
               f"git clone {git_url(location, 'some-repo', auth)} {shlex.quote(location)}/some-repo",
               f"diff -u {shlex.quote(location)}/reference/date.txt {shlex.quote(location)}/some-repo/date.txt"
           )
+
+      server.fail(f"GIT_ASKPASS=true git clone {git_url('(c)git', 'some-repo')} '(c)git/some-repo-2'")
+      server.succeed(f"GIT_ASKPASS=true git clone {git_url('scan-path', 'some-repo')} 'scan-path/some-repo-2'")
     '';
 }

--- a/nixos/tests/cgit.nix
+++ b/nixos/tests/cgit.nix
@@ -13,99 +13,103 @@ in
 
   nodes = {
     server =
-      { ... }:
+      { pkgs, ... }:
       {
-        services.cgit."localhost" = {
+        services.cgit = {
           enable = true;
-          package = pkgs.cgit.overrideAttrs (
-            { postInstall, ... }:
-            {
-              postInstall = ''
-                ${postInstall}
-                cp ${robotsTxt} "$out/cgit/robots.txt"
-              '';
-            }
-          );
-          nginx.location = "/(c)git/";
-          repos = {
-            some-repo = {
-              path = "/tmp/git/some-repo";
-              desc = "some-repo description";
+          virtualHosts."localhost" = {
+            package = pkgs.cgit.overrideAttrs (
+              { postInstall, ... }:
+              {
+                postInstall = ''
+                  ${postInstall}
+                  cp ${robotsTxt} "$out/cgit/robots.txt"
+                '';
+              }
+            );
+            locations = {
+              "/(c)git/" = {
+                repos = {
+                  some-repo = {
+                    path = "/var/lib/git/(c)git/some-repo";
+                    desc = "some-repo description";
+                  };
+                };
+              };
+              "/scan-path/" = {
+                scanPath = "/var/lib/git/scan-path";
+              };
             };
-          };
-          settings = {
-            readme = [
-              ":README.md"
-              ":date.txt"
-            ];
           };
         };
 
-        environment.systemPackages = [ pkgs.git ];
+        environment.systemPackages = [
+          pkgs.coreutils
+          pkgs.curl
+          pkgs.git
+        ];
       };
   };
 
   testScript =
     { nodes, ... }:
     ''
+      import shlex
+      from typing import Optional
+
+      locations = {
+          "(c)git": None,
+          "scan-path": None,
+      }
+
+
+      def curl_url(location: str, tail: str = "", auth: Optional[str] = None) -> str:
+          return (
+              ("" if auth is None else f"-u {shlex.quote(auth)} ")
+              + shlex.quote(f"http://localhost/{location}/{tail}")
+          )
+
+
+      def git_url(location: str, tail: str = "", auth: Optional[str] = None) -> str:
+          return shlex.quote(
+              "http://"
+              + ("" if auth is None else f"{auth}@")
+              + f"localhost/{location}/{tail}"
+          )
+
+
       start_all()
 
       server.wait_for_unit("nginx.service")
       server.wait_for_unit("network.target")
       server.wait_for_open_port(80)
 
-      server.succeed("curl -fsS http://localhost/%28c%29git/cgit.css")
+      server.succeed("curl -fsS http://localhost/cgit.css")
 
-      server.succeed("curl -fsS http://localhost/%28c%29git/robots.txt | diff -u - ${robotsTxt}")
+      server.succeed("curl -fsS http://localhost/robots.txt | diff -u - ${robotsTxt}")
 
-      server.succeed(
-          "curl -fsS http://localhost/%28c%29git/ | grep -F 'some-repo description'"
-      )
+      server.succeed(f"curl -fsS {curl_url('(c)git')} | grep -F 'some-repo description'")
 
-      server.fail("curl -fsS http://localhost/robots.txt")
+      for location, auth in locations.items():
+          server.succeed("${pkgs.writeShellScript "setup-cgit-test-repo" ''
+            set -eux
+            git init --bare -b master "/var/lib/git/$1/some-repo"
+            git init -b master "$1/reference"
+            cd "$1/reference"
+            git remote add origin "/var/lib/git/$1/some-repo"
+            date > date.txt
+            git add date.txt
+            git -c user.name=test -c user.email=test@localhost commit -m 'add date'
+            git push -u origin master
+          ''} " + shlex.quote(location))
 
-      server.succeed("sudo -u cgit ${pkgs.writeShellScript "setup-cgit-test-repo" ''
-        set -e
-        git init --bare -b master /tmp/git/some-repo
-        git init -b master reference
-        cd reference
-        git remote add origin /tmp/git/some-repo
-        { echo -n "cgit NixOS Test at "; date; } > date.txt
-        git add date.txt
-        git -c user.name=test -c user.email=test@localhost commit -m 'add date'
-        git push -u origin master
-      ''}")
+          server.succeed(
+              f"curl -fsS {curl_url(location, 'some-repo/plain/date.txt?id=master', auth)} | diff -u {shlex.quote(location)}/reference/date.txt -"
+          )
 
-      # test web download
-      server.succeed(
-          "curl -fsS 'http://localhost/%28c%29git/some-repo/plain/date.txt?id=master' | diff -u reference/date.txt -"
-      )
-
-      # test http clone
-      server.succeed(
-         "git clone http://localhost/%28c%29git/some-repo && diff -u reference/date.txt some-repo/date.txt"
-      )
-
-      # test list settings by greping for the fallback readme
-      server.succeed(
-          "curl -fsS 'http://localhost/%28c%29git/some-repo/about/' | grep -F 'cgit NixOS Test at'"
-      )
-
-      # add real readme
-      server.succeed("sudo -u cgit ${pkgs.writeShellScript "cgit-commit-readme" ''
-        set -e
-        echo '# cgit NixOS test README' > reference/README.md
-        git -C reference add README.md
-        git -C reference -c user.name=test -c user.email=test@localhost commit -m 'add readme'
-        git -C reference push
-      ''}")
-
-      # test list settings by greping for the real readme
-      server.succeed(
-          "curl -fsS 'http://localhost/%28c%29git/some-repo/about/' | grep -F '# cgit NixOS test README'"
-      )
-      server.fail(
-          "curl -fsS 'http://localhost/%28c%29git/some-repo/about/' | grep -F 'cgit NixOS Test at'"
-      )
+          server.succeed(
+              f"git clone {git_url(location, 'some-repo', auth)} {shlex.quote(location)}/some-repo",
+              f"diff -u {shlex.quote(location)}/reference/date.txt {shlex.quote(location)}/some-repo/date.txt"
+          )
     '';
 }


### PR DESCRIPTION
Overhaul the API of <https://github.com/NixOS/nixpkgs/pull/167319>.

Unlike previously assumed static files must be served on /, so multiple cgit instances on the same virtual host share those resources. To mirror this the options are reworked and now mirror those of nginx.

Additionally the option `locationConfig` is introduced, to pass common options to cgit's location blocks.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
