### PR TITLE
[staging-next] gupnp-av: mitigate build error due to deprecations in libxml2

### DIFF
--- a/pkgs/development/libraries/gupnp-av/default.nix
+++ b/pkgs/development/libraries/gupnp-av/default.nix
@@ -41,6 +41,10 @@ stdenv.mkDerivation rec {
     libxml2
   ];
 
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=deprecated-declarations"
+  ];
+
   mesonFlags = [
     "-Dgtk_doc=true"
   ];


### PR DESCRIPTION
###### Description of changes

More information: https://gitlab.gnome.org/GNOME/gupnp-av/-/issues/10

Targeting: https://github.com/NixOS/nixpkgs/pull/244111

Build error on hydra: https://hydra.nixos.org/build/228304557/nixlog/1

```
12/49] Compiling C object libgupnp-av/libgupnp-av-1.0.so.3.14.1.p/gupnp-didl-lite-parser.c.o
FAILED: libgupnp-av/libgupnp-av-1.0.so.3.14.1.p/gupnp-didl-lite-parser.c.o 
gcc -Ilibgupnp-av/libgupnp-av-1.0.so.3.14.1.p -Ilibgupnp-av -I../libgupnp-av -Iinternal -I../internal -I/nix/store/dcwr090bqdp45z21cdzx6pngacch97mb-glib-2.76.4-dev/include/glib-2.0 -I/nix/store/prf7zgzc9067aiw9qy583pfrrj1s65ah-glib-2.76.4/lib/glib-2.0/include -I/nix/store/dcwr090bqdp45z21cdzx6pngacch97mb-glib-2.76.4-dev/include -I/nix/store/k1rfz8y5bgnwkr0y483k4mpy7k9v8p13-libxml2-2.11.4-dev/include/libxml2 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c11 -Werror=deprecated-declarations -fPIC -Wpointer-arith -Wmissing-declarations -Wformat=2 -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wbad-function-cast -Wold-style-definition -Wunused -Wuninitialized -Wshadow -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wlogical-op -Werror=implicit -Werror=nonnull -Werror=init-self -Werror=main -Werror=missing-braces -Werror=sequence-point -Werror=return-type -Werror=trigraphs -Werror=array-bounds -Werror=write-strings -Werror=address -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -fno-strict-aliasing -Wno-int-conversion -MD -MQ libgupnp-av/libgupnp-av-1.0.so.3.14.1.p/gupnp-didl-lite-parser.c.o -MF libgupnp-av/libgupnp-av-1.0.so.3.14.1.p/gupnp-didl-lite-parser.c.o.d -o libgupnp-av/libgupnp-av-1.0.so.3.14.1.p/gupnp-didl-lite-parser.c.o -c ../libgupnp-av/gupnp-didl-lite-parser.c
../libgupnp-av/gupnp-didl-lite-parser.c: In function 'gupnp_didl_lite_parser_parse_didl_recursive':
../libgupnp-av/gupnp-didl-lite-parser.c:233:9: error: 'xmlRecoverMemory' is deprecated [-Werror=deprecated-declarations]
  233 |         doc = xmlRecoverMemory (didl, strlen (didl));
      |         ^~~
In file included from /nix/store/k1rfz8y5bgnwkr0y483k4mpy7k9v8p13-libxml2-2.11.4-dev/include/libxml2/libxml/globals.h:18,
                 from /nix/store/k1rfz8y5bgnwkr0y483k4mpy7k9v8p13-libxml2-2.11.4-dev/include/libxml2/libxml/threads.h:35,
                 from /nix/store/k1rfz8y5bgnwkr0y483k4mpy7k9v8p13-libxml2-2.11.4-dev/include/libxml2/libxml/xmlmemory.h:222,
                 from /nix/store/k1rfz8y5bgnwkr0y483k4mpy7k9v8p13-libxml2-2.11.4-dev/include/libxml2/libxml/tree.h:1310,
                 from ../libgupnp-av/gupnp-didl-lite-object.h:20,
                 from ../libgupnp-av/gupnp-av.h:13,
                 from ../libgupnp-av/gupnp-didl-lite-parser.c:22:
/nix/store/k1rfz8y5bgnwkr0y483k4mpy7k9v8p13-libxml2-2.11.4-dev/include/libxml2/libxml/parser.h:872:17: note: declared here
  872 |                 xmlRecoverMemory        (const char *buffer,
      |                 ^~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
[13/49] Compiling C object libgupnp-av/libgupnp-av-1.0.so.3.14.1.p/gupnp-didl-lite-object.c.o
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
