### PR TITLE
ruby-modules: add `suffix` and `gemType` in pathDerivation

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/functions.nix
+++ b/pkgs/development/ruby-modules/bundled-common/functions.nix
@@ -80,6 +80,8 @@ in rec {
           outputs = [ "out" ];
           out = res;
           outputName = "out";
+          suffix = version;
+          gemType = "path";
         };
     in res;
 


### PR DESCRIPTION
as required by the changes introduced in [this commit](
https://github.com/NixOS/nixpkgs/pull/237917/commits/6077061403503589d225fc0a51a514800517d813).

###### Description of changes

#237917 / https://github.com/NixOS/nixpkgs/pull/237917/commits/6077061403503589d225fc0a51a514800517d813 requires Ruby gem specifications to contain two additional attributes.  One is `suffix`: https://github.com/NixOS/nixpkgs/blob/4959cd51c6731a0e2fe92eaf0c9288f98333e2b5/pkgs/development/ruby-modules/bundled-common/default.nix#L54-L61
The other is `gemType`: https://github.com/NixOS/nixpkgs/blob/4959cd51c6731a0e2fe92eaf0c9288f98333e2b5/pkgs/development/ruby-modules/bundled-common/default.nix#L119-L121
This broke so-called `pathDerivation`s (corresponding to gem specifications with `type = "path"`) as constructed here: https://github.com/NixOS/nixpkgs/blob/4959cd51c6731a0e2fe92eaf0c9288f98333e2b5/pkgs/development/ruby-modules/bundled-common/functions.nix#L72-L84

This PR updates the `pathDerivation` function to add the `suffix` and `gemType` attributes, setting them to what I believe are sensible values given how `suffix` and `gemType` are defined and used elsewhere.

###### Things done

I wasn't able to find a good candidate package for testing in the nixpkgs collection.  I searched for packages whose `gemset.nix` contains at least one gem specification with `type = "path"`, and found two:

1. `anystyle-cli` has one, but [overrides the specification to instead use `type = "gem"`](https://github.com/NixOS/nixpkgs/blob/4959cd51c6731a0e2fe92eaf0c9288f98333e2b5/pkgs/tools/misc/anystyle-cli/default.nix#L14-L20).  
2. `gitlab` has a number of gem specifications with `type = "path"`; however, it and its  `passthru.tests.nixos-test-passes` test build successfully without the changes in this PR (they also build successfully _with_ those changes, FWIW).

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` also says `Nothing to be built`.

Outside of nixpkgs, I tested a branch of [`bashcov`](https://github.com/infertux/bashcov/tree/nix-support) that introduces Nix support.  The `bashcov` derivation (or rather the `bundlerEnv` it depends on) fails to build without the changes in this PR, and builds successfully with them.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
