### PR TITLE
gcc: strip debug symbols from libgcc output

### DIFF
--- a/pkgs/development/compilers/gcc/common/strip-attributes.nix
+++ b/pkgs/development/compilers/gcc/common/strip-attributes.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, langJit }:
+{ lib, stdenv, langJit, enableShared }:
+
+let enableLibGccOutput =
+      !langJit &&
+      !stdenv.hostPlatform.isDarwin &&
+      enableShared
+      ;
+
+in
 
 {
   # Note [Cross-compiler stripping]
@@ -59,11 +67,19 @@
       )
       popd
 
+  '' + lib.optionalString enableLibGccOutput ''
+    ${/*keep indentation*/ ""}
+      pushd $libgcc
+      local -ar libgccTargetFiles=(
+        lib{,32,64}/*.{a,o,so*}
+      )
+      popd
+
   '' + ''
       eval "$oldOpts"
 
       stripDebugList="$stripDebugList ''${outHostFiles[*]} ''${libHostFiles[*]}"
-      stripDebugListTarget="$stripDebugListTarget ''${outTargetFiles[*]} ''${libTargetFiles[*]}"
+      stripDebugListTarget="$stripDebugListTarget ''${outTargetFiles[*]} ''${libTargetFiles[*]} ''${libgccTargetFiles[*]}"
     }
     updateDebugListPaths
   '';


### PR DESCRIPTION
###### Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/243642 (I think). I've tested that this does indeed strip `libgcc_s.so.1`. Also I think the changes make sense based on my limited understanding of the code. However I'm not sure how to test that this doesn't break anything. Might try to run `nixpkgs-review` overnight.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).