### PR TITLE
jack-example-tools: init at 4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -93,6 +93,8 @@
 
 - `spamassassin` no longer supports the `Hashcash` module. The module needs to be removed from the `loadplugin` list if it was copied over from the default `initPreConf` option.
 
+- The official examples and tools from the JACK project have been moved out of the `jack2` package and into `jack-example-tools`. Install this new package into your environment if you need programs such as `jack_lsp` and `jack_connect`.
+
 - `services.outline.sequelizeArguments` has been removed, as `outline` no longer executes database migrations via the `sequelize` cli.
 
 - The Caddy module gained a new option named `services.caddy.enableReload` which is enabled by default. It allows reloading the service instead of restarting it, if only a config file has changed. This option must be disabled if you have turned off the [Caddy admin API](https://caddyserver.com/docs/caddyfile/options#admin). If you keep this option enabled, you should consider setting [`grace_period`](https://caddyserver.com/docs/caddyfile/options#grace-period) to a non-infinite value to prevent Caddy from delaying the reload indefinitely.

--- a/pkgs/misc/jackaudio/example-tools.nix
+++ b/pkgs/misc/jackaudio/example-tools.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, ninja, bash
+, jack, libsamplerate, libsndfile
+
+# Optional Dependencies
+, readline ? null
+, libopus ? null
+, alsa-lib ? null
+, zita-alsa-pcmi ? null
+, zita-resampler ? null
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jack-example-tools";
+  version = "4";
+
+  src = fetchFromGitHub {
+    owner = "jackaudio";
+    repo = "jack-example-tools";
+    rev = finalAttrs.version;
+    sha256 = "sha256-5jmynNxwNVLxEZ1MaqQUG6kRwipDkjhrdDCbZHtmAHk=";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = let
+    shouldUsePkg = pkg: pkg != null && lib.meta.availableOn stdenv.hostPlatform pkg;
+  in [
+    jack libsamplerate libsndfile libopus readline
+  ] ++ lib.filter shouldUsePkg [
+    alsa-lib zita-alsa-pcmi zita-resampler
+  ];
+
+  prePatch = ''
+    substituteInPlace scripts/meson_create_symlink \
+        --replace "/usr/bin/env sh" ${bash}/bin/bash
+  '';
+
+  meta = with lib; {
+    description = "JACK audio connection kit example clients and tools";
+    homepage = "https://jackaudio.org";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ goibhniu rvl ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39912,6 +39912,11 @@ with pkgs;
 
   libjack2 = jack2.override { prefix = "lib"; };
 
+  jack-example-tools = callPackage ../misc/jackaudio/example-tools.nix {
+    jack = jack2;  # includes libjackserver
+    libopus = libopus.override { withCustomModes = true; };
+  };
+
   jack-autoconnect = libsForQt5.callPackage ../applications/audio/jack-autoconnect { };
   jack_autoconnect = jack-autoconnect;
 


### PR DESCRIPTION
###### Description of changes

Since jack [version 1.9.22](https://github.com/jackaudio/jack2/releases/tag/v1.9.22) (nixpkgs PR #245492), most of the CLI tools have been moved out of the main codebase into a separate repo [jack-example-tools](https://github.com/jackaudio/jack-example-tools).

This PR adds a new nixpkgs package for those tools.

cc: @cillianderoiste

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`). I have tested functionality of these programs under pipewire:
   - `jack_lsp`
   - `jack_connect`
   - `jack_transport`
   - `jack_evmon`
   - `alsa_out -v -d sysdefault:CARD=Ga`
   - `alsa_in -c 1 -v -d sysdefault:CARD=Ga`
   - `jack_iodelay`
   - `jack_metro` - doesn't seem to make any sound.
   - `jack_midiseq Sequencer 24000 0 60 8000 12000 63 8000`
   - `jack_midi_dump`
- [x] [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md): Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I haven't tried building this new package on darwin, but it should hopefully work because packages such as `alsa-lib` are filtered out of `buildInputs`.
