### PR TITLE
pythonPackages: fix typo about input argument `disabled`

### DIFF
--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -75,7 +75,7 @@ rec {
         inherit (tor) geoip;
       })
     ];
-    disable = !isPy3k;
+    disabled = !isPy3k;
     propagatedBuildInputs = [
       colorama
       flask
@@ -127,7 +127,7 @@ rec {
       ./fix-qrcode-gui.patch
     ];
 
-    disable = !isPy3k;
+    disabled = !isPy3k;
     propagatedBuildInputs = [
       onionshare
       pyqt5

--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -75,7 +75,6 @@ rec {
         inherit (tor) geoip;
       })
     ];
-    disabled = !isPy3k;
     propagatedBuildInputs = [
       colorama
       flask
@@ -127,7 +126,6 @@ rec {
       ./fix-qrcode-gui.patch
     ];
 
-    disabled = !isPy3k;
     propagatedBuildInputs = [
       onionshare
       pyqt5

--- a/pkgs/development/python-modules/aiohttp-basicauth/default.nix
+++ b/pkgs/development/python-modules/aiohttp-basicauth/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   version = "1.0.0";
   format = "setuptools";
 
-  disable = pythonOlder "3.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "romis2012";

--- a/pkgs/development/python-modules/aioprometheus/default.nix
+++ b/pkgs/development/python-modules/aioprometheus/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   version = "unstable-2023-03-14";
   format = "setuptools";
 
-  disable = pythonOlder "3.8";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "claws";

--- a/pkgs/development/python-modules/beautiful-date/default.nix
+++ b/pkgs/development/python-modules/beautiful-date/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   version = "2.3.0";
   format = "setuptools";
 
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "kuzmoyev";

--- a/pkgs/development/python-modules/checksumdir/default.nix
+++ b/pkgs/development/python-modules/checksumdir/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   version = "1.2.0";
   pyproject = true;
 
-  disable = pythonOlder "3.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "to-mc";

--- a/pkgs/development/python-modules/dataprep-ml/default.nix
+++ b/pkgs/development/python-modules/dataprep-ml/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   version = "0.0.18";
   pyproject = true;
 
-  disable = pythonOlder "3.8";
+  disabled = pythonOlder "3.8";
 
   # using PyPI as github repo does not contain tags or release branches
   src = fetchPypi {

--- a/pkgs/development/python-modules/dtw-python/default.nix
+++ b/pkgs/development/python-modules/dtw-python/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   version = "1.3.0";
   format = "pyproject";
 
-  disable = pythonOlder "3.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "DynamicTimeWarping";

--- a/pkgs/development/python-modules/flask-openid/default.nix
+++ b/pkgs/development/python-modules/flask-openid/default.nix
@@ -9,7 +9,6 @@
 buildPythonPackage rec {
   pname = "flask-openid";
   version = "1.3.0";
-  disabled = !isPy3k;
 
   src = fetchPypi {
     pname = "Flask-OpenID";

--- a/pkgs/development/python-modules/flask-openid/default.nix
+++ b/pkgs/development/python-modules/flask-openid/default.nix
@@ -9,7 +9,7 @@
 buildPythonPackage rec {
   pname = "flask-openid";
   version = "1.3.0";
-  disable = !isPy3k;
+  disabled = !isPy3k;
 
   src = fetchPypi {
     pname = "Flask-OpenID";

--- a/pkgs/development/python-modules/furo/default.nix
+++ b/pkgs/development/python-modules/furo/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   version = "2023.7.26";
   format = "wheel";
 
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version format;

--- a/pkgs/development/python-modules/gcsa/default.nix
+++ b/pkgs/development/python-modules/gcsa/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   pname = "gcsa";
   version = "2.1.0";
   format = "setuptools";
-  disable = pythonOlder "3.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "kuzmoyev";

--- a/pkgs/development/python-modules/graphql-server-core/default.nix
+++ b/pkgs/development/python-modules/graphql-server-core/default.nix
@@ -11,7 +11,7 @@
 buildPythonPackage rec {
   pname = "graphql-server-core";
   version = "2.0.0";
-  disable = pythonOlder "3.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "graphql-python";

--- a/pkgs/development/python-modules/greynoise/default.nix
+++ b/pkgs/development/python-modules/greynoise/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   version = "2.0.1";
   format = "setuptools";
 
-  disable = pythonOlder "3.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "GreyNoise-Intelligence";

--- a/pkgs/development/python-modules/kotsu/default.nix
+++ b/pkgs/development/python-modules/kotsu/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   version = "0.3.3";
   format = "setuptools";
 
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "datavaluepeople";

--- a/pkgs/development/python-modules/mindsdb-evaluator/default.nix
+++ b/pkgs/development/python-modules/mindsdb-evaluator/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   version = "0.0.11";
   pyproject = true;
 
-  disable = pythonOlder "3.8";
+  disabled = pythonOlder "3.8";
 
   # using PyPI as git repository does not have release tags or branches
   src = fetchPypi {

--- a/pkgs/development/python-modules/mrsqm/default.nix
+++ b/pkgs/development/python-modules/mrsqm/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   version = "0.0.6";
   format = "setuptools";
 
-  disable = pythonOlder "3.8";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pmdarima/default.nix
+++ b/pkgs/development/python-modules/pmdarima/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   version = "2.0.3";
   format = "setuptools";
 
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "alkaline-ml";

--- a/pkgs/development/python-modules/py-partiql-parser/default.nix
+++ b/pkgs/development/python-modules/py-partiql-parser/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   version = "0.3.8";
   pyproject = true;
 
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "getmoto";

--- a/pkgs/development/python-modules/pyre-extensions/default.nix
+++ b/pkgs/development/python-modules/pyre-extensions/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage {
   inherit pname version;
   format = "setuptools";
 
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pytest-reverse/default.nix
+++ b/pkgs/development/python-modules/pytest-reverse/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   version = "1.7.0";
   format = "pyproject";
 
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "adamchainz";

--- a/pkgs/development/python-modules/schemainspect/default.nix
+++ b/pkgs/development/python-modules/schemainspect/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   pname = "schemainspect";
   version = "3.1.1663587362";
   format = "pyproject";
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "djrobstep";

--- a/pkgs/development/python-modules/seasonal/default.nix
+++ b/pkgs/development/python-modules/seasonal/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   version = "0.3.1";
   pyproject = true;
 
-  disable = pythonOlder "3.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "welch";

--- a/pkgs/development/python-modules/sphinx-basic-ng/default.nix
+++ b/pkgs/development/python-modules/sphinx-basic-ng/default.nix
@@ -8,7 +8,7 @@
 buildPythonPackage rec {
   pname = "sphinx-basic-ng";
   version = "1.0.0.beta2";
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pradyunsg";

--- a/pkgs/development/python-modules/tsfresh/default.nix
+++ b/pkgs/development/python-modules/tsfresh/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   version = "0.20.1";
   pyproject = true;
 
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "blue-yonder";

--- a/pkgs/development/python-modules/txtai/default.nix
+++ b/pkgs/development/python-modules/txtai/default.nix
@@ -99,7 +99,7 @@ buildPythonPackage {
   inherit version;
   format = "setuptools";
 
-  disable = pythonOlder "3.8";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "neuml";

--- a/pkgs/development/python-modules/type-infer/default.nix
+++ b/pkgs/development/python-modules/type-infer/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   version = "0.0.15";
   format = "pyproject";
 
-  disable = pythonOlder "3.8";
+  disabled = pythonOlder "3.8";
 
   # using PyPI because the repo does not have tags or release branches
   src = fetchPypi {

--- a/pkgs/development/python-modules/xformers/default.nix
+++ b/pkgs/development/python-modules/xformers/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage {
   inherit version;
   format = "setuptools";
 
-  disable = pythonOlder "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "facebookresearch";


### PR DESCRIPTION
###### Description of changes

`buildPythonPackage` accepts `disabled` instead of `disable` to throw evaluation error on unsupported Python interpreters. Attempt to access such option as `disable` without the trailing `d` will be ignored silently, with an unexpected environment variable `disable` being injected into the build environment.

This patch fixes those misspelled `disabled` specification.

This is an apparent bug, and the fix should hardly change the output content. Maybe we could backport it to the stable release. ~(I choose to target staging, as 87 packages got rebuilt due to `disable` environment variable being removed.)~

Update: Target the master branch as suggested by @tjni.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
