### PR TITLE
tests.haskell.upstreamStackHpackVersion: init

### DIFF
--- a/pkgs/test/haskell/default.nix
+++ b/pkgs/test/haskell/default.nix
@@ -7,4 +7,5 @@ lib.recurseIntoAttrs {
   setBuildTarget = callPackage ./setBuildTarget { };
   writers = callPackage ./writers { };
   incremental = callPackage ./incremental { };
+  upstreamStackHpackVersion = callPackage ./upstreamStackHpackVersion { };
 }

--- a/pkgs/test/haskell/upstreamStackHpackVersion/default.nix
+++ b/pkgs/test/haskell/upstreamStackHpackVersion/default.nix
@@ -1,0 +1,151 @@
+
+# This derivation confirms that the version of hpack used by stack in Nixpkgs
+# is the exact same version as the upstream stack release.
+#
+# It is important to make sure the version of hpack used by stack in Nixpkgs
+# matches with the version of hpack used by the upstream stack release.  This
+# is because hpack works slightly differently based on the version, and it can
+# be frustrating to use hpack in a team setting when members are using different
+# versions. See for more info: https://github.com/NixOS/nixpkgs/issues/223390
+#
+# This test is written as a fixed-output derivation, because we need to access
+# accesses the internet to download the upstream stack release.
+
+{ cacert, curl, lib, stack, stdenv }:
+
+let
+  # Find the hpack derivation that is a dependency of stack.  Throw exception
+  # if hpack cannot be found.
+  hpack =
+    lib.findFirst
+      (v: v.pname or "" == "hpack")
+      (throw "could not find stack's hpack dependency")
+      stack.passthru.getCabalDeps.executableHaskellDepends;
+
+  # This is a statically linked version of stack, so it should be usable within
+  # the Nixpkgs builder (at least on x86_64-linux).
+  stackDownloadUrl =
+    "https://github.com/commercialhaskell/stack/releases/download/v${stack.version}/stack-${stack.version}-linux-x86_64-static.tar.gz";
+
+  # This test code has been explicitly pulled out of the derivation below so
+  # that it can be hashed and added to the `name` of the derivation.  This is
+  # so that this test derivation won't be cached if the body of the test is
+  # modified.
+  #
+  # WARNING: When modifying this script, make sure you don't introduce any
+  # paths to the Nix store within it.  We only want this derivation to be re-run
+  # when the stack version (or the version of its hpack dependency) changes in
+  # Nixpkgs.
+  testScript = ''
+    curl=(
+      curl
+      --location
+      --max-redirs 20
+      --retry 3
+      --disable-epsv
+      --cookie-jar cookies
+      --user-agent "curl "
+      --insecure
+    )
+
+    # Fetch the statically-linked upstream Stack binary.
+    "''${curl[@]}" "${stackDownloadUrl}" > ./stack.tar.gz
+    tar xf ./stack.tar.gz
+
+    upstream_stack_version_output="$(./stack-${stack.version}-linux-x86_64-static/stack --version)"
+    echo "upstream \`stack --version\` output: $upstream_stack_version_output"
+
+    nixpkgs_stack_version_output="$(stack --version)"
+    echo "nixpkgs \`stack --version\` output: $nixpkgs_stack_version_output"
+
+    # Confirm that the upstream stack version is the same as the stack version
+    # in Nixpkgs. This check isn't strictly necessary, but it is a good sanity
+    # check.
+
+    if [[ "$upstream_stack_version_output" =~ "Version "([0-9]+((\.[0-9]+)+)) ]]; then
+      upstream_stack_version="''${BASH_REMATCH[1]}"
+
+      echo "parsed upstream stack version: $upstream_stack_version"
+      echo "stack version from nixpkgs: ${stack.version}"
+
+      if [[ "${stack.version}" != "$upstream_stack_version" ]]; then
+        echo "ERROR: stack version in Nixpkgs (${stack.version}) does not match the upstream version for some reason: $upstream_stack_version"
+        exit 1
+      fi
+    else
+      echo "ERROR: Upstream stack version cannot be found in --version output: $upstream_stack_version"
+      exit 1
+    fi
+
+    # Confirm that the hpack version used in the upstream stack release is the
+    # same as the hpack version used by the Nixpkgs stack binary.
+
+    if [[ "$upstream_stack_version_output" =~ hpack-([0-9]+((\.[0-9]+)+)) ]]; then
+      upstream_hpack_version="''${BASH_REMATCH[1]}"
+
+      echo "parsed upstream stack's hpack version: $upstream_hpack_version"
+      echo "Nixpkgs stack's hpack version: ${hpack.version}"
+
+      if [[ "${hpack.version}" != "$upstream_hpack_version" ]]; then
+        echo "ERROR: stack's hpack version in Nixpkgs (${hpack.version}) does not match the upstream stack's hpack version: $upstream_hpack_version"
+        echo "The stack derivation in Nixpkgs needs to be fixed up so that it depends on hpack-$upstream_hpack_version, instead of ${hpack.name}"
+        exit 1
+      fi
+    else
+      echo "ERROR: Upstream stack's hpack version cannot be found in --version output: $upstream_hpack_version"
+      exit 1
+    fi
+
+    # Output a string with a known hash.
+    echo "success" > $out
+  '';
+
+  testScriptHash = builtins.hashString "sha256" testScript;
+in
+
+stdenv.mkDerivation {
+
+  # This name is very important.
+  #
+  # The idea here is that want this derivation to be re-run everytime the
+  # version of stack (or the version of its hpack dependency) changes in
+  # Nixpkgs.  We also want to re-run this derivation whenever the test script
+  # is changed.
+  #
+  # Nix/Hydra will re-run derivations if their name changes (even if they are a
+  # FOD and they have the same hash).
+  #
+  # The name of this derivation contains the stack version string, the hpack
+  # version string, and a hash of the test script.  So Nix will know to
+  # re-run this version when (and only when) one of those values change.
+  name = "upstream-stack-hpack-version-test-${stack.name}-${hpack.name}-${testScriptHash}";
+
+  # This is the sha256 hash for the string "success", which is output upon this
+  # test succeeding.
+  outputHash = "sha256-gbK9TqmMjbZlVPvI12N6GmmhMPMx/rcyt1yqtMSGj9U=";
+  outputHashMode = "flat";
+  outputHashAlgo = "sha256";
+
+  nativeBuildInputs = [ curl stack ];
+
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
+  buildCommand = ''
+    # Make sure curl can access HTTPS sites, like GitHub.
+    #
+    # Note that we absolutely don't want the Nix store path of the cacert
+    # derivation in the testScript, because we don't want to rebuild this
+    # derivation when only the cacert derivation changes.
+    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
+  '' + testScript;
+
+  meta = with lib; {
+    description = "Test that the stack in Nixpkgs uses the same version of Hpack as the upstream stack release";
+    maintainers = with maintainers; [ cdepillabout ];
+
+    # This derivation internally runs a statically-linked version of stack from
+    # upstream.  This statically-linked version of stack is only available for
+    # x86_64-linux, so this test can only be run on x86_64-linux.
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

This PR adds a Nixpkgs test that confirms that the upstream `stack` release uses the same version of `hpack` as the `stack` in Nixpkgs.

Fixes https://github.com/NixOS/nixpkgs/issues/223390

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
