### PR TITLE
standardnotes: 3.162.8 -> 3.165.9

### DIFF
--- a/pkgs/applications/editors/standardnotes/src.json
+++ b/pkgs/applications/editors/standardnotes/src.json
@@ -1,13 +1,13 @@
 {
-  "version": "3.162.8",
+  "version": "3.165.9",
   "deb": {
     "x86_64-linux": {
-      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.162.8/standard-notes-3.162.8-linux-amd64.deb",
-      "hash": "sha512-XxSz1ZXCVzNBqX5BQ4nytFla1igEttV/pQ40r3HW6BQfy6yprQqmQ94OMJSx7kpfeQpxnwBMOUsA58QM3W7y1w=="
+      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.165.9/standard-notes-3.165.9-linux-amd64.deb",
+      "hash": "sha512-DR2wxCi0RgEeAQWbegJv7Zhp6rtO2PWF7RceVNd2KBrLigsRZbRfLVsPLesprKexZoGIryhYvOksecpX51VdUA=="
     },
     "aarch64-linux": {
-      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.162.8/standard-notes-3.162.8-linux-arm64.deb",
-      "hash": "sha512-Y1+89UaPfB+UKiVg3JWo3zwH1rFnjdKuU1CBwIjMblzf1775gEMXicU0n+6FpWTphcVmEeah9VISoq0oBHNHtg=="
+      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.165.9/standard-notes-3.165.9-linux-arm64.deb",
+      "hash": "sha512-ACYzEHQgw4pPZNgOUSDihAFY1dJ91Tmw3y2Lf1iihiOVcGn4qt5XJS2BG0+/bEWZjp0iuBKsfrlfWfSi6c95Sg=="
     }
   }
 }


### PR DESCRIPTION
###### Description of changes
Update standardnotes to 3.165.9.

Manual functionality test passes on NixOS x86_64-linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
