### PR TITLE
fetch9front: init

### DIFF
--- a/pkgs/build-support/fetch9front/default.nix
+++ b/pkgs/build-support/fetch9front/default.nix
@@ -1,0 +1,36 @@
+{ fetchgit, fetchzip, lib }:
+
+lib.makeOverridable (
+  { owner
+  , repo
+  , rev
+  , domain ? "git.9front.org"
+  , name ? "source"
+  , leaveDotGit ? false
+  , deepClone ? false
+  , ... # For hash agility
+  } @ args:
+
+  let
+    passthruAttrs = removeAttrs args [ "domain" "owner" "repo" "rev" "leaveDotGit" "deepClone" ];
+
+    useFetchGit = leaveDotGit || deepClone;
+    fetcher = if useFetchGit then fetchgit else fetchzip;
+
+    gitRepoUrl = "git://${domain}/${owner}/${repo}";
+
+    fetcherArgs = (if useFetchGit then {
+      # git9 does not support shallow fetches
+      inherit rev leaveDotGit;
+      url = gitRepoUrl;
+    } else {
+      url = "https://${domain}/${owner}/${repo}/${rev}/snap.tar.gz";
+
+      passthru = {
+        inherit gitRepoUrl;
+      };
+    }) // passthruAttrs // { inherit name; };
+  in
+
+  fetcher fetcherArgs // { inherit rev; }
+)

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -12,6 +12,7 @@
 , branch ? null
 , stableVersion ? false # Use version format according to RFC 107 (i.e. LAST_TAG+date=YYYY-MM-DD)
 , tagPrefix ? "" # strip this prefix from a tag name when using stable version
+, shallowClone ? true
 }:
 
 let
@@ -22,6 +23,7 @@ let
     branch=""
     use_stable_version=""
     tag_prefix=""
+    shallow_clone=""
 
     while (( $# > 0 )); do
         flag="$1"
@@ -38,6 +40,9 @@ let
             ;;
           --tag-prefix=*)
             tag_prefix="''${flag#*=}"
+            ;;
+          --shallow-clone)
+            shallow_clone=1
             ;;
           *)
             echo "$0: unknown option ‘''${flag}’"
@@ -58,8 +63,11 @@ let
 
     cloneArgs=(
       --bare
-      --depth=1
     )
+
+    if [[ "$shallow_clone" == "1" ]]; then
+        cloneArgs+=(--depth=1)
+    fi
 
     if [[ -n "$branch" ]]; then
         cloneArgs+=(--branch="$branch")
@@ -101,7 +109,8 @@ let
         --rev="$commit_sha"
   '';
 
-in [
+in
+[
   updateScript
   "--url=${builtins.toString url}"
 ] ++ lib.optionals (branch != null) [
@@ -109,4 +118,6 @@ in [
 ] ++ lib.optionals stableVersion [
   "--use-stable-version"
   "--tag-prefix=${tagPrefix}"
+] ++ lib.optionals shallowClone [
+  "--shallow-clone"
 ]

--- a/pkgs/shells/rc-9front/default.nix
+++ b/pkgs/shells/rc-9front/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
-, fetchgit
+, fetchFrom9Front
+, unstableGitUpdater
 , byacc
 , installShellFiles
 }:
@@ -9,8 +10,10 @@ stdenv.mkDerivation {
   pname = "rc-9front";
   version = "unstable-2022-11-01";
 
-  src = fetchgit {
-    url = "git://shithub.us/cinap_lenrek/rc";
+  src = fetchFrom9Front {
+    domain = "shithub.us";
+    owner = "cinap_lenrek";
+    repo = "rc";
     rev = "69041639483e16392e3013491fcb382efd2b9374";
     hash = "sha256-xc+EfC4bc9ZA97jCQ6CGCzeLGf+Hx3/syl090/x4ew4=";
   };
@@ -31,7 +34,10 @@ stdenv.mkDerivation {
     install -m644 rcmain.unix $out/lib/rcmain
   '';
 
-  passthru.shellPath = "/bin/rc";
+  passthru = {
+    shellPath = "/bin/rc";
+    updateScript = unstableGitUpdater { shallowClone = false; };
+  };
 
   meta = with lib; {
     description = "The 9front shell";

--- a/pkgs/tools/admin/drawterm/default.nix
+++ b/pkgs/tools/admin/drawterm/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
-, fetchgit
+, fetchFrom9Front
+, unstableGitUpdater
 , installShellFiles
 , makeWrapper
 , xorg
@@ -19,10 +20,11 @@ stdenv.mkDerivation {
   pname = "drawterm";
   version = "unstable-2023-06-27";
 
-  src = fetchgit {
-    url = "git://git.9front.org/plan9front/drawterm";
+  src = fetchFrom9Front {
+    owner = "plan9front";
+    repo = "drawterm";
     rev = "36debf46ac184a22c6936345d22e4cfad995948c";
-    sha256 = "ebqw1jqeRC0FWeUIO/HaEovuwzU6+B48TjZbVJXByvA=";
+    hash = "sha256-ebqw1jqeRC0FWeUIO/HaEovuwzU6+B48TjZbVJXByvA=";
   };
 
   enableParallelBuilding = true;
@@ -53,6 +55,8 @@ stdenv.mkDerivation {
   }."${config}" or (throw "unsupported CONF") + ''
     installManPage drawterm.1
   '';
+
+  passthru.updateScript = unstableGitUpdater { shallowClone = false; };
 
   meta = with lib; {
     description = "Connect to Plan 9 CPU servers from other operating systems.";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1122,6 +1122,8 @@ with pkgs;
 
   fetchFromGitiles = callPackage ../build-support/fetchgitiles { };
 
+  fetchFrom9Front = callPackage ../build-support/fetch9front { };
+
   fetchFromRepoOrCz = callPackage ../build-support/fetchrepoorcz { };
 
   fetchgx = callPackage ../build-support/fetchgx { };


### PR DESCRIPTION
###### Description of changes

This adds a `fetchFrom9Front`.
This updates two packages to use this new fetcher.
These git servers do not support shallow clones, so in order to facilitate `passthru.updateScript` these I added a argument to disable the shallow clones for `unstableGitUpdater`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
