### PR TITLE
nftables: 1.0.7 -> 1.0.8

### DIFF
--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -4,17 +4,18 @@
 , gmp, jansson, libedit
 , autoreconfHook
 , withDebugSymbols ? false
-, withPython ? false , python3
-, withXtables ? true , iptables
+, withPython ? false, python3
+, withXtables ? true, iptables
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.7";
+  version = "1.0.8";
   pname = "nftables";
 
   src = fetchurl {
     url = "https://netfilter.org/projects/nftables/files/${pname}-${version}.tar.xz";
-    hash = "sha256-wSrJQf/5ra7fFzZ9XOITeJuYoNMUJ3vCKz1x4QiR9BI=";
+    hash = "sha256-k3N0DeQagtvJiBjgpGoHP664qNBon6T6GnQ5nDK/PVA=";
   };
 
   nativeBuildInputs = [
@@ -27,7 +28,10 @@ stdenv.mkDerivation rec {
     libmnl libnftnl libpcap
     gmp jansson libedit
   ] ++ lib.optional withXtables iptables
-    ++ lib.optional withPython python3;
+    ++ lib.optionals withPython [
+      python3
+      python3.pkgs.setuptools
+    ];
 
   configureFlags = [
     "--with-json"
@@ -36,6 +40,11 @@ stdenv.mkDerivation rec {
     ++ lib.optional (!withPython) "--disable-python"
     ++ lib.optional withPython "--enable-python"
     ++ lib.optional withXtables "--with-xtables";
+
+  passthru.tests = {
+    inherit (nixosTests) firewall-nftables lxd-nftables;
+    nat = { inherit (nixosTests.nat.nftables) firewall standalone; };
+  };
 
   meta = with lib; {
     description = "The project that aims to replace the existing {ip,ip6,arp,eb}tables framework";


### PR DESCRIPTION
###### Description of changes
https://www.spinics.net/lists/netfilter/msg61165.html

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).