### PR TITLE
minipro-updater: init at unstable-2022-03-04

### DIFF
--- a/pkgs/tools/misc/minipro-updater/default.nix
+++ b/pkgs/tools/misc/minipro-updater/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qmake
+, wrapQtAppsHook
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "minipro-updater";
+  version = "2022-03-04";
+
+  src = fetchFromGitHub {
+    owner = "radiomanV";
+    repo = "TL866";
+    rev = "7d9a3c601e602c082f5bd60319e19817d60d553e";
+    sha256 = "sha256-1hg1dQhNQockLFougSdzd0bBrgD7wOEYLh8W/iHltIo=";
+  };
+
+  sourceRoot = "source/TL866_Updater/QT";
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+  buildInputs = [ libusb1 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 TL866_Updater -t $out/bin
+    mkdir -p $out/lib/udev/rules.d
+    cp ../../udev/60-minipro.rules $out/lib/udev/rules.d
+    cp ../../udev/61-minipro-plugdev.rules $out/lib/udev/rules.d
+    cp ../../udev/61-minipro-uaccess.rules $out/lib/udev/rules.d
+
+    runHook postInstall
+    '';
+
+  meta = with lib; {
+    homepage = "https://github.com/radiomanV/TL866";
+    description = "An open source program for updating the MiniPRO TL866xx programmer";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.luz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9691,6 +9691,8 @@ with pkgs;
 
   minipro = callPackage ../tools/misc/minipro { };
 
+  minipro-updater = libsForQt5.callPackage ../tools/misc/minipro-updater { };
+
   minisign = callPackage ../tools/security/minisign { };
 
   ministat = callPackage ../tools/misc/ministat { };


### PR DESCRIPTION
###### Description of changes
I used this package to upgrade the firmware of my minipro TL866A programmer.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
