### PR TITLE
mold: patch an upstream bug in --strip-debug

### DIFF
--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation rec {
     mimalloc
   ];
 
+  patches = [
+    ./fix-debug-strip.patch # fix --debug-strip; https://github.com/rui314/mold/pull/1038
+  ];
+
   postPatch = ''
     sed -i CMakeLists.txt -e '/.*set(DEST\ .*/d'
   '';

--- a/pkgs/development/tools/mold/fix-debug-strip.patch
+++ b/pkgs/development/tools/mold/fix-debug-strip.patch
@@ -1,0 +1,23 @@
+From b699b73451c57ac01c2680c0b86e1f56ca19e51c Mon Sep 17 00:00:00 2001
+From: Jakub Konka <kubkon@jakubkonka.com>
+Date: Sat, 6 May 2023 07:55:46 +0200
+Subject: [PATCH] Fix handling of --debug-strip
+
+Signed-off-by: Jakub Konka <kubkon@jakubkonka.com>
+---
+ elf/cmdline.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/elf/cmdline.cc b/elf/cmdline.cc
+index 3ac19f237..731af63ab 100644
+--- a/elf/cmdline.cc
++++ b/elf/cmdline.cc
+@@ -994,7 +994,7 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
+     } else if (read_flag("strip-all") || read_flag("s")) {
+       ctx.arg.strip_all = true;
+     } else if (read_flag("strip-debug") || read_flag("S")) {
+-      ctx.arg.strip_all = true;
++      ctx.arg.strip_debug = true;
+     } else if (read_flag("warn-unresolved-symbols")) {
+       ctx.arg.unresolved_symbols = UNRESOLVED_WARN;
+     } else if (read_flag("error-unresolved-symbols")) {


### PR DESCRIPTION
Mold currently has a bug where `--strip-debug` is treated the same as `--strip-all`; this causes things like Rust backtraces to stop working because the symbol tables get stripped.

The fix is trivial and obvious, and comes from an upstream patch that needs to be merged and release.

GitHub Issue: rui314/mold#1038
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
