### PR TITLE
python312Packages.disnake: init at 2.10.1

### DIFF
--- a/pkgs/development/python-modules/disnake/default.nix
+++ b/pkgs/development/python-modules/disnake/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  setuptools,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  libopus,
+  pynacl,
+  pythonOlder,
+  withVoice ? true,
+  ffmpeg,
+}:
+
+buildPythonPackage rec {
+  pname = "disnake";
+  version = "2.10.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "DisnakeDev";
+    repo = "disnake";
+    tag = "v${version}";
+    hash = "sha256-MQxYkUA3uclmY2cKBr4DsBg79ovsH1EsMOjiVPGaLVE=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies =
+    [
+      aiohttp
+    ]
+    ++ lib.optionals withVoice [
+      libopus
+      pynacl
+      ffmpeg
+    ];
+
+  postPatch = lib.optionalString withVoice ''
+    substituteInPlace "disnake/opus.py" \
+      --replace-fail 'ctypes.util.find_library("opus")' "'${libopus}/lib/libopus.so.0'"
+    substituteInPlace "disnake/player.py" \
+      --replace-fail 'executable: str = "ffmpeg"' 'executable: str="${ffmpeg}/bin/ffmpeg"'
+  '';
+
+  # Only have integration tests with discord
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "disnake"
+    "disnake.file"
+    "disnake.member"
+    "disnake.user"
+    "disnake.state"
+    "disnake.guild"
+    "disnake.webhook"
+    "disnake.ext.commands.bot"
+  ];
+
+  meta = {
+    description = "API wrapper for Discord written in Python";
+    homepage = "https://disnake.dev/";
+    changelog = "https://github.com/DisnakeDev/disnake/blob/v${version}/docs/whats_new.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3293,6 +3293,8 @@ self: super: with self; {
 
   diskcache = callPackage ../development/python-modules/diskcache { };
 
+  disnake = callPackage ../development/python-modules/disnake { };
+
   dissect = callPackage ../development/python-modules/dissect { };
 
   dissect-archive = callPackage ../development/python-modules/dissect-archive { };


### PR DESCRIPTION
###### Description of changes

Disnake is a fork of Discord.py, so the package is mostly copied from there, with build/check steps modified to account for the different name.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
