### PR TITLE
haskell.packages.{ghc90x,ghc94x}: Remove unnecessary jailbreaks

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -57,16 +57,6 @@ self: super: {
 
   # Jailbreaks & Version Updates
 
-  # This `doJailbreak` can be removed once the following PR is released to Hackage:
-  # https://github.com/thsutton/aeson-diff/pull/58
-  aeson-diff = doJailbreak super.aeson-diff;
-
-  async = doJailbreak super.async;
-  data-fix = doJailbreak super.data-fix;
-  dec = doJailbreak super.dec;
-  ed25519 = doJailbreak super.ed25519;
-  hackage-security = doJailbreak super.hackage-security;
-
   # For GHC < 9.4, some packages need data-array-byte as an extra dependency
   primitive = addBuildDepends [ self.data-array-byte ] super.primitive;
   hashable = addBuildDepends [
@@ -75,21 +65,8 @@ self: super: {
   ] super.hashable;
 
   hashable-time = doJailbreak super.hashable-time;
-  HTTP = overrideCabal (drv: { postPatch = "sed -i -e 's,! Socket,!Socket,' Network/TCP.hs"; }) (doJailbreak super.HTTP);
-  integer-logarithms = overrideCabal (drv: { postPatch = "sed -i -e 's,integer-gmp <1.1,integer-gmp < 2,' integer-logarithms.cabal"; }) (doJailbreak super.integer-logarithms);
-  lukko = doJailbreak super.lukko;
-  parallel = doJailbreak super.parallel;
-  regex-posix = doJailbreak super.regex-posix;
-  singleton-bool = doJailbreak super.singleton-bool;
-  split = doJailbreak super.split;
-  tar = doJailbreak super.tar;
-  time-compat = doJailbreak super.time-compat;
   tuple = addBuildDepend self.base-orphans super.tuple;
-  vector-binary-instances = doJailbreak super.vector-binary-instances;
   vector-th-unbox = doJailbreak super.vector-th-unbox;
-  zlib = doJailbreak super.zlib;
-  # 2021-11-08: Fixed in autoapply-0.4.2
-  autoapply = doJailbreak super.autoapply;
 
   doctest = dontCheck super.doctest;
   # Apply patches from head.hackage.
@@ -126,16 +103,6 @@ self: super: {
     hls-graph hls-plugin-api hls-refactor-plugin hyphenation lens lsp megaparsec
     parser-combinators prettyprinter refinery retrie syb unagi-chan unordered-containers
   ]) super.hls-tactics-plugin);
-
-  # The test suite depends on ChasingBottoms, which is broken with ghc-9.0.x.
-  unordered-containers = dontCheck super.unordered-containers;
-
-  # The test suite seems pretty broken.
-  base64-bytestring = dontCheck super.base64-bytestring;
-
-  # GHC 9.0.x doesn't like `import Spec (main)` in Main.hs
-  # https://github.com/snoyberg/mono-traversable/issues/192
-  mono-traversable = dontCheck super.mono-traversable;
 
   # Test suite sometimes segfaults with GHC 9.0.1 and 9.0.2
   # https://github.com/ekmett/reflection/issues/51

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -55,63 +55,20 @@ in {
   # still the case when updating: https://gitlab.haskell.org/ghc/ghc/-/blob/0198841877f6f04269d6050892b98b5c3807ce4c/ghc.mk#L463
   xhtml = if self.ghc.hasHaddock or true then null else self.xhtml_3000_2_2_1;
 
-  # Tests fail because of typechecking changes
-  conduit = dontCheck super.conduit;
-
   # consequences of doctest breakage follow:
 
   ghc-source-gen = checkAgainAfter super.ghc-source-gen "0.4.3.0" "fails to build" (markBroken super.ghc-source-gen);
 
-  haskell-src-meta = doJailbreak super.haskell-src-meta;
-
-  # Tests fail in GHC 9.2
-  extra = dontCheck super.extra;
-
   # Jailbreaks & Version Updates
 
-  assoc = doJailbreak super.assoc;
-  async = doJailbreak super.async;
-  base64-bytestring = doJailbreak super.base64-bytestring;
-  binary-instances = doJailbreak super.binary-instances;
-  ChasingBottoms = doJailbreak super.ChasingBottoms;
-  constraints = doJailbreak super.constraints;
-  cpphs = overrideCabal (drv: { postPatch = "sed -i -e 's,time >=1.5 && <1.11,time >=1.5 \\&\\& <1.12,' cpphs.cabal";}) super.cpphs;
-  data-fix = doJailbreak super.data-fix;
-  dec = doJailbreak super.dec;
-  ed25519 = doJailbreak super.ed25519;
-  ghc-byteorder = doJailbreak super.ghc-byteorder;
-  hackage-security = doJailbreak super.hackage-security;
   hashable-time = doJailbreak super.hashable-time;
-  HTTP = overrideCabal (drv: { postPatch = "sed -i -e 's,! Socket,!Socket,' Network/TCP.hs"; }) (doJailbreak super.HTTP);
-  integer-logarithms = overrideCabal (drv: { postPatch = "sed -i -e 's, <1.1, <1.3,' integer-logarithms.cabal"; }) (doJailbreak super.integer-logarithms);
-  lifted-async = doJailbreak super.lifted-async;
-  lukko = doJailbreak super.lukko;
-  lzma-conduit = doJailbreak super.lzma-conduit;
-  parallel = doJailbreak super.parallel;
-  path = doJailbreak super.path;
-  polyparse = overrideCabal (drv: { postPatch = "sed -i -e 's, <0.11, <0.12,' polyparse.cabal"; }) (doJailbreak super.polyparse);
-  regex-posix = doJailbreak super.regex-posix;
-  singleton-bool = doJailbreak super.singleton-bool;
   libmpd = doJailbreak super.libmpd;
-  generics-sop = doJailbreak super.generics-sop;
-  microlens-th = doJailbreak super.microlens-th;
   # generically needs base-orphans for 9.4 only
   base-orphans = dontCheck (doDistribute super.base-orphans);
-  generically = addBuildDepend self.base-orphans super.generically;
 
   # the dontHaddock is due to a GHC panic. might be this bug, not sure.
   # https://gitlab.haskell.org/ghc/ghc/-/issues/21619
   hedgehog = dontHaddock super.hedgehog;
-
-  # https://github.com/dreixel/syb/issues/38
-  syb = dontCheck super.syb;
-
-  splitmix = doJailbreak super.splitmix;
-  time-compat = doJailbreak super.time-compat;
-  tomland = doJailbreak super.tomland;
-  type-equality = doJailbreak super.type-equality;
-  unordered-containers = doJailbreak super.unordered-containers;
-  vector-binary-instances = doJailbreak super.vector-binary-instances;
 
   hpack = overrideCabal (drv: {
     # Cabal 3.6 seems to preserve comments when reading, which makes this test fail
@@ -133,8 +90,6 @@ in {
   # https://github.com/sjakobi/bsb-http-chunked/issues/38
   bsb-http-chunked = dontCheck super.bsb-http-chunked;
 
-  some = doJailbreak super.some;
-
   # 2022-08-01: Tests are broken on ghc 9.2.4: https://github.com/wz1000/HieDb/issues/46
   hiedb = dontCheck super.hiedb;
 
@@ -146,7 +101,6 @@ in {
   th-extras = doJailbreak super.th-extras;
 
   # requires newer versions to work with GHC 9.4
-  swagger2 = dontCheck super.swagger2;
   servant = doJailbreak super.servant;
   servant-server = doJailbreak super.servant-server;
   servant-auth = doJailbreak super.servant-auth;
@@ -155,7 +109,7 @@ in {
   servant-client-core = doJailbreak super.servant-client-core;
   servant-client = doJailbreak super.servant-client;
   # https://github.com/kowainik/relude/issues/436
-  relude = dontCheck (doJailbreak super.relude);
+  relude = dontCheck super.relude;
 
   fourmolu = overrideCabal (drv: {
     libraryHaskellDepends = drv.libraryHaskellDepends ++ [ self.file-embed ];


### PR DESCRIPTION
###### Description of changes

With the new Stackage LTS 21 snapshot based on GHC 9.4, many of these jailbreaks are no longer necessary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
