### PR TITLE
curl-impersonate-bin: 0.5.3 -> 0.5.4; follow upstream on platforms

### DIFF
--- a/pkgs/tools/networking/curl-impersonate/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/default.nix
@@ -1,12 +1,24 @@
 #TODO: It should be possible to build this from source, but it's currently a lot faster to just package the binaries.
 { lib, stdenv, fetchzip, zlib, autoPatchelfHook }:
+let
+  platformNames = {
+    "x86_64-linux" = "x86_64-linux-gnu";
+    "aarch64-linux" = "aarch64-linux-gnu";
+    "x86_64-darwin" = "x86_64-macos";
+  };
+  hashes = {
+    "x86_64-linux" = "sha256-HrP+bwY9LCL6v0l/ZTjAIRmliCV4cMjr/E5ANPSEnMo=";
+    "aarch64-linux" = "sha256-g44HjTceaHsJpS/tYi5VEwShYa9Z8xuXKOd2c1urBPw=";
+    "x86_64-darwin" = "sha256-9c9lbNTMnlw2OMb+EgeK4beKey/nAxTGKccWdhC3v34=";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "curl-impersonate-bin";
-  version = "v0.5.3";
+  version = "0.5.4";
 
   src = fetchzip {
-    url = "https://github.com/lwthiker/curl-impersonate/releases/download/${version}/curl-impersonate-${version}.x86_64-linux-gnu.tar.gz";
-    sha256 = "sha256-+cH1swAIadIrWG9anzf0dcW6qyBjcKsUHFWdv75F49g=";
+    url = "https://github.com/lwthiker/curl-impersonate/releases/download/v${version}/curl-impersonate-v${version}.${platformNames.${stdenv.system}}.tar.gz";
+    hash = hashes.${stdenv.system};
     stripRoot = false;
   };
 
@@ -17,11 +29,16 @@ stdenv.mkDerivation rec {
     cp * $out/bin
   '';
 
+  installCheckPhase = ''
+    $( ls "$out/bin"/curl_chrome* | head -n 1 ) --version
+  '';
+  doInstallCheck = true;
+
   meta = with lib; {
     description = "curl-impersonate: A special build of curl that can impersonate Chrome & Firefox ";
     homepage = "https://github.com/lwthiker/curl-impersonate";
     license = with licenses; [ curl mit ];
     maintainers = with maintainers; [ deliciouslytyped ];
-    platforms = platforms.linux; #TODO I'm unsure about the restrictions here, feel free to expand the platforms it if it works elsewhere.
+    platforms = lib.attrNames platformNames;
   };
 }


### PR DESCRIPTION
###### Description of changes

v0.5.4

Support all three platforms with upstream binaries (and don't pretend to support other Linux)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Tested that specific curl-disliking pages provide the actual content
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
