### PR TITLE
arandr: 0.1.10 -> 0.1.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7183,6 +7183,12 @@
       fingerprint = "1412 816B A9FA F62F D051 1975 D3E1 B013 B463 1293";
     }];
   };
+  itcger = {
+    email = "nixpkgs@dirk-osburg.de";
+    github = "itc-ger";
+    githubId = 17527538;
+    name = "Dirk Osburg";
+  };
   ius = {
     email = "j.de.gram@gmail.com";
     name = "Joerie de Gram";

--- a/pkgs/tools/X11/arandr/default.nix
+++ b/pkgs/tools/X11/arandr/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchurl
+, fetchFromGitLab
 , python3Packages
 , gobject-introspection
 , gsettings-desktop-schemas
@@ -13,11 +14,13 @@ let
 in
 buildPythonApplication rec {
   pname = "arandr";
-  version = "0.1.10";
+  version = "0.1.11";
 
-  src = fetchurl {
-    url = "https://christian.amsuess.com/tools/arandr/files/${pname}-${version}.tar.gz";
-    sha256 = "135q0llvm077jil2fr92ssw3p095m4r8jfj0lc5rr3m71n4srj6v";
+  src = fetchFromGitLab {
+    owner = "${pname}";
+    repo = "${pname}";
+    rev = "${version}";
+    sha256 = "sha256-nQtfOKAnWKsy2DmvtRGJa4+Y9uGgX41BeHpd9m4d9YA=";
   };
 
   preBuild = ''
@@ -31,10 +34,10 @@ buildPythonApplication rec {
   nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
   propagatedBuildInputs = [ xrandr pygobject3 ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://christian.amsuess.com/tools/arandr/";
     description = "A simple visual front end for XRandR";
-    license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.domenkozar ];
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ domenkozar itcger ];
   };
 }


### PR DESCRIPTION
###### Description of changes

- [ARandR Changelog](https://github.com/chrysn/arandr/blob/release/ChangeLog)
  - Fix Python 3.11 compatibility by replacing getargspec with getfullargspec

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
