### PR TITLE
rio: 0.0.8 -> 0.0.9

### DIFF
--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -72,6 +72,9 @@ let tests = {
       qterminal.pkg = p: p.lxqt.qterminal;
       qterminal.kill = true;
 
+      rio.pkg = p: p.rio;
+      rio.cmd = "rio -e $command";
+
       roxterm.pkg = p: p.roxterm;
       roxterm.cmd = "roxterm -e $command";
 

--- a/pkgs/applications/terminal-emulators/rio/default.nix
+++ b/pkgs/applications/terminal-emulators/rio/default.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchFromGitHub
 , rustPlatform
-, gitUpdater
+, nix-update-script
 
 , autoPatchelfHook
 , pkg-config
@@ -68,9 +68,8 @@ rustPlatform.buildRustPackage rec {
   ];
 
   passthru = {
-    updateScript = gitUpdater {
-      rev-prefix = "v";
-      ignoredVersions = ".(rc|beta).*";
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex" "v([0-9.]+)" ];
     };
   };
 

--- a/pkgs/applications/terminal-emulators/rio/default.nix
+++ b/pkgs/applications/terminal-emulators/rio/default.nix
@@ -43,16 +43,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "rio";
-  version = "0.0.8";
+  version = "0.0.9";
 
   src = fetchFromGitHub {
     owner = "raphamorim";
     repo = "rio";
     rev = "v${version}";
-    hash = "sha256-NonIMGBASbkbc5JsHKwfaZ9dGQt1f8+hFh/FFyIlIZs=";
+    hash = "sha256-faK0KShbMUuvFbR2m9oCeWSwwrSxyXNWreODtHFyp5U=";
   };
 
-  cargoHash = "sha256-4IJJtLa25aZkFwkMYpnYyRQLeqoBwncgCjorF6Gx6pk=";
+  cargoHash = "sha256-54uyqk6fW3pHCK7JC5T7c8C/0Hcq0K/PBn71tNwnA0g=";
 
   nativeBuildInputs = [
     autoPatchelfHook
@@ -70,6 +70,11 @@ rustPlatform.buildRustPackage rec {
   buildFeatures = [
     (lib.optionalString withX11 "x11")
     (lib.optionalString withWayland "wayland")
+  ];
+
+  checkFlags = [
+    # Fail to run in sandbox environment.
+    "--skip=screen::context::test"
   ];
 
   postInstall = ''

--- a/pkgs/applications/terminal-emulators/rio/default.nix
+++ b/pkgs/applications/terminal-emulators/rio/default.nix
@@ -4,6 +4,7 @@
 , nix-update-script
 
 , autoPatchelfHook
+, ncurses
 , pkg-config
 
 , gcc-unwrapped
@@ -54,6 +55,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    ncurses
     pkg-config
   ];
 
@@ -61,11 +63,20 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = rlinkLibs;
 
+  outputs = [ "out" "terminfo" ];
+
   buildNoDefaultFeatures = true;
   buildFeatures = [
     (lib.optionalString withX11 "x11")
     (lib.optionalString withWayland "wayland")
   ];
+
+  postInstall = ''
+    install -dm 755 "$terminfo/share/terminfo/r/"
+    tic -xe rio,rio-direct -o "$terminfo/share/terminfo" misc/rio.terminfo
+    mkdir -p $out/nix-support
+    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
+  '';
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/applications/terminal-emulators/rio/default.nix
+++ b/pkgs/applications/terminal-emulators/rio/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , rustPlatform
+, nixosTests
 , nix-update-script
 
 , autoPatchelfHook
@@ -82,6 +83,8 @@ rustPlatform.buildRustPackage rec {
     updateScript = nix-update-script {
       extraArgs = [ "--version-regex" "v([0-9.]+)" ];
     };
+
+    tests.test = nixosTests.terminal-emulators.rio;
   };
 
   meta = {


### PR DESCRIPTION
###### Description of changes

- rio: 0.0.8 -> 0.0.9
- rio: add nixosTests support using terminal-emulators existing set
- rio: install new terminfo file
- rio: replace gitUpdater with nix-update-script

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->