### PR TITLE
ocamlPackages.dypgen: init at 0.2 for OCaml ≥ 4.07

### DIFF
--- a/pkgs/development/ocaml-modules/dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/dypgen/default.nix
@@ -1,21 +1,26 @@
-{stdenv, lib, fetchurl, ocaml, findlib}:
+{ stdenv, lib, fetchFromGitHub, fetchurl, ocaml, findlib }:
 
-let
-  pname = "dypgen";
-in
-
-if lib.versionAtLeast ocaml.version "4.06"
-then throw "${pname} is not available for OCaml ${ocaml.version}"
-else
+let params =
+  if lib.versionAtLeast ocaml.version "4.07" then rec {
+    version = "0.2";
+    src = fetchFromGitHub {
+      owner = "grain-lang";
+      repo = "dypgen";
+      rev = version;
+      hash = "sha256-fKuO/e5YbA2B7XcghWl9pXxwvKw9YlhnmZDZcuKe3cs=";
+    };
+  } else if lib.versionOlder ocaml.version "4.06" then {
+    version = "20120619-1";
+    src = fetchurl {
+      url = "http://dypgen.free.fr/dypgen-20120619-1.tar.bz2";
+      sha256 = "ecb53d6e469e9ec4d57ee6323ff498d45b78883ae13618492488e7c5151fdd97";
+    };
+  } else throw "dypgen is not available for OCaml ${ocaml.version}"
+; in
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
-  version = "20120619-1";
-
-  src = fetchurl {
-    url = "http://dypgen.free.fr/dypgen-20120619-1.tar.bz2";
-    sha256 = "ecb53d6e469e9ec4d57ee6323ff498d45b78883ae13618492488e7c5151fdd97";
-  };
+  pname = "ocaml${ocaml.version}-dypgen";
+  inherit (params) src version;
 
   nativeBuildInputs = [ ocaml findlib ];
 


### PR DESCRIPTION
###### Description of changes

Support recent versions of OCaml.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
