### PR TITLE
glfw-wayland-minecraft: init at unstable-2023-06-01

### DIFF
--- a/pkgs/development/libraries/glfw/3.x-wayland-minecraft.nix
+++ b/pkgs/development/libraries/glfw/3.x-wayland-minecraft.nix
@@ -1,0 +1,55 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch2, cmake, extra-cmake-modules
+, libGL, wayland, wayland-protocols, libxkbcommon, libdecor
+}:
+
+stdenv.mkDerivation {
+  version = "unstable-2023-06-01";
+  pname = "glfw-wayland-minecraft";
+
+  src = fetchFromGitHub {
+    owner = "glfw";
+    repo = "GLFW";
+    rev = "3eaf1255b29fdf5c2895856c7be7d7185ef2b241";
+    sha256 = "sha256-UnwuE/3q6I4dS5syagpnqrDEVDK9XSVdyOg7KNkdUUA=";
+  };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://raw.githubusercontent.com/Admicos/minecraft-wayland/15f88a515c63a9716cfdf4090fab8e16543f4ebd/0003-Don-t-crash-on-calls-to-focus-or-icon.patch";
+      hash = "sha256-NZbKh16h+tWXXnz13QcFBFaeGXMNxZKGQb9xJEahFnE=";
+    })
+    (fetchpatch2 {
+      url = "https://raw.githubusercontent.com/Admicos/minecraft-wayland/15f88a515c63a9716cfdf4090fab8e16543f4ebd/0005-Add-warning-about-being-an-unofficial-patch.patch";
+      hash = "sha256-QMUNlnlCeFz5gIVdbM+YXPsrmiOl9cMwuVRSOvlw+T0=";
+    })
+  ];
+
+  propagatedBuildInputs = [ libGL ];
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+
+  buildInputs = [ wayland wayland-protocols libxkbcommon ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DGLFW_BUILD_WAYLAND=ON"
+    "-DGLFW_BUILD_X11=OFF"
+    "-DCMAKE_C_FLAGS=-D_GLFW_EGL_LIBRARY='\"${lib.getLib libGL}/lib/libEGL.so.1\"'"
+  ];
+
+  postPatch = ''
+    substituteInPlace src/wl_init.c \
+      --replace "libxkbcommon.so.0" "${lib.getLib libxkbcommon}/lib/libxkbcommon.so.0"
+
+    substituteInPlace src/wl_init.c \
+      --replace "libdecor-0.so.0" "${lib.getLib libdecor}/lib/libdecor-0.so.0"
+  '';
+
+  meta = with lib; {
+    description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time - with patches to support Minecraft on Wayland";
+    homepage = "https://www.glfw.org/";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ Scrumplex ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21141,6 +21141,7 @@ with pkgs;
   glfw-wayland = glfw.override {
     waylandSupport = true;
   };
+  glfw-wayland-minecraft = callPackage ../development/libraries/glfw/3.x-wayland-minecraft.nix {};
   glfw2 = callPackage ../development/libraries/glfw/2.x.nix { };
   glfw3 = callPackage ../development/libraries/glfw/3.x.nix {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa Kernel OpenGL;


### PR DESCRIPTION
###### Description of changes

This is a special patched version of glfw3, that allows running Minecraft natively on Wayland.
Without these patches the launch usually fails immediately.

This will be used by `prismlauncher` in the future to enable a native Wayland experience.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
