### PR TITLE
nextcloud.generate.sh: update script

### DIFF
--- a/pkgs/servers/nextcloud/packages/generate.sh
+++ b/pkgs/servers/nextcloud/packages/generate.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -I nixpkgs=../../../.. -i bash -p nc4nix
+#!nix-shell nc4nix-shell.nix -i bash
 
 set -e
 set -u
 set -o pipefail
 set -x
 
-export NEXTCLOUD_VERSIONS=$(nix-instantiate --eval -E 'import ./nc-versions.nix {}' -A e)
+echo "versions: $NEXTCLOUD_VERSIONS"
 
-APPS=`cat nextcloud-apps.json | jq -r '.[]' | sed -z 's/\n/,/g;s/,$/\n/'`
+APPS=$(jq -r '.[]' "$SCRIPT_FOLDER"/nextcloud-apps.json | sed -z 's/\n/,/g;s/,$/\n/')
 
-nc4nix -apps $APPS
-rm *.log
+# nc4nix needs NEXTCLOUD_VERSIONS
+nc4nix -apps "$APPS"
+rm ./*.log

--- a/pkgs/servers/nextcloud/packages/nc4nix-shell.nix
+++ b/pkgs/servers/nextcloud/packages/nc4nix-shell.nix
@@ -1,0 +1,21 @@
+{ pkgs ? import ../../../.. { }
+}:
+let
+  lib = pkgs.lib;
+  n = lib.mapAttrsToList (_: v: v.version) (
+      lib.filterAttrs (k: v: builtins.match "nextcloud[0-9]+" k != null && (builtins.tryEval v.version).success)
+    pkgs);
+
+in
+
+with pkgs;
+mkShell {
+  packages = [
+    jq
+    nc4nix
+    gnused
+  ];
+
+  NEXTCLOUD_VERSIONS = lib.concatStringsSep "," n;
+  SCRIPT_FOLDER=./.;
+}


### PR DESCRIPTION
so that it can be run from any folder.
it's also now more portable as it makes sure to run with nixpkgs' sed and jq (which were assumed to be installed before this PR).

cc @onny 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
