### PR TITLE
openfortivpn-webview: init at 1.1.2

### DIFF
--- a/pkgs/tools/networking/openfortivpn-webview/default.nix
+++ b/pkgs/tools/networking/openfortivpn-webview/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, qmake
+, qtbase
+, qtwebengine
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openfortivpn-webview";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "gm-vm";
+    repo = pname;
+    rev = "607dc949730f24611a6dba6c5c6cb9a5669fd7ac";
+    hash = "sha256-BNotbb2pL7McBm0SQwcgEvjgS2GId4HVaxWUz/ODs6w=";
+  };
+
+  sourceRoot = "source/openfortivpn-webview-qt";
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+  buildInputs = [ qtwebengine ];
+
+  installPhase = "install -Dm755 ${pname} -t $out/bin";
+
+  meta = with lib; {
+    description = "Application to perform the SAML single sing-on and easily retrieve the SVPNCOOKIE needed by openfortivpn.";
+    homepage = "https://github.com/gm-vm/openfortivpn-webview";
+    license = licenses.mit;
+    maintainers = with maintainers; [ luz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10961,6 +10961,8 @@ with pkgs;
 
   openfortivpn = callPackage ../tools/networking/openfortivpn { };
 
+  openfortivpn-webview = qt6Packages.callPackage ../tools/networking/openfortivpn-webview { };
+
   opensnitch = callPackage ../tools/networking/opensnitch/daemon.nix {
     # Build currently fails on Go > 1.18
     # See https://github.com/evilsocket/opensnitch/issues/851


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ x ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
