### PR TITLE
dioxus-cli: 0.1.4 -> 0.3.2

### DIFF
--- a/pkgs/development/tools/rust/dioxus-cli/default.nix
+++ b/pkgs/development/tools/rust/dioxus-cli/default.nix
@@ -1,17 +1,24 @@
-{ lib, fetchCrate, rustPlatform, openssl, pkg-config, stdenv, CoreServices }:
+{ lib, fetchCrate, rustPlatform, openssl, pkg-config, cacert, stdenv, CoreServices }:
 rustPlatform.buildRustPackage rec {
   pname = "dioxus-cli";
-  version = "0.1.4";
+  version = "0.3.2";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-SnmDOMxc+39LX6kOzma2zA6T91UGCnvr7WWhX+wXnLo=";
+    sha256 = "sha256-8S8zUOb2oiXbJQRgY/g9H2+EW+wWOQugr8+ou34CYPg=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config cacert ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ CoreServices ];
 
-  cargoSha256 = "sha256-Mf/WtOO/vFuhg90DoPDwOZ6XKj423foHZ8vHugXakb0=";
+  cargoSha256 = "sha256-sCP8njwYA29XmYu2vfuog0NCL1tZlsZiupkDVImrYCE=";
+
+  checkFlags = [
+    # these tests require dioxous binary in PATH,
+    # can be removed after: https://github.com/DioxusLabs/dioxus/pull/1138
+    "--skip=cli::autoformat::spawn_properly"
+    "--skip=cli::translate::generates_svgs"
+  ];
 
   meta = with lib; {
     description = "CLI tool for developing, testing, and publishing Dioxus apps";


### PR DESCRIPTION
###### Description of changes

* update src
* add cacert as native dependecy (via rustls)
* skip tests that require bin: https://github.com/DioxusLabs/dioxus/pull/1138

[Release Notes](https://github.com/DioxusLabs/dioxus/releases).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
nix shell .#dioxus-cli
dioxus
dioxus -V
# further commands require rust toolchain
```