### PR TITLE
python3Packages.mhcflurry: init at 2.0.6

### DIFF
--- a/pkgs/development/python-modules/mhcflurry/default.nix
+++ b/pkgs/development/python-modules/mhcflurry/default.nix
@@ -1,0 +1,99 @@
+{ appdirs
+, buildPythonPackage
+, fetchFromGitHub
+, keras
+, lib
+, mhcgnomes
+, nose
+, pandas
+, pytestCheckHook
+, pythonRelaxDepsHook
+, pyyaml
+, scikit-learn
+, tensorflow
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "mhcflurry";
+  version = "2.0.6";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "openvax";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Cr7L6uo6Kc1PSeG5nK6zQSD7eeCFcUJUzhsX+waz7og=";
+  };
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
+  pythonRemoveDeps = [
+    # See https://github.com/openvax/mhcflurry/issues/216.
+    "np-utils"
+  ];
+
+  # keras and tensorflow are not in the official setup.py requirements but are required for the CLI utilities to run.
+  propagatedBuildInputs = [
+    appdirs
+    keras
+    mhcgnomes
+    pandas
+    pyyaml
+    scikit-learn
+    tensorflow
+    tqdm
+  ];
+
+  nativeCheckInputs = [ nose pytestCheckHook ];
+
+  disabledTests = [
+    # RuntimeError: Missing MHCflurry downloadable file: /homeless-shelter/.local...
+    "test_a1_mage_epitope_downloaded_models"
+    "test_a1_titin_epitope_downloaded_models"
+    "test_a2_hiv_epitope_downloaded_models"
+    "test_basic"
+    "test_caching"
+    "test_class1_neural_network_a0205_training_accuracy"
+    "test_commandline_sequences"
+    "test_correlation"
+    "test_csv"
+    "test_downloaded_predictor_gives_percentile_ranks"
+    "test_downloaded_predictor_invalid_peptides"
+    "test_downloaded_predictor_is_savable"
+    "test_downloaded_predictor_is_serializable"
+    "test_downloaded_predictor_small"
+    "test_downloaded_predictor"
+    "test_fasta_50nm"
+    "test_fasta_best"
+    "test_fasta"
+    "test_merge"
+    "test_no_csv"
+    "test_on_hpv"
+    "test_run_cluster_parallelism"
+    "test_run_parallel"
+    "test_run_serial"
+    "test_speed_allele_specific"
+    "test_speed_pan_allele"
+
+    # See https://github.com/openvax/mhcflurry/issues/217
+    "test_more"
+    "test_small"
+  ];
+
+  disabledTestPaths = [
+    # RuntimeError: Missing MHCflurry downloadable file: /homeless-shelter/.local...
+    "test/test_changing_allele_representations.py"
+    "test/test_class1_affinity_predictor.py"
+    "test/test_class1_pan.py"
+  ];
+
+  pythonImportsCheck = [ "mhcflurry" ];
+
+  meta = with lib; {
+    description = "Peptide-MHC I binding affinity prediction";
+    homepage = "https://github.com/openvax/mhcflurry";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/mhcgnomes/default.nix
+++ b/pkgs/development/python-modules/mhcgnomes/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pandas
+, pyyaml
+, serializable
+}:
+
+buildPythonPackage rec {
+  pname = "mhcgnomes";
+  version = "1.8.6";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "pirl-unc";
+    repo = pname;
+    # See https://github.com/pirl-unc/mhcgnomes/issues/20. As of 2023-07-13,
+    # they do no have version tags.
+    rev = "c7e779b60e35a031f6e0f0ea6ae70e8a8e7671c6";
+    hash = "sha256-KKiBlnFlavRnaQnOpAzG0dyxmFB+zF9L6t/H05LkFZE=";
+  };
+
+  propagatedBuildInputs = [ pandas pyyaml serializable ];
+
+  pythonImportsCheck = [ "mhcgnomes" ];
+
+  meta = with lib; {
+    description = "Parsing MHC nomenclature in the wild";
+    homepage = "https://github.com/pirl-unc/mhcgnomes";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/serializable/default.nix
+++ b/pkgs/development/python-modules/serializable/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, simplejson
+, six
+, typechecks
+}:
+
+buildPythonPackage rec {
+  pname = "serializable";
+  version = "unstable-2023-07-13";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "iskandr";
+    repo = pname;
+    # See https://github.com/iskandr/serializable/issues/7. As of 2023-07-13,
+    # they do no have version tags.
+    rev = "ed309a6f8f2590b525fc0f93c00549223c8c944f";
+    hash = "sha256-AXlgIc1B7bkR+joXn6ZSxk/t848CWlgVZp8WIsSZFKQ=";
+  };
+
+  propagatedBuildInputs = [ simplejson six typechecks ];
+
+  pythonImportsCheck = [ "serializable" ];
+
+  meta = with lib; {
+    description = "Base class with serialization methods for user-defined Python objects";
+    homepage = "https://github.com/iskandr/serializable";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/typechecks/default.nix
+++ b/pkgs/development/python-modules/typechecks/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "typechecks";
+  version = "unstable-2023-07-13";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "openvax";
+    repo = pname;
+    # See https://github.com/openvax/typechecks/issues/2. As of 2023-07-13,
+    # they do no have version tags.
+    rev = "5340b4e8a2f419b3a7aa816a5b19e2e0a6ce0679";
+    hash = "sha256-GdmBtkyuzLfpk6oneWgJ5M1bnhGJ5/lSbGliwoAQWZs=";
+  };
+
+  pythonImportsCheck = [ "typechecks" ];
+
+  meta = with lib; {
+    description = "Type checking helpers for Python";
+    homepage = "https://github.com/openvax/typechecks";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6367,6 +6367,8 @@ self: super: with self; {
 
   mf2py = callPackage ../development/python-modules/mf2py { };
 
+  mhcflurry = callPackage ../development/python-modules/mhcflurry { };
+
   mhcgnomes = callPackage ../development/python-modules/mhcgnomes { };
 
   micawber = callPackage ../development/python-modules/micawber { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12775,6 +12775,8 @@ self: super: with self; {
 
   txzmq = callPackage ../development/python-modules/txzmq { };
 
+  typechecks = callPackage ../development/python-modules/typechecks { };
+
   typecode = callPackage ../development/python-modules/typecode { };
 
   typecode-libmagic = callPackage ../development/python-modules/typecode/libmagic.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6367,6 +6367,8 @@ self: super: with self; {
 
   mf2py = callPackage ../development/python-modules/mf2py { };
 
+  mhcgnomes = callPackage ../development/python-modules/mhcgnomes { };
+
   micawber = callPackage ../development/python-modules/micawber { };
 
   microdata = callPackage ../development/python-modules/microdata { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11313,6 +11313,8 @@ self: super: with self; {
 
   serialio = callPackage ../development/python-modules/serialio { };
 
+  serializable = callPackage ../development/python-modules/serializable { };
+
   serpent = callPackage ../development/python-modules/serpent { };
 
   serpy = callPackage ../development/python-modules/serpy { };


### PR DESCRIPTION
###### Description of changes

Adds https://openvax.github.io/mhcflurry/index.html for MHC class I peptide presentation prediction.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
