### PR TITLE
python310Packages.pikepdf: 7.2.0 -> 8.1.1

### DIFF
--- a/pkgs/development/python-modules/cairocffi/default.nix
+++ b/pkgs/development/python-modules/cairocffi/default.nix
@@ -8,27 +8,28 @@
 , makeFontsConf
 , freefont_ttf
 , pikepdf
-, pytest
-, glibcLocales
+, pytestCheckHook
 , cairo
 , cffi
 , numpy
 , withXcffib ? false
 , xcffib
-, python
 , glib
 , gdk-pixbuf
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "cairocffi";
-  version = "1.4.0";
+  version = "1.5.1";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.7";
+
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-UJM5syzNjXsAwiBMMnNs3njbU6MuahYtMSR40lYmzZo=";
+    hash = "sha256-Bxq3ty41MzALC/1VpSBWtP/cHtbmVneeKs7Ztwm4opU=";
   };
 
   patches = [
@@ -43,36 +44,23 @@ buildPythonPackage rec {
     ./fix_test_scaled_font.patch
   ];
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "pytest-runner" "" \
-      --replace "pytest-cov" "" \
-      --replace "pytest-flake8" "" \
-      --replace "pytest-isort" "" \
-      --replace "--flake8 --isort" ""
-  '';
-
-  LC_ALL = "en_US.UTF-8";
-
-  # checkPhase require at least one 'normal' font and one 'monospace',
-  # otherwise glyph tests fails
-  FONTCONFIG_FILE = makeFontsConf {
-    fontDirectories = [ freefont_ttf ];
-  };
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedNativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cairo cffi ]
     ++ lib.optional withXcffib xcffib;
 
-  # pytestCheckHook does not work
-  nativeCheckInputs = [ numpy pikepdf pytest glibcLocales ];
-
-  checkPhase = ''
-    py.test $out/${python.sitePackages}
-  '';
+  nativeCheckInputs = [
+    numpy
+    pikepdf
+    pytestCheckHook
+  ];
 
   meta = with lib; {
+    changelog = "https://github.com/Kozea/cairocffi/blob/v${version}/NEWS.rst";
     homepage = "https://github.com/SimonSapin/cairocffi";
     license = licenses.bsd3;
     maintainers = with maintainers; [ SuperSandro2000 ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
