### PR TITLE
creep2: init at unstable-2021-03-25

### DIFF
--- a/pkgs/data/fonts/creep2/default.nix
+++ b/pkgs/data/fonts/creep2/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchFromGitHub, libfaketime
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "creep2";
+  version = "unstable-2021-03-25";
+
+  src = fetchFromGitHub {
+    owner = "raymond-w-ko";
+    repo = pname;
+    rev = "69dc0de03d89f31b8074981cec0be45d4aceb245";
+    sha256 = "sha256-iVppvnqgui/KUZTqYeEX9Qw8k325ix40+AVG49qmGVw=";
+  };
+
+  nativeBuildInputs = [ libfaketime xorg.fonttosfnt xorg.mkfontscale ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    faketime -f "1970-01-01 00:00:01" fonttosfnt -g 2 -m 2 -o creep2.otb creep2-11.bdf
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 creep2.otb creep2-11.bdf -t "$out/share/fonts/misc/"
+    insll -Dm644 creep2.ttf -t "$out/share/fonts/truetype"
+    mkfontdir "$out/share/fonts/misc"
+    mkfontscale "$out/share/fonts/truetype"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A copy of the 'creep' font by romeovs but with a strict character bounding box";
+    homepage = "https://github.com/raymond-w-ko/creep2";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ dariof4 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28710,6 +28710,8 @@ with pkgs;
 
   creep = callPackage ../data/fonts/creep { };
 
+  creep2 = callPackage ../data/fonts/creep2 { };
+
   crimson = callPackage ../data/fonts/crimson { };
 
   crimson-pro = callPackage ../data/fonts/crimson-pro { };


### PR DESCRIPTION
###### Description of changes

Added the `creep2` font, a recreation of the `creep` font with a strict bounding box (the `creep` font renders weird on most modern applications due having negative line and character width spacing)

Closes:  #129888

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
