### PR TITLE
systemd-sysupdate: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -34,6 +34,7 @@
 
 - [ebusd](https://ebusd.eu), a daemon for handling communication with eBUS devices connected to a 2-wire bus system (“energy bus” used by numerous heating systems). Available as [services.ebusd](#opt-services.ebusd.enable).
 
+- [systemd-sysupdate](https://www.freedesktop.org/software/systemd/man/systemd-sysupdate.html), atomically updates the host OS, container images, portable service images or other sources. Available as [systemd.sysupdate](opt-systemd.sysupdate).
 
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1398,6 +1398,7 @@
   ./system/boot/systemd/oomd.nix
   ./system/boot/systemd/repart.nix
   ./system/boot/systemd/shutdown.nix
+  ./system/boot/systemd/sysupdate.nix
   ./system/boot/systemd/tmpfiles.nix
   ./system/boot/systemd/user.nix
   ./system/boot/systemd/userdbd.nix

--- a/nixos/modules/system/boot/systemd/sysupdate.nix
+++ b/nixos/modules/system/boot/systemd/sysupdate.nix
@@ -1,0 +1,142 @@
+{ config, lib, pkgs, utils, ... }:
+
+let
+  cfg = config.systemd.sysupdate;
+
+  format = pkgs.formats.ini { };
+
+  listOfDefinitions = lib.mapAttrsToList
+    (name: format.generate "${name}.conf")
+    (lib.filterAttrs (k: _: !(lib.hasPrefix "_" k)) cfg.transfers);
+
+  definitionsDirectory = pkgs.runCommand "sysupdate.d" { } ''
+    mkdir -p $out
+    ${(lib.concatStringsSep "\n"
+      (map (pkg: "cp ${pkg} $out/${pkg.name}") listOfDefinitions)
+    )}
+  '';
+in
+{
+  options.systemd.sysupdate = {
+
+    enable = lib.mkEnableOption (lib.mdDoc "systemd-sysupdate") // {
+      description = lib.mdDoc ''
+        Atomically update the host OS, container images, portable service
+        images or other sources.
+
+        If enabled, updates are triggered in regular intervals via a
+        `systemd.timer` unit.
+
+        Please see
+        <https://www.freedesktop.org/software/systemd/man/systemd-sysupdate.html>
+        for more details.
+      '';
+    };
+
+    timerConfig = utils.systemdUtils.unitOptions.timerOptions.options.timerConfig // {
+      default = { };
+      description = lib.mdDoc ''
+        The timer configuration for performing the update.
+
+        By default, the upstream configuration is used:
+        <https://github.com/systemd/systemd/blob/main/units/systemd-sysupdate.timer>
+      '';
+    };
+
+    reboot = {
+      enable = lib.mkEnableOption (lib.mdDoc "automatically rebooting after an update") // {
+        description = lib.mdDoc ''
+          Whether to automatically reboot after an update.
+
+          If set to `true`, the system will automatically reboot via a
+          `systemd.timer` unit but only after a new version was installed.
+
+          This uses a unit completely separate from the one performing the
+          update because it is typically advisable to download updates
+          regularly while the system is up, but delay reboots until the
+          appropriate time (i.e. typically at night).
+
+          Set this to `false` if you do not want to reboot after an update. This
+          is useful when you update a container image or another source where
+          rebooting is not necessary in order to finalize the update.
+        '';
+      };
+
+      timerConfig = utils.systemdUtils.unitOptions.timerOptions.options.timerConfig // {
+        default = { };
+        description = lib.mdDoc ''
+          The timer configuration for rebooting after an update.
+
+          By default, the upstream configuration is used:
+          <https://github.com/systemd/systemd/blob/main/units/systemd-sysupdate-reboot.timer>
+        '';
+      };
+    };
+
+    transfers = lib.mkOption {
+      type = with lib.types; attrsOf format.type;
+      default = { };
+      example = {
+        "10-uki.conf" = {
+          Transfer = {
+            ProtectVersion = "%A";
+          };
+
+          Source = {
+            Type = "url-file";
+            Path = "https://download.example.com/";
+            MatchPattern = "nixos_@v.efi.xz";
+          };
+
+          Target = {
+            Type = "regular-file";
+            Path = "/EFI/Linux";
+            PathRelativeTo = "boot";
+            MatchPattern = ''
+              nixos_@v+@l-@d.efi"; \
+              nixos_@v+@l.efi \
+              nixos_@v.efi
+            '';
+            Mode = "0444";
+            TriesLeft = 3;
+            TriesDone = 0;
+            InstancesMax = 2;
+          };
+        };
+      };
+      description = lib.mdDoc ''
+        Specify transfers as a set of the names of the transfer files as the
+        key and the configuration as its value. The configuration can use all
+        upstream options. See
+        <https://www.freedesktop.org/software/systemd/man/sysupdate.d.html>
+        for all available options.
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    systemd.additionalUpstreamSystemUnits = [
+      "systemd-sysupdate.service"
+      "systemd-sysupdate.timer"
+      "systemd-sysupdate-reboot.service"
+      "systemd-sysupdate-reboot.timer"
+    ];
+
+    systemd.timers = {
+      "systemd-sysupdate" = {
+        wantedBy = [ "timers.target" ];
+        timerConfig = cfg.timerConfig;
+      };
+      "systemd-sysupdate-reboot" = lib.mkIf cfg.reboot.enable {
+        wantedBy = [ "timers.target" ];
+        timerConfig = cfg.reboot.timerConfig;
+      };
+    };
+
+    environment.etc."sysupdate.d".source = definitionsDirectory;
+  };
+
+  meta.maintainers = with lib.maintainers; [ nikstur ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -772,6 +772,7 @@ in {
   systemd-portabled = handleTest ./systemd-portabled.nix {};
   systemd-repart = handleTest ./systemd-repart.nix {};
   systemd-shutdown = handleTest ./systemd-shutdown.nix {};
+  systemd-sysupdate = runTest ./systemd-sysupdate.nix;
   systemd-timesyncd = handleTest ./systemd-timesyncd.nix {};
   systemd-user-tmpfiles-rules = handleTest ./systemd-user-tmpfiles-rules.nix {};
   systemd-misc = handleTest ./systemd-misc.nix {};

--- a/nixos/tests/common/gpg-keyring.nix
+++ b/nixos/tests/common/gpg-keyring.nix
@@ -1,0 +1,23 @@
+{ pkgs, ... }:
+
+pkgs.runCommand "gpg-keyring" { nativeBuildInputs = [ pkgs.gnupg ]; } ''
+  mkdir -p $out
+  export GNUPGHOME=$out
+  cat > foo <<EOF
+    %echo Generating a basic OpenPGP key
+    %no-protection
+    Key-Type: DSA
+    Key-Length: 1024
+    Subkey-Type: ELG-E
+    Subkey-Length: 1024
+    Name-Real: Bob Foobar
+    Name-Email: bob@foo.bar
+    Expire-Date: 0
+    # Do a commit here, so that we can later print "done"
+    %commit
+    %echo done
+  EOF
+  gpg --batch --generate-key foo
+  rm $out/S.gpg-agent $out/S.gpg-agent.*
+  gpg --export bob@foo.bar -a > $out/pubkey.gpg
+''

--- a/nixos/tests/common/gpg-keyring.nix
+++ b/nixos/tests/common/gpg-keyring.nix
@@ -6,10 +6,8 @@ pkgs.runCommand "gpg-keyring" { nativeBuildInputs = [ pkgs.gnupg ]; } ''
   cat > foo <<EOF
     %echo Generating a basic OpenPGP key
     %no-protection
-    Key-Type: DSA
-    Key-Length: 1024
-    Subkey-Type: ELG-E
-    Subkey-Length: 1024
+    Key-Type: EdDSA
+    Key-Curve: ed25519
     Name-Real: Bob Foobar
     Name-Email: bob@foo.bar
     Expire-Date: 0

--- a/nixos/tests/systemd-nspawn.nix
+++ b/nixos/tests/systemd-nspawn.nix
@@ -1,26 +1,6 @@
 import ./make-test-python.nix ({pkgs, lib, ...}:
 let
-  gpgKeyring = (pkgs.runCommand "gpg-keyring" { buildInputs = [ pkgs.gnupg ]; } ''
-    mkdir -p $out
-    export GNUPGHOME=$out
-    cat > foo <<EOF
-      %echo Generating a basic OpenPGP key
-      %no-protection
-      Key-Type: DSA
-      Key-Length: 1024
-      Subkey-Type: ELG-E
-      Subkey-Length: 1024
-      Name-Real: Bob Foobar
-      Name-Email: bob@foo.bar
-      Expire-Date: 0
-      # Do a commit here, so that we can later print "done"
-      %commit
-      %echo done
-    EOF
-    gpg --batch --generate-key foo
-    rm $out/S.gpg-agent $out/S.gpg-agent.*
-    gpg --export bob@foo.bar -a > $out/pubkey.gpg
-  '');
+  gpgKeyring = import ./common/gpg-keyring.nix { inherit pkgs; };
 
   nspawnImages = (pkgs.runCommand "localhost" { buildInputs = [ pkgs.coreutils pkgs.gnupg ]; } ''
     mkdir -p $out

--- a/nixos/tests/systemd-sysupdate.nix
+++ b/nixos/tests/systemd-sysupdate.nix
@@ -1,0 +1,66 @@
+# Tests downloading a signed update aritfact from a server to a target machine.
+# This test does not rely on the `systemd.timer` units provided by the
+# `systemd-sysupdate` module but triggers the `systemd-sysupdate` service
+# manually to make the test more robust.
+
+{ lib, pkgs, ... }:
+
+let
+  gpgKeyring = import ./common/gpg-keyring.nix { inherit pkgs; };
+in
+{
+  name = "systemd-sysupdate";
+
+  meta.maintainers = with lib.maintainers; [ nikstur ];
+
+  nodes = {
+    server = { pkgs, ... }: {
+      networking.firewall.enable = false;
+      services.nginx = {
+        enable = true;
+        virtualHosts."server" = {
+          root = pkgs.runCommand "sysupdate-artifacts" { buildInputs = [ pkgs.gnupg ]; } ''
+            mkdir -p $out
+            cd $out
+
+            echo "nixos" > nixos_1.efi
+            sha256sum nixos_1.efi > SHA256SUMS
+
+            export GNUPGHOME="$(mktemp -d)"
+            cp -R ${gpgKeyring}/* $GNUPGHOME
+
+            gpg --batch --sign --detach-sign --output SHA256SUMS.gpg SHA256SUMS
+          '';
+        };
+      };
+    };
+
+    target = {
+      systemd.sysupdate = {
+        enable = true;
+        transfers = {
+          "uki" = {
+            Source = {
+              Type = "url-file";
+              Path = "http://server/";
+              MatchPattern = "nixos_@v.efi";
+            };
+            Target = {
+              Path = "/boot/EFI/Linux";
+              MatchPattern = "nixos_@v.efi";
+            };
+          };
+        };
+      };
+
+      environment.etc."systemd/import-pubring.gpg".source = "${gpgKeyring}/pubkey.gpg";
+    };
+  };
+
+  testScript = ''
+    server.wait_for_unit("nginx.service")
+
+    target.succeed("systemctl start systemd-sysupdate")
+    assert "nixos" in target.wait_until_succeeds("cat /boot/EFI/Linux/nixos_1.efi", timeout=5)
+  '';
+}


### PR DESCRIPTION
###### Description of changes

Introduces systemd-sysupdate. Among other things, this enables partition based A/B updates for NixOS appliances that do not rely on the traditional NixOS generations mechanism. 

The first commit factors the generation of a gpg-keyring out of `nixos/tests/systemd-nspawn` into `nixos/tests/common/gpg-keyring.nix` so it can be re-used for testing systemd-sysupdate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
