### PR TITLE
`lib.lists.{hasPrefix,removePrefix}`: init

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -612,6 +612,21 @@ rec {
     # Input list
     list: sublist count (length list) list;
 
+  /* Whether the first list is a prefix of the second list.
+
+  Type: hasPrefix :: [a] -> [a] -> bool
+
+  Example:
+    hasPrefix [ 1 2 ] [ 1 2 3 4 ]
+    => true
+    hasPrefix [ 0 1 ] [ 1 2 3 4 ]
+    => false
+  */
+  hasPrefix =
+    list1:
+    list2:
+    take (length list1) list2 == list1;
+
   /* Return a list consisting of at most `count` elements of `list`,
      starting at index `start`.
 

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -627,6 +627,25 @@ rec {
     list2:
     take (length list1) list2 == list1;
 
+  /* Remove the first list as a prefix from the second list.
+  Error if the first list isn't a prefix of the second list.
+
+  Type: removePrefix :: [a] -> [a] -> [a]
+
+  Example:
+    removePrefix [ 1 2 ] [ 1 2 3 4 ]
+    => [ 3 4 ]
+    removePrefix [ 0 1 ] [ 1 2 3 4 ]
+    => <error>
+  */
+  removePrefix =
+    list1:
+    list2:
+    if hasPrefix list1 list2 then
+      drop (length list1) list2
+    else
+      throw "lib.lists.removePrefix: First argument is not a list prefix of the second argument";
+
   /* Return a list consisting of at most `count` elements of `list`,
      starting at index `start`.
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -501,6 +501,23 @@ runTests {
     expected = false;
   };
 
+  testListRemovePrefixExample1 = {
+    expr = lists.removePrefix [ 1 2 ] [ 1 2 3 4 ];
+    expected = [ 3 4 ];
+  };
+  testListRemovePrefixExample2 = {
+    expr = (builtins.tryEval (lists.removePrefix [ 0 1 ] [ 1 2 3 4 ])).success;
+    expected = false;
+  };
+  testListRemovePrefixEmptyPrefix = {
+    expr = lists.removePrefix [ ] [ 1 2 ];
+    expected = [ 1 2 ];
+  };
+  testListRemovePrefixEmptyList = {
+    expr = (builtins.tryEval (lists.removePrefix [ 1 2 ] [ ])).success;
+    expected = false;
+  };
+
   testFoldAttrs = {
     expr = foldAttrs (n: a: [n] ++ a) [] [
     { a = 2; b = 7; }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -480,6 +480,27 @@ runTests {
     ([ 1 2 3 ] == (take 4 [  1 2 3 ]))
   ];
 
+  testListHasPrefixExample1 = {
+    expr = lists.hasPrefix [ 1 2 ] [ 1 2 3 4 ];
+    expected = true;
+  };
+  testListHasPrefixExample2 = {
+    expr = lists.hasPrefix [ 0 1 ] [ 1 2 3 4 ];
+    expected = false;
+  };
+  testListHasPrefixLazy = {
+    expr = lists.hasPrefix [ 1 ] [ 1 (abort "lib.lists.hasPrefix is not lazy") ];
+    expected = true;
+  };
+  testListHasPrefixEmptyPrefix = {
+    expr = lists.hasPrefix [ ] [ 1 2 ];
+    expected = true;
+  };
+  testListHasPrefixEmptyList = {
+    expr = lists.hasPrefix [ 1 2 ] [ ];
+    expected = false;
+  };
+
   testFoldAttrs = {
     expr = foldAttrs (n: a: [n] ++ a) [] [
     { a = 2; b = 7; }


### PR DESCRIPTION
###### Description of changes

Adds two new functions:
- `lib.lists.hasPrefix :: [ a ] -> [ a ] -> bool`: Whether the first list is a prefix of the second list:
  ```nix
  lib.lists.hasPrefix [ 1 2 ] [ 1 2 3 4 ]
  -> true
  ```
- `lib.lists.removePrefix :: [ a ] -> [ a ] -> [ a ]`: Remove the first list as a prefix from the second list, erroring if it's not a prefix:
  ```nix
  lib.lists.removePrefix [ 1 2 ] [ 1 2 3 4 ]
  -> [ 3 4 ]
  lib.lists.removePrefix [ 1 2 ] [ 3 4 ]
  -> <error>
  ```

This is distantly part of the [path library effort](https://github.com/NixOS/nixpkgs/issues/210426), in order to be able to work with lists of path components.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

###### Things done
- [x] Docs
- [x] Tests