### PR TITLE
vivaldi-ffmpeg-codecs 112.0.5615.49 -> 111306

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5589,6 +5589,12 @@
     githubId = 84968;
     name = "Florian Paul Schmidt";
   };
+  fptje = {
+    email = "fpeijnenburg@gmail.com";
+    github = "FPtje";
+    githubId = 1202014;
+    name = "Falco Peijnenburg";
+  };
   fragamus = {
     email = "innovative.engineer@gmail.com";
     github = "fragamus";

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://ffmpeg.org/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license     = licenses.lgpl21;
-    maintainers = with maintainers; [ betaboon cawilliamson lluchs fptje ];
+    maintainers = with maintainers; [ betaboon cawilliamson fptje ];
     platforms   = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -1,22 +1,24 @@
-{ dpkg, fetchurl, lib, stdenv }:
+{ squashfsTools, fetchurl, lib, stdenv }:
 
+# This derivation roughly follows the update-ffmpeg script that ships with the official Vivaldi
+# downloads at https://vivaldi.com/download/
 stdenv.mkDerivation rec {
   pname = "chromium-codecs-ffmpeg-extra";
-  version = "112.0.5615.49";
+  version = "111306";
 
   src = fetchurl {
-    url = "https://launchpadlibrarian.net/660647727/${pname}_${version}-0ubuntu0.18.04.1_amd64.deb";
-    sha256 = "sha256-mHjvjRG+toRcsOMca+JPXNZPgyQROH2qtSpBPHLmt3s=";
+    url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_34.snap";
+    sha256 = "sha256-Dna9yFgP7JeQLAeZWvSZ+eSMX2yQbX2/+mX0QC22lYY=";
   };
 
-  buildInputs = [ dpkg ];
+  buildInputs = [ squashfsTools ];
 
   unpackPhase = ''
-    dpkg-deb -x $src .
+    unsquashfs -dest . $src
   '';
 
   installPhase = ''
-    install -vD usr/lib/chromium-browser/libffmpeg.so $out/lib/libffmpeg.so
+    install -vD chromium-ffmpeg-${version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
   '';
 
   meta = with lib; {
@@ -24,7 +26,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://ffmpeg.org/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license     = licenses.lgpl21;
-    maintainers = with maintainers; [ betaboon cawilliamson lluchs ];
+    maintainers = with maintainers; [ betaboon cawilliamson lluchs fptje ];
     platforms   = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/243618
Cross reference: https://forum.vivaldi.net/topic/88884/page-crash-due-to-read-out-of-range-on-nixos

This package had not been updated in a while. The latest version of Vivaldi is incompatible, leading to page crashes.

I realized that this package was based on the `update-ffmpeg` script in Vivaldi's official distributions. That script used to download from launchpad. However, the launchpad package has been turned into an empty shell in favour of the snap package. The `update-ffmpeg` script has been updated accordingly, to download the Snap package.

## Notes

- It might be a good idea for the future to build the chromium-ffmpeg package from source. For now, this fix is the quick solution.
  - A benefit would be that it would be compatible with more platforms than just x86-64_linux
  - A downside would be that this built-from-source version would not be supported by Vivaldi. If e.g. we update chromium-ffmpeg to a _too new_ version, we would get the same page crashes. The situation is a little awkward and might warrant some discussion.
- I added myself as maintainer, as I'm willing to update this package every now and then.
- The version format changes, the new version number (`111306`) corresponds to a Chromium release. See [this post](https://forum.snapcraft.io/t/using-chromium-ffmpeg-in-third-party-browser-snaps/6545) for an explanation
- With the change in version, it's a bit hard to find a specific changelog, but I suppose the most important change is that it now no longer crashes in Vivaldi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
