### PR TITLE
minichlink: init at version bbe0e83

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10090,6 +10090,13 @@
     githubId = 1651325;
     name = "maralorn";
   };
+  marble = {
+    email = "marble@computer-in.love";
+    matrix = "@marble:chaos.jetzt";
+    github = "cyber-murmel";
+    githubId = 30078229;
+    name = "marble";
+  };
   marcus7070 = {
     email = "marcus@geosol.com.au";
     github = "marcus7070";

--- a/pkgs/development/embedded/minichlink/default.nix
+++ b/pkgs/development/embedded/minichlink/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, libusb1 }:
+
+stdenv.mkDerivation rec {
+  pname = "minichlink";
+  version = "bbe0e8333eca4d3f74b774491be8bf5716c9f27b";
+
+  src = fetchFromGitHub {
+    owner = "cnlohr";
+    repo = "ch32v003fun";
+    rev = version;
+    sha256 = "sha256-hHU+TrBHGtAIt7plD4cKdYDtS6fjPpnXItD6IQdAPgM=";
+  };
+
+  buildInputs = [
+    libusb1.dev
+  ];
+
+  makeFlags = [
+    "-C minichlink"
+  ];
+
+  installPhase = ''
+    install -Dm755 -t $out/bin minichlink/minichlink
+  '' + lib.optionalString stdenv.isLinux ''
+    install -Dm644 -t $out/etc/udev/rules.d minichlink/99-minichlink.rules
+  '';
+
+  meta = with lib; {
+    description = "A free, open mechanism to use the CH-LinkE $4 programming dongle for the CH32V003";
+    homepage = "https://github.com/cnlohr/ch32v003fun/tree/master/minichlink";
+    license = licenses.mit;
+    maintainers = with maintainers; [ marble ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18855,6 +18855,8 @@ with pkgs;
 
   md-tangle = callPackage ../development/tools/literate-programming/md-tangle { };
 
+  minichlink = callPackage ../development/embedded/minichlink { };
+
   # NOTE: Override and set useIcon = false to use Awk instead of Icon.
   noweb = callPackage ../development/tools/literate-programming/noweb { };
 


### PR DESCRIPTION
currently there is no explicit versioning, as it is part of a bigger repo

###### Description of changes
this add the ch32v003 debugging tool by cnlohr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I managed to flash the blink program to the IC using this.
