### PR TITLE
awscurl: init at unstable-2023-07-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7168,6 +7168,12 @@
     githubId = 137306;
     name = "Michele Catalano";
   };
+  isaacshaha = {
+    email = "isaac.shaha64@gmail.com";
+    github = "IsaacShaha";
+    githubId = 24405680;
+    name = "Isaac Shaha";
+  };
   isaozler = {
     email = "isaozler@gmail.com";
     github = "isaozler";

--- a/pkgs/tools/networking/awscurl/default.nix
+++ b/pkgs/tools/networking/awscurl/default.nix
@@ -1,0 +1,72 @@
+{ fetchFromGitHub
+, lib
+, makeWrapper
+, python3
+}: with python3.pkgs;
+let
+  awscurl = buildPythonApplication {
+    pname = "awscurl";
+    # The latest stable version of awscurl (0.29) requires urllib3[secure],
+    # which is deprecated and requires a package that is not in nixpkgs
+    # (urllib3-secure-extra). Stable can be added with awscurl 0.30 presumably.
+    version = "unstable-2023-07-10";
+    format = "setuptools";
+
+    src = fetchFromGitHub {
+      owner = "okigan";
+      repo = "awscurl";
+      rev = "e47119b384edb33ca734f8b930e8ffde33882f3e";
+      hash = "sha256-NVGPB29kgLYpJnAiSUYoC9M11G9J1shbe1ZXbywRyUU=";
+    };
+
+    doCheck = true;
+
+    checkInputs = [
+      mock
+      pytest
+    ];
+
+    # Remove tests that require access to the internet or home directory.
+    checkPhase = ''
+      python -m pytest -k 'not integration_test'
+    '';
+
+    buildInputs = [
+      cryptography
+      pyopenssl
+    ];
+
+    propagatedBuildInputs = [
+      botocore
+      configargparse
+      configparser
+      requests
+      urllib3
+    ];
+
+    meta = with lib; {
+      description = "curl-like tool with AWS Signature Version 4 request signing.";
+      homepage = "https://github.com/okigan/awscurl";
+      license = licenses.mit;
+      maintainers = [ maintainers.isaacshaha ];
+      # I believe this would work on all platforms, but I don't have the
+      # resources to verify.
+      platforms = [
+        "x86_64-linux"
+      ];
+    };
+  };
+in
+stdenv.mkDerivation {
+  inherit (awscurl) pname version meta;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  # Wrap awscurl so that Python is not in path.
+  buildCommand = ''
+    makeWrapper ${awscurl}/bin/awscurl $out/bin/awscurl \
+      --set PYTHONHOME "${python3}"
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1577,6 +1577,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  awscurl = callPackage ../tools/networking/awscurl { };
+
   balena-cli = callPackage ../tools/admin/balena-cli { };
 
   basez = callPackage ../tools/misc/basez { };


### PR DESCRIPTION
*This is my first time contributing to the world of open source, please let me know how I can improve my contribution :slightly_smiling_face:*

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Added [awscurl](https://github.com/okigan/awscurl), a curl-like tool with AWS Signature Version 4 request signing.
    - Used `makeWrapper` to isolate from path the Python that was used to install awscurl, since awscurl is primarily a CLI utility and is not used from within Python. This prevents clashes with other potential Python environments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
