### PR TITLE
rustPlatform.maturinBuildHook: fix postBuild hook to use ./dist contract

### DIFF
--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -24,8 +24,6 @@ maturinBuildHook() {
         ${maturinBuildFlags-}
     )
 
-    runHook postBuild
-
     if [ ! -z "${buildAndTestSubdir-}" ]; then
         popd
     fi
@@ -33,6 +31,9 @@ maturinBuildHook() {
     # Move the wheel to dist/ so that regular Python tooling can find it.
     mkdir -p dist
     mv target/wheels/*.whl dist/
+
+    # These are python build hooks and may depend on ./dist
+    runHook postBuild
 
     echo "Finished maturinBuildHook"
 }

--- a/pkgs/servers/matrix-synapse/plugins/rendezvous.nix
+++ b/pkgs/servers/matrix-synapse/plugins/rendezvous.nix
@@ -29,13 +29,8 @@ buildPythonPackage rec {
     maturinBuildHook
   ]);
 
-  preBuild = ''
-    cd synapse
-  '';
+  buildAndTestSubdir = "synapse";
 
-  postBuild = ''
-    cd ..
-  '';
 
   pythonImportsCheck = [ "matrix_http_rendezvous_synapse" ];
 


### PR DESCRIPTION
This rebuilds approx 1800 packages, hence targeting `staging`.

###### Description of changes

While maturin build hook is part of the rust tooling, it targets python packages.

Some `postBuild`, such as for example the `python-relaxe-deps-hook` depend on
the wheel being already placed inside `./dist`.

This PR ensures that contract and fixes the only package that had used the
maturin build hook and a potentially conflicting custom `postBuild` hook.

Detected via: `rg 'postBuild' $(rg  'maturinBuildHook' . -Nol)`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
