### PR TITLE
tuxedo-keyboard: set it as broken for kernel <= 5.4

### DIFF
--- a/pkgs/os-specific/linux/tuxedo-keyboard/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-keyboard/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, kernel, linuxHeaders, pahole }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tuxedo-keyboard-${kernel.version}";
   version = "3.2.7";
 
   src = fetchFromGitHub {
     owner = "tuxedocomputers";
     repo = "tuxedo-keyboard";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-Q0wnejeLGLSDS0GPxQuYUKCAdzbYA66KT0DuWsEKIRs=";
   };
 
@@ -19,25 +19,29 @@ stdenv.mkDerivation rec {
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out/lib/modules/${kernel.modDirVersion}"
 
     for module in clevo_acpi.ko clevo_wmi.ko tuxedo_keyboard.ko tuxedo_io/tuxedo_io.ko uniwill_wmi.ko; do
         mv src/$module $out/lib/modules/${kernel.modDirVersion}
     done
+
+    runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
+    broken = stdenv.isAarch64 || (lib.versionOlder kernel.version "5.5");
     description = "Keyboard and hardware I/O driver for TUXEDO Computers laptops";
+    homepage = "https://github.com/tuxedocomputers/tuxedo-keyboard/";
+    license = lib.licenses.gpl3Plus;
     longDescription = ''
       This driver provides support for Fn keys, brightness/color/mode for most TUXEDO
       keyboards (except white backlight-only models).
 
       Can be used with the "hardware.tuxedo-keyboard" NixOS module.
     '';
-    homepage = "https://github.com/tuxedocomputers/tuxedo-keyboard/";
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
-    broken = stdenv.isAarch64;
-    maintainers = [ maintainers.blanky0230 ];
+    maintainers = [ lib.maintainers.blanky0230 ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
- Switch to `finalAttrs` pattern
- Add missing phase hooks
- Sort `meta` attribute
- Update `meta.broken` attribute

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
