### PR TITLE
dark-mode-notify: init at 2022-07-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18502,6 +18502,13 @@
     githubId = 647076;
     name = "Yorick van Pelt";
   };
+  YorikSar = {
+    name = "Yuriy Taraday";
+    email = "yorik.sar@gmail.com";
+    matrix = "@yorik.sar:matrix.org";
+    github = "YorikSar";
+    githubId = 428074;
+  };
   yrashk = {
     email = "yrashk@gmail.com";
     github = "yrashk";

--- a/pkgs/os-specific/darwin/dark-mode-notify/default.nix
+++ b/pkgs/os-specific/darwin/dark-mode-notify/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, swift
+, swiftpm
+, darwin
+}:
+
+stdenv.mkDerivation (final: {
+  pname = "dark-mode-notify";
+  version = "unstable-2022-07-18";
+
+  src = fetchFromGitHub {
+    owner = "bouk";
+    repo = "dark-mode-notify";
+    rev = "4d7fe211f81c5b67402fad4bed44995344a260d1";
+    hash = "sha256-LsAQ5v5jgJw7KsJnQ3Mh6+LNj1EMHICMoD5WzF3hRmU=";
+  };
+
+  nativeBuildInputs = [
+    swift
+    swiftpm
+  ];
+
+  buildInputs = with darwin.apple_sdk.frameworks; [
+    Foundation
+    Cocoa
+  ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = {
+    description = "Run a script whenever dark mode changes in macOS";
+    homepage = "https://github.com/bouk/dark-mode-notify";
+    # Doesn't build on x86_64 because of some CoreGraphics issue, even with SDK 11.0
+    platforms = [ "aarch64-darwin" ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ YorikSar ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3584,6 +3584,8 @@ with pkgs;
 
   dcap = callPackage ../tools/networking/dcap { };
 
+  dark-mode-notify = callPackage ../os-specific/darwin/dark-mode-notify { };
+
   deltachat-cursed = callPackage ../applications/networking/instant-messengers/deltachat-cursed { };
 
   delayarchitect = callPackage ../applications/audio/delayarchitect { };


### PR DESCRIPTION
###### Description of changes

`dark-mode-notify` is a small too that calls a binary whenever dark mode status changes in macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
