### PR TITLE
[23.05] age-plugin-tpm: init at 0.1.0

### DIFF
--- a/pkgs/tools/security/age-plugin-tpm/default.nix
+++ b/pkgs/tools/security/age-plugin-tpm/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, swtpm
+}:
+
+buildGoModule {
+  pname = "age-plugin-tpm";
+  version = "unstable-2023-05-02";
+
+  src = fetchFromGitHub {
+    owner = "Foxboron";
+    repo = "age-plugin-tpm";
+    rev = "c570739b05c067087c44f651efce6890eedc0647";
+    hash = "sha256-xlJtyNAYi/6vBWLsjymFLGfr30w80OplwG2xGTEB118=";
+  };
+
+  vendorHash = "sha256-S9wSxw0ZMibCOspgGt5vjzFhPL+bZncjTdIX2mkX5vE=";
+
+  postConfigure = ''
+    substituteInPlace vendor/github.com/foxboron/swtpm_test/swtpm.go \
+      --replace "/usr/share/swtpm/swtpm-create-user-config-files" "${swtpm}/share/swtpm/swtpm-create-user-config-files"
+  '';
+
+  nativeCheckInputs = [
+    swtpm
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = with lib; {
+    description = "TPM 2.0 plugin for age";
+    homepage = "https://github.com/Foxboron/age-plugin-tpm";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kranzes ];
+  };
+}

--- a/pkgs/tools/security/age-plugin-tpm/default.nix
+++ b/pkgs/tools/security/age-plugin-tpm/default.nix
@@ -4,18 +4,18 @@
 , swtpm
 }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "age-plugin-tpm";
-  version = "unstable-2023-05-02";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "Foxboron";
     repo = "age-plugin-tpm";
-    rev = "c570739b05c067087c44f651efce6890eedc0647";
-    hash = "sha256-xlJtyNAYi/6vBWLsjymFLGfr30w80OplwG2xGTEB118=";
+    rev = "v${version}";
+    hash = "sha256-Gp7n2/+vgQbsm/En6PQ1to/W6lvFam4Wh3LHdCZnafc=";
   };
 
-  vendorHash = "sha256-S9wSxw0ZMibCOspgGt5vjzFhPL+bZncjTdIX2mkX5vE=";
+  vendorHash = "sha256-oZni/n2J0N3ZxNhf+RlUWyWeOFwL4+6KUIk6DQF8YpA=";
 
   postConfigure = ''
     substituteInPlace vendor/github.com/foxboron/swtpm_test/swtpm.go \

--- a/pkgs/tools/security/age-plugin-tpm/default.nix
+++ b/pkgs/tools/security/age-plugin-tpm/default.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
-    description = "TPM 2.0 plugin for age";
+    description = "TPM 2.0 plugin for age (This software is experimental, use it at your own risk)";
     homepage = "https://github.com/Foxboron/age-plugin-tpm";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6477,6 +6477,8 @@ with pkgs;
 
   agebox = callPackage ../tools/security/agebox { };
 
+  age-plugin-tpm = callPackage ../tools/security/age-plugin-tpm { };
+
   age-plugin-yubikey = darwin.apple_sdk_11_0.callPackage ../tools/security/age-plugin-yubikey {
     inherit (darwin.apple_sdk_11_0.frameworks) Foundation PCSC IOKit;
   };


### PR DESCRIPTION
###### Description of changes
Manual backport of #237801 and #243082
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
