### PR TITLE
lib.generators: add toTOML

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -234,6 +234,50 @@ rec {
     */
   toJSON = {}: builtins.toJSON;
 
+  toTOML = let
+    inherit (builtins) toJSON concatStringsSep isAttrs isList isFloat;
+    inherit (libStr) concatMapStringsSep isStringLike;
+    inherit (libAttr) mapAttrsToList;
+
+    # We use `toJSON` for serialization of string, numbers and booleans.
+    # The only incompatibility is that JSON allows `"\/"` while TOML does not.
+    # But `builtins.toJSON` does not escape `/` anyway, so it's fine.
+
+    inf = 1.0e308 * 10;
+
+    toTopLevel = obj:
+      concatStringsSep ""
+        (mapAttrsToList
+          (name: value: "${toJSON name}=${toInline value}\n")
+          obj);
+
+    toInline = obj:
+      # Exclude drvs here, or we'll easily get infinite recursion.
+      if isAttrs obj && !isStringLike obj then
+        "{${concatStringsSep ","
+          (mapAttrsToList
+            (name: value: "${toJSON name}=${toInline value}")
+            obj)
+        }}"
+      else if isList obj then
+        "[${concatMapStringsSep "," toInline obj}]"
+      else if obj == null then
+        throw "“null” is not supported by TOML"
+      else if !isFloat obj then
+        # Strings, integers and booleans.
+        toJSON obj
+      # Sanitize +-inf and NaN. They'll produce "null", which is invalid for TOML.
+      else if obj == inf then
+        "inf"
+      else if obj == -inf then
+        "-inf"
+      else if obj != obj then
+        "nan"
+      else
+        toJSON obj;
+
+  in
+    {}: toTopLevel;
 
   /* YAML has been a strict superset of JSON since 1.2, so we
     * use toJSON. Before it only had a few differences referring

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -820,6 +820,25 @@ runTests {
       expected = builtins.toJSON val;
   };
 
+  testToTOMLSimple =
+    let val = {
+      section = {
+        foo = "string\n\"";
+        "\"ba r\"" = [ true 4.2 ];
+        deep.nested = { };
+      };
+      list = [ { one = 1; } { two = 2; } ];
+      drv = { outPath = "/store/path"; };
+    };
+    in {
+      expr = generators.toTOML {} val;
+      expected = ''
+        "drv"="/store/path"
+        "list"=[{"one"=1},{"two"=2}]
+        "section"={"\"ba r\""=[true,4.2],"deep"={"nested"={}},"foo"="string\n\""}
+      '';
+  };
+
   /* right now only invocation check */
   testToYAMLSimple =
     let val = {


### PR DESCRIPTION
###### Description of changes

TOML is a quite common format for configuration files. This PR introduces a TOML serializer at eval-time. Current `pkgs.formats.toml` uses `remarshal` to convert JSON to TOML, which is at runtime and has a large closure size.

Unresolved: A quick grep shows 44 usages of `formats.toml`. Most of them have input settings known at eval-time, but also use the types defined by `formats.toml`. Mixing `lib.generators.toTOML` for serialization and `pkgs.formats.toml` for types together is kinda messy to me. Not sure if there is a clean way to make them use eval-time `toTOML` instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
