### PR TITLE
buck2: update, migrate to musl build

### DIFF
--- a/pkgs/development/tools/build-managers/buck2/default.nix
+++ b/pkgs/development/tools/build-managers/buck2/default.nix
@@ -35,7 +35,7 @@ let
     aarch64-linux  = "aarch64-unknown-linux-gnu";
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  buck2-version = "2023-07-11";
+  buck2-version = "2023-07-15";
   src =
     let
       hashes = builtins.fromJSON (builtins.readFile ./hashes.json);

--- a/pkgs/development/tools/build-managers/buck2/default.nix
+++ b/pkgs/development/tools/build-managers/buck2/default.nix
@@ -1,5 +1,4 @@
 { fetchurl, lib, stdenv, zstd
-, autoPatchelfHook, gcc-unwrapped
 , testers, buck2 # for passthru.tests
 }:
 
@@ -27,12 +26,8 @@ let
   suffix = {
     x86_64-darwin  = "x86_64-apple-darwin";
     aarch64-darwin = "aarch64-apple-darwin";
-    # TODO (aseipp): there's an aarch64-linux musl build of buck2, but not a
-    # x86_64-linux musl build. keep things consistent for now and use glibc
-    # builds for both; but we should fix this in the future to be less fragile;
-    # we can then remove autoPatchelfHook.
-    x86_64-linux   = "x86_64-unknown-linux-gnu";
-    aarch64-linux  = "aarch64-unknown-linux-gnu";
+    x86_64-linux   = "x86_64-unknown-linux-musl";
+    aarch64-linux  = "aarch64-unknown-linux-musl";
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   buck2-version = "2023-07-15";
@@ -48,23 +43,19 @@ stdenv.mkDerivation {
   version = "unstable-${buck2-version}"; # TODO (aseipp): kill 'unstable' once a non-prerelease is made
   inherit src;
 
-  buildInputs = lib.optionals stdenv.isLinux [ gcc-unwrapped ]; # need libgcc_s.so.1 for patchelf
-  nativeBuildInputs = [ zstd ]
-    # TODO (aseipp): move to musl build and nuke this?
-    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [ zstd ];
 
+  doCheck = true;
   dontConfigure = true;
+  dontStrip = true;
+
   unpackPhase = "unzstd ${src} -o ./buck2";
   buildPhase = "chmod +x ./buck2";
+  checkPhase = "./buck2 --version";
   installPhase = ''
     mkdir -p $out/bin
     install -D buck2 $out/bin/buck2
   '';
-
-  # NOTE (aseipp): use installCheckPhase instead of checkPhase so that
-  # autoPatchelfHook kicks in first.
-  doInstallCheck = true;
-  installCheckPhase = "$out/bin/buck2 --version";
 
   passthru = {
     updateScript = ./update.sh;

--- a/pkgs/development/tools/build-managers/buck2/hashes.json
+++ b/pkgs/development/tools/build-managers/buck2/hashes.json
@@ -1,0 +1,5 @@
+{ "x86_64-linux": "sha256-Nkx/GONX867kfU3pKhilIhbi71PRXFwjRVu/3GTpI1M="
+, "x86_64-darwin": "sha256-d8GD7SwCM1gcWILkmSLRY7nq2w9+AMxgbGiWwAK0BAo="
+, "aarch64-linux": "sha256-xSVYx6Go/hBL4fWi1LPkH8bSFVsTtSVfy1eEuaOvQd4="
+, "aarch64-darwin": "sha256-jswrwf37/0Rec551mORXYf+s45Nx16OeaRjRS9ROR4E="
+}

--- a/pkgs/development/tools/build-managers/buck2/hashes.json
+++ b/pkgs/development/tools/build-managers/buck2/hashes.json
@@ -1,5 +1,5 @@
-{ "x86_64-linux": "sha256-Nkx/GONX867kfU3pKhilIhbi71PRXFwjRVu/3GTpI1M="
+{ "x86_64-linux": "sha256-xd8MZF1xpVYqEDoL3nUBptiFMn9UkgC+zIgfDkDxwfM="
 , "x86_64-darwin": "sha256-d8GD7SwCM1gcWILkmSLRY7nq2w9+AMxgbGiWwAK0BAo="
-, "aarch64-linux": "sha256-xSVYx6Go/hBL4fWi1LPkH8bSFVsTtSVfy1eEuaOvQd4="
+, "aarch64-linux": "sha256-zBVgIgQ+tlBUuHwsZB5JmQJtWZ5soKP6//NxkU96xmo="
 , "aarch64-darwin": "sha256-jswrwf37/0Rec551mORXYf+s45Nx16OeaRjRS9ROR4E="
 }

--- a/pkgs/development/tools/build-managers/buck2/hashes.json
+++ b/pkgs/development/tools/build-managers/buck2/hashes.json
@@ -1,5 +1,0 @@
-{ "x86_64-linux": "sha256-dVOshrjpsFomstnJsZMPBDfakXOkU+ORbv//fq8Oxss="
-, "x86_64-darwin": "sha256-BuzA8irlqLWnv5fGUdIHu0grz9smTBdOs5yTUBZLUKg="
-, "aarch64-linux": "sha256-Thr9RsI7AkumBeraq08KoxDAXYKv63bZUTrTYN0GAss="
-, "aarch64-darwin": "sha256-vRu0ra6YN7+o1AId6+v0ZLQucO84KwS3Ila6Ksmp1J0="
-}

--- a/pkgs/development/tools/build-managers/buck2/update.sh
+++ b/pkgs/development/tools/build-managers/buck2/update.sh
@@ -12,9 +12,9 @@ VERSION=$(curl -s https://api.github.com/repos/facebook/buck2/releases \
 echo "Latest buck2 prerelease: $VERSION"
 
 ARCHS=(
-    "x86_64-linux:x86_64-unknown-linux-gnu"
+    "x86_64-linux:x86_64-unknown-linux-musl"
     "x86_64-darwin:x86_64-apple-darwin"
-    "aarch64-linux:aarch64-unknown-linux-gnu"
+    "aarch64-linux:aarch64-unknown-linux-musl"
     "aarch64-darwin:aarch64-apple-darwin"
 )
 

--- a/pkgs/development/tools/build-managers/buck2/update.sh
+++ b/pkgs/development/tools/build-managers/buck2/update.sh
@@ -4,10 +4,11 @@
 set -euo pipefail
 
 VERSION=$(curl -s https://api.github.com/repos/facebook/buck2/releases \
-  | jq -r '. |
-           sort_by(.created_at) | .[] |
-           select ((.prerelease == true) and (.name != "latest")) |
-           .name')
+  | jq -r 'sort_by(.created_at) | reverse |
+           (map
+             (select ((.prerelease == true) and (.name != "latest"))) |
+             first
+           ) | .name')
 echo "Latest buck2 prerelease: $VERSION"
 
 ARCHS=(


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).