### PR TITLE
nnn: fix file mime opts on darwin

### DIFF
--- a/pkgs/applications/file-managers/nnn/darwin-fix-file-mime-opts.patch
+++ b/pkgs/applications/file-managers/nnn/darwin-fix-file-mime-opts.patch
@@ -1,0 +1,15 @@
+diff --git a/src/nnn.c b/src/nnn.c
+index b3c0f986..c74e1ec9 100644
+--- a/src/nnn.c
++++ b/src/nnn.c
+@@ -508,9 +508,7 @@ alignas(max_align_t) static char g_pipepath[TMP_LEN_MAX];
+ static runstate g_state;
+ 
+ /* Options to identify file MIME */
+-#if defined(__APPLE__)
+-#define FILE_MIME_OPTS "-bIL"
+-#elif !defined(__sun) /* no MIME option for 'file' */
++#if !defined(__sun) /* no MIME option for 'file' */
+ #define FILE_MIME_OPTS "-biL"
+ #endif
+ 

--- a/pkgs/applications/file-managers/nnn/default.nix
+++ b/pkgs/applications/file-managers/nnn/default.nix
@@ -34,6 +34,10 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # Nix-specific: ensure nnn passes correct arguments to the Nix file command on Darwin.
+    # By default, nnn expects the macOS default file command, not the one provided by Nix.
+    # However, both commands use different arguments to obtain the MIME type.
+    ./darwin-fix-file-mime-opts.patch
     # FIXME: remove for next release
     (fetchpatch {
       url = "https://github.com/jarun/nnn/commit/20e944f5e597239ed491c213a634eef3d5be735e.patch";


### PR DESCRIPTION
###### Description of changes

Resolves: #243503

`nnn`  should call `file` with the `-i` switch to get the mime type even on the macOS environment since it depends on the Nix-installed `file` not the OS default one.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
