### PR TITLE
vintagestory: add support for experimental .net 7 build

### DIFF
--- a/pkgs/games/vintagestory/default.nix
+++ b/pkgs/games/vintagestory/default.nix
@@ -13,20 +13,39 @@
 , libGLU
 , SDL2
 , freealut
+, libglvnd
+, pipewire
+, libpulseaudio
+, experimental ? false
+, dotnet-runtime_7
 }:
 
 stdenv.mkDerivation rec {
   pname = "vintagestory";
-  version = "1.18.6";
+  version = if experimental then "1.18.6" else "1.18.6";
 
-  src = fetchurl {
-    url = "https://cdn.vintagestory.at/gamefiles/stable/vs_archive_${version}.tar.gz";
-    sha256 = "sha256-Sa5R/Msg36pKRpZJXXJgM4lcCADJX9x81fMnTD3tjAI=";
-  };
+  src =
+    if experimental
+    then
+      (fetchurl {
+        url = "https://cdn.vintagestory.at/gamefiles/net7/vs_client_linux-x64_${version}.tar.gz";
+        sha256 = "sha256-h4TyMDFid3eB6oPJix92/tmS0v+Ox6CFSRyn/JRNbxg=";
+      })
+    else
+      (fetchurl {
+        url = "https://cdn.vintagestory.at/gamefiles/stable/vs_archive_${version}.tar.gz";
+        sha256 = "sha256-Sa5R/Msg36pKRpZJXXJgM4lcCADJX9x81fMnTD3tjAI=";
+      });
+
 
   nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
-  buildInputs = [ mono ];
+  buildInputs =
+    if experimental then [
+      dotnet-runtime_7
+    ] else [
+      mono
+    ];
 
   runtimeLibs = lib.makeLibraryPath ([
     gtk2
@@ -36,6 +55,9 @@ stdenv.mkDerivation rec {
     libGLU
     SDL2
     freealut
+    libglvnd
+    pipewire
+    libpulseaudio
   ] ++ (with xorg; [
     libX11
     libXi
@@ -43,7 +65,7 @@ stdenv.mkDerivation rec {
 
   desktopItems = makeDesktopItem {
     name = "vintagestory";
-    desktopName = "Vintage Story";
+    desktopName = if experimental then "Vintage Story Experimental .net 7" else "Vintage Story";
     exec = "vintagestory";
     icon = "vintagestory";
     comment = "Innovate and explore in a sandbox world";
@@ -61,14 +83,21 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  preFixup = ''
+  preFixup = (if experimental then ''
+    makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --add-flags $out/share/vintagestory/Vintagestory.dll
+    makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory-server \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --add-flags $out/share/vintagestory/VintagestoryServer.dll
+  '' else ''
     makeWrapper ${mono}/bin/mono $out/bin/vintagestory \
       --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
       --add-flags $out/share/vintagestory/Vintagestory.exe
     makeWrapper ${mono}/bin/mono $out/bin/vintagestory-server \
       --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
       --add-flags $out/share/vintagestory/VintagestoryServer.exe
-
+  '') + ''
     find "$out/share/vintagestory/assets/" -not -path "*/fonts/*" -regex ".*/.*[A-Z].*" | while read -r file; do
       local filename="$(basename -- "$file")"
       ln -sf "$filename" "''${file%/*}"/"''${filename,,}"

--- a/pkgs/games/vintagestory/default.nix
+++ b/pkgs/games/vintagestory/default.nix
@@ -108,6 +108,6 @@ stdenv.mkDerivation rec {
     description = "An in-development indie sandbox game about innovation and exploration";
     homepage = "https://www.vintagestory.at/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ artturin ];
+    maintainers = with maintainers; [ artturin gigglesquid ];
   };
 }


### PR DESCRIPTION
Future versions (1.19+) will be built exclusively on .net 7, see: https://www.vintagestory.at/blog.html/news/v1186-stable-security-patch-r360/ and https://www.vintagestory.at/blog.html/news/v1186-rc2-hunting-the-performance-leak-r359/ This change crates the foundations for suporting .net 7 going forward and adds an override option to enable the experimental .net 7 build

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
