### PR TITLE
minify: 2.11.1 -> 2.12.7

### DIFF
--- a/pkgs/development/web/minify/default.nix
+++ b/pkgs/development/web/minify/default.nix
@@ -1,24 +1,51 @@
-{ buildGoModule, fetchFromGitHub, lib }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, nix-update-script
+, testers
+, minify
+}:
 
 buildGoModule rec {
   pname = "minify";
-  version = "2.11.1";
+  version = "2.12.7";
 
   src = fetchFromGitHub {
     owner = "tdewolff";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-qna2u+Y4eRGLNvRKDbL/VQud1pn8b1wWzbKQM1p0Yws=";
+    hash = "sha256-V3lFM58ciU9RrIp5s+ZMaCUAfRJxbTuQxusXhLCiGmI=";
   };
 
-  vendorSha256 = "sha256-stj3fOaPM70kF6vTX/DEs4qFq/O0Vq0TFw0J/3L5NmA=";
+  patches = [ ./update-go-version-mod.patch ];
+
+  vendorHash = "sha256-v3ZPaeE1YW9BRXHxGsmN8tHv3ApOY+NivfePctOmYlM=";
+
+  nativeBuildInputs = [ installShellFiles ];
 
   ldflags = [ "-s" "-w" "-X main.Version=${version}" ];
 
+  subPackages = [ "cmd/minify" ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      inherit version;
+      package = minify;
+      command = "minify --version";
+    };
+  };
+
+  postInstall = ''
+    installShellCompletion --cmd minify --bash cmd/minify/bash_completion
+  '';
+
   meta = with lib; {
-    description = "Minifiers for web formats";
-    license = licenses.mit;
+    description = "Go minifiers for web formats";
     homepage = "https://go.tacodewolff.nl/minify";
     downloadPage = "https://github.com/tdewolff/minify";
+    changelog = "https://github.com/tdewolff/minify/releases/tag/v${version}";
+    license = licenses.mit;
   };
 }

--- a/pkgs/development/web/minify/update-go-version-mod.patch
+++ b/pkgs/development/web/minify/update-go-version-mod.patch
@@ -1,0 +1,12 @@
+diff --git a/go.mod b/go.mod
+index cebe363..f9ae9c8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/tdewolff/minify/v2
+ 
+-go 1.13
++go 1.18
+ 
+ require (
+ 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect


### PR DESCRIPTION
###### Description of changes

This PR update minify to its latest relase: https://github.com/tdewolff/minify/releases/tag/v2.12.7

I also made a few adjustments and add bash shell completion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
