### PR TITLE
haskellPackages.patat: Patch to bump dependencies, override pandoc

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -270,14 +270,24 @@ self: super: {
   # 2023-06-10: Too strict version bound on https://github.com/haskell/ThreadScope/issues/118
   threadscope = doJailbreak super.threadscope;
 
-  # patat main branch has an unreleased commit that fixes the build by
-  # relaxing restrictive upper boundaries. This can be removed once there's a
-  # new release following version 0.8.8.0.
-  patat = appendPatch (fetchpatch {
+  patat = appendPatches [
+    # patat main branch has an unreleased commit that fixes the build by
+    # relaxing restrictive upper boundaries. This can be removed once there's a
+    # new release following version 0.8.8.0.
+    (fetchpatch {
     url = "https://github.com/jaspervdj/patat/commit/be9e0fe5642ba6aa7b25705ba17950923e9951fa.patch";
     sha256 = "sha256-Vxxi46qrkIyzYQZ+fe1vNTPldcQEI2rX2H40GvFJR2M=";
     excludes = ["stack.yaml" "stack.yaml.lock"];
-  }) super.patat;
+    })
+    # Patching with a commit bumping dependencies that's not released to hackage yet.
+    (fetchpatch {
+    url = "https://github.com/jaspervdj/patat/commit/b4c5a7e641b813ef1c34821984a9e897f4ecf84e.patch";
+    sha256 = "sha256-01xdlN3r3p/r8TwAzbcWoTMIBesGvL8HZcXJRDZyWQM=";
+    excludes = ["stack.yaml" "stack.yaml.lock"];
+    })
+    # Overriding the version pandoc dependency uses as the latest release has version bounds
+    # defined as >= 3.1  && < 3.2, can be removed once pandoc gets bumped by Stackage.
+  ] (super.patat.override { pandoc = self.pandoc_3_1_4; });
 
   # The latest release on hackage has an upper bound on containers which
   # breaks the build, though it works with the version of containers present


### PR DESCRIPTION
###### Description of changes
Adding a patch, overriding a dependency.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
 
###### Things done

Added a second patch from the default upstream branch to fix the build until there's a new release. Also overrode the version of a dependency, namely pandoc, as its Stackage version is pointing to an older version that's no longer within the accepted version bounds of this package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
