### PR TITLE
microsoft-edge: ensure stable order for upstream sources

### DIFF
--- a/pkgs/applications/networking/browsers/microsoft-edge/update.py
+++ b/pkgs/applications/networking/browsers/microsoft-edge/update.py
@@ -2,13 +2,12 @@
 #! nix-shell -i python3 -p python3Packages.packaging python3Packages.debian
 
 import base64
-import gzip
 import textwrap
 from urllib import request
 
+from collections import OrderedDict
 from debian.deb822 import Packages
 from debian.debian_support import Version
-
 
 def packages():
     packages_url = 'https://packages.microsoft.com/repos/edge/dists/stable/main/binary-amd64/Packages'
@@ -17,7 +16,7 @@ def packages():
 
 
 def latest_packages(packages: bytes):
-    latest_packages: dict[str, Packages] = {}
+    latest_packages: OrderedDict[str, Packages] = {}
     for package in Packages.iter_paragraphs(packages, use_apt_pkg=False):
         name: str = package['Package']
         if not name.startswith('microsoft-edge-'):


### PR DESCRIPTION
###### Description of changes

This commit addresses the issue of unstable key ordering in default.nix. Previously, the keys could appear in different orders such as "stable, beta, dev" or "beta, stable, dev".
To simplify the reviewing process and minimize merge conflicts, this commit introduces the use of OrderedDict, ensuring consistent key ordering for upstream sources.
Also, the gzip import was unused, so just drop it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
