### PR TITLE
pineflash: init at 0.5.4

### DIFF
--- a/pkgs/by-name/pi/pineflash/package.nix
+++ b/pkgs/by-name/pi/pineflash/package.nix
@@ -1,0 +1,94 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, makeDesktopItem
+, copyDesktopItems
+, atk
+, blisp
+, bzip2
+, cairo
+, dfu-util
+, gdk-pixbuf
+, glib
+, gtk3
+, libusb1
+, libxkbcommon
+, openssl
+, pango
+, udev
+, stdenv
+, darwin
+, wayland
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pineflash";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "Spagett1";
+    repo = "PineFlash";
+    rev = version;
+    hash = "sha256-4izfxApaCLbetZmMMKZIAknb+88B7z2WO+sBafehKHI=";
+    fetchSubmodules = true;
+  };
+
+  desktopItems = [(makeDesktopItem {
+    name = pname;
+    exec = "pineflash";
+    desktopName = "PineFlash";
+    comment = meta.description;
+    categories = [ "Utility" ];
+  })];
+
+  cargoHash = "sha256-VtUq/scRnx52ibqvUIqvaloaQpZyyXUlJYd2UIKQTjg=";
+
+  nativeBuildInputs = [
+    pkg-config
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    atk
+    bzip2
+    blisp
+    cairo
+    dfu-util
+    gdk-pixbuf
+    glib
+    gtk3
+    libusb1
+    libxkbcommon
+    openssl
+    pango
+    udev
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.AppKit
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.CoreGraphics
+    darwin.apple_sdk.frameworks.Foundation
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.SystemConfiguration
+  ] ++ lib.optionals stdenv.isLinux [
+    wayland
+  ];
+
+  postPatch = ''
+    # Linux
+    substituteInPlace src/submodules/flash.rs \
+      --replace 'dfupath = "dfu-util";' 'dfupath = "${dfu-util}/bin/dfu-util";' \
+      --replace 'blisppath = "blisp";' 'blisppath = "${blisp}/bin/blisp";'
+    # Darwin
+    substituteInPlace src/submodules/flash.rs \
+        --replace 'Command::new("dfu-util")' 'Command::new("${dfu-util}/bin/dfu-util")' \
+        --replace 'Command::new("blisp")' 'Command::new("${blisp}/bin/blisp")'
+  '';
+
+  meta = with lib; {
+    description = "A tool to flash ironos to the pinecil soldering iron and possibly other pine64 devices in the future";
+    homepage = "https://github.com/Spagett1/PineFlash";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ janik ];
+  };
+}


### PR DESCRIPTION
###### Description of changes
https;//github.com/spagett1/pineFlash/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

I have some problems with dfu-util when trying to flash a pinecil with pineflash it complaints about not finding dfu-util no matter iif I put it into buildInputs, nativeBuildInputs or propagatedBuildInputs what does work is spawning a nix-shell like that: `nix-shell -p dfu-util` and then opening pineflash from that nix-shell. I'm guessing this is caused by some wired behavior of $PATH but I don't know.