### PR TITLE
python3Packages.numpy: fix failing tests and clang 16

### DIFF
--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -64,6 +64,14 @@ in buildPythonPackage rec {
       url = "https://github.com/numpy/numpy/commit/609fee4324f3521d81a3454f5fcc33abb0d3761e.patch";
       hash = "sha256-6Dbmf/RWvQJPTIjvchVaywHGcKCsgap/0wAp5WswuCo=";
     })
+  ]
+  ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+    # Backport from 1.25. `platform.machine` returns `arm64` on aarch64-darwin, which causes
+    # differing results between `_selected_real_kind_func` and Fortran’s `selected_real_kind`.
+    (fetchpatch {
+      url = "https://github.com/numpy/numpy/commit/afcedf4b63f4a94187e6995c2adea0da3bb18e83.patch";
+      hash = "sha256-cxBoimX5a9wC2qUIGAo5o/M2E9+eV63bV2/wLmfDYKg=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -72,6 +72,12 @@ in buildPythonPackage rec {
       url = "https://github.com/numpy/numpy/commit/afcedf4b63f4a94187e6995c2adea0da3bb18e83.patch";
       hash = "sha256-cxBoimX5a9wC2qUIGAo5o/M2E9+eV63bV2/wLmfDYKg=";
     })
+  ]
+  ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    # Disable `numpy/core/tests/test_umath.py::TestComplexFunctions::test_loss_of_precision[complex256]`
+    # on x86_64-darwin because it fails under Rosetta 2 due to issues with trig functions and
+    # 80-bit long double complex numbers.
+    ./disable-failing-long-double-test-Rosetta-2.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/numpy/disable-failing-long-double-test-Rosetta-2.patch
+++ b/pkgs/development/python-modules/numpy/disable-failing-long-double-test-Rosetta-2.patch
@@ -1,0 +1,23 @@
+diff --git a/numpy/core/tests/test_umath.py b/numpy/core/tests/test_umath.py
+index 6951d41e4..eefe86ad4 100644
+--- a/numpy/core/tests/test_umath.py
++++ b/numpy/core/tests/test_umath.py
+@@ -4180,7 +4180,17 @@ def test_against_cmath(self):
+     )
+     @pytest.mark.xfail(IS_MUSL, reason="gh23049")
+     @pytest.mark.xfail(IS_WASM, reason="doesn't work")
+-    @pytest.mark.parametrize('dtype', [np.complex64, np.complex_, np.longcomplex])
++    @pytest.mark.parametrize('dtype', [
++        np.complex64,
++        np.complex_,
++        pytest.param(
++            np.longcomplex,
++            marks=pytest.mark.skipif(
++                sys.platform == "darwin" and platform.machine() == "x86_64",
++                reason="doesn’t work under Rosetta 2",
++            ),
++        ),
++    ])
+     def test_loss_of_precision(self, dtype):
+         """Check loss of precision in complex arc* functions"""
+ 


### PR DESCRIPTION
###### Description of changes

This PR fixes the failing tests on Darwin. The clang 16 fix was submitted upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
