### PR TITLE
scanmem: enable GUI, some drive-by cleanups

### DIFF
--- a/pkgs/tools/misc/scanmem/default.nix
+++ b/pkgs/tools/misc/scanmem/default.nix
@@ -1,8 +1,18 @@
-{ lib, stdenv, autoconf, automake, intltool, libtool, fetchFromGitHub, readline }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, gobject-introspection
+, intltool
+, wrapGAppsHook
+, procps
+, python3
+, readline
+}:
 
 stdenv.mkDerivation rec {
-  version = "0.17";
   pname = "scanmem";
+  version = "0.17";
 
   src = fetchFromGitHub {
     owner  = "scanmem";
@@ -11,12 +21,27 @@ stdenv.mkDerivation rec {
     sha256 = "17p8sh0rj8yqz36ria5bp48c8523zzw3y9g8sbm2jwq7sc27i7s9";
   };
 
-  nativeBuildInputs = [ autoconf automake intltool libtool ];
-  buildInputs = [ readline ];
+  nativeBuildInputs = [ autoreconfHook gobject-introspection intltool wrapGAppsHook ];
+  buildInputs = [ readline python3 ];
+  configureFlags = ["--enable-gui"];
 
-  preConfigure = ''
-    ./autogen.sh
+  # we don't need to wrap the main executable, just the GUI
+  dontWrapGApps = true;
+
+  fixupPhase = ''
+    runHook preFixup
+
+    # replace the upstream launcher which does stupid things
+    # also add procps because it shells out to `ps` and expects it to be procps
+    makeWrapper ${python3}/bin/python3 $out/bin/gameconqueror \
+      "''${gappsWrapperArgs[@]}" \
+      --set PYTHONPATH "${python3.pkgs.makePythonPath [ python3.pkgs.pygobject3 ]}" \
+      --prefix PATH : "${procps}/bin" \
+      --add-flags "$out/share/gameconqueror/GameConqueror.py"
+
+    runHook postFixup
   '';
+
   meta = with lib; {
     homepage = "https://github.com/scanmem/scanmem";
     description = "Memory scanner for finding and poking addresses in executing processes";


### PR DESCRIPTION
###### Description of changes

Requested on Matrix. Seems to work? Upstream launcher unconditionally runs this with pkexec, we probably don't want that, but we can keep it if someone thinks it's a good idea.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
