### PR TITLE
protoc-gen-es: init at 1.10.0, protoc-gen-connect-es: init at 1.4.0

### DIFF
--- a/pkgs/by-name/np/npm-lockfile-fix/package.nix
+++ b/pkgs/by-name/np/npm-lockfile-fix/package.nix
@@ -28,6 +28,6 @@ python3.pkgs.buildPythonApplication rec {
     description = "Add missing integrity and resolved fields to a package-lock.json file";
     mainProgram = "npm-lockfile-fix";
     license = lib.licenses.mit;
-    maintainers = [ maintainers.lucasew ];
+    maintainers = with maintainers; [ lucasew felschr ];
   };
 }

--- a/pkgs/by-name/np/npm-lockfile-fix/package.nix
+++ b/pkgs/by-name/np/npm-lockfile-fix/package.nix
@@ -26,6 +26,7 @@ python3.pkgs.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Add missing integrity and resolved fields to a package-lock.json file";
+    homepage = "https://github.com/jeslie0/npm-lockfile-fix";
     mainProgram = "npm-lockfile-fix";
     license = lib.licenses.mit;
     maintainers = with maintainers; [ lucasew felschr ];

--- a/pkgs/by-name/pr/protoc-gen-connect-es/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-connect-es/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  npm-lockfile-fix,
+}:
+
+buildNpmPackage rec {
+  pname = "protoc-gen-connect-es";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "connectrpc";
+    repo = "connect-es";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-qCIwr4Hyc5PARUa7tMntuyWRmO6ognmtjxN0myo8FXc=";
+
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} $out/package-lock.json
+    '';
+  };
+
+  npmDepsHash = "sha256-OGwEpXZqzMSIES+cmseQlo6/vzkx5ztO0gM/rUB0tGY=";
+
+  npmWorkspace = "packages/protoc-gen-connect-es";
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "Protobuf plugin for generating Connect-ecompatiblenabled ECMAScript code";
+    homepage = "https://github.com/connectrpc/connect-es";
+    changelog = "https://github.com/connectrpc/connect-es/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [
+      felschr
+      jtszalay
+    ];
+  };
+}

--- a/pkgs/by-name/pr/protoc-gen-connect-es/update.sh
+++ b/pkgs/by-name/pr/protoc-gen-connect-es/update.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env -S nix shell nixpkgs#gnugrep nixpkgs#gnused nixpkgs#coreutils nixpkgs#curl nixpkgs#wget nixpkgs#jq nixpkgs#nix-update nixpkgs#prefetch-npm-deps nixpkgs#npm-lockfile-fix nixpkgs#nodejs --command bash
+
+set -euo pipefail
+
+version="$(
+  curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s "https://api.github.com/repos/connectrpc/connect-es/releases" |
+    jq -r 'map(select(.prerelease == false)) | .[0].tag_name' |
+    grep -oP "^v\K.*"
+)"
+url="https://raw.githubusercontent.com/connectrpc/connect-es/v$version/"
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
+  echo "Already up to date!"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "$tmp"' EXIT
+
+pushd -- "$tmp"
+wget "$url/package-lock.json"
+npm-lockfile-fix package-lock.json
+npm_hash=$(prefetch-npm-deps package-lock.json)
+popd
+
+pushd "$(dirname "${BASH_SOURCE[0]}")"
+sed -i 's#npmDepsHash = "[^"]*"#npmDepsHash = "'"$npm_hash"'"#' package.nix
+popd
+
+nix-update protoc-gen-connect-es --version "$version"

--- a/pkgs/by-name/pr/protoc-gen-es/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-es/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  npm-lockfile-fix,
+}:
+
+buildNpmPackage rec {
+  pname = "protoc-gen-es";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "bufbuild";
+    repo = "protobuf-es";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-bHl8gqNrTm1+Cnj43RWmrLDUz+G11C4gprEiNOpyOdQ=";
+
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} $out/package-lock.json
+    '';
+  };
+
+  npmDepsHash = "sha256-ozkkakfSBycu83gTs8Orhm5Tg8kRSrF/vMJxVnPjhIw=";
+
+  npmWorkspace = "packages/protoc-gen-es";
+
+  preBuild = ''
+    npm run --workspace=packages/protobuf build
+    npm run --workspace=packages/protoplugin build
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "Protobuf plugin for generating ECMAScript code";
+    homepage = "https://github.com/bufbuild/protobuf-es";
+    changelog = "https://github.com/bufbuild/protobuf-es/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [
+      felschr
+      jtszalay
+    ];
+  };
+}

--- a/pkgs/by-name/pr/protoc-gen-es/update.sh
+++ b/pkgs/by-name/pr/protoc-gen-es/update.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env -S nix shell nixpkgs#gnugrep nixpkgs#gnused nixpkgs#coreutils nixpkgs#curl nixpkgs#wget nixpkgs#jq nixpkgs#nix-update nixpkgs#prefetch-npm-deps nixpkgs#npm-lockfile-fix nixpkgs#nodejs --command bash
+
+set -euo pipefail
+
+version="$(
+  curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s "https://api.github.com/repos/bufbuild/protobuf-es/releases" |
+    jq -r 'map(select(.prerelease == false)) | .[0].tag_name' |
+    grep -oP "^v\K.*"
+)"
+url="https://raw.githubusercontent.com/bufbuild/protobuf-es/v$version/"
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
+  echo "Already up to date!"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "$tmp"' EXIT
+
+pushd -- "$tmp"
+wget "$url/package-lock.json"
+npm-lockfile-fix package-lock.json
+npm_hash=$(prefetch-npm-deps package-lock.json)
+popd
+
+pushd "$(dirname "${BASH_SOURCE[0]}")"
+sed -i 's#npmDepsHash = "[^"]*"#npmDepsHash = "'"$npm_hash"'"#' package.nix
+popd
+
+nix-update protoc-gen-es --version "$version"


### PR DESCRIPTION
###### Description of changes
Add 2 protoc plugins for the ECMAScript ecosystem developed by Buf for use with Protobuf & Connect:
[protoc-gen-es](https://github.com/bufbuild/protobuf-es/tree/main/packages/protoc-gen-es)
[protoc-gen-connect-es](https://github.com/connectrpc/connect-es/tree/main/packages/protoc-gen-connect-es)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).