### PR TITLE
Ebusd: new package & module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -28,6 +28,8 @@
 
 - [osquery](https://www.osquery.io/), a SQL powered operating system instrumentation, monitoring, and analytics.
 
+- [ebusd](https://ebusd.eu), a daemon for handling communication with eBUS devices connected to a 2-wire bus system (“energy bus” used by numerous heating systems). Available as [services.ebusd](#opt-services.ebusd.enable).
+
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 
 - The `boot.loader.raspberryPi` options have been marked deprecated, with intent for removal for NixOS 24.11. They had a limited use-case, and do not work like people expect. They required either very old installs ([before mid-2019](https://github.com/NixOS/nixpkgs/pull/62462)) or customized builds out of scope of the standard and generic AArch64 support. That option set never supported the Raspberry Pi 4 family of devices.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -536,6 +536,7 @@
   ./services/hardware/usbrelayd.nix
   ./services/hardware/vdr.nix
   ./services/hardware/keyd.nix
+  ./services/home-automation/ebusd.nix
   ./services/home-automation/esphome.nix
   ./services/home-automation/evcc.nix
   ./services/home-automation/home-assistant.nix

--- a/nixos/modules/services/home-automation/ebusd.nix
+++ b/nixos/modules/services/home-automation/ebusd.nix
@@ -1,0 +1,270 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.ebusd;
+
+  package = pkgs.ebusd;
+
+  arguments = [
+    "${package}/bin/ebusd"
+    "--foreground"
+    "--updatecheck=off"
+    "--device=${cfg.device}"
+    "--port=${toString cfg.port}"
+    "--configpath=${cfg.configpath}"
+    "--scanconfig=${cfg.scanconfig}"
+    "--log=main:${cfg.logs.main}"
+    "--log=network:${cfg.logs.network}"
+    "--log=bus:${cfg.logs.bus}"
+    "--log=update:${cfg.logs.update}"
+    "--log=other:${cfg.logs.other}"
+    "--log=all:${cfg.logs.all}"
+  ] ++ lib.optionals cfg.readonly [
+    "--readonly"
+  ] ++ lib.optionals cfg.mqtt.enable [
+    "--mqtthost=${cfg.mqtt.host}"
+    "--mqttport=${toString cfg.mqtt.port}"
+    "--mqttuser=${cfg.mqtt.user}"
+    "--mqttpass=${cfg.mqtt.password}"
+  ] ++ lib.optionals cfg.mqtt.home-assistant [
+    "--mqttint=${package}/etc/ebusd/mqtt-hassio.cfg"
+    "--mqttjson"
+  ] ++ lib.optionals cfg.mqtt.retain [
+    "--mqttretain"
+  ] ++ cfg.extraArguments;
+
+  usesDev = hasPrefix "/" cfg.device;
+
+  command = concatStringsSep " " arguments;
+
+in
+{
+  meta.maintainers = with maintainers; [ nathan-gs ];
+
+  options.services.ebusd = {
+    enable = mkEnableOption (lib.mdDoc "ebusd service");
+
+    device = mkOption {
+      type = types.str;
+      default = "";
+      example = "IP:PORT";
+      description = lib.mdDoc ''
+        Use DEV as eBUS device [/dev/ttyUSB0].
+        This can be either:
+          enh:DEVICE or enh:IP:PORT for enhanced device (only adapter v3 and newer),
+          ens:DEVICE for enhanced high speed serial device (only adapter v3 and newer with firmware since 20220731),
+          DEVICE for serial device (normal speed, for all other serial adapters like adapter v2 as well as adapter v3 in non-enhanced mode), or
+          [udp:]IP:PORT for network device.
+        https://github.com/john30/ebusd/wiki/2.-Run#device-options
+      '';
+    };
+
+    port = mkOption {
+      default = 8888;
+      type = types.port;
+      description = lib.mdDoc ''
+        The port on which to listen on
+      '';
+    };
+
+    readonly = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+         Only read from device, never write to it
+      '';
+    };
+
+    configpath = mkOption {
+      type = types.str;
+      default = "https://cfg.ebusd.eu/";
+      description = lib.mdDoc ''
+        Read CSV config files from PATH (local folder or HTTPS URL) [https://cfg.ebusd.eu/]
+      '';
+    };
+
+    scanconfig = mkOption {
+      type = types.str;
+      default = "full";
+      description = lib.mdDoc ''
+        Pick CSV config files matching initial scan ("none" or empty for no initial scan message, "full" for full scan, or a single hex address to scan, default is to send a broadcast ident message).
+        If combined with --checkconfig, you can add scan message data as arguments for checking a particular scan configuration, e.g. "FF08070400/0AB5454850303003277201". For further details on this option,
+        see [Automatic configuration](https://github.com/john30/ebusd/wiki/4.7.-Automatic-configuration).
+      '';
+    };
+
+    logs = {
+      main = mkOption {
+        type = types.enum [ "error" "notice" "info" "debug"];
+        default = "info";
+        description = lib.mdDoc ''
+          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
+        '';
+      };
+
+      network = mkOption {
+        type = types.enum [ "error" "notice" "info" "debug"];
+        default = "info";
+        description = lib.mdDoc ''
+          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
+        '';
+      };
+
+      bus = mkOption {
+        type = types.enum [ "error" "notice" "info" "debug"];
+        default = "info";
+        description = lib.mdDoc ''
+          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
+        '';
+      };
+
+      update = mkOption {
+        type = types.enum [ "error" "notice" "info" "debug"];
+        default = "info";
+        description = lib.mdDoc ''
+          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
+        '';
+      };
+
+      other = mkOption {
+        type = types.enum [ "error" "notice" "info" "debug"];
+        default = "info";
+        description = lib.mdDoc ''
+          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
+        '';
+      };
+
+      all = mkOption {
+        type = types.enum [ "error" "notice" "info" "debug"];
+        default = "info";
+        description = lib.mdDoc ''
+          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (error|notice|info|debug) [all:notice].
+        '';
+      };
+    };
+
+    mqtt = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Adds support for MQTT
+        '';
+      };
+
+      host = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = lib.mdDoc ''
+          Connect to MQTT broker on HOST.
+        '';
+      };
+
+      port = mkOption {
+        default = 1883;
+        type = types.port;
+        description = lib.mdDoc ''
+          The port on which to connect to MQTT
+        '';
+      };
+
+      home-assistant = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Adds the Home Assistant topics to MQTT, read more at [MQTT Integration](https://github.com/john30/ebusd/wiki/MQTT-integration)
+        '';
+      };
+
+      retain = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Set the retain flag on all topics instead of only selected global ones
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        description = lib.mdDoc ''
+          The MQTT user to use
+        '';
+      };
+
+      password = mkOption {
+        type = types.str;
+        description = lib.mdDoc ''
+          The MQTT password.
+        '';
+      };
+
+    };
+
+    extraArguments = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = lib.mdDoc ''
+        Extra arguments to the ebus daemon
+      '';
+    };
+
+  };
+
+  config = mkIf (cfg.enable) {
+
+    systemd.services.ebusd = {
+      description = "EBUSd Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = command;
+        DynamicUser = true;
+        Restart = "on-failure";
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        DeviceAllow = lib.optionals usesDev [
+          cfg.device
+        ] ;
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false;
+        NoNewPrivileges = true;
+        PrivateDevices = usesDev;
+        PrivateUsers = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SupplementaryGroups = [
+          "dialout"
+        ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service @pkey"
+          "~@privileged @resources"
+        ];
+        UMask = "0077";
+      };
+    };
+
+  };
+}

--- a/pkgs/servers/ebusd/default.nix
+++ b/pkgs/servers/ebusd/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, pkgs, fetchFromGitHub, argparse, mosquitto, cmake, autoconf, automake, libtool, pkg-config, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "ebusd";
+  version = "23.2";
+
+  src = fetchFromGitHub {
+    owner = "john30";
+    repo = "ebusd";
+    rev = version;
+    sha256 = "2CkcTTxEzVrEPtUVVDxXPPkYqZT6+gsCcfTrt83sFv8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    autoconf
+    automake
+    libtool
+    pkg-config
+  ];
+
+  buildInputs = [
+    argparse
+    mosquitto
+    openssl
+  ];
+
+  patches = [
+    ./patches/ebusd-cmake.patch
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_SYSCONFDIR=${placeholder "out"}/etc"
+    "-DCMAKE_INSTALL_BINDIR=${placeholder "out"}/bin"
+    "-DCMAKE_INSTALL_LOCALSTATEDIR=${placeholder "TMPDIR"}"
+  ];
+
+  postInstall = ''
+    mv $out/usr/bin $out
+    rmdir $out/usr
+  '';
+
+  meta = with lib; {
+    description = "ebusd";
+    homepage = "https://github.com/john30/ebusd";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ nathan-gs ];
+    platforms = platforms.linux;
+ };
+}

--- a/pkgs/servers/ebusd/patches/ebusd-cmake.patch
+++ b/pkgs/servers/ebusd/patches/ebusd-cmake.patch
@@ -1,0 +1,21 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -184,16 +184,11 @@
+ add_subdirectory(src/lib/knx)
+ add_subdirectory(src/tools)
+
+-if(EXISTS "${ROOT}/etc/debian_version")
+-  install(FILES ${CMAKE_SOURCE_DIR}/contrib/debian/default/ebusd DESTINATION /etc/default/)
+-  install(FILES ${CMAKE_SOURCE_DIR}/contrib/debian/init.d/ebusd DESTINATION /etc/init.d/)
+-  install(FILES ${CMAKE_SOURCE_DIR}/contrib/debian/systemd/ebusd.service DESTINATION /lib/systemd/system/)
+-endif()
+ if(HAVE_MQTT)
+   FILE(GLOB MQTT_CFG_FILES "${CMAKE_SOURCE_DIR}/contrib/etc/ebusd/mqtt-*.cfg")
+-  install(FILES ${MQTT_CFG_FILES} DESTINATION /etc/ebusd/)
++  install(FILES ${MQTT_CFG_FILES} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/ebusd/)
+ endif(HAVE_MQTT)
+ if(HAVE_KNX)
+   FILE(GLOB KNX_CFG_FILES "${CMAKE_SOURCE_DIR}/contrib/etc/ebusd/knx*.cfg")
+-  install(FILES ${KNX_CFG_FILES} DESTINATION /etc/ebusd/)
++  install(FILES ${KNX_CFG_FILES} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/ebusd/)
+ endif(HAVE_KNX)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -583,6 +583,8 @@ with pkgs;
 
   each = callPackage ../tools/text/each { };
 
+  ebusd = callPackage ../servers/ebusd { };
+
   eclipse-mat = callPackage ../development/tools/eclipse-mat { };
 
   edgedb = callPackage ../tools/networking/edgedb {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
New package & module for [ebusd](https://ebusd.eu/) [github](https://github.com/john30/ebusd). ebusd is a daemon for handling communication with eBUS devices connected to a 2-wire bus system (“energy bus” used by numerous heating systems).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
