### PR TITLE
nyxt: 3.3.0 -> 3.4.0

### DIFF
--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -255,7 +255,7 @@ let
 
     lispLibs = [
       self.cl-containers
-      self.nclasses_0_5_0
+      self.nclasses
       super.alexandria
       super.calispel
       super.closer-mop
@@ -268,7 +268,7 @@ let
 
   };
 
-  nasdf-unstable = build-asdf-system {
+  nasdf = build-asdf-system {
     pname = "nasdf";
     version = "20230524-git";
     src = pkgs.fetchFromGitHub {
@@ -279,7 +279,7 @@ let
     };
   };
 
-  njson_1_0_0 = build-asdf-system {
+  njson = build-asdf-system {
     pname = "njson";
     version = "1.0.0";
     src = pkgs.fetchFromGitHub {
@@ -288,11 +288,11 @@ let
       rev = "1.0.0";
       sha256 = "sha256-zeOxkoi5cPl1sw1oEOaMsKhhs3Pb8EzzKTjvuDNj/Ko=";
     };
-    lispLibs = [ self.nasdf-unstable super.cl-json ];
+    lispLibs = [ self.nasdf super.cl-json ];
     systems = [ "njson" "njson/cl-json" ];
   };
 
-  nsymbols_0_3_1 = build-asdf-system {
+  nsymbols = build-asdf-system {
     pname = "nsymbols";
     version = "0.3.1";
     src = pkgs.fetchFromGitHub {
@@ -306,7 +306,7 @@ let
 
   };
 
-  nclasses_0_5_0 = build-asdf-system {
+  nclasses = build-asdf-system {
     pname = "nclasses";
     version = "0.5.0";
     src = pkgs.fetchFromGitHub {
@@ -315,10 +315,10 @@ let
       rev = "0.5.0";
       sha256 = "sha256-UcavZ0fCA2hkVU/CqUZfyCqJ8gXKPpXTCP0WLUIF1Ss=";
     };
-    lispLibs = [ self.nasdf-unstable super.moptilities ];
+    lispLibs = [ self.nasdf super.moptilities ];
   };
 
-  nfiles_1_1_2 = build-asdf-system {
+  nfiles = build-asdf-system {
     pname = "nfiles";
     version = "1.1.2";
     src = pkgs.fetchFromGitHub {
@@ -328,9 +328,9 @@ let
       sha256 = "sha256-YsVcCFrJIFL9Z4wQNAv6chiz6wB/eB8v/EUMXPLs3fw=";
     };
     lispLibs = [
-      self.nasdf-unstable
-      self.nclasses_0_5_0
       self.quri_7_0
+      self.nasdf
+      self.nclasses
       super.alexandria
       super.iolib
       super.serapeum
@@ -372,8 +372,8 @@ let
       alexandria
       cl-custom-hash-table
       local-time
-      nasdf-unstable
-      nclasses_0_5_0
+      nasdf
+      nclasses
       trivial-package-local-nicknames
     ];
   };
@@ -383,16 +383,6 @@ let
     version = "3.3.0";
 
     lispLibs = (with super; [
-      self.nasdf-unstable
-      self.prompter
-      self.cl-colors2_0_5_4
-      self.njson_1_0_0
-      self.nsymbols_0_3_1
-      self.nclasses_0_5_0
-      self.nfiles_1_1_2
-      self.quri_7_0
-      self.cl-webkit2_3_5_8
-      self.swank
       alexandria
       bordeaux-threads
       calispel
@@ -444,6 +434,16 @@ let
       history-tree
       nhooks
       nkeymaps
+      quri_7_0
+      nasdf
+      prompter
+      cl-colors2_0_5_4
+      njson
+      nsymbols
+      nclasses
+      nfiles
+      cl-webkit2_3_5_8
+      swank
     ]);
 
     src = pkgs.fetchFromGitHub {

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -207,18 +207,6 @@ let
     lispLibs = super.mathkit.lispLibs ++ [ super.sb-cga ];
   };
 
-  quri_7_0 = build-asdf-system {
-    inherit (super.quri) pname systems lispLibs;
-    version = "0.7.0";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "fukamachi";
-      repo = "quri";
-      rev = "0.7.0";
-      sha256 = "sha256-/9p67rfbkdrx5nn4kXEUAM9MzV7NYUsRcKsrP/e2MlA=";
-    };
-  };
-
   cl-colors2_0_5_4 = build-asdf-system {
     inherit (super.cl-colors2) pname systems lispLibs;
     version = "0.5.4";
@@ -328,9 +316,9 @@ let
       sha256 = "sha256-YsVcCFrJIFL9Z4wQNAv6chiz6wB/eB8v/EUMXPLs3fw=";
     };
     lispLibs = [
-      self.quri_7_0
       self.nasdf
       self.nclasses
+      super.quri
       super.alexandria
       super.iolib
       super.serapeum
@@ -396,7 +384,6 @@ let
       cl-qrencode
       cl-tld
       closer-mop
-      cl-containers
       dissect
       moptilities
       dexador
@@ -430,11 +417,11 @@ let
       cluffer
       cl-cffi-gtk
       cl-gobject-introspection
+      quri
     ]) ++ (with self; [
       history-tree
       nhooks
       nkeymaps
-      quri_7_0
       nasdf
       prompter
       cl-colors2_0_5_4
@@ -444,6 +431,7 @@ let
       nfiles
       cl-webkit2_3_5_8
       swank
+      cl-containers
     ]);
 
     src = pkgs.fetchFromGitHub {

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -218,15 +218,15 @@ let
     };
   };
 
-  cl-webkit2_3_5_8 = build-asdf-system {
+  cl-webkit2_3_5_9 = build-asdf-system {
     inherit (super.cl-webkit2) pname systems nativeLibs lispLibs;
-    version = "3.5.8";
+    version = "3.5.9";
 
     src = pkgs.fetchFromGitHub {
       owner = "joachifm";
       repo = "cl-webkit";
-      rev = "3.5.8";
-      sha256 = "sha256-wZ/zRRJlTiOIny4BsU+wsFtxtS5YKx3WalwpCVQPFSY=";
+      rev = "3.5.9";
+      sha256 = "sha256-YJo5ahL6+HLeJrxFBuZZjuK3OfA6DnAu82vvXMsNBgI=";
     };
   };
 
@@ -308,12 +308,12 @@ let
 
   nfiles = build-asdf-system {
     pname = "nfiles";
-    version = "1.1.2";
+    version = "20230705-git";
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nfiles";
-      rev = "1.1.2";
-      sha256 = "sha256-YsVcCFrJIFL9Z4wQNAv6chiz6wB/eB8v/EUMXPLs3fw=";
+      rev = "3626e8d512a84efc12479ceb3969d194511757f7";
+      sha256 = "sha256-MoJdbTOVfw2rJk4cf/rEnR55BxdXkoqqu9Txd/R9OYQ=";
     };
     lispLibs = [
       self.nasdf
@@ -368,7 +368,7 @@ let
 
   nyxt-gtk = build-asdf-system {
     pname = "nyxt";
-    version = "3.3.0";
+    version = "3.4.0";
 
     lispLibs = (with super; [
       alexandria
@@ -429,7 +429,7 @@ let
       nsymbols
       nclasses
       nfiles
-      cl-webkit2_3_5_8
+      cl-webkit2_3_5_9
       swank
       cl-containers
     ]);
@@ -437,8 +437,8 @@ let
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nyxt";
-      rev = "3.3.0";
-      sha256 = "sha256-hSu+XGb87yzZPbJgcUhU81VGhNdMiN6GKspGQJU+SxY=";
+      rev = "3.4.0";
+      sha256 = "sha256-o+GAMHKi+9q+EGY6SEZrxKCEO4IxdOiB4oPpJPGYO0w=";
     };
 
     nativeBuildInputs = [ pkgs.makeWrapper ];


### PR DESCRIPTION
###### Description of changes

Updates `nyxt` to version 3.4.0.

Also updates `nfiles` and the pinned version of `cl-webkit2` to the version pinned by `nyxt`'s upstream submodules (https://github.com/atlas-engineer/nyxt/commit/95a0e48bf5b1560019b1005bca15888eaaef03ba and https://github.com/atlas-engineer/nyxt/commit/95a0e48bf5b1560019b1005bca15888eaaef03ba)

I also went ahead and
1. removed the version from the attribute name of `nyxt`'s internal dependencies (`nfiles`, `nsymbols`, `njson`, etc.) and `nasdf` since it's no longer needed to pin them to a version different than the one on quicklisp, because they have been removed from quicklisp in the June 2023 update.
2. removed the pinned `quri` version since the quicklisp one is updated now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
