### PR TITLE
darwin.adv_cmds: fix build with clang 16

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
@@ -1,5 +1,17 @@
-{ lib, appleDerivation, xcbuild, ncurses, libutil, Libc }:
+{ stdenv, lib, appleDerivation, xcbuild, ncurses, libutil, Libc }:
 
+let
+  # Libc conflicts with libc++ 16, so provide only the header from it that’s needed to build.
+  msgcat = stdenv.mkDerivation {
+    pname = "Libc-msgcat";
+    version = lib.getVersion Libc;
+
+    buildCommand = ''
+      mkdir -p "$out/include"
+      ln -s ${lib.getDev Libc}/include/msgcat.h "$out/include/"
+    '';
+  };
+in
 appleDerivation {
   # We can't just run the root build, because https://github.com/facebook/xcbuild/issues/264
 
@@ -44,7 +56,7 @@ appleDerivation {
   '';
 
   nativeBuildInputs = [ xcbuild ];
-  buildInputs = [ ncurses libutil Libc ];
+  buildInputs = [ ncurses libutil msgcat ];
 
   meta = {
     platforms = lib.platforms.darwin;


### PR DESCRIPTION
###### Description of changes

darwin.Libc conflicts with libc++ 16. adv_cmds only needs `msgcat.h`, so symlink it into the build from Libc instead of adding the whole thing to `buildInputs`.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
