### PR TITLE
ameba: patch to build against crystal 1.9

### DIFF
--- a/pkgs/development/tools/ameba/default.nix
+++ b/pkgs/development/tools/ameba/default.nix
@@ -16,6 +16,24 @@ crystal.buildCrystalPackage rec {
       url = "https://github.com/crystal-ameba/ameba/commit/c7f2cba409787a1928fbb54494b4645ec11005cc.patch";
       hash = "sha256-tYEPke6omMdCGG2llJGXDZ3jTO4YAqpknzTPi2576UI=";
     })
+    (fetchpatch {
+      # Fixes: Error: type must be Ameba::Severity, not (Ameba::Severity | Nil)
+      name = "crystal-1.9-compatibility-1.patch";
+      url = "https://github.com/crystal-ameba/ameba/commit/d0d8b18c8365fd956d1e65ae6051e83a5e129f18.patch";
+      hash = "sha256-NmA3OoS5aOW+28TV/D/LUKEEu3lzHlcpolggHBB/wHE=";
+    })
+    (fetchpatch {
+      # Ignore some failing lints on the Ameba codebase run during the check phase.
+      name = "crystal-1.9-compatibility-2.patch";
+      url = "https://github.com/crystal-ameba/ameba/commit/c9d25f3409e6a127bbd7188267810657a2c2924e.patch";
+      hash = "sha256-JMKiO0izSXfgw7uM9XXQ0r/ntOwRnjzYeVHqVLAvLXo=";
+    })
+    (fetchpatch {
+      # Fixes test failures due to Crystal compiler error messages changing.
+      name = "crystal-1.9-compatibility-3.patch";
+      url = "https://github.com/crystal-ameba/ameba/commit/db59b23f9bfcf53dbe53d2918bd9c3d79ac24bb6.patch";
+      hash = "sha256-MKbEm9CR4+VzioCjcOFuFF0xnc1Ty0Ij4d3FcvQO6hY=";
+    })
   ];
 
   format = "make";


### PR DESCRIPTION
###### Description of changes

This has started failing since https://github.com/NixOS/nixpkgs/pull/243165. Fortunately, upstream has unreleased fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
