### PR TITLE
nickel: disable checks on Darwin

### DIFF
--- a/pkgs/development/interpreters/nickel/default.nix
+++ b/pkgs/development/interpreters/nickel/default.nix
@@ -3,13 +3,14 @@
 , fetchFromGitHub
 , python3
 , nix-update-script
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nickel";
   version = "1.1.1";
 
-  src  = fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "tweag";
     repo = pname;
     rev = "refs/tags/${version}";
@@ -23,6 +24,9 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     python3
   ];
+
+  # Disable checks on Darwin because of issue described in https://github.com/tweag/nickel/pull/1454
+  doCheck = !stdenv.isDarwin;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/tools/language-servers/nls/default.nix
+++ b/pkgs/development/tools/language-servers/nls/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , nickel
+, stdenv
 }:
 
 rustPlatform.buildRustPackage {
@@ -11,6 +12,9 @@ rustPlatform.buildRustPackage {
   cargoHash = "sha256-UGfc5cr6vl10aCVihOEEZktF8MzT56C9/wSvSQhCiVs=";
 
   cargoBuildFlags = [ "-p nickel-lang-lsp" ];
+
+  # Disable checks on Darwin because of issue described in https://github.com/tweag/nickel/pull/1454
+  doCheck = !stdenv.isDarwin;
 
   meta = {
     inherit (nickel.meta) homepage changelog license maintainers;


### PR DESCRIPTION

###### Description of changes

Workaround to address build issue introduced in 1.1.1 update.
Upstream issue: https://github.com/tweag/nickel/pull/1454

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
