### PR TITLE
Add `lib.trivial.orElse`, and tests for `lib.trivial.mapNullable`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -68,10 +68,10 @@ let
       lessThan listToAttrs pathExists readFile replaceStrings seq
       stringLength sub substring tail trace;
     inherit (self.trivial) id const pipe concat or and bitAnd bitOr bitXor
-      bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
-      importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
-      info showWarnings nixpkgsVersion version isInOldestRelease
-      mod compare splitByAndCompare
+      bitNot boolToString mergeAttrs flip orElse mapNullable inNixShell isFloat
+      min max importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot
+      checkListOfEnum info showWarnings nixpkgsVersion version
+      isInOldestRelease mod compare splitByAndCompare
       functionArgs setFunctionArgs isFunction toFunction
       toHexString toBaseDigits inPureEvalMode;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -146,6 +146,16 @@ runTests {
     expected = { x = false; };
   };
 
+  testMapNullableNull = {
+    expr = mapNullable (x: x + 1) null;
+    expected = null;
+  };
+
+  testMapNullableValue = {
+    expr = mapNullable (x: x + 1) 22;
+    expected = 23;
+  };
+
 # STRINGS
 
   testConcatMapStrings = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -146,6 +146,16 @@ runTests {
     expected = { x = false; };
   };
 
+  testOrElseNull = {
+    expr = orElse 1 null;
+    expected = 1;
+  };
+
+  testOrElseValue = {
+    expr = orElse 1 2;
+    expected = 2;
+  };
+
   testMapNullableNull = {
     expr = mapNullable (x: x + 1) null;
     expected = null;

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -137,6 +137,23 @@ rec {
   */
   flip = f: a: b: f b a;
 
+  /* Returns the value if present, otherwise return the provided
+     default.
+
+    Type: orElse :: a -> b -> either a b
+
+    Example:
+      orElse 1 null
+      => 1
+      orElse 1 2
+      => 2
+  */
+  orElse =
+    # Argument to return if `b` is null
+    a:
+    # Argument to return if it is not null
+    b: if b == null then a else b;
+
   /* Apply function if the supplied argument is non-null.
 
      Example:


### PR DESCRIPTION
###### Description of changes

This is a new function `orElse`, which aims to make nullable mapping through pipes cleaner.

The reason behind the argument ordering, is ease of use with `lib.pipe`, and ease of currying in general. It's consistent with `mapNullable`, and fits it well:

```nix
lib.pipe null [
  (mapNullable (x: x + 1))
  (orElse 1)
];
```

You can find multiple places where it might be worth using, by running `nix-shell -p ripgrep --command "rg 'if .* [!=]= null then'"` in nixpkgs.

Tests for `mapNullabe` were also added, since they were pretty similar.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
