### PR TITLE
python310Packages.repeated-test: 2.3.1 -> 2.3.3

### DIFF
--- a/pkgs/development/python-modules/repeated-test/default.nix
+++ b/pkgs/development/python-modules/repeated-test/default.nix
@@ -3,13 +3,12 @@
 , fetchPypi
 , pythonOlder
 , setuptools-scm
-, six
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "repeated-test";
-  version = "2.3.1";
+  version = "2.3.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.5";
@@ -17,15 +16,11 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "repeated_test";
     inherit version;
-    hash = "sha256-TbVyQA7EjCSwo6qfDksbE8IU1ElkSCABEUBWy5j1KJc=";
+    hash = "sha256-3YPU8SL9rud5s0pnwwH5TJk1MXsDhdkDnZp/Oj6sgXs=";
   };
 
   nativeBuildInputs = [
     setuptools-scm
-  ];
-
-  propagatedBuildInputs = [
-    six
   ];
 
   nativeCheckInputs = [
@@ -39,6 +34,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Unittest-compatible framework for repeating a test function over many fixtures";
     homepage = "https://github.com/epsy/repeated_test";
+    changelog = "https://github.com/epsy/repeated_test/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ tjni ];
   };


### PR DESCRIPTION
###### Description of changes

https://github.com/epsy/repeated_test/releases/tag/v2.3.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
