### PR TITLE
libnfc: Support static builds

### DIFF
--- a/pkgs/development/libraries/libnfc/default.nix
+++ b/pkgs/development/libraries/libnfc/default.nix
@@ -1,10 +1,12 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , libusb-compat-0_1
 , readline
 , cmake
 , pkg-config
+, static ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -17,6 +19,15 @@ stdenv.mkDerivation rec {
     rev = "libnfc-${version}";
     sha256 = "5gMv/HajPrUL/vkegEqHgN2d6Yzf01dTMrx4l34KMrQ=";
   };
+
+  patches = [
+    # From: https://github.com/nfc-tools/libnfc/pull/595
+    (fetchpatch {
+      name = "libnfc-Enable-selection-of-static-vs-shared-builds.patch";
+      url = "https://github.com/kino-dome/libnfc/commit/992f1c56ca7663357911c24843834a88ef98d8dc.patch";
+      hash = "sha256:1q74nylxpmbw3iqxdi24kra4bfx7gjx1v0i0nzb1jkpp15580hp1";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -32,9 +43,12 @@ stdenv.mkDerivation rec {
     "sysconfdir=/etc"
   ];
 
-  cmakeFlags = lib.optionals stdenv.isDarwin [
-    "-DLIBNFC_DRIVER_PN532_I2C=OFF"
-    "-DLIBNFC_DRIVER_PN532_SPI=OFF"
+  cmakeFlags = lib.concatLists [
+    (lib.optionals stdenv.isDarwin [
+      "-DLIBNFC_DRIVER_PN532_I2C=OFF"
+      "-DLIBNFC_DRIVER_PN532_SPI=OFF"
+    ])
+    (lib.optional (!static) "-DBUILD_SHARED_LIBS:BOOL=ON")
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Makes building `pkgsStatic.libnfc` possible. I made it as part of [static-haskell-nix](https://github.com/nh2/static-haskell-nix).

Uses not-yet-merged patch from: https://github.com/nfc-tools/libnfc/pull/595

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
