### PR TITLE
lvm2: fix libdevmapper SONAME when onlyLib is on

### DIFF
--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     "--with-default-run-dir=/run/lvm"
     "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     "--with-systemd-run=/run/current-system/systemd/bin/systemd-run"
-  ] ++ lib.optionals (!enableCmdlib) [
+  ] ++ lib.optionals (!enableCmdlib && !onlyLib) [
     "--bindir=${placeholder "bin"}/bin"
     "--sbindir=${placeholder "bin"}/bin"
     "--libdir=${placeholder "lib"}/lib"
@@ -126,7 +126,7 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = lib.optionalString onlyLib ''
-    install -D -t $out/lib libdm/ioctl/libdevmapper.${if stdenv.hostPlatform.isStatic then "a" else "so"}
+    make -C libdm install_${if stdenv.hostPlatform.isStatic then "static" else "dynamic"}
     make -C libdm install_include
     make -C libdm install_pkgconfig
   '';


### PR DESCRIPTION
###### Description of changes

Building `cryptsetup` with `onlyLib` on leads to linker errors, because the SONAME of `libdevmapper` includes a version number, and the library is installed without one.

To check this you can build [this branch](https://github.com/NixOS/nixpkgs/compare/master...jonathan-conder:nixpkgs:broken/lvm2-onlyLib) on `x86_64-linux` (or probably any dynamically linked platform):
```console
$ nix build github:jonathan-conder/nixpkgs/broken/lvm2-onlyLib#cryptsetup
```

This patch fixes that by delegating more of the install to make. That uncovered another issue, where invalid placeholder strings were being passed to the build, so I fixed that as well.

Tested on `x86_64-linux` by building `.#cryptsetup`, which succeeds. The shared libraries are identical, but the new one is now a symlink to `libdevmapper.so.1.02`. The store paths in the `pkgconfig` file also changed (as expected).

After building `.#pkgsStatic.cryptsetup`, the only difference are the paths in `pkgconfig` file (one of which was a placeholder anyway).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
