### PR TITLE
jetbrains: ide and plugin plugin versions updated

### DIFF
--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -17,14 +17,13 @@
       ],
       "builds": {
         "223.8836.1185": "https://plugins.jetbrains.com/files/164/275091/IdeaVim-2.1.0.zip",
-        "231.9011.35": "https://plugins.jetbrains.com/files/164/347833/IdeaVim-2.3.0-signed.zip",
-        "231.9161.29": "https://plugins.jetbrains.com/files/164/347833/IdeaVim-2.3.0-signed.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/164/347833/IdeaVim-2.3.0-signed.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/164/347833/IdeaVim-2.3.0-signed.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/164/347833/IdeaVim-2.3.0-signed.zip",
-        "231.9225.12": "https://plugins.jetbrains.com/files/164/347833/IdeaVim-2.3.0-signed.zip",
-        "231.9225.15": "https://plugins.jetbrains.com/files/164/347833/IdeaVim-2.3.0-signed.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/164/347833/IdeaVim-2.3.0-signed.zip"
+        "231.9011.35": "https://plugins.jetbrains.com/files/164/364022/IdeaVim-2.4.0-signed.zip",
+        "231.9225.12": "https://plugins.jetbrains.com/files/164/364022/IdeaVim-2.4.0-signed.zip",
+        "231.9225.15": "https://plugins.jetbrains.com/files/164/364022/IdeaVim-2.4.0-signed.zip",
+        "231.9225.16": "https://plugins.jetbrains.com/files/164/364022/IdeaVim-2.4.0-signed.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/164/364022/IdeaVim-2.4.0-signed.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/164/364022/IdeaVim-2.4.0-signed.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/164/364022/IdeaVim-2.4.0-signed.zip"
       },
       "name": "ideavim"
     },
@@ -65,13 +64,12 @@
       "builds": {
         "223.8836.1185": null,
         "231.9011.35": null,
-        "231.9161.29": "https://plugins.jetbrains.com/files/6981/351503/ini-231.9161.47.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/6981/351503/ini-231.9161.47.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/6981/351503/ini-231.9161.47.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/6981/351503/ini-231.9161.47.zip",
-        "231.9225.12": "https://plugins.jetbrains.com/files/6981/360771/ini-231.9225.18.zip",
-        "231.9225.15": "https://plugins.jetbrains.com/files/6981/360771/ini-231.9225.18.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/6981/360771/ini-231.9225.18.zip"
+        "231.9225.12": "https://plugins.jetbrains.com/files/6981/363869/ini-231.9225.21.zip",
+        "231.9225.15": "https://plugins.jetbrains.com/files/6981/363869/ini-231.9225.21.zip",
+        "231.9225.16": "https://plugins.jetbrains.com/files/6981/363869/ini-231.9225.21.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/6981/363869/ini-231.9225.21.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/6981/363869/ini-231.9225.21.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/6981/363869/ini-231.9225.21.zip"
       },
       "name": "ini"
     },
@@ -81,8 +79,8 @@
         "phpstorm"
       ],
       "builds": {
-        "231.9161.47": "https://plugins.jetbrains.com/files/7219/355564/Symfony_Plugin-2022.1.253.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/7219/355564/Symfony_Plugin-2022.1.253.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/7219/355564/Symfony_Plugin-2022.1.253.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/7219/355564/Symfony_Plugin-2022.1.253.zip"
       },
       "name": "symfony-support"
     },
@@ -92,8 +90,8 @@
         "phpstorm"
       ],
       "builds": {
-        "231.9161.47": "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip"
       },
       "name": "php-annotations"
     },
@@ -106,8 +104,8 @@
       ],
       "builds": {
         "231.9011.35": "https://plugins.jetbrains.com/files/7322/326457/python-ce-231.8770.65.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/7322/326457/python-ce-231.8770.65.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/7322/357028/python-ce-231.9225.4.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/7322/357028/python-ce-231.9225.4.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/7322/357028/python-ce-231.9225.4.zip"
       },
       "name": "python-community-edition"
     },
@@ -129,13 +127,12 @@
       "builds": {
         "223.8836.1185": "https://plugins.jetbrains.com/files/8182/329558/intellij-rust-0.4.194.5382-223.zip",
         "231.9011.35": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
-        "231.9161.29": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
         "231.9225.12": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
         "231.9225.15": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip"
       },
       "name": "rust"
     },
@@ -156,14 +153,13 @@
       ],
       "builds": {
         "223.8836.1185": null,
-        "231.9011.35": "https://plugins.jetbrains.com/files/8182/355173/intellij-rust-0.4.198.5444-231-beta.zip",
-        "231.9161.29": "https://plugins.jetbrains.com/files/8182/355173/intellij-rust-0.4.198.5444-231-beta.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/8182/355173/intellij-rust-0.4.198.5444-231-beta.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/8182/355173/intellij-rust-0.4.198.5444-231-beta.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/8182/355173/intellij-rust-0.4.198.5444-231-beta.zip",
-        "231.9225.12": "https://plugins.jetbrains.com/files/8182/355173/intellij-rust-0.4.198.5444-231-beta.zip",
-        "231.9225.15": "https://plugins.jetbrains.com/files/8182/355173/intellij-rust-0.4.198.5444-231-beta.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/8182/355173/intellij-rust-0.4.198.5444-231-beta.zip"
+        "231.9011.35": "https://plugins.jetbrains.com/files/8182/363621/intellij-rust-0.4.199.5413-231-beta.zip",
+        "231.9225.12": "https://plugins.jetbrains.com/files/8182/363621/intellij-rust-0.4.199.5413-231-beta.zip",
+        "231.9225.15": "https://plugins.jetbrains.com/files/8182/363621/intellij-rust-0.4.199.5413-231-beta.zip",
+        "231.9225.16": "https://plugins.jetbrains.com/files/8182/363621/intellij-rust-0.4.199.5413-231-beta.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/8182/363621/intellij-rust-0.4.199.5413-231-beta.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/8182/363621/intellij-rust-0.4.199.5413-231-beta.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/8182/363621/intellij-rust-0.4.199.5413-231-beta.zip"
       },
       "name": "rust-beta"
     },
@@ -178,10 +174,10 @@
         "webstorm"
       ],
       "builds": {
-        "231.9161.29": "https://plugins.jetbrains.com/files/8554/326468/featuresTrainer-231.8770.66.zip",
         "231.9225.12": "https://plugins.jetbrains.com/files/8554/326468/featuresTrainer-231.8770.66.zip",
         "231.9225.15": "https://plugins.jetbrains.com/files/8554/326468/featuresTrainer-231.8770.66.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/8554/326468/featuresTrainer-231.8770.66.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/8554/326468/featuresTrainer-231.8770.66.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/8554/326468/featuresTrainer-231.8770.66.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -203,13 +199,12 @@
       "builds": {
         "223.8836.1185": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
         "231.9011.35": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
-        "231.9161.29": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
         "231.9225.12": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
         "231.9225.15": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip"
       },
       "name": "nixidea"
     },
@@ -240,13 +235,12 @@
       "builds": {
         "223.8836.1185": "https://plugins.jetbrains.com/files/10037/358812/CSVEditor-3.2.1-223.zip",
         "231.9011.35": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
-        "231.9161.29": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
         "231.9225.12": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
         "231.9225.15": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip"
       },
       "name": "csv-editor"
     },
@@ -268,13 +262,12 @@
       "builds": {
         "223.8836.1185": "https://plugins.jetbrains.com/files/12559/257029/keymap-eclipse-223.7571.125.zip",
         "231.9011.35": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
-        "231.9161.29": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
         "231.9225.12": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
         "231.9225.15": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -296,13 +289,12 @@
       "builds": {
         "223.8836.1185": "https://plugins.jetbrains.com/files/13017/257030/keymap-visualStudio-223.7571.125.zip",
         "231.9011.35": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
-        "231.9161.29": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
         "231.9225.12": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
         "231.9225.15": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -324,13 +316,12 @@
       "builds": {
         "223.8836.1185": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "231.9011.35": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "231.9161.29": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "231.9161.40": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "231.9161.46": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "231.9161.47": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "231.9225.12": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "231.9225.15": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "231.9225.16": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "231.9225.16": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "231.9225.18": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "231.9225.21": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "231.9225.23": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -352,13 +343,12 @@
       "builds": {
         "223.8836.1185": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
         "231.9011.35": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
-        "231.9161.29": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
         "231.9225.12": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
         "231.9225.15": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip"
       },
       "name": "github-copilot"
     },
@@ -380,13 +370,12 @@
       "builds": {
         "223.8836.1185": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "231.9011.35": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "231.9161.29": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "231.9161.40": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "231.9161.46": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "231.9161.47": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "231.9225.12": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "231.9225.15": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "231.9225.16": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "231.9225.16": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     }
@@ -400,20 +389,19 @@
     "https://plugins.jetbrains.com/files/13017/307831/keymap-visualStudio-231.8109.91.zip": "sha256-b/SFrQX+pIV/R/Dd72EjqbbRgaSgppe3kv4aSxWr//Y=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/164/275091/IdeaVim-2.1.0.zip": "sha256-2dM/r79XT+1MHDeRAUnZw6WO3dmw7MZfx9alHmBqMk0=",
-    "https://plugins.jetbrains.com/files/164/347833/IdeaVim-2.3.0-signed.zip": "sha256-K4HQXGdvFhs7X25Kw+pljep/lqJ9lwewnGSEvbnNetE=",
+    "https://plugins.jetbrains.com/files/164/364022/IdeaVim-2.4.0-signed.zip": "sha256-aetarXrmK7EdYqLqAY0QNmi/djxDJnEyNTV1E0pay7Q=",
     "https://plugins.jetbrains.com/files/17718/360520/github-copilot-intellij-1.2.13.2776.zip": "sha256-9KTWE7rudLZwxCEv5QNu/9rxA0o0GdQK4+oqkzeOtyA=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/631/360005/python-231.9225.16.zip": "sha256-vin0+O9f4rY3FYqztzdIlyal5bvrvrt8Q8neDrXRmsU=",
     "https://plugins.jetbrains.com/files/6954/357005/kotlin-plugin-231-1.9.0-release-358-IJ8770.65.zip": "sha256-v2EB05au8mkC5VnoEILLJ3tesEeCWCYSNJ9RzfJZA1o=",
-    "https://plugins.jetbrains.com/files/6981/351503/ini-231.9161.47.zip": "sha256-oAgTPyTnfqEKjaGcK50k9O16hDY+A4lfL2l9IpGKyCY=",
-    "https://plugins.jetbrains.com/files/6981/360771/ini-231.9225.18.zip": "sha256-FHv/cELjKf3Jral2Cqc3QiE4bx1mm6jy42AsR27nt9g=",
+    "https://plugins.jetbrains.com/files/6981/363869/ini-231.9225.21.zip": "sha256-/HljUhlum/bmgw0sfhK+33AgxCJsT32uU/UjQIzIbKs=",
     "https://plugins.jetbrains.com/files/7219/355564/Symfony_Plugin-2022.1.253.zip": "sha256-vE+fobPbtWlaSHGTLlbDcC6NkaJiA4Qp50h8flXHaJc=",
     "https://plugins.jetbrains.com/files/7320/346181/PHP_Annotations-9.4.0.zip": "sha256-hT5K4w4lhvNwDzDMDSvsIDGj9lyaRqglfOhlbNdqpWs=",
     "https://plugins.jetbrains.com/files/7322/326457/python-ce-231.8770.65.zip": "sha256-LjHpwdBtC4C9KXrHQ+EvmGL1A+Tfbqzc17Kf80SP/lE=",
     "https://plugins.jetbrains.com/files/7322/357028/python-ce-231.9225.4.zip": "sha256-77v4vSHULX2vC0NFMeo2HoOaD3i4WG7zVCmaPUHQJIE=",
     "https://plugins.jetbrains.com/files/8182/329558/intellij-rust-0.4.194.5382-223.zip": "sha256-AgaKH4ZaxLhumk1P9BVJGpvluKnpYIulCDIRQpaWlKA=",
-    "https://plugins.jetbrains.com/files/8182/355173/intellij-rust-0.4.198.5444-231-beta.zip": "sha256-OuOUVUYHfg5JFLX2xAQ/VHaS8gUI0H7SZEdau8fbAAY=",
     "https://plugins.jetbrains.com/files/8182/359429/intellij-rust-0.4.198.5409-231.zip": "sha256-kCS/fglqb4MD/sE+mGHchvQCUOdZiDrYtTAzn7XITkM=",
+    "https://plugins.jetbrains.com/files/8182/363621/intellij-rust-0.4.199.5413-231-beta.zip": "sha256-PasY5Ep9vlbM5SAs/uB4j8b7F6dl8keeV/yLAuoTcZY=",
     "https://plugins.jetbrains.com/files/8554/326468/featuresTrainer-231.8770.66.zip": "sha256-N5woM9O9y+UequeWcjCLL93rjHDW0Tnvh8h3iLrwmjk=",
     "https://plugins.jetbrains.com/files/8607/318851/NixIDEA-0.4.0.9.zip": "sha256-byShwSfnAG8kXhoNu7CfOwvy4Viav784NT0UmzKY6hQ=",
     "https://plugins.jetbrains.com/files/9568/360002/go-plugin-231.9225.16.zip": "sha256-VZoavuQyHP7rJ3p/R+maoHetEt8bYP/eSnlfEgfFrFc="

--- a/pkgs/applications/editors/jetbrains/versions.json
+++ b/pkgs/applications/editors/jetbrains/versions.json
@@ -3,10 +3,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2023.1.4",
-      "sha256": "03830bd8c32eca51d2cb54aafbb74ce46003eaab9601465876c84107c0a19a23",
-      "url": "https://download.jetbrains.com/cpp/CLion-2023.1.4.tar.gz",
-      "build_number": "231.9161.40"
+      "version": "2023.1.5",
+      "sha256": "69a274098fe35ca53edbed460f1044691cedf595d080e291644a013905591bf3",
+      "url": "https://download.jetbrains.com/cpp/CLion-2023.1.5.tar.gz",
+      "build_number": "231.9225.21"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -67,10 +67,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
-      "version": "2023.1.3",
-      "sha256": "c12c99b39615bd2d37eec93ed29faee2387294624eaed7fabd5c7cc8de9faf9f",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.1.3.tar.gz",
-      "build_number": "231.9161.47",
+      "version": "2023.1.4",
+      "sha256": "7b44d704641c6015ce49e12e82c8866e9fdd8e8d421590235e536b3b1312b180",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.1.4.tar.gz",
+      "build_number": "231.9225.18",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -92,10 +92,10 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2023.1.3",
-      "sha256": "192be48828cb7515e8158cec8aa6ba4d320d3b65ebd09a921e85085143e9bd56",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.3.tar.gz",
-      "build_number": "231.9161.46"
+      "version": "2023.1.4",
+      "sha256": "0ff1916d0db4f081629e118da5418353e14d57bf2c0ec983db931d989becc683",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.4.tar.gz",
+      "build_number": "231.9225.23"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -108,20 +108,20 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2023.1.3",
-      "sha256": "1cef18a6d80e063b520dd8e9a0cf5b27a9cb05bbfa5b680e97c54a7cb435c9c6",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.1.3.tar.gz",
-      "build_number": "231.9161.29"
+      "version": "2023.1.4",
+      "sha256": "d522583e234aaf66d3da760908d2fa1254990a2497bb7c6eb84ee9d0bb3c5ffe",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.1.4.tar.gz",
+      "build_number": "231.9225.18"
     }
   },
   "x86_64-darwin": {
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2023.1.4",
-      "sha256": "fdb801c7c42e87fa0db94b68192e09319583118461385e4133ce9cd01125cb41",
-      "url": "https://download.jetbrains.com/cpp/CLion-2023.1.4.dmg",
-      "build_number": "231.9161.40"
+      "version": "2023.1.5",
+      "sha256": "d372abe2e1598e9ae3ca121a85d7d89211e65d99b4ca2183ef05dd3172212c44",
+      "url": "https://download.jetbrains.com/cpp/CLion-2023.1.5.dmg",
+      "build_number": "231.9225.21"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -182,10 +182,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
-      "version": "2023.1.3",
-      "sha256": "d181a8c9ff92f183f1ce68c1867de61b17e5a82f5b16ec472baa99f5a5f9ce83",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.1.3.dmg",
-      "build_number": "231.9161.47",
+      "version": "2023.1.4",
+      "sha256": "4d3d9005772d2136e44f7774377fae053b690501800ea5e650d0f35882690fdd",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.1.4.dmg",
+      "build_number": "231.9225.18",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -207,10 +207,10 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2023.1.3",
-      "sha256": "f7727c5f1b38352ca6ce7ad5ee410152b733bb72b98416d54b7b3e627fd6f2a9",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.3.dmg",
-      "build_number": "231.9161.46"
+      "version": "2023.1.4",
+      "sha256": "5f1fc9acebd587902908e310a97ff4e0fb12e6d840584618ffff6102d756d703",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.4.dmg",
+      "build_number": "231.9225.23"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -223,20 +223,20 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2023.1.3",
-      "sha256": "ac8a4edbc2d846e2ac205ebf62ad0d883df5eac812b226b1b99c4f19764df005",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.1.3.dmg",
-      "build_number": "231.9161.29"
+      "version": "2023.1.4",
+      "sha256": "9e80e3047396b99f82d541813a1177e058f3acb0fc81d27a625e3f62cc1ddadb",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.1.4.dmg",
+      "build_number": "231.9225.18"
     }
   },
   "aarch64-darwin": {
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2023.1.4",
-      "sha256": "f3aa638dbf08df9763d557c02c5408be864442af25c7e4b0dce7889a800f3a49",
-      "url": "https://download.jetbrains.com/cpp/CLion-2023.1.4-aarch64.dmg",
-      "build_number": "231.9161.40"
+      "version": "2023.1.5",
+      "sha256": "432955fc7926a5387c1fa9b30433b0e68f49ab88ea40d0bddef711692b28e8b1",
+      "url": "https://download.jetbrains.com/cpp/CLion-2023.1.5-aarch64.dmg",
+      "build_number": "231.9225.21"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -297,10 +297,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2023.1.3",
-      "sha256": "49ca043ee6119ae31c5f3fd12aa085f22dc0117c95bf70fca8afe29960c1a546",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.1.3-aarch64.dmg",
-      "build_number": "231.9161.47",
+      "version": "2023.1.4",
+      "sha256": "3285135fc4c529640ecfc5b451fa9b51d9df2a323915509cc6cbb3f25717c9e2",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2023.1.4-aarch64.dmg",
+      "build_number": "231.9225.18",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -322,10 +322,10 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2023.1.3",
-      "sha256": "d8477d115836913063996abc43ecc531cf08b10f3fb8fc21f58d385743895337",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.3-aarch64.dmg",
-      "build_number": "231.9161.46"
+      "version": "2023.1.4",
+      "sha256": "3995b3566fb64938931d6308891cc63d1a7743076d27cab4ebee1ed028d8f9a5",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.4-aarch64.dmg",
+      "build_number": "231.9225.23"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -338,10 +338,10 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2023.1.3",
-      "sha256": "c5cc29db9a12515892beed79e1970e628a816f78c629045795ea16c6e5629a2b",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.1.3-aarch64.dmg",
-      "build_number": "231.9161.29"
+      "version": "2023.1.4",
+      "sha256": "15d1a6a65c6cb073479f82394d2691fd84c54bc7eb2c5f55a6db77bdb6e500bd",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2023.1.4-aarch64.dmg",
+      "build_number": "231.9225.18"
     }
   }
 }


### PR DESCRIPTION
###### Description of changes

Update Jetbrains IDEs & plugins that were not available when https://github.com/NixOS/nixpkgs/pull/243265 was created

- clion
- rider
- ideavim
- phpstorm
- webstorm

Followed the [Submitting Changes](https://nixos.org/manual/nixpkgs/stable/#chap-submitting-changes) guidelines. Versions were updated using update_ides.py

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

