### PR TITLE
nixos/gonic: allow access to audio devices when jukebox-enabled

### DIFF
--- a/nixos/modules/services/audio/gonic.nix
+++ b/nixos/modules/services/audio/gonic.nix
@@ -41,7 +41,11 @@ in
       description = "Gonic Media Server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
+      serviceConfig = let
+        jukeboxEnabled = if cfg.settings?jukebox-enabled
+        then lib.last cfg.settings.jukebox-enabled
+        else false;
+      in {
         ExecStart =
           let
             # these values are null by default but should not appear in the final config
@@ -64,9 +68,10 @@ in
         ++ lib.optional (cfg.settings.tls-cert != null) cfg.settings.tls-cert
         ++ lib.optional (cfg.settings.tls-key != null) cfg.settings.tls-key;
         CapabilityBoundingSet = "";
+        DeviceAllow = lib.optionalString jukeboxEnabled "char-alsa rw";
         RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
         RestrictNamespaces = true;
-        PrivateDevices = true;
+        PrivateDevices = !jukeboxEnabled;
         PrivateUsers = true;
         ProtectClock = true;
         ProtectControlGroups = true;
@@ -74,6 +79,7 @@ in
         ProtectKernelLogs = true;
         ProtectKernelModules = true;
         ProtectKernelTunables = true;
+        SupplementaryGroups = lib.optionals jukeboxEnabled ["audio"];
         SystemCallArchitectures = "native";
         SystemCallFilter = [ "@system-service" "~@privileged" ];
         RestrictRealtime = true;


### PR DESCRIPTION
###### Description of changes

Gonic's jukebox mode needs access to the system's audio devices. If it doesn't have access mpv silently fails to play anything.

This PR makes 3 changes to the systemd service when `settings.jukebox-enabled` is true:

- `PrivateDevices=false`
- `DeviceAllow=char-alsa rw`
- `SupplementaryGroups=audio`

My understanding (based on `man systemd.resource-control`) is that when `DeviceAllow` is set the behaviour is roughly equivalent to `PrivateDevices`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - `nix-build -A nixosTests.gonic`
  - built a nixos system against this branch with `jukebox-enabled` set
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - apparently I don't have enough memory to run this (it got OOM-killed)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Module updates) Added a release notes entry if the change is significant
    - this is not a significant or breaking change AFAICT
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tried adding `jukebox-enabled` to `nixos/tests/gonic.nix` - the test fails with:

```
panic: error in job: create tmp sock file: mkdir /tmp/gonic-jukebox-2699349867: read-only file system
```

The setting works fine on a real system, so I didn't spend much time investigating it.