### PR TITLE
nixos/nvidia: clean up and add dynamic boost

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -1,21 +1,14 @@
-# This module provides the proprietary NVIDIA X11 / OpenGL drivers.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  nvidia_x11 =
+    if (lib.elem "nvidia" config.services.xserver.videoDrivers)
+    then cfg.package
+    else null;
 
-{ config, lib, pkgs, ... }:
-
-with lib;
-
-let
-  nvidia_x11 = let
-    drivers = config.services.xserver.videoDrivers;
-    isDeprecated = str: (hasPrefix "nvidia" str) && (str != "nvidia");
-    hasDeprecated = drivers: any isDeprecated drivers;
-  in if (hasDeprecated drivers) then
-    throw ''
-      Selecting an nvidia driver has been modified for NixOS 19.03. The version is now set using `hardware.nvidia.package`.
-    ''
-  else if (elem "nvidia" drivers) then cfg.package else null;
-
-  enabled = nvidia_x11 != null;
   cfg = config.hardware.nvidia;
 
   pCfg = cfg.prime;
@@ -23,90 +16,62 @@ let
   offloadCfg = pCfg.offload;
   reverseSyncCfg = pCfg.reverseSync;
   primeEnabled = syncCfg.enable || reverseSyncCfg.enable || offloadCfg.enable;
-  nvidiaPersistencedEnabled =  cfg.nvidiaPersistenced;
-  nvidiaSettings = cfg.nvidiaSettings;
-  busIDType = types.strMatching "([[:print:]]+[\:\@][0-9]{1,3}\:[0-9]{1,2}\:[0-9])?";
-
+  busIDType = lib.types.strMatching "([[:print:]]+[\:\@][0-9]{1,3}\:[0-9]{1,2}\:[0-9])?";
   ibtSupport = cfg.open || (nvidia_x11.ibtSupport or false);
-in
-
-{
-  imports =
-    [
-      (mkRenamedOptionModule [ "hardware" "nvidia" "optimus_prime" "enable" ] [ "hardware" "nvidia" "prime" "sync" "enable" ])
-      (mkRenamedOptionModule [ "hardware" "nvidia" "optimus_prime" "allowExternalGpu" ] [ "hardware" "nvidia" "prime" "allowExternalGpu" ])
-      (mkRenamedOptionModule [ "hardware" "nvidia" "prime" "sync" "allowExternalGpu" ] [ "hardware" "nvidia" "prime" "allowExternalGpu" ])
-      (mkRenamedOptionModule [ "hardware" "nvidia" "optimus_prime" "nvidiaBusId" ] [ "hardware" "nvidia" "prime" "nvidiaBusId" ])
-      (mkRenamedOptionModule [ "hardware" "nvidia" "optimus_prime" "intelBusId" ] [ "hardware" "nvidia" "prime" "intelBusId" ])
-    ];
-
+in {
   options = {
-    hardware.nvidia.powerManagement.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = lib.mdDoc ''
-        Experimental power management through systemd. For more information, see
+    hardware.nvidia = {
+      powerManagement.enable = lib.mkEnableOption (lib.mdDoc ''
+        experimental power management through systemd. For more information, see
         the NVIDIA docs, on Chapter 21. Configuring Power Management Support.
-      '';
-    };
+      '');
 
-    hardware.nvidia.powerManagement.finegrained = mkOption {
-      type = types.bool;
-      default = false;
-      description = lib.mdDoc ''
-        Experimental power management of PRIME offload. For more information, see
-        the NVIDIA docs, chapter 22. PCI-Express runtime power management.
-      '';
-    };
+      powerManagement.finegrained = lib.mkEnableOption (lib.mdDoc ''
+        experimental power management of PRIME offload. For more information, see
+        the NVIDIA docs, on Chapter 22. PCI-Express Runtime D3 (RTD3) Power Management.
+      '');
 
-    hardware.nvidia.modesetting.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = lib.mdDoc ''
-        Enable kernel modesetting when using the NVIDIA proprietary driver.
+      modesetting.enable = lib.mkEnableOption (lib.mdDoc ''
+        kernel modesetting when using the NVIDIA proprietary driver.
 
         Enabling this fixes screen tearing when using Optimus via PRIME (see
         {option}`hardware.nvidia.prime.sync.enable`. This is not enabled
         by default because it is not officially supported by NVIDIA and would not
         work with SLI.
-      '';
-    };
+      '');
 
-    hardware.nvidia.prime.nvidiaBusId = mkOption {
-      type = busIDType;
-      default = "";
-      example = "PCI:1:0:0";
-      description = lib.mdDoc ''
-        Bus ID of the NVIDIA GPU. You can find it using lspci; for example if lspci
-        shows the NVIDIA GPU at "01:00.0", set this option to "PCI:1:0:0".
-      '';
-    };
+      prime.nvidiaBusId = lib.mkOption {
+        type = busIDType;
+        default = "";
+        example = "PCI:1:0:0";
+        description = lib.mdDoc ''
+          Bus ID of the NVIDIA GPU. You can find it using lspci; for example if lspci
+          shows the NVIDIA GPU at "01:00.0", set this option to "PCI:1:0:0".
+        '';
+      };
 
-    hardware.nvidia.prime.intelBusId = mkOption {
-      type = busIDType;
-      default = "";
-      example = "PCI:0:2:0";
-      description = lib.mdDoc ''
-        Bus ID of the Intel GPU. You can find it using lspci; for example if lspci
-        shows the Intel GPU at "00:02.0", set this option to "PCI:0:2:0".
-      '';
-    };
+      prime.intelBusId = lib.mkOption {
+        type = busIDType;
+        default = "";
+        example = "PCI:0:2:0";
+        description = lib.mdDoc ''
+          Bus ID of the Intel GPU. You can find it using lspci; for example if lspci
+          shows the Intel GPU at "00:02.0", set this option to "PCI:0:2:0".
+        '';
+      };
 
-    hardware.nvidia.prime.amdgpuBusId = mkOption {
-      type = busIDType;
-      default = "";
-      example = "PCI:4:0:0";
-      description = lib.mdDoc ''
-        Bus ID of the AMD APU. You can find it using lspci; for example if lspci
-        shows the AMD APU at "04:00.0", set this option to "PCI:4:0:0".
-      '';
-    };
+      prime.amdgpuBusId = lib.mkOption {
+        type = busIDType;
+        default = "";
+        example = "PCI:4:0:0";
+        description = lib.mdDoc ''
+          Bus ID of the AMD APU. You can find it using lspci; for example if lspci
+          shows the AMD APU at "04:00.0", set this option to "PCI:4:0:0".
+        '';
+      };
 
-    hardware.nvidia.prime.sync.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = lib.mdDoc ''
-        Enable NVIDIA Optimus support using the NVIDIA proprietary driver via PRIME.
+      prime.sync.enable = lib.mkEnableOption (lib.mdDoc ''
+        NVIDIA Optimus support using the NVIDIA proprietary driver via PRIME.
         If enabled, the NVIDIA GPU will be always on and used for all rendering,
         while enabling output to displays attached only to the integrated Intel/AMD
         GPU without a multiplexer.
@@ -127,54 +92,38 @@ in
         Note that this configuration will only be successful when a display manager
         for which the {option}`services.xserver.displayManager.setupCommands`
         option is supported is used.
-      '';
-    };
+      '');
 
-    hardware.nvidia.prime.allowExternalGpu = mkOption {
-      type = types.bool;
-      default = false;
-      description = lib.mdDoc ''
-        Configure X to allow external NVIDIA GPUs when using Prime [Reverse] sync optimus.
-      '';
-    };
+      prime.allowExternalGpu = lib.mkEnableOption (lib.mdDoc ''
+        configuring X to allow external NVIDIA GPUs when using Prime [Reverse] sync optimus.
+      '');
 
-    hardware.nvidia.prime.offload.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = lib.mdDoc ''
-        Enable render offload support using the NVIDIA proprietary driver via PRIME.
+      prime.offload.enable = lib.mkEnableOption (lib.mdDoc ''
+        render offload support using the NVIDIA proprietary driver via PRIME.
 
         If this is enabled, then the bus IDs of the NVIDIA and Intel/AMD GPUs have to
         be specified ({option}`hardware.nvidia.prime.nvidiaBusId` and
         {option}`hardware.nvidia.prime.intelBusId` or
         {option}`hardware.nvidia.prime.amdgpuBusId`).
-      '';
-    };
+      '');
 
-    hardware.nvidia.prime.offload.enableOffloadCmd = mkOption {
-      type = types.bool;
-      default = false;
-      description = lib.mdDoc ''
-        Adds a `nvidia-offload` convenience script to {option}`environment.systemPackages`
+      prime.offload.enableOffloadCmd = lib.mkEnableOption (lib.mdDoc ''
+        adding a `nvidia-offload` convenience script to {option}`environment.systemPackages`
         for offloading programs to an nvidia device. To work, should have also enabled
         {option}`hardware.nvidia.prime.offload.enable` or {option}`hardware.nvidia.prime.reverseSync.enable`.
 
         Example usage `nvidia-offload sauerbraten_client`.
-      '';
-    };
+      '');
 
-    hardware.nvidia.prime.reverseSync.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = lib.mdDoc ''
-        Warning: This feature is relatively new, depending on your system this might
-        work poorly. AMD support, especially so.
-        See: https://forums.developer.nvidia.com/t/the-all-new-outputsink-feature-aka-reverse-prime/129828
-
-        Enable NVIDIA Optimus support using the NVIDIA proprietary driver via reverse
+      prime.reverseSync.enable = lib.mkEnableOption (lib.mdDoc ''
+        NVIDIA Optimus support using the NVIDIA proprietary driver via reverse
         PRIME. If enabled, the Intel/AMD GPU will be used for all rendering, while
         enabling output to displays attached only to the NVIDIA GPU without a
         multiplexer.
+
+        Warning: This feature is relatively new, depending on your system this might
+        work poorly. AMD support, especially so.
+        See: https://forums.developer.nvidia.com/t/the-all-new-outputsink-feature-aka-reverse-prime/129828
 
         Note that this option only has any effect if the "nvidia" driver is specified
         in {option}`services.xserver.videoDrivers`, and it should preferably
@@ -192,316 +141,326 @@ in
         Note that this configuration will only be successful when a display manager
         for which the {option}`services.xserver.displayManager.setupCommands`
         option is supported is used.
-      '';
-    };
+      '');
 
-    hardware.nvidia.nvidiaSettings = mkOption {
-      default = true;
-      type = types.bool;
-      description = lib.mdDoc ''
-        Whether to add nvidia-settings, NVIDIA's GUI configuration tool, to
-        systemPackages.
-      '';
-    };
+      nvidiaSettings =
+        (lib.mkEnableOption (lib.mdDoc ''
+          nvidia-settings, NVIDIA's GUI configuration tool.
+        ''))
+        // {default = true;};
 
-    hardware.nvidia.nvidiaPersistenced = mkOption {
-      default = false;
-      type = types.bool;
-      description = lib.mdDoc ''
-        Update for NVIDA GPU headless mode, i.e. nvidia-persistenced. It ensures all
-        GPUs stay awake even during headless mode.
-      '';
-    };
+      nvidiaPersistenced = lib.mkEnableOption (lib.mdDoc ''
+        nvidia-persistenced a update for NVIDIA GPU headless mode, i.e.
+        It ensures all GPUs stay awake even during headless mode.
+      '');
 
-    hardware.nvidia.forceFullCompositionPipeline = lib.mkOption {
-      default = false;
-      type = types.bool;
-      description = lib.mdDoc ''
-        Whether to force-enable the full composition pipeline.
+      forceFullCompositionPipeline = lib.mkEnableOption (lib.mdDoc ''
+        forcefully the full composition pipeline.
         This sometimes fixes screen tearing issues.
         This has been reported to reduce the performance of some OpenGL applications and may produce issues in WebGL.
         It also drastically increases the time the driver needs to clock down after load.
-      '';
-    };
+      '');
 
-    hardware.nvidia.package = lib.mkOption {
-      type = types.package;
-      default = config.boot.kernelPackages.nvidiaPackages.stable;
-      defaultText = literalExpression "config.boot.kernelPackages.nvidiaPackages.stable";
-      description = lib.mdDoc ''
-        The NVIDIA X11 derivation to use.
-      '';
-      example = literalExpression "config.boot.kernelPackages.nvidiaPackages.legacy_340";
-    };
+      package = lib.mkPackageOptionMD config.boot.kernelPackages.nvidiaPackages "nvidia_x11" {
+        default = "stable";
+        example = lib.mdDoc "config.boot.kernelPackages.nvidiaPackages.legacy_470";
+      };
 
-    hardware.nvidia.open = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = lib.mdDoc ''
-        Whether to use the open source kernel module
-      '';
+      open = lib.mkEnableOption (lib.mdDoc ''
+        the open source NVIDIA kernel module
+      '');
     };
   };
 
   config = let
-      igpuDriver = if pCfg.intelBusId != "" then "modesetting" else "amdgpu";
-      igpuBusId = if pCfg.intelBusId != "" then pCfg.intelBusId else pCfg.amdgpuBusId;
-  in mkIf enabled {
-    assertions = [
-      {
-        assertion = primeEnabled -> pCfg.intelBusId == "" || pCfg.amdgpuBusId == "";
-        message = ''
-          You cannot configure both an Intel iGPU and an AMD APU. Pick the one corresponding to your processor.
-        '';
-      }
+    igpuDriver =
+      if pCfg.intelBusId != ""
+      then "modesetting"
+      else "amdgpu";
+    igpuBusId =
+      if pCfg.intelBusId != ""
+      then pCfg.intelBusId
+      else pCfg.amdgpuBusId;
+  in
+    lib.mkIf (nvidia_x11 != null) {
+      assertions = [
+        {
+          assertion = primeEnabled -> pCfg.intelBusId == "" || pCfg.amdgpuBusId == "";
+          message = "You cannot configure both an Intel iGPU and an AMD APU. Pick the one corresponding to your processor.";
+        }
 
-      {
-        assertion = offloadCfg.enableOffloadCmd -> offloadCfg.enable || reverseSyncCfg.enable;
-        message = ''
-          Offload command requires offloading or reverse prime sync to be enabled.
-        '';
-      }
+        {
+          assertion = offloadCfg.enableOffloadCmd -> offloadCfg.enable || reverseSyncCfg.enable;
+          message = "Offload command requires offloading or reverse prime sync to be enabled.";
+        }
 
-      {
-        assertion = primeEnabled -> pCfg.nvidiaBusId != "" && (pCfg.intelBusId != "" || pCfg.amdgpuBusId != "");
-        message = ''
-          When NVIDIA PRIME is enabled, the GPU bus IDs must be configured.
-        '';
-      }
+        {
+          assertion = primeEnabled -> pCfg.nvidiaBusId != "" && (pCfg.intelBusId != "" || pCfg.amdgpuBusId != "");
+          message = "When NVIDIA PRIME is enabled, the GPU bus IDs must be configured.";
+        }
 
-      {
-        assertion = offloadCfg.enable -> versionAtLeast nvidia_x11.version "435.21";
-        message = "NVIDIA PRIME render offload is currently only supported on versions >= 435.21.";
-      }
+        {
+          assertion = offloadCfg.enable -> lib.versionAtLeast nvidia_x11.version "435.21";
+          message = "NVIDIA PRIME render offload is currently only supported on versions >= 435.21.";
+        }
 
-      {
-        assertion = (reverseSyncCfg.enable && pCfg.amdgpuBusId != "") -> versionAtLeast nvidia_x11.version "470.0";
-        message = "NVIDIA PRIME render offload for AMD APUs is currently only supported on versions >= 470 beta.";
-      }
+        {
+          assertion = (reverseSyncCfg.enable && pCfg.amdgpuBusId != "") -> lib.versionAtLeast nvidia_x11.version "470.0";
+          message = "NVIDIA PRIME render offload for AMD APUs is currently only supported on versions >= 470 beta.";
+        }
 
-      {
-        assertion = !(syncCfg.enable && offloadCfg.enable);
-        message = "PRIME Sync and Offload cannot be both enabled";
-      }
+        {
+          assertion = !(syncCfg.enable && offloadCfg.enable);
+          message = "PRIME Sync and Offload cannot be both enabled";
+        }
 
-      {
-        assertion = !(syncCfg.enable && reverseSyncCfg.enable);
-        message = "PRIME Sync and PRIME Reverse Sync cannot be both enabled";
-      }
+        {
+          assertion = !(syncCfg.enable && reverseSyncCfg.enable);
+          message = "PRIME Sync and PRIME Reverse Sync cannot be both enabled";
+        }
 
-      {
-        assertion = !(syncCfg.enable && cfg.powerManagement.finegrained);
-        message = "Sync precludes powering down the NVIDIA GPU.";
-      }
+        {
+          assertion = !(syncCfg.enable && cfg.powerManagement.finegrained);
+          message = "Sync precludes powering down the NVIDIA GPU.";
+        }
 
-      {
-        assertion = cfg.powerManagement.finegrained -> offloadCfg.enable;
-        message = "Fine-grained power management requires offload to be enabled.";
-      }
+        {
+          assertion = cfg.powerManagement.finegrained -> offloadCfg.enable;
+          message = "Fine-grained power management requires offload to be enabled.";
+        }
 
-      {
-        assertion = cfg.powerManagement.enable -> versionAtLeast nvidia_x11.version "430.09";
-        message = "Required files for driver based power management only exist on versions >= 430.09.";
-      }
+        {
+          assertion = cfg.powerManagement.enable -> lib.versionAtLeast nvidia_x11.version "430.09";
+          message = "Required files for driver based power management only exist on versions >= 430.09.";
+        }
 
-      {
-        assertion = cfg.open -> (cfg.package ? open && cfg.package ? firmware);
-        message = "This version of NVIDIA driver does not provide a corresponding opensource kernel driver";
-      }
-    ];
+        {
+          assertion = cfg.open -> (cfg.package ? open && cfg.package ? firmware);
+          message = "This version of NVIDIA driver does not provide a corresponding opensource kernel driver";
+        }
+      ];
 
-    # If Optimus/PRIME is enabled, we:
-    # - Specify the configured NVIDIA GPU bus ID in the Device section for the
-    #   "nvidia" driver.
-    # - Add the AllowEmptyInitialConfiguration option to the Screen section for the
-    #   "nvidia" driver, in order to allow the X server to start without any outputs.
-    # - Add a separate Device section for the Intel GPU, using the "modesetting"
-    #   driver and with the configured BusID.
-    # - OR add a separate Device section for the AMD APU, using the "amdgpu"
-    #   driver and with the configures BusID.
-    # - Reference that Device section from the ServerLayout section as an inactive
-    #   device.
-    # - Configure the display manager to run specific `xrandr` commands which will
-    #   configure/enable displays connected to the Intel iGPU / AMD APU.
+      # If Optimus/PRIME is enabled, we:
+      # - Specify the configured NVIDIA GPU bus ID in the Device section for the
+      #   "nvidia" driver.
+      # - Add the AllowEmptyInitialConfiguration option to the Screen section for the
+      #   "nvidia" driver, in order to allow the X server to start without any outputs.
+      # - Add a separate Device section for the Intel GPU, using the "modesetting"
+      #   driver and with the configured BusID.
+      # - OR add a separate Device section for the AMD APU, using the "amdgpu"
+      #   driver and with the configures BusID.
+      # - Reference that Device section from the ServerLayout section as an inactive
+      #   device.
+      # - Configure the display manager to run specific `xrandr` commands which will
+      #   configure/enable displays connected to the Intel iGPU / AMD APU.
 
-    # reverse sync implies offloading
-    hardware.nvidia.prime.offload.enable = mkDefault reverseSyncCfg.enable;
+      # reverse sync implies offloading
+      hardware.nvidia.prime.offload.enable = lib.mkDefault reverseSyncCfg.enable;
 
-    services.xserver.drivers = optional primeEnabled {
-      name = igpuDriver;
-      display = offloadCfg.enable;
-      modules = optionals (igpuDriver == "amdgpu") [ pkgs.xorg.xf86videoamdgpu ];
-      deviceSection = ''
-        BusID "${igpuBusId}"
-        ${optionalString (syncCfg.enable && igpuDriver != "amdgpu") ''Option "AccelMethod" "none"''}
-      '';
-    } ++ singleton {
-      name = "nvidia";
-      modules = [ nvidia_x11.bin ];
-      display = !offloadCfg.enable;
-      deviceSection = optionalString primeEnabled
+      services.xserver.drivers =
+        lib.optional primeEnabled {
+          name = igpuDriver;
+          display = offloadCfg.enable;
+          modules = lib.optional (igpuDriver == "amdgpu") pkgs.xorg.xf86videoamdgpu;
+          deviceSection =
+            ''
+              BusID "${igpuBusId}"
+            ''
+            + lib.optionalString (syncCfg.enable && igpuDriver != "amdgpu") ''
+              Option "AccelMethod" "none"
+            '';
+        }
+        ++ lib.singleton {
+          name = "nvidia";
+          modules = [nvidia_x11.bin];
+          display = !offloadCfg.enable;
+          deviceSection =
+            lib.optionalString primeEnabled
+            ''
+              BusID "${pCfg.nvidiaBusId}"
+            ''
+            + lib.optionalString pCfg.allowExternalGpu ''
+              Option "AllowExternalGpus"
+            '';
+          screenSection =
+            ''
+              Option "RandRRotation" "on"
+            ''
+            + lib.optionalString syncCfg.enable ''
+              Option "AllowEmptyInitialConfiguration"
+            ''
+            + lib.optionalString cfg.forceFullCompositionPipeline ''
+              Option         "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"
+              Option         "AllowIndirectGLXProtocol" "off"
+              Option         "TripleBuffer" "on"
+            '';
+        };
+
+      services.xserver.serverLayoutSection =
+        lib.optionalString syncCfg.enable ''
+          Inactive "Device-${igpuDriver}[0]"
         ''
-          BusID "${pCfg.nvidiaBusId}"
-          ${optionalString pCfg.allowExternalGpu "Option \"AllowExternalGpus\""}
+        + lib.optionalString reverseSyncCfg.enable ''
+          Inactive "Device-nvidia[0]"
+        ''
+        + lib.optionalString offloadCfg.enable ''
+          Option "AllowNVIDIAGPUScreens"
         '';
-      screenSection =
-        ''
-          Option "RandRRotation" "on"
-        '' + optionalString syncCfg.enable ''
-          Option "AllowEmptyInitialConfiguration"
-        '' + optionalString cfg.forceFullCompositionPipeline ''
-          Option         "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"
-          Option         "AllowIndirectGLXProtocol" "off"
-          Option         "TripleBuffer" "on"
-        ''
-        ;
-    };
 
-    services.xserver.serverLayoutSection = optionalString syncCfg.enable ''
-      Inactive "Device-${igpuDriver}[0]"
-    '' + optionalString reverseSyncCfg.enable ''
-      Inactive "Device-nvidia[0]"
-    '' + optionalString offloadCfg.enable ''
-      Option "AllowNVIDIAGPUScreens"
-    '';
+      services.xserver.displayManager.setupCommands = let
+        gpuProviderName =
+          if igpuDriver == "amdgpu"
+          then
+            # find the name of the provider if amdgpu
+            "`${lib.getExe pkgs.xorg.xrandr} --listproviders | ${lib.getExe pkgs.gnugrep} -i AMD | ${lib.getExe pkgs.gnused} -n 's/^.*name://p'`"
+          else igpuDriver;
+        providerCmdParams =
+          if syncCfg.enable
+          then "\"${gpuProviderName}\" NVIDIA-0"
+          else "NVIDIA-G0 \"${gpuProviderName}\"";
+      in
+        lib.optionalString (syncCfg.enable || reverseSyncCfg.enable) ''
+          # Added by nvidia configuration module for Optimus/PRIME.
+          ${lib.getExe pkgs.xorg.xrandr} --setprovideroutputsource ${providerCmdParams}
+          ${lib.getExe pkgs.xorg.xrandr} --auto
+        '';
 
-    services.xserver.displayManager.setupCommands = let
-      gpuProviderName = if igpuDriver == "amdgpu" then
-        # find the name of the provider if amdgpu
-        "`${pkgs.xorg.xrandr}/bin/xrandr --listproviders | ${pkgs.gnugrep}/bin/grep -i AMD | ${pkgs.gnused}/bin/sed -n 's/^.*name://p'`"
-      else
-        igpuDriver;
-      providerCmdParams = if syncCfg.enable then "\"${gpuProviderName}\" NVIDIA-0" else "NVIDIA-G0 \"${gpuProviderName}\"";
-    in optionalString (syncCfg.enable || reverseSyncCfg.enable) ''
-      # Added by nvidia configuration module for Optimus/PRIME.
-      ${pkgs.xorg.xrandr}/bin/xrandr --setprovideroutputsource ${providerCmdParams}
-      ${pkgs.xorg.xrandr}/bin/xrandr --auto
-    '';
+      environment.etc = {
+        "nvidia/nvidia-application-profiles-rc" = lib.mkIf nvidia_x11.useProfiles {source = "${nvidia_x11.bin}/share/nvidia/nvidia-application-profiles-rc";};
 
-    environment.etc."nvidia/nvidia-application-profiles-rc" = mkIf nvidia_x11.useProfiles {
-      source = "${nvidia_x11.bin}/share/nvidia/nvidia-application-profiles-rc";
-    };
+        # 'nvidia_x11' installs it's files to /run/opengl-driver/...
+        "egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";
+      };
 
-    # 'nvidia_x11' installs it's files to /run/opengl-driver/...
-    environment.etc."egl/egl_external_platform.d".source =
-      "/run/opengl-driver/share/egl/egl_external_platform.d/";
-
-    hardware.opengl.extraPackages = [
-      nvidia_x11.out
-      pkgs.nvidia-vaapi-driver
-    ];
-    hardware.opengl.extraPackages32 = [
-      nvidia_x11.lib32
-      pkgs.pkgsi686Linux.nvidia-vaapi-driver
-    ];
-
-    environment.systemPackages = [ nvidia_x11.bin ]
-      ++ optionals cfg.nvidiaSettings [ nvidia_x11.settings ]
-      ++ optionals nvidiaPersistencedEnabled [ nvidia_x11.persistenced ]
-      ++ optionals offloadCfg.enableOffloadCmd [
+      hardware.opengl = {
+        extraPackages = [
+          nvidia_x11.out
+          pkgs.nvidia-vaapi-driver
+        ];
+        extraPackages32 = [
+          nvidia_x11.lib32
+          pkgs.pkgsi686Linux.nvidia-vaapi-driver
+        ];
+      };
+      environment.systemPackages =
+        [nvidia_x11.bin]
+        ++ lib.optional cfg.nvidiaSettings nvidia_x11.settings
+        ++ lib.optional cfg.nvidiaPersistenced nvidia_x11.persistenced
+        ++ lib.optional offloadCfg.enableOffloadCmd
         (pkgs.writeShellScriptBin "nvidia-offload" ''
           export __NV_PRIME_RENDER_OFFLOAD=1
           export __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0
           export __GLX_VENDOR_LIBRARY_NAME=nvidia
           export __VK_LAYER_NV_optimus=NVIDIA_only
           exec "$@"
-        '')
-      ];
+        '');
 
-    systemd.packages = optional cfg.powerManagement.enable nvidia_x11.out;
+      systemd.packages = lib.optional cfg.powerManagement.enable nvidia_x11.out;
 
-    systemd.services = let
-      baseNvidiaService = state: {
-        description = "NVIDIA system ${state} actions";
-
-        path = with pkgs; [ kbd ];
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = "${nvidia_x11.out}/bin/nvidia-sleep.sh '${state}'";
-        };
-      };
-
-      nvidiaService = sleepState: (baseNvidiaService sleepState) // {
-        before = [ "systemd-${sleepState}.service" ];
-        requiredBy = [ "systemd-${sleepState}.service" ];
-      };
-
-      services = (builtins.listToAttrs (map (t: nameValuePair "nvidia-${t}" (nvidiaService t)) ["hibernate" "suspend"]))
-        // {
-          nvidia-resume = (baseNvidiaService "resume") // {
-            after = [ "systemd-suspend.service" "systemd-hibernate.service" ];
-            requiredBy = [ "systemd-suspend.service" "systemd-hibernate.service" ];
-          };
-        };
-    in optionalAttrs cfg.powerManagement.enable services
-      // optionalAttrs nvidiaPersistencedEnabled {
-        "nvidia-persistenced" = mkIf nvidiaPersistencedEnabled {
-          description = "NVIDIA Persistence Daemon";
-          wantedBy = [ "multi-user.target" ];
+      systemd.services = let
+        nvidiaService = state: {
+          description = "NVIDIA system ${state} actions";
+          path = [pkgs.kbd];
           serviceConfig = {
-            Type = "forking";
-            Restart = "always";
-            PIDFile = "/var/run/nvidia-persistenced/nvidia-persistenced.pid";
-            ExecStart = "${nvidia_x11.persistenced}/bin/nvidia-persistenced --verbose";
-            ExecStopPost = "${pkgs.coreutils}/bin/rm -rf /var/run/nvidia-persistenced";
+            Type = "oneshot";
+            ExecStart = "${nvidia_x11.out}/bin/nvidia-sleep.sh '${state}'";
           };
+          before = ["systemd-${state}.service"];
+          requiredBy = ["systemd-${state}.service"];
         };
-      };
+      in
+        lib.mkMerge [
+          (lib.mkIf cfg.powerManagement.enable {
+            nvidia-suspend = nvidiaService "suspend";
+            nvidia-hibernate = nvidiaService "hibernate";
+            nvidia-resume =
+              (nvidiaService "resume")
+              // {
+                before = [];
+                after = ["systemd-suspend.service" "systemd-hibernate.service"];
+                requiredBy = ["systemd-suspend.service" "systemd-hibernate.service"];
+              };
+          })
+          (lib.mkIf cfg.nvidiaPersistenced {
+            "nvidia-persistenced" = {
+              description = "NVIDIA Persistence Daemon";
+              wantedBy = ["multi-user.target"];
+              serviceConfig = {
+                Type = "forking";
+                Restart = "always";
+                PIDFile = "/var/run/nvidia-persistenced/nvidia-persistenced.pid";
+                ExecStart = "${lib.getExe nvidia_x11.persistenced} --verbose";
+                ExecStopPost = "${pkgs.coreutils}/bin/rm -rf /var/run/nvidia-persistenced";
+              };
+            };
+          })
+        ];
 
-    systemd.tmpfiles.rules = optional config.virtualisation.docker.enableNvidia
+      services.acpid.enable = true;
+
+      hardware.firmware = lib.optional cfg.open nvidia_x11.firmware;
+
+      systemd.tmpfiles.rules =
+        lib.optional config.virtualisation.docker.enableNvidia
         "L+ /run/nvidia-docker/bin - - - - ${nvidia_x11.bin}/origBin"
-      ++ optional (nvidia_x11.persistenced != null && config.virtualisation.docker.enableNvidia)
+        ++ lib.optional (nvidia_x11.persistenced != null && config.virtualisation.docker.enableNvidia)
         "L+ /run/nvidia-docker/extras/bin/nvidia-persistenced - - - - ${nvidia_x11.persistenced}/origBin/nvidia-persistenced";
 
-    boot.extraModulePackages = if cfg.open then [ nvidia_x11.open ] else [ nvidia_x11.bin ];
-    hardware.firmware = lib.optional cfg.open nvidia_x11.firmware;
+      boot = {
+        blacklistedKernelModules = ["nouveau" "nvidiafb"];
 
-    # nvidia-uvm is required by CUDA applications.
-    boot.kernelModules = [ "nvidia-uvm" ] ++
-      optionals config.services.xserver.enable [ "nvidia" "nvidia_modeset" "nvidia_drm" ];
+        extraModulePackages =
+          if cfg.open
+          then [nvidia_x11.open]
+          else [nvidia_x11.bin];
 
-    # If requested enable modesetting via kernel parameter.
-    boot.kernelParams = optional (offloadCfg.enable || cfg.modesetting.enable) "nvidia-drm.modeset=1"
-      ++ optional cfg.powerManagement.enable "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
-      ++ optional cfg.open "nvidia.NVreg_OpenRmEnableUnsupportedGpus=1"
-      ++ optional (config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport) "ibt=off";
+        # nvidia-uvm is required by CUDA applications.
+        kernelModules =
+          ["nvidia-uvm"]
+          ++ lib.optionals config.services.xserver.enable ["nvidia" "nvidia_modeset" "nvidia_drm"];
 
-    services.udev.extraRules =
-      ''
-        # Create /dev/nvidia-uvm when the nvidia-uvm module is loaded.
-        KERNEL=="nvidia", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidiactl c $$(grep nvidia-frontend /proc/devices | cut -d \  -f 1) 255'"
-        KERNEL=="nvidia", RUN+="${pkgs.runtimeShell} -c 'for i in $$(cat /proc/driver/nvidia/gpus/*/information | grep Minor | cut -d \  -f 4); do mknod -m 666 /dev/nvidia$${i} c $$(grep nvidia-frontend /proc/devices | cut -d \  -f 1) $${i}; done'"
-        KERNEL=="nvidia_modeset", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-modeset c $$(grep nvidia-frontend /proc/devices | cut -d \  -f 1) 254'"
-        KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 0'"
-        KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm-tools c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 1'"
-      '' + optionalString cfg.powerManagement.finegrained (
-      optionalString (versionOlder config.boot.kernelPackages.kernel.version "5.5") ''
-        # Remove NVIDIA USB xHCI Host Controller devices, if present
-        ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{remove}="1"
+        # If requested enable modesetting via kernel parameter.
+        kernelParams =
+          lib.optional (offloadCfg.enable || cfg.modesetting.enable) "nvidia-drm.modeset=1"
+          ++ lib.optional cfg.powerManagement.enable "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
+          ++ lib.optional cfg.open "nvidia.NVreg_OpenRmEnableUnsupportedGpus=1"
+          ++ lib.optional (config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport) "ibt=off";
 
-        # Remove NVIDIA USB Type-C UCSI devices, if present
-        ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", ATTR{remove}="1"
+        # enable finegrained power management
+        extraModprobeConfig = lib.optionalString cfg.powerManagement.finegrained ''
+          options nvidia "NVreg_DynamicPowerManagement=0x02"
+        '';
+      };
 
-        # Remove NVIDIA Audio devices, if present
-        ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{remove}="1"
-      '' + ''
-        # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
-        ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"
-        ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="auto"
+      services.udev.extraRules =
+        ''
+          # Create /dev/nvidia-uvm when the nvidia-uvm module is loaded.
+          KERNEL=="nvidia", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidiactl c $$(grep nvidia-frontend /proc/devices | cut -d \  -f 1) 255'"
+          KERNEL=="nvidia", RUN+="${pkgs.runtimeShell} -c 'for i in $$(cat /proc/driver/nvidia/gpus/*/information | grep Minor | cut -d \  -f 4); do mknod -m 666 /dev/nvidia$${i} c $$(grep nvidia-frontend /proc/devices | cut -d \  -f 1) $${i}; done'"
+          KERNEL=="nvidia_modeset", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-modeset c $$(grep nvidia-frontend /proc/devices | cut -d \  -f 1) 254'"
+          KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 0'"
+          KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm-tools c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 1'"
+        ''
+        + lib.optionalString cfg.powerManagement.finegrained (
+          lib.optionalString (lib.versionOlder config.boot.kernelPackages.kernel.version "5.5") ''
+            # Remove NVIDIA USB xHCI Host Controller devices, if present
+            ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{remove}="1"
 
-        # Disable runtime PM for NVIDIA VGA/3D controller devices on driver unbind
-        ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="on"
-        ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="on"
-      '');
+            # Remove NVIDIA USB Type-C UCSI devices, if present
+            ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", ATTR{remove}="1"
 
-    boot.extraModprobeConfig = mkIf cfg.powerManagement.finegrained ''
-      options nvidia "NVreg_DynamicPowerManagement=0x02"
-    '';
+            # Remove NVIDIA Audio devices, if present
+            ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{remove}="1"
+          ''
+          + ''
+            # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
+            ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"
+            ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="auto"
 
-    boot.blacklistedKernelModules = [ "nouveau" "nvidiafb" ];
-
-    services.acpid.enable = true;
-
-  };
-
+            # Disable runtime PM for NVIDIA VGA/3D controller devices on driver unbind
+            ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="on"
+            ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="on"
+          ''
+        );
+    };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -196,9 +196,12 @@ installPhase() {
         mkdir -p $bin/share/man/man1
         cp -p *.1.gz $bin/share/man/man1
         rm -f $bin/share/man/man1/{nvidia-xconfig,nvidia-settings,nvidia-persistenced}.1.gz
+        if [ -e "nvidia-dbus.conf" ]; then
+            install -Dm644 nvidia-dbus.conf $bin/share/dbus-1/system.d/nvidia-dbus.conf
+        fi
 
         # Install the programs.
-        for i in nvidia-cuda-mps-control nvidia-cuda-mps-server nvidia-smi nvidia-debugdump; do
+        for i in nvidia-cuda-mps-control nvidia-cuda-mps-server nvidia-smi nvidia-debugdump nvidia-powerd; do
             if [ -e "$i" ]; then
                 install -Dm755 $i $bin/bin/$i
                 # unmodified binary backup for mounting in containers

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -51,6 +51,7 @@ let
     libdrm xorg.libXext xorg.libX11
     xorg.libXv xorg.libXrandr xorg.libxcb zlib stdenv.cc.cc
     wayland mesa libGL openssl
+    dbus # for nvidia-powerd
   ]);
 
   self = stdenv.mkDerivation {


### PR DESCRIPTION
###### Description of changes
Closes: #211300
The NVIDIA module was in need of some TLC so I cleaned it up and re-formatted.

the only actual change in the first commit should be the removal of the `isDeprecated = str: (hasPrefix "nvidia" str) && (str != "nvidia");` check from: #99323 
(2 years old)
and the nvidia prime rename from: #66601
(4 years old)

The second commit is the addition of [NVIDIA Dynamic Boost](https://download.nvidia.com/XFree86/Linux-x86_64/525.53/README/dynamicboost.html) from #211300 

Some more testing would be appreciated

Questions: should I be using `lib.mdDoc` and `lib.options.mkPackageOptionMD` here or not?
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
