### PR TITLE
ayatana-indicators: init messaging indicator, module, test

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -437,6 +437,7 @@
   ./services/databases/surrealdb.nix
   ./services/databases/victoriametrics.nix
   ./services/desktops/accountsservice.nix
+  ./services/desktops/ayatana-indicators.nix
   ./services/desktops/bamf.nix
   ./services/desktops/blueman.nix
   ./services/desktops/cpupower-gui.nix

--- a/nixos/modules/services/desktops/ayatana-indicators.nix
+++ b/nixos/modules/services/desktops/ayatana-indicators.nix
@@ -1,0 +1,58 @@
+{ config
+, pkgs
+, lib
+, ...
+}:
+
+let
+  cfg = config.services.ayatana-indicators;
+in
+{
+  options.services.ayatana-indicators = {
+    enable = lib.mkEnableOption (lib.mdDoc ''
+      Ayatana Indicators, a continuation of Canonical's Application Indicators
+    '');
+
+    packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression "with pkgs; [ ayatana-indicator-messages ]";
+      description = lib.mdDoc ''
+        List of packages containing Ayatana Indicator services
+        that should be brought up by the SystemD "ayatana-indicators" user target.
+
+        Packages specified here must have passthru.ayatana-indicators set correctly.
+
+        If, how, and where these indicators are displayed will depend on your DE.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      systemPackages = cfg.packages;
+
+      pathsToLink = [
+        "/share/ayatana"
+      ];
+    };
+
+    # libayatana-common's ayatana-indicators.target with explicit Wants & Before to bring up requested indicator services
+    systemd.user.targets."ayatana-indicators" =
+      let
+        indicatorServices = lib.lists.flatten
+          (map
+            (pkg:
+              (map (ind: "${ind}.service") pkg.passthru.ayatana-indicators))
+            cfg.packages);
+      in
+      {
+        description = "Target representing the lifecycle of the Ayatana Indicators. Each indicator should be bound to it in its individual service file";
+        partOf = [ "graphical-session.target" ];
+        wants = indicatorServices;
+        before = indicatorServices;
+      };
+  };
+
+  meta.maintainers = with lib.maintainers; [ OPNA2608 ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -124,6 +124,7 @@ in {
   authelia = handleTest ./authelia.nix {};
   avahi = handleTest ./avahi.nix {};
   avahi-with-resolved = handleTest ./avahi.nix { networkd = true; };
+  ayatana-indicators = handleTest ./ayatana-indicators.nix {};
   babeld = handleTest ./babeld.nix {};
   bazarr = handleTest ./bazarr.nix {};
   bcachefs = handleTestOn ["x86_64-linux" "aarch64-linux"] ./bcachefs.nix {};

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -1,0 +1,71 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: let
+  user = "alice";
+in {
+  name = "ayatana-indicators";
+
+  meta = {
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+  };
+
+  nodes.machine = { config, ... }: {
+    imports = [
+      ./common/auto.nix
+      ./common/user-account.nix
+    ];
+
+    test-support.displayManager.auto = {
+      enable = true;
+      inherit user;
+    };
+
+    services.xserver = {
+      enable = true;
+      desktopManager.mate.enable = true;
+      displayManager.defaultSession = lib.mkForce "mate";
+    };
+
+    services.ayatana-indicators = {
+      enable = true;
+      packages = with pkgs; [
+        ayatana-indicator-messages
+      ];
+    };
+
+    # Services needed by some indicators
+    services.accounts-daemon.enable = true; # messages
+  };
+
+  # TODO session indicator starts up in a semi-broken state, but works fine after a restart. maybe being started before graphical session is truly up & ready?
+  testScript = { nodes, ... }: let
+    runCommandPerIndicatorService = command: lib.strings.concatMapStringsSep "\n" command nodes.machine.systemd.user.targets."ayatana-indicators".wants;
+  in ''
+    start_all()
+    machine.wait_for_x()
+
+    # Desktop environment should reach graphical-session.target
+    machine.wait_for_unit("graphical-session.target", "${user}")
+
+    # MATE relies on XDG autostart to bring up the indicators.
+    # Not sure *when* XDG autostart fires them up, and awaiting pgrep success seems to misbehave?
+    machine.sleep(10)
+
+    # Now check if all indicators were brought up successfully, and kill them for later
+  '' + (runCommandPerIndicatorService (service: let serviceExec = builtins.replaceStrings [ "." ] [ "-" ] service; in ''
+    machine.succeed("pgrep -f ${serviceExec}")
+    machine.succeed("pkill -f ${serviceExec}")
+  '')) + ''
+
+    # Ayatana target is the preferred way of starting up indicators on SystemD session, the graphical session is responsible for starting this if it supports them.
+    # Mate currently doesn't do this, so start it manually for checking (https://github.com/mate-desktop/mate-indicator-applet/issues/63)
+    machine.systemctl("start ayatana-indicators.target", "${user}")
+    machine.wait_for_unit("ayatana-indicators.target", "${user}")
+
+    # Let all indicator services do their startups, potential post-launch crash & restart cycles so we can properly check for failures
+    # Not sure if there's a better way of awaiting this without false-positive potential
+    machine.sleep(10)
+
+    # Now check if all indicator services were brought up successfully
+  '' + runCommandPerIndicatorService (service: ''
+    machine.wait_for_unit("${service}", "${user}")
+  '');
+})

--- a/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
@@ -1,0 +1,143 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gitUpdater
+, testers
+, accountsservice
+, cmake
+, dbus-test-runner
+, withDocumentation ? true
+, docbook_xsl
+, docbook_xml_dtd_45
+, glib
+, gobject-introspection
+, gtest
+, gtk-doc
+, intltool
+, lomiri
+, pkg-config
+, python3
+, systemd
+, vala
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ayatana-indicator-messages";
+  version = "23.10.0";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "ayatana-indicator-messages";
+    rev = finalAttrs.version;
+    hash = "sha256-FBJeP5hOXJcOk04cRJpw+oN7L3w3meDX3ivLmFWkhVI=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ] ++ lib.optionals withDocumentation [
+    "devdoc"
+  ];
+
+  postPatch = ''
+    # Uses pkg_get_variable, cannot substitute prefix with that
+    substituteInPlace data/CMakeLists.txt \
+      --replace "\''${SYSTEMD_USER_DIR}" "$out/lib/systemd/user"
+
+    # Bad concatenation
+    substituteInPlace libmessaging-menu/messaging-menu.pc.in \
+      --replace "\''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@" '@CMAKE_INSTALL_FULL_LIBDIR@' \
+      --replace "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" '@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+  '' + lib.optionalString (!withDocumentation) ''
+    sed -i CMakeLists.txt \
+      '/add_subdirectory(doc)/d'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    glib # For glib-compile-schemas
+    intltool
+    pkg-config
+    vala
+    wrapGAppsHook
+  ] ++ lib.optionals withDocumentation [
+    docbook_xsl
+    docbook_xml_dtd_45
+    gtk-doc
+  ];
+
+  buildInputs = [
+    accountsservice
+    lomiri.cmake-extras
+    glib
+    gobject-introspection
+    systemd
+  ];
+
+  nativeCheckInputs = [
+    (python3.withPackages (ps: with ps; [
+      pygobject3
+      python-dbusmock
+    ]))
+  ];
+
+  checkInputs = [
+    dbus-test-runner
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    "-DGSETTINGS_LOCALINSTALL=ON"
+    "-DGSETTINGS_COMPILE=ON"
+  ];
+
+  makeFlags = lib.optionals withDocumentation [
+    # gtk-doc doesn't call ld with the correct arguments
+    # ld: ...: undefined reference to symbol 'strncpy@@GLIBC_2.2.5', 'qsort@@GLIBC_2.2.5'
+    "LD=${stdenv.cc.targetPrefix}cc"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    # test-client imports gir, whose solib entry points to final store location
+    install -Dm644 libmessaging-menu/libmessaging-menu.so.0.0.0 $out/lib/libmessaging-menu.so.0
+  '';
+
+  postCheck = ''
+    # remove the above solib-installation, let it be done properly
+    rm -r $out
+  '';
+
+  preInstall = lib.optionalString withDocumentation ''
+    # installing regenerates docs, generated files are created without write permissions, errors out while trying to overwrite them
+    chmod +w doc/reference/html/*
+  '';
+
+  passthru = {
+    ayatana-indicators = [
+      "ayatana-indicator-messages"
+    ];
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Ayatana Indicator Messages Applet";
+    longDescription = ''
+      The -messages Ayatana System Indicator is the messages menu indicator for Unity7, MATE and Lomiri (optionally for
+      others, e.g. XFCE, LXDE).
+    '';
+    homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-messages";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ OPNA2608 ];
+    pkgConfigModules = [
+      "messaging-menu"
+    ];
+  };
+})

--- a/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , gitUpdater
+, nixosTests
 , testers
 , accountsservice
 , cmake
@@ -122,7 +123,10 @@ stdenv.mkDerivation (finalAttrs: {
     ayatana-indicators = [
       "ayatana-indicator-messages"
     ];
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      vm = nixosTests.ayatana-indicators;
+    };
     updateScript = gitUpdater { };
   };
 


### PR DESCRIPTION
###### Description of changes

Working towards #99090.

[Ayatana Indicators](https://ayatanaindicators.github.io/) are a continuation of Canonical's [Application Indicators](https://wiki.ubuntu.com/DesktopExperienceTeam/ApplicationIndicators). Lomiri makes use of them for its top bar system: without at least [ayatana-indicator-session](https://github.com/AyatanaIndicators/ayatana-indicator-session), you won't be able to exit the session as there will be no way to trigger the dialogue :stuck_out_tongue:.

This PR:
- Inits `ayatana-indicator-messages` as a start.
- Inits a NixOS module for having `ayatana-indicators.target` bring up a list of desired indicators. I'll happily accept better solutions for this.
  - The individual indicator services normally bind to the target via `WantedBy`, but we don't install (user) services on NixOS so one of the sides from this interaction needs to be get an explicit `Wants` (to the best of my knowledge)
  - Rewriting the target all the services bind to seemed easier than rewriting all the services
  - A custom `passthru.ayatana-indicators = [ "thingy" ]` attribute is expected to be present in all requested indicator package, listing the indicator services they provide. There's no individual package with multiple services that I'm aware of, but I see no reason to disallow this in practice.
- Adds a VM test that makes sure the various indicators we're going to add work & keep working.

---

Some future indicators will come with optional Lomiri-specific support. I'll enable this when possible, and try to keep an eye on closure size increase so future non-Lomiri uses won't be too affected. See #262118 for a first push for that + initial closure considerations there.

The test is using MATE because it's one of the DEs with theoretical support for them, and because the target is supposed to depend on a graphical session, but its support is not really being used. [`mate.mate-indicator-applet` would first have to be patched to use Ayatana indicators and find new-style ones](https://github.com/NixOS/nixpkgs/pull/262172), it would require (graphical?) panel configuration to load the indicator applet, and it doesn't seem to support/show some indicators (only 1/3 of the ones I tested showed up, but maybe I just picked some not-useful ones). Maybe it can be rewritten to use Lomiri later on, which has none of those issues, but it's somewhat-secondry to me when the entire rendering part of the interplay is really DE-specific.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
