### PR TITLE
cc-wrapper: use -fwrapv instead of -fno-strict-overflow in clang

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -81,8 +81,18 @@ for flag in "${!hardeningEnableMap[@]}"; do
       hardeningCFlags+=('-fPIC')
       ;;
     strictoverflow)
-       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling strictoverflow >&2; fi
-      hardeningCFlags+=('-fno-strict-overflow')
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling strictoverflow >&2; fi
+      if (( @isClang@ )); then
+        # In Clang, -fno-strict-overflow only serves to set -fwrapv and is
+        # reported as an unused CLI argument if -fwrapv or -fno-wrapv is set
+        # explicitly, so we side step that by doing the conversion here.
+        #
+        # See: https://github.com/llvm/llvm-project/blob/llvmorg-16.0.6/clang/lib/Driver/ToolChains/Clang.cpp#L6315
+        #
+        hardeningCFlags+=('-fwrapv')
+      else
+        hardeningCFlags+=('-fno-strict-overflow')
+      fi
       ;;
     format)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling format >&2; fi

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -609,6 +609,8 @@ stdenv.mkDerivation {
 
 
   env = {
+    inherit isClang;
+
     # for substitution in utils.bash
     expandResponseParams = "${expand-response-params}/bin/expand-response-params";
     shell = getBin shell + shell.shellPath or "";


### PR DESCRIPTION
###### Description of changes

~Please consider this a proof of concept that still needs discussion and testing. I'd appreciate opinions on whether this is the right thing to do. If it is, I'd also like thoughts on how to implement it in a simple, elegant way.~

**Background and Motivation**

Reported in https://github.com/NixOS/nixpkgs/issues/39687, builds on macOS can encounter warnings like :
```
clang-11: error: argument unused during compilation: '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]
```
If we want to suppress this warning (such as in Kitty's build), we can add:
```
hardeningDisable = lib.optionals stdenv.cc.isClang ["strictoverflow"];
```
I find these warnings distracting when I debug builds, so I'd like to fix them once and for all (if possible).

**Why does Clang emit this warning?**

I think it is related to code at https://github.com/llvm/llvm-project/blob/main/clang/lib/Driver/ToolChains/Clang.cpp#L6449:
```
// -fno-strict-overflow implies -fwrapv if it isn't disabled, but
// -fstrict-overflow won't turn off an explicitly enabled -fwrapv.
if (Arg *A = Args.getLastArg(options::OPT_fwrapv, options::OPT_fno_wrapv)) {
  if (A->getOption().matches(options::OPT_fwrapv))
    CmdArgs.push_back("-fwrapv");
} else if (Arg *A = Args.getLastArg(options::OPT_fstrict_overflow,
                                    options::OPT_fno_strict_overflow)) {
  if (A->getOption().matches(options::OPT_fno_strict_overflow))
    CmdArgs.push_back("-fwrapv");
}
```
That is, `-fno-strict-overflow` does nothing more than imply `-fwrapv`. When upstream adds `-fwrapv` (or even `-fno-wrapv`) itself, then `-fno-strict-overflow` does nothing, and I suspect it gets reported as unused.

**What does this PR do?**

It simply checks if cc-wrapper is wrapping Clang and uses `-fwrapv` instead of `-fno-strict-overflow` if so. ~However, I don't think the way I've done it is so elegant.~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
