### PR TITLE
eigenpy: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/development/libraries/crocoddyl/default.nix
+++ b/pkgs/development/libraries/crocoddyl/default.nix
@@ -9,25 +9,17 @@
 , python3Packages
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "crocoddyl";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "loco-3d";
-    repo = pname;
-    rev = "v${version}";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-wDHCHTJXmJjU7mhQ2huUVdEc9ap7PMeqlHPrKm//jBQ=";
+    hash = "sha256-h7rzLSvmWOZCP8rvmUEhFeMEiPhojfbvkt+fNKpgoXo=";
   };
-
-  patches = [
-    # error: no matching function for call to 'max(double&, int)'
-    (fetchpatch {
-      url = "https://github.com/loco-3d/crocoddyl/commit/d2e4116257595317740975e745739bb76b92e5c0.patch";
-      hash = "sha256-M79jNdIxzx9PfW3TStRny76dVo/HDf/Rp08ZPx+ymBg";
-    })
-  ];
 
   strictDeps = true;
 
@@ -48,11 +40,26 @@ stdenv.mkDerivation rec {
     "-DBUILD_PYTHON_INTERFACE=OFF"
   ];
 
+  prePatch = ''
+    substituteInPlace \
+      examples/CMakeLists.txt \
+      examples/log/check_logfiles.sh \
+      --replace /bin/bash ${stdenv.shell}
+  '';
+
+  doCheck = true;
+  pythonImportsCheck = [
+    "crocoddyl"
+  ];
+  checkInputs = lib.optionals (pythonSupport) [
+    python3Packages.scipy
+  ];
+
   meta = with lib; {
     description = "Crocoddyl optimal control library";
     homepage = "https://github.com/loco-3d/crocoddyl";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ wegank ];
+    maintainers = with maintainers; [ nim65s wegank ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/development/libraries/example-robot-data/default.nix
+++ b/pkgs/development/libraries/example-robot-data/default.nix
@@ -6,16 +6,16 @@
 , python3Packages
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "example-robot-data";
-  version = "4.0.7";
+  version = "4.0.8";
 
   src = fetchFromGitHub {
     owner = "Gepetto";
-    repo = pname;
-    rev = "v${version}";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-dN23ukKPkTohqD1J/0EneLyG6Cg0zriMr1l6WLFemd8=";
+    hash = "sha256-xeNbx1f9QCAOJrXfkk3jo9XH2/4HNtnRA1OSnqA2cLs=";
   };
 
   strictDeps = true;
@@ -32,11 +32,16 @@ stdenv.mkDerivation rec {
     "-DBUILD_PYTHON_INTERFACE=OFF"
   ];
 
+  doCheck = true;
+  pythonImportsCheck = [
+    "example_robot_data"
+  ];
+
   meta = with lib; {
     description = "Set of robot URDFs for benchmarking and developed examples.";
     homepage = "https://github.com/Gepetto/example-robot-data";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ wegank ];
+    maintainers = with maintainers; [ nim65s wegank ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -7,16 +7,16 @@
 , numpy
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "eigenpy";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
-    repo = pname;
-    rev = "v${version}";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-xaeMsn3G4x5DS6gXc6mbZvi96K1Yu8CuzjcGnYJYrvs=";
+    hash = "sha256-+SMTGMsxdCIGZo+pa54pdeDnZOjoDZfEXG7uHy5/Kek=";
   };
 
   strictDeps = true;
@@ -34,12 +34,17 @@ stdenv.mkDerivation rec {
     numpy
   ];
 
+  doCheck = true;
+  pythonImportsCheck = [
+    "eigenpy"
+  ];
+
   meta = with lib; {
     description = "Bindings between Numpy and Eigen using Boost.Python";
     homepage = "https://github.com/stack-of-tasks/eigenpy";
     changelog = "https://github.com/stack-of-tasks/eigenpy/releases/tag/v${version}";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ wegank ];
+    maintainers = with maintainers; [ nim65s wegank ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

Hi,

This update 
- eigenpy to v3.1.0, ref. https://github.com/stack-of-tasks/eigenpy/releases/tag/v3.1.0 for changelog
- example-robot-data to v4.0.8, ref. https://github.com/Gepetto/example-robot-data/releases/tag/v4.0.8 for changelog
- crocoddyl to v2.0.1, ref https://github.com/loco-3d/crocoddyl/releases/tag/v2.0.1 for changelog

while here:
- use finalAttrs instead of rec
- add check & python import check
- add myself in maintainers (not sure how this should be done, but I'd like to get tagged if there is any issue on those packages, as I'm their upstream maintainer ;) )

This is on staging, because this needs #242877 to get tests working on python 3.11.

---

Closes #238837.
Closes #235940.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
