### PR TITLE
temporal-cli: fix missing meta.platforms preventing Hydra builds

### DIFF
--- a/pkgs/applications/networking/cluster/temporal-cli/default.nix
+++ b/pkgs/applications/networking/cluster/temporal-cli/default.nix
@@ -1,6 +1,13 @@
 { lib, fetchFromGitHub, buildGoModule, installShellFiles, symlinkJoin }:
 
 let
+  metaCommon = with lib; {
+    description = "Command-line interface for running Temporal Server and interacting with Workflows, Activities, Namespaces, and other parts of Temporal";
+    homepage = "https://docs.temporal.io/cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aaronjheng ];
+  };
+
   overrideModAttrs = old: {
     # https://gitlab.com/cznic/libc/-/merge_requests/10
     postBuild = ''
@@ -44,6 +51,10 @@ let
     '';
 
     __darwinAllowLocalNetworking = true;
+
+    meta = metaCommon // {
+      mainProgram = "temporal";
+    };
   };
 
   tctl = buildGoModule rec {
@@ -78,6 +89,10 @@ let
     '';
 
     __darwinAllowLocalNetworking = true;
+
+    meta = metaCommon // {
+      mainProgram = "tctl";
+    };
   };
 in
 symlinkJoin rec {
@@ -92,11 +107,7 @@ symlinkJoin rec {
 
   passthru = { inherit tctl tctl-next; };
 
-  meta = with lib; {
-    description = "Command-line interface for running Temporal Server and interacting with Workflows, Activities, Namespaces, and other parts of Temporal";
-    homepage = "https://docs.temporal.io/cli";
-    license = licenses.mit;
-    maintainers = with maintainers; [ aaronjheng ];
+  meta = metaCommon // {
     mainProgram = "temporal";
   };
 }

--- a/pkgs/applications/networking/cluster/temporal-cli/default.nix
+++ b/pkgs/applications/networking/cluster/temporal-cli/default.nix
@@ -109,5 +109,6 @@ symlinkJoin rec {
 
   meta = metaCommon // {
     mainProgram = "temporal";
+    platforms = lib.unique (lib.concatMap (drv: drv.meta.platforms) paths);
   };
 }

--- a/pkgs/applications/networking/cluster/temporal-cli/default.nix
+++ b/pkgs/applications/networking/cluster/temporal-cli/default.nix
@@ -93,8 +93,8 @@ symlinkJoin rec {
   passthru = { inherit tctl tctl-next; };
 
   meta = with lib; {
-    description = "Temporal CLI";
-    homepage = "https://temporal.io";
+    description = "Command-line interface for running Temporal Server and interacting with Workflows, Activities, Namespaces, and other parts of Temporal";
+    homepage = "https://docs.temporal.io/cli";
     license = licenses.mit;
     maintainers = with maintainers; [ aaronjheng ];
     mainProgram = "temporal";


### PR DESCRIPTION
At least, hopefully.

See https://github.com/NixOS/nixpkgs/issues/243087.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Note that x86_64-darwin build is failing with sandbox; see https://github.com/NixOS/nixpkgs/pull/242721

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
