### PR TITLE
errbot: 6.1.7 -> 6.1.9

### DIFF
--- a/pkgs/applications/networking/errbot/default.nix
+++ b/pkgs/applications/networking/errbot/default.nix
@@ -1,25 +1,26 @@
 { lib
 , fetchFromGitHub
-, glibcLocales
-, python39
+, python3
 }:
 
-let
-  python3 = python39;
-in python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "errbot";
-  version = "6.1.7";
+  version = "6.1.9";
+
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "errbotio";
     repo = "errbot";
     rev = version;
-    sha256 = "02h44qd3d91zy657hyqsw3gskgxg31848pw6zpb8dhd1x84z5y77";
+    hash = "sha256-BmHChLWWnrtg0p4WH8bANwpo+p4RTwjYbXfyPnz6mp8=";
   };
 
-  LC_ALL = "en_US.utf8";
+  nativeBuildInputs = with python3.pkgs; [
+    pythonRelaxDepsHook
+  ];
 
-  buildInputs = [ glibcLocales ];
+  pythonRelaxDeps = true;
 
   propagatedBuildInputs = with python3.pkgs; [
     ansi
@@ -28,7 +29,6 @@ in python3.pkgs.buildPythonApplication rec {
     deepmerge
     dulwich
     flask
-    hypchat
     irc
     jinja2
     markdown
@@ -38,9 +38,8 @@ in python3.pkgs.buildPythonApplication rec {
     pygments-markdown-lexer
     pyopenssl
     requests
-    slackclient
-    sleekxmpp
-    telegram
+    slixmpp
+    python-telegram-bot
     webtest
   ];
 
@@ -49,18 +48,20 @@ in python3.pkgs.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  # Slack backend test has an import issue
+  # errbot-backend-slackv3 has not been packaged
   pytestFlagsArray = [ "--ignore=tests/backend_tests/slack_test.py" ];
 
   disabledTests = [
-    "backup"
-    "broken_plugin"
-    "plugin_cycle"
+    # require networking
+    "test_backup"
+    "test_broken_plugin"
+    "test_plugin_cycle"
   ];
 
   pythonImportsCheck = [ "errbot" ];
 
   meta = with lib; {
+    changelog = "https://github.com/errbotio/errbot/blob/${version}/CHANGES.rst";
     description = "Chatbot designed to be simple to extend with plugins written in Python";
     homepage = "http://errbot.io/";
     maintainers = with maintainers; [ globin ];


### PR DESCRIPTION
###### Description of changes
Diff: https://github.com/errbotio/errbot/compare/6.1.7...6.1.9

Changelog: https://github.com/errbotio/errbot/blob/6.1.9/CHANGES.rst


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
