### PR TITLE
hydrus: 520 -> 544, init python3Packages.pillow-heif

### DIFF
--- a/pkgs/applications/graphics/hydrus/0001-inform-nixpkgs.patch
+++ b/pkgs/applications/graphics/hydrus/0001-inform-nixpkgs.patch
@@ -1,0 +1,18 @@
+diff --git a/hydrus/core/HydrusConstants.py b/hydrus/core/HydrusConstants.py
+index 809338ef..9125928f 100644
+--- a/hydrus/core/HydrusConstants.py
++++ b/hydrus/core/HydrusConstants.py
+@@ -59,12 +59,7 @@ elif PLATFORM_HAIKU:
+ RUNNING_FROM_SOURCE = sys.argv[0].endswith( '.py' ) or sys.argv[0].endswith( '.pyw' )
+ RUNNING_FROM_MACOS_APP = os.path.exists( os.path.join( BASE_DIR, 'running_from_app' ) )
+ 
+-if RUNNING_FROM_SOURCE:
+-    NICE_RUNNING_AS_STRING = 'from source'
+-elif RUNNING_FROM_FROZEN_BUILD:
+-    NICE_RUNNING_AS_STRING = 'from frozen build'
+-elif RUNNING_FROM_MACOS_APP:
+-    NICE_RUNNING_AS_STRING = 'from App'
++NICE_RUNNING_AS_STRING = "from nixpkgs (source)"
+ 
+ BIN_DIR = os.path.join( BASE_DIR, 'bin' )
+ HELP_DIR = os.path.join( BASE_DIR, 'help' )

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,15 +12,20 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "520";
+  version = "544";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-y8KfPe3cBBq/iPCG7hNXrZDkOSNi+qSir6rO/65SHkI=";
+    hash = "sha256-e3VvkdJAQx5heKDJ1Ms6XpXrXWdzv48f8yu0DHfPy1A=";
   };
+
+  patches = [
+    # Nixpkgs specific, can be removed if upstream makes a more reasonable check
+    ./0001-inform-nixpkgs.patch
+  ];
 
   nativeBuildInputs = [
     wrapQtAppsHook
@@ -37,13 +42,16 @@ python3Packages.buildPythonPackage rec {
     cbor2
     chardet
     cloudscraper
+    dateparser
     html5lib
     lxml
     lz4
     numpy
     opencv4
     pillow
+    pillow-heif
     psutil
+    psd-tools
     pympler
     pyopenssl
     pyqt6
@@ -56,7 +64,6 @@ python3Packages.buildPythonPackage rec {
     requests
     send2trash
     service-identity
-    six
     twisted
   ];
 
@@ -92,6 +99,7 @@ python3Packages.buildPythonPackage rec {
     -e TestHydrusSessions \
     -e TestServer \
     -e TestClientMetadataMigration \
+    -e TestClientFileStorage \
   '';
 
   outputs = [ "out" "doc" ];
@@ -100,13 +108,16 @@ python3Packages.buildPythonPackage rec {
     # Move the hydrus module and related directories
     mkdir -p $out/${python3Packages.python.sitePackages}
     mv {hydrus,static} $out/${python3Packages.python.sitePackages}
+    # Fix random files being marked with execute permissions
+    chmod -x $out/${python3Packages.python.sitePackages}/static/*.{png,svg,ico}
+    # Build docs
     mkdocs build -d help
     mv help $out/doc/
 
     # install the hydrus binaries
     mkdir -p $out/bin
-    install -m0755 server.py $out/bin/hydrus-server
-    install -m0755 client.py $out/bin/hydrus-client
+    install -m0755 hydrus_server.py $out/bin/hydrus-server
+    install -m0755 hydrus_client.py $out/bin/hydrus-client
   '' + lib.optionalString enableSwftools ''
     mkdir -p $out/${python3Packages.python.sitePackages}/bin
     # swfrender seems to have to be called sfwrender_linux

--- a/pkgs/development/python-modules/pillow-heif/default.nix
+++ b/pkgs/development/python-modules/pillow-heif/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, pillow
+, pytest
+, nasm
+, libheif
+, libaom
+, libde265
+, x265
+}:
+
+buildPythonPackage rec {
+  pname = "pillow_heif";
+  version = "0.13.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "bigcat88";
+    repo = "pillow_heif";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-GbOW29rGpLMS7AfShuO6UCzcspdHtFS7hyNKori0otI=";
+  };
+
+  nativeBuildInputs = [ cmake nasm ];
+  buildInputs = [ libheif libaom libde265 x265 ];
+  propagatedBuildInputs = [ pillow ];
+  nativeCheckInputs = [ pytest ];
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "pillow_heif" ];
+
+  meta = {
+    description = "Python library for working with HEIF images and plugin for Pillow";
+    homepage = "https://github.com/bigcat88/pillow_heif";
+    license = with lib.licenses; [ bsd3 lgpl3 ];
+    maintainers = with lib.maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8190,6 +8190,8 @@ self: super: with self; {
     inherit (pkgs.xorg) libX11 libxcb;
   };
 
+  pillow-heif = callPackage ../development/python-modules/pillow-heif { };
+
   pillow-simd = callPackage ../development/python-modules/pillow-simd {
       inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
       inherit (pkgs.xorg) libX11;


### PR DESCRIPTION
###### Description of changes

After a lot of back and forth with the upstream and testing, this feels stable enough for an update again.


<del>Also upgrades python3Packages.mpv</del> This has languished for so long that this got done by someone else in the meantime

Initialises pillow-heif
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
