### PR TITLE
libayatana-common: init at 0.9.8

### DIFF
--- a/pkgs/development/libraries/libayatana-common/default.nix
+++ b/pkgs/development/libraries/libayatana-common/default.nix
@@ -1,0 +1,78 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gitUpdater
+, testers
+, cmake
+, cmake-extras
+, glib
+, gobject-introspection
+, gtest
+, intltool
+, pkg-config
+, systemd
+, vala
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libayatana-common";
+  version = "0.9.8";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "libayatana-common";
+    rev = finalAttrs.version;
+    hash = "sha256-5cHFjBQ3NgNaoprPrFytnrwBRL7gDG7QZLWomgGBJMg=";
+  };
+
+  postPatch = ''
+    # Queries via pkg_get_variable, can't override prefix
+    substituteInPlace data/CMakeLists.txt \
+      --replace 'DESTINATION "''${SYSTEMD_USER_UNIT_DIR}"' 'DESTINATION "${placeholder "out"}/lib/systemd/user"'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gobject-introspection
+    intltool
+    pkg-config
+    vala
+  ];
+
+  buildInputs = [
+    cmake-extras
+    glib
+    systemd
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    "-DENABLE_LOMIRI_FEATURES=OFF"
+    "-DGSETTINGS_LOCALINSTALL=ON"
+    "-DGSETTINGS_COMPILE=ON"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Common functions for Ayatana System Indicators";
+    homepage = "https://github.com/AyatanaIndicators/libayatana-common";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "libayatana-common"
+    ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21961,6 +21961,10 @@ with pkgs;
 
   libavif = callPackage ../development/libraries/libavif { };
 
+  libayatana-common = callPackage ../development/libraries/libayatana-common {
+    inherit (lomiri) cmake-extras;
+  };
+
   libb2 = callPackage ../development/libraries/libb2 { };
 
   libbacktrace = callPackage ../development/libraries/libbacktrace { };


### PR DESCRIPTION
###### Description of changes

Working towards #99090.

[libayatana-common](https://github.com/AyatanaIndicators/libayatana-common), collection of code shared by at least 2 Ayatana indicators. Required by Lomiri, since many of its menu elements in the top-right corner connect to either regular upstream Ayatana indicators, or custom indicators using the ayatana system.

There's some Lomiri-specific features that can be enabled, but it needs Lomiri packages that aren't in Nixpkgs yet. I'll start with packaging all the upstream indicators without their Lomiri-specific features because they *should* work outside of Lomiri, although I only really know how to make them appear & do anything outside of Lomiri.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
