### PR TITLE
remmina: support building on macOS

### DIFF
--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -41,17 +41,15 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals withKf5Wallet [ libsForQt5.kwallet ]
     ++ lib.optionals withVte [ vte ];
 
-  cmakeFlags = let
-    sharedLibraryExt = if stdenv.isDarwin then "dylib" else "so";
-  in [
+  cmakeFlags = [
     "-DWITH_VTE=${if withVte then "ON" else "OFF"}"
     "-DWITH_TELEPATHY=OFF"
     "-DWITH_AVAHI=OFF"
     "-DWITH_KF5WALLET=${if withKf5Wallet then "ON" else "OFF"}"
     "-DWITH_LIBSECRET=${if withLibsecret then "ON" else "OFF"}"
-    "-DFREERDP_LIBRARY=${freerdp}/lib/libfreerdp2.${sharedLibraryExt}"
-    "-DFREERDP_CLIENT_LIBRARY=${freerdp}/lib/libfreerdp-client2.${sharedLibraryExt}"
-    "-DFREERDP_WINPR_LIBRARY=${freerdp}/lib/libwinpr2.${sharedLibraryExt}"
+    "-DFREERDP_LIBRARY=${freerdp}/lib/libfreerdp2${stdenv.hostPlatform.extensions.sharedLibrary}"
+    "-DFREERDP_CLIENT_LIBRARY=${freerdp}/lib/libfreerdp-client2${stdenv.hostPlatform.extensions.sharedLibrary}"
+    "-DFREERDP_WINPR_LIBRARY=${freerdp}/lib/libwinpr2${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DWINPR_INCLUDE_DIR=${freerdp}/include/winpr2"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DHAVE_LIBAPPINDICATOR=OFF"

--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -7,19 +7,19 @@
 , openssl, gsettings-desktop-schemas, json-glib, libsodium, webkitgtk_4_1, harfbuzz
 # The themes here are soft dependencies; only icons are missing without them.
 , gnome
-, withKf5Wallet ? true, libsForQt5
-, withLibsecret ? true
+, withKf5Wallet ? stdenv.isLinux, libsForQt5
+, withLibsecret ? stdenv.isLinux
 , withVte ? true
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "remmina";
   version = "1.4.31";
 
   src = fetchFromGitLab {
     owner  = "Remmina";
     repo   = "Remmina";
-    rev    = "v${version}";
+    rev    = "v${finalAttrs.version}";
     sha256 = "sha256-oEgpav4oQ9Sld9PY4TsutS5xEnhQgOHnpQhDesRFTeQ=";
   };
 
@@ -29,34 +29,50 @@ stdenv.mkDerivation rec {
     gsettings-desktop-schemas
     glib gtk3 gettext libxkbfile libX11
     freerdp libssh libgcrypt gnutls
-    pcre2 libdbusmenu-gtk3 libappindicator-gtk3
+    pcre2
     libvncserver libpthreadstubs libXdmcp libxkbcommon
     libsoup_3 spice-protocol
     spice-gtk
     libepoxy at-spi2-core
-    openssl gnome.adwaita-icon-theme json-glib libsodium webkitgtk_4_1
+    openssl gnome.adwaita-icon-theme json-glib libsodium
     harfbuzz python3
-  ] ++ lib.optionals withLibsecret [ libsecret ]
+  ] ++ lib.optionals stdenv.isLinux [ libappindicator-gtk3 libdbusmenu-gtk3 webkitgtk_4_1 ]
+    ++ lib.optionals withLibsecret [ libsecret ]
     ++ lib.optionals withKf5Wallet [ libsForQt5.kwallet ]
     ++ lib.optionals withVte [ vte ];
 
-  cmakeFlags = [
+  cmakeFlags = let
+    sharedLibraryExt = if stdenv.isDarwin then "dylib" else "so";
+  in [
     "-DWITH_VTE=${if withVte then "ON" else "OFF"}"
     "-DWITH_TELEPATHY=OFF"
     "-DWITH_AVAHI=OFF"
     "-DWITH_KF5WALLET=${if withKf5Wallet then "ON" else "OFF"}"
     "-DWITH_LIBSECRET=${if withLibsecret then "ON" else "OFF"}"
-    "-DFREERDP_LIBRARY=${freerdp}/lib/libfreerdp2.so"
-    "-DFREERDP_CLIENT_LIBRARY=${freerdp}/lib/libfreerdp-client2.so"
-    "-DFREERDP_WINPR_LIBRARY=${freerdp}/lib/libwinpr2.so"
+    "-DFREERDP_LIBRARY=${freerdp}/lib/libfreerdp2.${sharedLibraryExt}"
+    "-DFREERDP_CLIENT_LIBRARY=${freerdp}/lib/libfreerdp-client2.${sharedLibraryExt}"
+    "-DFREERDP_WINPR_LIBRARY=${freerdp}/lib/libwinpr2.${sharedLibraryExt}"
     "-DWINPR_INCLUDE_DIR=${freerdp}/include/winpr2"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DHAVE_LIBAPPINDICATOR=OFF"
+    "-DWITH_CUPS=OFF"
+    "-DWITH_ICON_CACHE=OFF"
+    "-DWITH_WEBKIT2GTK=OFF"
   ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin (toString [
+    "-DTARGET_OS_IPHONE=0"
+    "-DTARGET_OS_WATCH=0"
+  ]);
 
   dontWrapQtApps = true;
 
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "${libX11.out}/lib"
+      ${lib.optionalString stdenv.isDarwin ''
+        --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
+      ''}
     )
   '';
 
@@ -65,6 +81,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/Remmina/Remmina";
     description = "Remote desktop client written in GTK";
     maintainers = with maintainers; [ melsigl ryantm ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12367,7 +12367,7 @@ with pkgs;
 
   remind = callPackage ../tools/misc/remind { };
 
-  remmina = callPackage ../applications/networking/remote/remmina { };
+  remmina = darwin.apple_sdk_11_0.callPackage ../applications/networking/remote/remmina { };
 
   rename = callPackage ../tools/misc/rename { };
 


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).