### PR TITLE
pyrodigal: init

### DIFF
--- a/pkgs/development/python-modules/pyrodigal/default.nix
+++ b/pkgs/development/python-modules/pyrodigal/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, cython
+, archspec
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyrodigal";
+  version = "2.2.0";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    pname = "pyrodigal";
+    inherit version;
+    hash = "sha256-1RZXeqb4F3ryDRdsB1e7zhc2Ha+1z/wosqMs/xJWwyU=";
+  };
+
+  propagatedBuildInputs = [ archspec ];
+
+  nativeBuildInputs = [ cython ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyrodigal" ];
+
+  sandboxProfile = ''
+    # Used by archspec to detect the CPU when importing pyrodigal.
+    (allow process-exec (literal "/usr/sbin/sysctl"))
+  '';
+
+  meta = {
+    description = "Cython bindings and Python interface to Prodigal, an ORF finder for genomes and metagenomes";
+    homepage = "https://github.com/althonos/pyrodigal";
+    license = lib.licenses.gpl3Only;
+    changelog = "https://github.com/althonos/pyrodigal/blob/v${version}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ thyol ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7772,6 +7772,8 @@ self: super: with self; {
 
   pyproject-hooks = callPackage ../development/python-modules/pyproject-hooks { };
 
+  pyrodigal = callPackage ../development/python-modules/pyrodigal { };
+
   pypsrp = callPackage ../development/python-modules/pypsrp { };
 
   phpserialize = callPackage ../development/python-modules/phpserialize { };


### PR DESCRIPTION
###### Description of changes

> Cython bindings and Python interface to Prodigal, an ORF finder for genomes and metagenomes. Now with SIMD! 
https://github.com/althonos/pyrodigal

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
