### PR TITLE
build2: use lld from llvm 16 to link on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/build2/bootstrap.nix
+++ b/pkgs/development/tools/build-managers/build2/bootstrap.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchurl
 , pkgs
+, buildPackages
 , fixDarwinDylibNames
 }:
 stdenv.mkDerivation rec {
@@ -25,6 +26,10 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = lib.optionals stdenv.targetPlatform.isDarwin [
     fixDarwinDylibNames
+
+    # Build2 needs to use lld on Darwin because it creates thin archives when it detects `llvm-ar`,
+    # which ld64 does not support.
+    (lib.getBin buildPackages.llvmPackages_16.lld)
   ];
 
   doCheck = true;
@@ -38,6 +43,11 @@ stdenv.mkDerivation rec {
     runHook preInstall
     install -D build2/b-boot $out/bin/b
     runHook postInstall
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/nix-support/setup-hook \
+      --subst-var-by isTargetDarwin '${toString stdenv.targetPlatform.isDarwin}'
   '';
 
   inherit (pkgs.build2) passthru;

--- a/pkgs/development/tools/build-managers/build2/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/build2/setup-hook.sh
@@ -19,6 +19,12 @@ build2ConfigurePhase() {
         $build2ConfigureFlags "${build2ConfigureFlagsArray[@]}"
     )
 
+    if [ -n "@isTargetDarwin@" ]; then
+        flagsArray+=("config.bin.ld=ld64-lld")
+        flagsArray+=("config.cc.loptions+=-fuse-ld=lld")
+        flagsArray+=("config.cc.loptions+=-headerpad_max_install_names")
+    fi
+
     echo 'configure flags' "${flagsArray[@]}"
 
     b configure "${flagsArray[@]}"


### PR DESCRIPTION
###### Description of changes

This seems to fix the build of `build2` after the darwin stdenv rework in https://github.com/NixOS/nixpkgs/pull/240433. For some reason, the `ar` from cctools-llvm produces an artifact that breaks linking in this package with the following error:
```
ld: warning: ignoring file libbuild2/libbuild2.dylib.u.a, building for macOS-arm64 but attempting to link with file built for unknown-unsupported file format ( 0x21 0x3C 0x74 0x68 0x69 0x6E 0x3E 0x0A 0x2F 0x20 0x20 0x20 0x20 0x20 0x20 0x20 )
```
Also wouldn't mind a better solution than this.

Broken right now in staging-next so targeting it: https://github.com/NixOS/nixpkgs/pull/241951

/cc @reckenrode 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
