### PR TITLE
nodejs: use a response file with llvm-ar

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -160,9 +160,14 @@ let
       ${if stdenv.buildPlatform.isGnu then ''
         ar -cqs $libv8/lib/libv8.a @files
       '' else ''
-        cat files | while read -r file; do
-          ar -cqS $libv8/lib/libv8.a $file
-        done
+        # llvm-ar supports response files, so take advantage of it if it’s available.
+        if [ "$(basename $(readlink -f $(command -v ar)))" = "llvm-ar" ]; then
+          ar -cqs $libv8/lib/libv8.a @files
+        else
+          cat files | while read -r file; do
+            ar -cqS $libv8/lib/libv8.a $file
+          done
+        fi
       ''}
       popd
 


### PR DESCRIPTION
###### Description of changes

nodejs produces a static archive in its `postInstall`. It detects if the `ar` is GNU ar and uses a response file. Otherwise, it adds the files individually. This is apparently very slow with `llvm-ar`, which Darwin now uses by default. Fortunately, `llvm-ar` also supports response files, so detect whether the `ar` is `llvm-ar` and use a response file.

I tested the build on aarch64-darwin. `postInstall` took less than a minute to generate a 59 MiB static archive. Comparing to the build on master, the only difference between the two archives is `llvm-ar` zeroes out the dates, uids, and gids by default. Compared disassembly of the archives appeared identical.

This fixes the timeouts on staging-next. #241951

https://hydra.nixos.org/build/227170390

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
