### PR TITLE
cereal: 1.3.0 -> 1.3.2

### DIFF
--- a/pkgs/development/libraries/cereal/default.nix
+++ b/pkgs/development/libraries/cereal/default.nix
@@ -1,35 +1,31 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
-stdenv.mkDerivation rec {
-  pname = "cereal";
-  version = "1.3.0";
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+}:
 
-  nativeBuildInputs = [ cmake ];
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cereal";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "USCiLab";
     repo = "cereal";
-    rev = "v${version}";
-    sha256 = "0hc8wh9dwpc1w1zf5lfss4vg5hmgpblqxbrpp1rggicpx9ar831p";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-HapnwM5oSNKuqoKm5x7+i2zt0sny8z8CePwobz1ITQs=";
   };
 
-  patches = [
-    # https://nvd.nist.gov/vuln/detail/CVE-2020-11105
-    # serialized std::shared_ptr variables cannot always be expected to
-    # serialize back into their original values. This can have any number of
-    # consequences, depending on the context within which this manifests.
-    (fetchpatch {
-      name = "CVE-2020-11105.patch";
-      url = "https://github.com/USCiLab/cereal/commit/f27c12d491955c94583512603bf32c4568f20929.patch";
-      sha256 = "CIkbJ7bAN0MXBhTXQdoQKXUmY60/wQvsdn99FaWt31w=";
-    })
-  ];
+  nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DJUST_INSTALL_CEREAL=yes" ];
 
-  meta = with lib; {
+  meta = {
+    homepage = "https://uscilab.github.io/cereal/";
     description = "A header-only C++11 serialization library";
-    homepage    = "https://uscilab.github.io/cereal/";
-    platforms   = platforms.all;
-    license     = licenses.mit;
+    changelog = "https://github.com/USCiLab/cereal/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ AndersonTorres ];
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
