### PR TITLE
gamja: init at 1.0.0-beta.8

### DIFF
--- a/pkgs/applications/misc/gamja/default.nix
+++ b/pkgs/applications/misc/gamja/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, buildNpmPackage
+, python3
+, writeText
+# optional configuration attrSet, see https://git.sr.ht/~emersion/gamja#configuration-file for possible values
+, gamjaConfig ? null
+}:
+
+buildNpmPackage rec {
+  pname = "gamja";
+  version = "1.0.0-beta.8";
+
+  src = fetchFromSourcehut {
+    owner = "~emersion";
+    repo = "gamja";
+    rev = "v${version}";
+    hash = "sha256-viyNE6R22jN98OUSsNp1kdH8VAiXlIQWitamPJlXMCQ=";
+  };
+
+  npmDepsHash = "sha256-3rpMoYHRkYHriSYyNBW9uufbJuBQR4WrdStib5FtYfw=";
+
+  # without this, the aarch64-linux build fails
+  nativeBuildInputs = [ python3 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+    ${lib.optionalString (gamjaConfig != null) "cp ${writeText "gamja-config" (builtins.toJSON gamjaConfig)} $out/config.json"}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A simple IRC web client";
+    homepage = "https://git.sr.ht/~emersion/gamja";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ apfelkuchen6 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39681,6 +39681,8 @@ with pkgs;
     gst-plugins-good = gst_all_1.gst-plugins-good.override { gtkSupport = true; };
   };
 
+  gamja = callPackage ../applications/misc/gamja { };
+
   gammu = callPackage ../applications/misc/gammu { };
 
   ghostscript = callPackage ../misc/ghostscript { };


### PR DESCRIPTION
gamja is an IRC web client.
Project url: https://git.sr.ht/~emersion/gamja

Initializing with beta version as there is no stable release yet.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
