### PR TITLE
flatpak-external-data-checker: init at 0-unstable-2023-04-27

### DIFF
--- a/pkgs/development/tools/flatpak-external-data-checker/default.nix
+++ b/pkgs/development/tools/flatpak-external-data-checker/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, fetchFromGitHub
+, python3
+, unstableGitUpdater
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "flatpak-external-data-checker";
+  version = "0-unstable-2023-04-27";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "flathub";
+    repo = "flatpak-external-data-checker";
+    rev = "4766d06d7af38d0b749c1975a9938ec6dd9ea138";
+    hash = "sha256-mMnjbUf9/A6HCBbNT0+n7unt+kq3Rb2vIWmJ6JG6j+E=";
+  };
+
+  buildInputs = [
+    python3
+  ];
+
+  pythonPath = with python3.pkgs; [
+    pygobject3
+    requests
+    pygithub
+    ruamel-yaml
+    toml
+    pyelftools
+    aiohttp
+    semver
+    jsonschema
+    editorconfig
+    lxml
+    packaging
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    datadir="$out/share/flatpak-external-data-checker"
+    mkdir -p "$out/bin" "$datadir"
+
+    cp -r \
+      canonicalize-manifest \
+      flatpak-external-data-checker \
+      src/ \
+      "$datadir"
+
+    ln -s "$datadir/canonicalize-manifest" "$datadir/flatpak-external-data-checker" "$out/bin"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    # Prevent Python modules from being accidentally wrapped.
+    find "$datadir/src" -type f -executable -exec chmod -x '{}' ';'
+
+    # Wrap the entry points.
+    wrapPythonProgramsIn "$datadir" "$out $pythonPath"
+  '';
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Tool for checking if the external data used in Flatpak manifests is still up to date";
+    homepage = "https://github.com/flathub/flatpak-external-data-checker";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7746,6 +7746,8 @@ with pkgs;
     binutils = binutils-unwrapped;
   };
 
+  flatpak-external-data-checker = callPackage ../development/tools/flatpak-external-data-checker { };
+
   fltrdr = callPackage ../tools/misc/fltrdr {
     icu = icu63;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
