### PR TITLE
fetchers: remove md5 argument

### DIFF
--- a/pkgs/build-support/fetchdarcs/default.nix
+++ b/pkgs/build-support/fetchdarcs/default.nix
@@ -4,14 +4,10 @@ lib.makeOverridable (
 { url
 , rev ? null
 , context ? null
-, md5 ? ""
 , sha256 ? ""
 , name ? "fetchdarcs"
 }:
 
-if md5 != "" then
-  throw "fetchdarcs does not support md5 anymore, please use sha256"
-else
 stdenvNoCC.mkDerivation {
   builder = ./builder.sh;
   nativeBuildInputs = [cacert darcs];

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -11,7 +11,7 @@
   in "${if matched == null then base else builtins.head matched}${appendShort}";
 in
 lib.makeOverridable (
-{ url, rev ? "HEAD", md5 ? "", sha256 ? "", hash ? "", leaveDotGit ? deepClone
+{ url, rev ? "HEAD", sha256 ? "", hash ? "", leaveDotGit ? deepClone
 , fetchSubmodules ? true, deepClone ? false
 , branchName ? null
 , sparseCheckout ? []
@@ -56,9 +56,7 @@ lib.makeOverridable (
 assert deepClone -> leaveDotGit;
 assert nonConeMode -> (sparseCheckout != []);
 
-if md5 != "" then
-  throw "fetchgit does not support md5 anymore, please use sha256"
-else if hash != "" && sha256 != "" then
+if hash != "" && sha256 != "" then
   throw "Only one of sha256 or hash can be set"
 else if builtins.isString sparseCheckout then
   # Changed to throw on 2023-06-04

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -2,15 +2,12 @@
 { name ? null
 , url
 , rev ? null
-, md5 ? null
 , sha256 ? null
 , hash ? null
 , fetchSubrepos ? false
 , preferLocalBuild ? true }:
 
-if md5 != null then
-  throw "fetchhg does not support md5 anymore, please use sha256 or hash"
-else if hash != null && sha256 != null then
+if hash != null && sha256 != null then
   throw "Only one of sha256 or hash can be set"
 else
 # TODO: statically check if mercurial as the https support if the url starts woth https.

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -2,7 +2,7 @@
 , subversion, glibcLocales, sshSupport ? true, openssh ? null
 }:
 
-{ url, rev ? "HEAD", md5 ? "", sha256 ? "", hash ? ""
+{ url, rev ? "HEAD", sha256 ? "", hash ? ""
 , ignoreExternals ? false, ignoreKeywords ? false, name ? null
 , preferLocalBuild ? true
 }:
@@ -32,9 +32,7 @@ let
   name_ = if name == null then "${repoName}-r${toString rev}" else name;
 in
 
-if md5 != "" then
-  throw "fetchsvn does not support md5 anymore, please use sha256"
-else if hash != "" && sha256 != "" then
+if hash != "" && sha256 != "" then
   throw "Only one of sha256 or hash can be set"
 else
 stdenvNoCC.mkDerivation {

--- a/pkgs/build-support/fetchsvnssh/default.nix
+++ b/pkgs/build-support/fetchsvnssh/default.nix
@@ -1,10 +1,7 @@
 {stdenvNoCC, subversion, sshSupport ? true, openssh ? null, expect}:
-{username, password, url, rev ? "HEAD", md5 ? "", sha256 ? ""}:
+{username, password, url, rev ? "HEAD", sha256 ? ""}:
 
 
-if md5 != "" then
-  throw "fetchsvnssh does not support md5 anymore, please use sha256"
-else
 stdenvNoCC.mkDerivation {
   name = "svn-export-ssh";
   builder = ./builder.sh;

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -67,7 +67,6 @@ in
 , # Legacy ways of specifying the hash.
   outputHash ? ""
 , outputHashAlgo ? ""
-, md5 ? ""
 , sha1 ? ""
 , sha256 ? ""
 , sha512 ? ""
@@ -125,7 +124,6 @@ let
     if hash != "" && sha256 != "" then throw "multiple hashes passed to fetchurl" else
 
     if hash != "" then { outputHashAlgo = null; outputHash = hash; }
-    else if md5 != "" then throw "fetchurl does not support md5 anymore, please use sha256 or sha512"
     else if (outputHash != "" && outputHashAlgo != "") then { inherit outputHashAlgo outputHash; }
     else if sha512 != "" then { outputHashAlgo = "sha512"; outputHash = sha512; }
     else if sha256 != "" then { outputHashAlgo = "sha256"; outputHash = sha256; }


### PR DESCRIPTION
###### Description of changes

For fetchers that have been throwing an error for years when they receive md5 as an argument, clean up that code. At this point, I don't personally think any additional notice or documentation is necessary, but I'll also add anything reasonable that folks request to mitigate concerns.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
