### PR TITLE
linuxPackages.trelay: init at 22.03.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1231,6 +1231,12 @@
     githubId = 914687;
     name = "Alexis Praga";
   };
+  aprl = {
+    email = "aprl@acab.dev";
+    github = "cutestnekoaqua";
+    githubId = 30842467;
+    name = "April John";
+  };
   ar1a = {
     email = "aria@ar1as.space";
     github = "ar1a";

--- a/pkgs/os-specific/linux/trelay/Makefile
+++ b/pkgs/os-specific/linux/trelay/Makefile
@@ -1,0 +1,14 @@
+KERNELRELEASE ?= $(shell uname -r)
+KERNEL_DIR  ?= /lib/modules/$(KERNELRELEASE)/build
+PWD := $(shell pwd)
+
+obj-m := trelay.o
+
+all:
+	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules
+
+install:
+	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules_install
+
+clean:
+	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) clean

--- a/pkgs/os-specific/linux/trelay/default.nix
+++ b/pkgs/os-specific/linux/trelay/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, fetchgit, kernel, kmod }:
+let
+  version = "22.03.5";
+in
+stdenv.mkDerivation {
+  pname = "trelay";
+  version = "${version}-${kernel.version}";
+
+  src = fetchgit {
+    url = "https://git.openwrt.org/openwrt/openwrt.git";
+    rev = "v${version}";
+    hash = "sha256-5f9LvaZUxtfTpTR268QMkEmHUpn/nct+MVa44SBGT5c=";
+    sparseCheckout = [ "package/kernel/trelay/src" ];
+  };
+
+  sourceRoot = "openwrt/package/kernel/trelay/src";
+  hardeningDisable = [ "pic" "format" ];
+  nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
+
+  postPatch = ''
+    cp '${./Makefile}' Makefile
+  '';
+
+  makeFlags = kernel.makeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "For relaying IP packets between two devices to build a IP bridge between them";
+    longDescription = ''
+      A kernel module that relays ethernet packets between two devices (similar to a bridge),
+      but without any MAC address checks.
+
+      This makes it possible to bridge client mode or ad-hoc mode wifi devices to ethernet VLANs,
+      assuming the remote end uses the same source MAC address as the device that packets are
+      supposed to exit from.
+    '';
+    homepage = "https://github.com/openwrt/openwrt/tree/main/package/kernel/trelay";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.aprl ];
+    platforms = platforms.linux;
+    broken = lib.versionOlder kernel.version "5.10";
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -504,6 +504,8 @@ in {
 
     turbostat = callPackage ../os-specific/linux/turbostat { };
 
+    trelay = callPackage ../os-specific/linux/trelay { };
+
     usbip = callPackage ../os-specific/linux/usbip { };
 
     v86d = callPackage ../os-specific/linux/v86d { };


### PR DESCRIPTION
###### Description of changes

Added kernel module trelay.
Trelay is a kernel module that relays ethernet packets between two devices (similar to a bridge), but without any MAC address checks.
This makes it possible to bridge client mode or ad-hoc mode wifi devices to ethernet VLANs, assuming the remote end uses the same source MAC address as the device that packets are supposed to exit from.

Related to https://github.com/NixOS/nixpkgs/issues/241991

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
