### PR TITLE
openldap: disable flaky test 063

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -96,6 +96,9 @@ stdenv.mkDerivation rec {
   preCheck = ''
     substituteInPlace tests/scripts/all \
       --replace "/bin/rm" "rm"
+
+    # skip flaky tests
+    rm -f tests/scripts/test063-delta-multiprovider
   '';
 
   doCheck = true;


### PR DESCRIPTION
This disables a flaky tests which sometimes fails
(most likely due to some race condition).

It's also disabled for Debian since 2.5.13:
https://launchpad.net/debian/+source/openldap/2.5.13+dfsg-3

For reference, the failure looks like this:

    >>>>> 00:13:52 Starting test063-delta-multiprovider for mdb...
    running defines.sh
    Initializing server configurations...
    Starting server 1 on TCP/IP port 9011...
    Using ldapsearch to check that server 1 is running...
    Using ldapadd for context on server 1...
    Starting server 2 on TCP/IP port 9012...
    Using ldapsearch to check that server 2 is running...
    Starting server 3 on TCP/IP port 9013...
    Using ldapsearch to check that server 3 is running...
    Starting server 4 on TCP/IP port 9014...
    Using ldapsearch to check that server 4 is running...
    Using ldapadd to populate server 1...
    Waiting 7 seconds for syncrepl to receive changes...
    Using ldapsearch to read all the entries from server 1...
    Using ldapsearch to read all the entries from server 2...
    Using ldapsearch to read all the entries from server 3...
    Using ldapsearch to read all the entries from server 4...
    Comparing retrieved entries from server 1 and server 2...
    Comparing retrieved entries from server 1 and server 3...
    Comparing retrieved entries from server 1 and server 4...
    test failed - server 1 and server 4 databases differ
    >>>>> 00:14:25 Failed   test063-delta-multiprovider for mdb after 33 seconds
    (exit 1)
    make[2]: *** [Makefile:320: mdb-yes] Error 1
    make[2]: Leaving directory '/build/openldap-2.6.4/tests'
    make[1]: *** [Makefile:287: test] Error 2
    make[1]: Leaving directory '/build/openldap-2.6.4/tests'
    make: *** [Makefile:298: test] Error 2
    error: builder for '/nix/store/ypmpgzfjc992x24h8ga7xvbmk24qbfml-openldap-2.6.4.drv' failed with exit code 2;
