### PR TITLE
mlt: fix binary not being wrapped if enableQt is disabled

### DIFF
--- a/pkgs/development/libraries/mlt/default.nix
+++ b/pkgs/development/libraries/mlt/default.nix
@@ -13,6 +13,7 @@
 , libsamplerate
 , libvorbis
 , libxml2
+, makeWrapper
 , movit
 , opencv4
 , rtaudio
@@ -52,6 +53,7 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
     which
+    makeWrapper
   ] ++ lib.optionals cudaSupport [
     cudaPackages.cuda_nvcc
   ] ++ lib.optionals enablePython [
@@ -102,11 +104,13 @@ stdenv.mkDerivation rec {
     "-DSWIG_PYTHON=ON"
   ];
 
-  qtWrapperArgs = [
-    "--prefix FREI0R_PATH : ${frei0r}/lib/frei0r-1"
-  ] ++ lib.optionals enableJackrack [
-    "--prefix LADSPA_PATH : ${ladspaPlugins}/lib/ladspa"
-  ];
+  preFixup = ''
+    wrapProgram $out/bin/melt \
+      --prefix FREI0R_PATH : ${frei0r}/lib/frei0r-1 \
+      ${lib.optionalString enableJackrack "--prefix LADSPA_PATH : ${ladspaPlugins}/lib/ladspa"} \
+      ${lib.optionalString enableQt "\${qtWrapperArgs[@]}"}
+
+  '';
 
   postFixup = ''
     substituteInPlace "$dev"/lib/pkgconfig/mlt-framework-7.pc \


### PR DESCRIPTION
###### Description of changes
Melt, by default, uses the wrapQtAppsHook flags to wrap the binary to find both LADSPA and frei0r and because of that can't find some essential plugins to do rendering.

It also has limited support for kdenlive project effects if enableQt is disabled but that's another story.

This PR fixes the wrapping of the binary if enableQt is disabled. That fixes a warning asking about frei0r. I tested with a simple Kdenlive project with that zoom blur effect that still was only nicely rendered with Qt enabled and with a valid DISPLAY value. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
