### PR TITLE
limesuite: fix darwin build

### DIFF
--- a/pkgs/applications/radio/limesuite/default.nix
+++ b/pkgs/applications/radio/limesuite/default.nix
@@ -2,7 +2,7 @@
 , sqlite, wxGTK32, libusb1, soapysdr
 , mesa_glu, libX11, gnuplot, fltk
 , GLUT
-, withGui ? true
+, withGui ? !stdenv.isDarwin # withGui transitively depends on mesa, which is broken on darwin
 }:
 
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Description of changes
`limesuite` defaults to `withGui = true` , which requires `mesa`, which is [broken on darwin platforms](https://github.com/NixOS/nixpkgs/blob/6e7ca62140f17b3e9fb9933f9291a7ab740c3505/pkgs/development/libraries/mesa/default.nix#L378-L379). This changes the default value for `withGui` to `!stdenv.isDarwin` in order to prevent it (and its downstream dependencies) from being broken on darwin.

Transitively, it fixes `sdrangel` on aarch64-darwin.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note:
I've tested this on top of `nixos-unstable`, but since `qt5.qtwebengine` has a pending rebuild, I couldn't test it over `master` just yet (not that it sholud matter).
