### PR TITLE
dnf5: init at 5.0.15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10041,6 +10041,11 @@
     githubId = 2914269;
     name = "Malo Bourgon";
   };
+  malt3 = {
+    github = "malt3";
+    githubId = 1780588;
+    name = "Malte Poll";
+  };
   malte-v = {
     email = "nixpkgs@mal.tc";
     github = "malte-v";

--- a/pkgs/development/libraries/libsolv/default.nix
+++ b/pkgs/development/libraries/libsolv/default.nix
@@ -1,18 +1,28 @@
-{ lib, stdenv, fetchFromGitHub, cmake, ninja, pkg-config
-, zlib, xz, bzip2, zchunk, zstd
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, pkg-config
+, zlib
+, xz
+, bzip2
+, zchunk
+, zstd
 , expat
-, withRpm ? !stdenv.isDarwin, rpm
+, withRpm ? !stdenv.isDarwin
+, rpm
 , db
 }:
 
 stdenv.mkDerivation rec {
-  version  = "0.7.24";
+  version = "0.7.24";
   pname = "libsolv";
 
   src = fetchFromGitHub {
-    owner  = "openSUSE";
-    repo   = "libsolv";
-    rev    = version;
+    owner = "openSUSE";
+    repo = "libsolv";
+    rev = version;
     sha256 = "sha256-UTVnGJO/9mQF9RwK75hh6IkoP1MwAlFaLCtdYU8uS34=";
   };
 
@@ -37,9 +47,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A free package dependency solver";
-    homepage    = "https://github.com/openSUSE/libsolv";
-    license     = licenses.bsd3;
-    platforms   = platforms.linux ++ platforms.darwin;
+    homepage = "https://github.com/openSUSE/libsolv";
+    license = licenses.bsd3;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ copumpkin ];
   };
 }

--- a/pkgs/development/libraries/libsolv/default.nix
+++ b/pkgs/development/libraries/libsolv/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_ZCHUNK_COMPRESSION=true"
     "-DWITH_SYSTEM_ZCHUNK=true"
   ] ++ lib.optionals withRpm [
+    "-DENABLE_COMPS=true"
     "-DENABLE_PUBKEY=true"
     "-DENABLE_RPMDB=true"
     "-DENABLE_RPMDB_BYRPMHEADER=true"
@@ -42,4 +43,3 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ copumpkin ];
   };
 }
-

--- a/pkgs/tools/package-management/dnf5/default.nix
+++ b/pkgs/tools/package-management/dnf5/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, createrepo_c
+, gettext
+, help2man
+, pkg-config
+, cppunit
+, fmt
+, glib
+, json_c
+, libmodulemd
+, libpeas
+, librepo
+, libsmartcols
+, libsolv
+, libxml2
+, rpm
+, sdbus-cpp
+, sqlite
+, systemd
+, toml11
+, zchunk
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dnf5";
+  version = "5.0.15";
+
+  src = fetchFromGitHub {
+    owner = "rpm-software-management";
+    repo = "dnf5";
+    rev = finalAttrs.version;
+    hash = "sha256-0MR9CJDFL1vbuO7FZyyn3PNb0p27oaho6I2eminTyYU=";
+  };
+
+  nativeBuildInputs = [ cmake createrepo_c gettext help2man pkg-config ];
+  buildInputs = [
+    cppunit
+    fmt
+    glib
+    json_c
+    libmodulemd
+    libpeas
+    librepo
+    libsmartcols
+    libsolv
+    libxml2
+    rpm
+    sdbus-cpp
+    sqlite
+    systemd
+    toml11
+    zchunk
+  ];
+
+  # workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+  NIX_CFLAGS_COMPILE = "-Wno-restrict -Wno-maybe-uninitialized";
+
+  cmakeFlags = [
+    "-DWITH_PERL5=OFF"
+    "-DWITH_PYTHON3=OFF"
+    "-DWITH_RUBY=OFF"
+    "-DWITH_TESTS=OFF"
+    # TODO: fix man installation paths
+    "-DWITH_MAN=OFF"
+    # the cmake package does not handle absolute CMAKE_INSTALL_INCLUDEDIR correctly
+    # (setting it to an absolute path causes include files to go to $out/$out/include,
+    #  because the absolute path is interpreted with root at $out).
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
+
+  prePatch = ''
+    substituteInPlace dnf5daemon-server/dbus/CMakeLists.txt \
+      --replace '/etc' "$out/etc" \
+      --replace '/usr' "$out"
+    substituteInPlace dnf5daemon-server/polkit/CMakeLists.txt \
+      --replace '/usr' "$out"
+    substituteInPlace dnf5/CMakeLists.txt \
+      --replace '/etc/bash_completion.d' "$out/etc/bash_completion.d"
+  '';
+
+  dontFixCmake = true;
+
+  meta = with lib; {
+    description = "Next-generation RPM package management system";
+    homepage = "https://github.com/rpm-software-management/dnf5";
+    license = licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ malt3 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -553,6 +553,8 @@ with pkgs;
 
   dec-decode = callPackage ../development/tools/dec-decode { };
 
+  dnf5 = callPackage ../tools/package-management/dnf5 { };
+
   dsq = callPackage ../tools/misc/dsq { };
 
   dtv-scan-tables = callPackage ../data/misc/dtv-scan-tables { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add [dnf5](https://github.com/rpm-software-management/dnf5). This will be the default package manager for future versions of Fedora and can be used to generate OS images for RPM based distros based on a list of RPM files.
Thanks @katexochen, @Artturin, @K900 for your help!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
