### PR TITLE
crowdsec: Correct versioning flags in build

### DIFF
--- a/pkgs/tools/security/crowdsec/default.nix
+++ b/pkgs/tools/security/crowdsec/default.nix
@@ -23,8 +23,12 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version=v${version}"
-    "-X github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=1970-01-01_00:00:00"
+    "-X github.com/crowdsecurity/go-cs-lib/pkg/version.Version=v${version}"
+    "-X github.com/crowdsecurity/go-cs-lib/pkg/version.BuildDate=1970-01-01_00:00:00"
+    "-X github.com/crowdsecurity/go-cs-lib/pkg/version.Tag=${src.rev}"
+    "-X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=alphaga"
+    "-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=/etc/crowdsec"
+    "-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=/var/lib/crowdsec/data"
   ];
 
   postBuild = "mv $GOPATH/bin/{crowdsec-cli,cscli}";


### PR DESCRIPTION
###### Description of changes

Passes the right versioning flags so that the crowdsec binary is able to use it's version at runtime.
Flags retrieved from the [upstream Makefile](https://github.com/crowdsecurity/crowdsec/blob/master/Makefile#L67-L73)

```
# Output with this change applied via a flake
❯ crowdsec -version
2023/07/17 23:04:48 version: v1.5.2-v1.5.2
2023/07/17 23:04:48 Codename: alphaga
2023/07/17 23:04:48 BuildDate: 1970-01-01_00:00:00
2023/07/17 23:04:48 GoVersion: 1.20.5
2023/07/17 23:04:48 Platform: linux
2023/07/17 23:04:48 Constraint_parser: >= 1.0, <= 2.0
2023/07/17 23:04:48 Constraint_scenario: >= 1.0, < 3.0
2023/07/17 23:04:48 Constraint_api: v1
2023/07/17 23:04:48 Constraint_acquis: >= 1.0, < 2.0

❯ cscli hub update
INFO[17-07-2023 23:06:49] hub index is up to date
INFO[17-07-2023 23:06:49] Wrote new 787710 bytes index to /etc/crowdsec/hub/.index.json


#
# Output without this change
#
❯ crowdsec -version
2023/07/17 23:00:01 version: -
2023/07/17 23:00:01 Codename:
2023/07/17 23:00:01 BuildDate:
2023/07/17 23:00:01 GoVersion: 1.20.5
2023/07/17 23:00:01 Platform: linux
2023/07/17 23:00:01 Constraint_parser: >= 1.0, <= 2.0
2023/07/17 23:00:01 Constraint_scenario: >= 1.0, < 3.0
2023/07/17 23:00:01 Constraint_api: v1
2023/07/17 23:00:01 Constraint_acquis: >= 1.0, < 2.0

❯ cscli hub update
WARN[17-07-2023 20:04:33] Crowdsec version is not set, using master branch for the hub
INFO[17-07-2023 20:04:33] hub index is up to date
INFO[17-07-2023 20:04:33] Wrote new 787710 bytes index to /etc/crowdsec/hub/.index.json
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
