### PR TITLE
python310Packages.ome-zarr: 0.6.1 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/ome-zarr/default.nix
+++ b/pkgs/development/python-modules/ome-zarr/default.nix
@@ -6,47 +6,38 @@
 , pytestCheckHook
 , aiohttp
 , dask
+, distributed
 , fsspec
 , numpy
 , requests
 , scikit-image
-, s3fs
 , toolz
 , zarr
 }:
 
 buildPythonPackage rec {
   pname = "ome-zarr";
-  version = "0.6.1";
+  version = "0.8.0";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "ome";
     repo = "ome-zarr-py";
     rev = "refs/tags/v${version}";
-    hash = "sha256-dpweOuqruh7mAqmSaNbehLCr8OCLe1IZNWV4bpHpTl0=";
+    hash = "sha256-DMBTrDyUmNsrjOsFKrqukJNZ1f/mAjz4aunNUcwVMKg=";
   };
-
-  patches = [
-    # remove after next release:
-    (fetchpatch {
-      name = "fix-writer-bug";
-      url = "https://github.com/ome/ome-zarr-py/commit/c1302e05998dfe2faf94b0f958c92888681f5ffa.patch";
-      hash = "sha256-1WANObABUXkjqeGdnmg0qJ48RcZcuAwgitZyMwiRYUw=";
-    })
-  ];
 
   propagatedBuildInputs = [
     numpy
     dask
+    distributed
     zarr
     fsspec
     aiohttp
     requests
-    s3fs
     scikit-image
     toolz
-  ];
+  ] ++ fsspec.passthru.optional-dependencies.s3;
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
###### Description of changes

Routine update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).