### PR TITLE
 tree-wide: make rust jemalloc-sys use nixpkgs jemalloc build

### DIFF
--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -14,6 +14,7 @@
 , rustPlatform
 , Security
 , sqlite
+, rust-jemalloc-sys
 , stdenv
 , SystemConfiguration
 , testers
@@ -70,6 +71,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     sqlite
+    rust-jemalloc-sys
   ] ++ lib.optionals stdenv.isDarwin [
     CoreFoundation
     Security

--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -2,6 +2,7 @@
 , lib
 , protobuf
 , rocksdb
+, rust-jemalloc-sys-unprefixed
 , rustPlatform
 , rustc-wasm32
 , stdenv
@@ -60,7 +61,9 @@ rustPlatform.buildRustPackage rec {
     rustc-wasm32.llvmPackages.lld
   ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
+  buildInputs = [
+    rust-jemalloc-sys-unprefixed
+  ] ++ lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
 
   # NOTE: we need to force lld otherwise rust-lld is not found for wasm32 target
   CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_LINKER = "lld";

--- a/pkgs/applications/office/activitywatch/default.nix
+++ b/pkgs/applications/office/activitywatch/default.nix
@@ -5,6 +5,7 @@
 , pkg-config
 , perl
 , openssl
+, rust-jemalloc-sys
 , python3
 , wrapQtAppsHook
 , qtbase
@@ -173,6 +174,7 @@ rec {
 
     buildInputs = [
       openssl
+      rust-jemalloc-sys
     ];
 
     postFixup = ''

--- a/pkgs/development/libraries/jemalloc/rust.nix
+++ b/pkgs/development/libraries/jemalloc/rust.nix
@@ -1,0 +1,24 @@
+{ lib
+, stdenv
+, jemalloc
+, writeText
+
+, unprefixed ? false
+}:
+
+let
+  # On some platforms the unprefixed feature will be ignored:
+  # https://github.com/tikv/jemallocator/blob/ab0676d77e81268cd09b059260c75b38dbef2d51/jemalloc-sys/src/env.rs
+  unprefixed' = unprefixed && !stdenv.hostPlatform.isMusl && !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isAndroid;
+
+in jemalloc.overrideAttrs (oldAttrs: {
+  configureFlags = oldAttrs.configureFlags ++ [
+    "--with-private-namespace=_rjem_"
+  ] ++ lib.optionals (!unprefixed') [
+    "--with-jemalloc-prefix=_rjem_"
+  ];
+
+  setupHook = writeText "setup-hook.sh" ''
+    export JEMALLOC_OVERRIDE="@out@/lib/libjemalloc${stdenv.hostPlatform.extensions.library}"
+  '';
+})

--- a/pkgs/development/python-modules/polars/default.nix
+++ b/pkgs/development/python-modules/polars/default.nix
@@ -6,6 +6,7 @@
 , libiconv
 , fetchFromGitHub
 , typing-extensions
+, rust-jemalloc-sys
 , darwin
 }:
 let
@@ -49,7 +50,9 @@ buildPythonPackage {
 
   nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [
+  buildInputs = [
+    rust-jemalloc-sys
+  ] ++ lib.optionals stdenv.isDarwin [
     libiconv
     darwin.apple_sdk.frameworks.Security
   ];

--- a/pkgs/development/tools/ruff/default.nix
+++ b/pkgs/development/tools/ruff/default.nix
@@ -4,6 +4,7 @@
 , installShellFiles
 , stdenv
 , darwin
+, rust-jemalloc-sys
   # tests
 , ruff-lsp
 }:
@@ -31,18 +32,14 @@ rustPlatform.buildRustPackage rec {
     installShellFiles
   ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [
+  buildInputs = [
+    rust-jemalloc-sys
+  ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.CoreServices
   ];
 
   cargoBuildFlags = [ "--package=ruff_cli" ];
   cargoTestFlags = cargoBuildFlags;
-
-  preBuild = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
-    # See https://github.com/jemalloc/jemalloc/issues/1997
-    # Using a value of 48 should work on both emulated and native x86_64-darwin.
-    export JEMALLOC_SYS_WITH_LG_VADDR=48
-  '';
 
   # tests expect no colors
   preCheck = ''

--- a/pkgs/servers/kanidm/default.nix
+++ b/pkgs/servers/kanidm/default.nix
@@ -11,6 +11,7 @@
 , sqlite
 , pam
 , bashInteractive
+, rust-jemalloc-sys
 }:
 
 let
@@ -59,6 +60,7 @@ rustPlatform.buildRustPackage rec {
     openssl
     sqlite
     pam
+    rust-jemalloc-sys
   ];
 
   # The UI needs to be in place before the tests are run.

--- a/pkgs/servers/matrix-conduit/default.nix
+++ b/pkgs/servers/matrix-conduit/default.nix
@@ -7,6 +7,7 @@
 , darwin
 , nixosTests
 , rocksdb
+, rust-jemalloc-sys
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -42,7 +43,10 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  buildInputs = [ sqlite ] ++ lib.optionals stdenv.isDarwin [
+  buildInputs = [
+    sqlite
+    rust-jemalloc-sys
+  ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
 

--- a/pkgs/servers/search/qdrant/default.nix
+++ b/pkgs/servers/search/qdrant/default.nix
@@ -5,6 +5,7 @@
 , stdenv
 , pkg-config
 , openssl
+, rust-jemalloc-sys
 , nix-update-script
 , Security
 }:
@@ -32,7 +33,10 @@ rustPlatform.buildRustPackage rec {
   # Needed to get openssl-sys to use pkg-config.
   OPENSSL_NO_VENDOR = 1;
 
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [
+    openssl
+    rust-jemalloc-sys
+  ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
   nativeBuildInputs = [ protobuf rustPlatform.bindgenHook pkg-config ];
 

--- a/pkgs/servers/search/quickwit/default.nix
+++ b/pkgs/servers/search/quickwit/default.nix
@@ -4,6 +4,7 @@
 , rustPlatform
 , nix-update-script
 , protobuf
+, rust-jemalloc-sys
 , Security
 }:
 
@@ -32,7 +33,9 @@ rustPlatform.buildRustPackage rec {
 
   sourceRoot = "${src.name}/quickwit";
 
-  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [
+    rust-jemalloc-sys
+  ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/tools/misc/fd/default.nix
+++ b/pkgs/tools/misc/fd/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, installShellFiles, testers, fd }:
+{ lib, rustPlatform, fetchFromGitHub, installShellFiles, rust-jemalloc-sys, testers, fd }:
 
 rustPlatform.buildRustPackage rec {
   pname = "fd";
@@ -14,6 +14,8 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-AstE8KGICgPhqRKlJecrE9iPUUWaOvca6ocWf85IzNo=";
 
   nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [ rust-jemalloc-sys ];
 
   # skip flaky test
   checkFlags = [

--- a/pkgs/tools/misc/turbo/default.nix
+++ b/pkgs/tools/misc/turbo/default.nix
@@ -12,6 +12,7 @@
 , openssl
 , extra-cmake-modules
 , fontconfig
+, rust-jemalloc-sys
 , testers
 , turbo
 , nix-update-script
@@ -149,6 +150,7 @@ rustPlatform.buildRustPackage {
   buildInputs = [
     openssl
     fontconfig
+    rust-jemalloc-sys
   ] ++ lib.optionals stdenv.isDarwin [
       IOKit
       CoreServices

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -8,6 +8,7 @@
 , rdkafka
 , oniguruma
 , zstd
+, rust-jemalloc-sys
 , Security
 , libiconv
 , coreutils
@@ -59,7 +60,7 @@ rustPlatform.buildRustPackage {
     };
   };
   nativeBuildInputs = [ pkg-config cmake perl git rustPlatform.bindgenHook ];
-  buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]
+  buildInputs = [ oniguruma openssl protobuf rdkafka zstd rust-jemalloc-sys ]
     ++ lib.optionals stdenv.isDarwin [ Security libiconv coreutils CoreServices ];
 
   # needed for internal protobuf c wrapper library

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22231,6 +22231,9 @@ with pkgs;
 
   jemalloc = callPackage ../development/libraries/jemalloc { };
 
+  rust-jemalloc-sys = callPackage ../development/libraries/jemalloc/rust.nix { };
+  rust-jemalloc-sys-unprefixed = rust-jemalloc-sys.override { unprefixed = true; };
+
   jose = callPackage ../development/libraries/jose { };
 
   jpcre2 = callPackage ../development/libraries/jpcre2 { };


### PR DESCRIPTION
###### Description of changes

Addresses #202863

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
