### PR TITLE
maxfetch: init at unstable-2023-07-31

### DIFF
--- a/pkgs/by-name/ma/maxfetch/package.nix
+++ b/pkgs/by-name/ma/maxfetch/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, makeBinaryWrapper
+, gnused
+, ncurses
+, procps
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "maxfetch";
+  version = "unstable-2023-07-31";
+
+  src = fetchFromGitHub {
+    owner = "jobcmax";
+    repo = "maxfetch";
+    rev = "17baa4047073e20572403b70703c69696af6b68d";
+    hash = "sha256-LzOhrFFjGs9GIDjk1lUFKhlnzJuEUrKjBcv1eT3kaY8=";
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 maxfetch $out/bin/maxfetch
+    wrapProgram $out/bin/maxfetch \
+     --prefix PATH : ${lib.makeBinPath [ gnused ncurses procps ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Nice fetching program written in sh";
+    homepage = "https://github.com/jobcmax/maxfetch";
+    license = licenses.gpl2Plus;
+    mainProgram = "maxfetch";
+    maintainers = with maintainers; [ jtbx ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Added maxfetch, a nice fetching program written in sh.
https://github.com/jobcmax/maxfetch

The package consists of one shell script so it shouldn't require excessive testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
