### PR TITLE
netease-cloud-music: init at 1.2.1

### DIFF
--- a/pkgs/applications/audio/netease-cloud-music/default.nix
+++ b/pkgs/applications/audio/netease-cloud-music/default.nix
@@ -1,0 +1,146 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+  # , qt5
+, xorg
+, libdrm
+, alsa-lib
+, taglib
+, vlc
+, krb5
+, gtk2
+, gtk3
+, tcp_wrappers
+, e2fsprogs
+, gnutls
+, avahi
+, sqlite
+, libogg
+, libvorbis
+, libsndfile
+, libasyncns
+, dbus-glib
+, cups
+, nspr
+, gnome2
+, nss
+, icu60
+, libinput
+, mtdev
+, libpulseaudio
+  # , libjpeg_original
+  # , double-conversion
+  # , eudev
+}:
+stdenv.mkDerivation rec {
+  pname = "netease-cloud-music";
+  version = "1.2.1";
+  src = fetchurl {
+    url = "https://d1.music.126.net/dmusic/netease-cloud-music_1.2.1_amd64_ubuntu_20190428.deb";
+    sha256 = "sha256-HunwKELmwsjHnEiy6TIHT5whOo60I45eY/IEOFYv7Ls=";
+    curlOpts = "-AMozilla/5.0";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+  # some libraries' versions don't match, comment them
+  buildInputs = [
+    stdenv.cc.cc.lib
+    # qt5.qtbase
+    # qt5.qtdeclarative
+    # qt5.qtwebchannel
+    # qt5.qtx11extras
+    # xorg.libXtst
+    xorg.libXScrnSaver
+    xorg.xcbutilkeysyms
+    xorg.xcbutilimage
+    xorg.xcbutilwm
+    xorg.xcbutilrenderutil
+    libdrm
+    alsa-lib
+    taglib
+    vlc
+    krb5
+    gtk2
+    gtk3
+    tcp_wrappers
+    e2fsprogs
+    gnutls
+    avahi
+    sqlite
+    libogg
+    libvorbis
+    libsndfile
+    libasyncns
+    dbus-glib
+    cups
+    nspr
+    gnome2.GConf
+    nss
+    icu60
+    libinput
+    mtdev
+    libpulseaudio
+    # libjpeg_original
+    # double-conversion
+    # eudev
+  ];
+
+  # Refer https://aur.archlinux.org/cgit/aur.git/tree/exclude.list?h=netease-cloud-music
+  # don't use NixOS's qt5
+  # --set QT_PLUGIN_PATH "${qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}" \
+  # --set QT_QPA_PLATFORM_PLUGIN_PATH "${qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}/platforms" \
+  installPhase = ''
+    install -D opt/netease/netease-cloud-music/netease-cloud-music -t $out/bin
+    install -Dm644 \
+      opt/netease/netease-cloud-music/libs/libdouble-conversion.so.1 \
+      opt/netease/netease-cloud-music/libs/libjpeg.so.8 \
+      opt/netease/netease-cloud-music/libs/libqcef.so.1.1.4 \
+      opt/netease/netease-cloud-music/libs/libudev.so.1 \
+      opt/netease/netease-cloud-music/libs/libXtst.so.6 \
+      opt/netease/netease-cloud-music/libs/libQt5Core.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5Gui.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5XcbQpa.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5Network.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5Xml.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5Qml.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5Svg.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5EglFSDeviceIntegration.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5X11Extras.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5DBus.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5WebChannel.so.5 \
+      opt/netease/netease-cloud-music/libs/libQt5Widgets.so.5 \
+      -t $out/lib/netease-cloud-music
+    cp -r opt/netease/netease-cloud-music/plugins $out/lib/netease-cloud-music
+    cp -r opt/netease/netease-cloud-music/libs/qcef $out/lib/netease-cloud-music
+    cp -r usr/share $out
+  '';
+
+  preFixup = ''
+    rm -r *
+    ln -s libqcef.so.1.1.4 $out/lib/netease-cloud-music/libqcef.so.1
+  '';
+  postFixup = ''
+    wrapProgram $out/bin/netease-cloud-music \
+      --set QT_PLUGIN_PATH "$out/lib/netease-cloud-music/plugins" \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH "$out/lib/netease-cloud-music/plugins/platforms" \
+      --set QCEF_INSTALL_PATH "$out/lib/netease-cloud-music/qcef" \
+      --set QT_XKB_CONFIG_ROOT "${xorg.xkeyboardconfig}/share/X11/xkb" \
+      --set XDG_SESSION_TYPE x11 \
+      --set QT_QPA_PLATFORM xcb
+  '';
+
+  meta = with lib; {
+    description = "Client for Netease Cloud Music service";
+    homepage = "https://music.163.com";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ mlatus Freed-Wu ];
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1142,7 +1142,6 @@ mapAliases ({
   ncat = throw "'ncat' has been renamed to/replaced by 'nmap'"; # Converted to throw 2022-02-22
   neap = throw "neap was removed from nixpkgs, as it relies on python2"; # Added 2022-01-12
   neochat = libsForQt5.kdeGear.neochat; # added 2022-05-10
-  netease-cloud-music = throw "netease-cloud-music has been removed together with deepin"; # Added 2020-08-31
   nettools_mptcp = throw "'nettools_mptcp' has been moved to https://github.com/teto/mptcp-flake"; # Converted to throw 2022-10-04
   networkmanager_fortisslvpn = throw "'networkmanager_fortisslvpn' has been renamed to/replaced by 'networkmanager-fortisslvpn'"; # Converted to throw 2022-02-22
   networkmanager_iodine = throw "'networkmanager_iodine' has been renamed to/replaced by 'networkmanager-iodine'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29185,6 +29185,8 @@ with pkgs;
 
   netease-music-tui = callPackage ../applications/audio/netease-music-tui { };
 
+  netease-cloud-music = callPackage ../applications/audio/netease-cloud-music { };
+
   netease-cloud-music-gtk = callPackage ../applications/audio/netease-cloud-music-gtk {
     inherit (darwin.apple_sdk.frameworks) Foundation SystemConfiguration;
   };


### PR DESCRIPTION
nixos/doc/manual/release-notes/rl-2009.section.md said netease-cloud-music depends on deepin desktop environment and because deepin desktop environment had been removed, netease-cloud-music is also removed.
However, it seems that netease-cloud-music can work without deepin desktop environment. So I package it again.

https://github.com/NixOS/nixpkgs/issues/94870 removed DDE
https://github.com/NixOS-CN/flakes/pull/51 recommend to push this package to NixOS/nixpkgs

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
