### PR TITLE
nixos/keyd: add support for multiple configuration in different files

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -60,6 +60,8 @@
 
 - `util-linux` is now supported on Darwin and is no longer an alias to `unixtools`. Use the `unixtools.util-linux` package for access to the Apple variants of the utilities.
 
+- `services.keyd` changed API. Now you can create multiple configuration files.
+
 - `services.ddclient` has been removed on the request of the upstream maintainer because it is unmaintained and has bugs. Please switch to a different software like `inadyn` or `knsupdate`.
 
 - The `vlock` program from the `kbd` package has been moved into its own package output and should now be referenced explicitly as `kbd.vlock` or replaced with an alternative such as the standalone `vlock` package or `physlock`.

--- a/nixos/modules/services/hardware/keyd.nix
+++ b/nixos/modules/services/hardware/keyd.nix
@@ -3,12 +3,9 @@ with lib;
 let
   cfg = config.services.keyd;
   settingsFormat = pkgs.formats.ini { };
-in
-{
-  options = {
-    services.keyd = {
-      enable = mkEnableOption (lib.mdDoc "keyd, a key remapping daemon");
 
+  keyboardOptions = { ... }: {
+    options = {
       ids = mkOption {
         type = types.listOf types.string;
         default = [ "*" ];
@@ -35,24 +32,71 @@ in
           };
         };
         description = lib.mdDoc ''
-          Configuration, except `ids` section, that is written to {file}`/etc/keyd/default.conf`.
+          Configuration, except `ids` section, that is written to {file}`/etc/keyd/<keyboard>.conf`.
+          Appropriate names can be used to write non-alpha keys, for example "equal" instead of "=" sign (see <https://github.com/NixOS/nixpkgs/issues/236622>).
           See <https://github.com/rvaiya/keyd> how to configure.
         '';
       };
     };
   };
+in
+{
+  imports = [
+    (mkRemovedOptionModule [ "services" "keyd" "ids" ]
+      ''Use keyboards.<filename>.ids instead. If you don't need a multi-file configuration, just add keyboards.default before the ids. See https://github.com/NixOS/nixpkgs/pull/243271.'')
+    (mkRemovedOptionModule [ "services" "keyd" "settings" ]
+      ''Use keyboards.<filename>.settings instead. If you don't need a multi-file configuration, just add keyboards.default before the settings. See https://github.com/NixOS/nixpkgs/pull/243271.'')
+  ];
+
+  options.services.keyd = {
+    enable = mkEnableOption (lib.mdDoc "keyd, a key remapping daemon");
+
+    keyboards = mkOption {
+      type = types.attrsOf (types.submodule keyboardOptions);
+      default = { };
+      example = literalExpression ''
+        {
+          default = {
+            ids = [ "*" ];
+            settings = {
+              main = {
+                capslock = "overload(control, esc)";
+              };
+            };
+          };
+          externalKeyboard = {
+            ids = [ "1ea7:0907" ];
+            settings = {
+              main = {
+                esc = capslock;
+              };
+            };
+          };
+        }
+      '';
+      description = mdDoc ''
+        Configuration for one or more device IDs. Corresponding files in the /etc/keyd/ directory are created according to the name of the keys (like `default` or `externalKeyboard`).
+      '';
+    };
+  };
 
   config = mkIf cfg.enable {
-    environment.etc."keyd/default.conf".source = pkgs.runCommand "default.conf"
-      {
-        ids = ''
-          [ids]
-          ${concatStringsSep "\n" cfg.ids}
-        '';
-        passAsFile = [ "ids" ];
-      } ''
-      cat $idsPath <(echo) ${settingsFormat.generate "keyd-main.conf" cfg.settings} >$out
-    '';
+    # Creates separate files in the `/etc/keyd/` directory for each key in the dictionary
+    environment.etc = mapAttrs'
+      (name: options:
+        nameValuePair "keyd/${name}.conf" {
+          source = pkgs.runCommand "${name}.conf"
+            {
+              ids = ''
+                [ids]
+                ${concatStringsSep "\n" options.ids}
+              '';
+              passAsFile = [ "ids" ];
+            } ''
+            cat $idsPath <(echo) ${settingsFormat.generate "keyd-${name}.conf" options.settings} >$out
+          '';
+        })
+      cfg.keyboards;
 
     hardware.uinput.enable = lib.mkDefault true;
 
@@ -62,9 +106,11 @@ in
 
       wantedBy = [ "multi-user.target" ];
 
-      restartTriggers = [
-        config.environment.etc."keyd/default.conf".source
-      ];
+      restartTriggers = mapAttrsToList
+        (name: options:
+          config.environment.etc."keyd/${name}.conf".source
+        )
+        cfg.keyboards;
 
       # this is configurable in 2.4.2, later versions seem to remove this option.
       # post-2.4.2 may need to set makeFlags in the derivation:

--- a/nixos/tests/keyd.nix
+++ b/nixos/tests/keyd.nix
@@ -32,7 +32,7 @@ let
     nodes.machine = {
       services.keyd = {
         enable = true;
-        inherit settings;
+        keyboards.default = { inherit settings; };
       };
     };
 


### PR DESCRIPTION
Add `keyboards` option to define different configurations for different IDs. This creates the appropriate files in `/etc/keyd` instead of just `default.conf` as before.

Fixes #241867 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
