### PR TITLE
kingstvis: init at 3.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9729,6 +9729,15 @@
     githubId = 22085373;
     name = "Luis Hebendanz";
   };
+  luisdaranda = {
+    email = "luisdomingoaranda@gmail.com";
+    github = "propet";
+    githubId = 8515861;
+    name = "Luis D. Aranda Sánchez";
+    keys = [{
+      fingerprint = "AB7C 81F4 9E07 CC64 F3E7  BC25 DCAC C6F4 AAFC C04E";
+    }];
+  };
   luisnquin = {
     email = "lpaandres2020@gmail.com";
     matrix = "@luisnquin:matrix.org";

--- a/pkgs/applications/science/electronics/kingstvis/default.nix
+++ b/pkgs/applications/science/electronics/kingstvis/default.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, buildFHSUserEnv
+, lib
+, fetchurl
+, glib
+, xorg
+, libGL
+, zlib
+, fontconfig
+, freetype
+, xkeyboard_config
+, dbus
+}:
+
+let
+
+  pkg = stdenv.mkDerivation (rec {
+    pname = "kingstvis";
+    version = "3.6.1";
+
+    src = fetchurl {
+      url = "http://res.kingst.site/kfs/KingstVIS_v3.6.1.tar.gz";
+      sha256 = "sha256-WWLlUm7031E8v5EVobXpNo9sURh+S4aVfmhDlWjK7qA=";
+    };
+
+    dontBuild = true;
+    installPhase = ''
+      cp -R . $out
+    '';
+  });
+
+in
+
+buildFHSUserEnv {
+  name = "kingstvis";
+
+  targetPkgs = pkgs: (with pkgs; [
+    glib
+    xorg.libXext
+    xorg.libX11
+    libGL
+    zlib
+    xorg.libXi
+    fontconfig
+    freetype
+    xorg.libXrender
+    xorg.libSM
+    xorg.libICE
+    xorg.libxcb
+    xkeyboard_config
+    dbus
+  ]);
+
+  runScript = "${pkg.outPath}/KingstVIS";
+
+  # usage:
+  # services.udev.packages = [ pkgs.kingstvis ];
+  extraInstallCommands = ''
+    # Install udev rule
+    install -Dvm644 ${pkg.outPath}/Driver/99-Kingst.rules  \
+      $out/lib/udev/rules.d/99-Kingst.rules
+  '';
+
+  meta = {
+    description = "Kingst Virtual Instruments Studio. Software for logic analyzers.";
+    homepage = "http://www.qdkingst.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.luisdaranda ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16073,6 +16073,8 @@ with pkgs;
 
   knightos-genkfs = callPackage ../development/tools/knightos/genkfs { };
 
+  kingstvis = callPackage ../applications/science/electronics/kingstvis { };
+
   regenkfs = callPackage ../development/tools/knightos/regenkfs { };
 
   knightos-kcc = callPackage ../development/tools/knightos/kcc { };


### PR DESCRIPTION
###### Description of changes

Kingstvis is a GUI for kingst logic analyzers (http://www.qdkingst.com/)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
