### PR TITLE
aperture: add aperture 0.2-beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15543,6 +15543,12 @@
     githubId = 6391601;
     name = "Roger Mason";
   };
+  sputn1ck = {
+    email = "kon@kon.ninja";
+    github = "sputn1ck";
+    githubId = 8904314;
+    name = "Konstantin Nick";
+  };
   squalus = {
     email = "squalus@squalus.net";
     github = "squalus";

--- a/pkgs/applications/blockchains/aperture/default.nix
+++ b/pkgs/applications/blockchains/aperture/default.nix
@@ -1,0 +1,27 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "aperture";
+  version = "0.2-beta";
+
+  src = fetchFromGitHub {
+    owner = "lightninglabs";
+    repo = "aperture";
+    rev = "v${version}";
+    hash = "sha256-l1fpjCAg+1PGNotKrjFLoYOMEzRNXC1mfdjRPfE0DsY=";
+  };
+
+  vendorHash = "sha256-tWFFmRSDUZXijAUTgR8k4EERHwIEBOyZZZ9BGXso/tU=";
+
+  subPackages = [ "cmd/aperture" ];
+
+  meta = with lib; {
+    description = "L402 (Lightning HTTP 402) Reverse Proxy";
+    homepage = "https://github.com/lightninglabs/aperture";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sputn1ck ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36389,6 +36389,8 @@ with pkgs;
     withGui = false;
   };
 
+  aperture = callPackage ../applications/blockchains/aperture { };
+
   balanceofsatoshis = nodePackages.balanceofsatoshis;
 
   bitcoin  = libsForQt5.callPackage ../applications/blockchains/bitcoin {


### PR DESCRIPTION
###### Description of changes

This PR adds https://github.com/lightninglabs/aperture to the nixpkgs. Aperture is L402 (Lightning HTTP 402) Reverse Proxy, which allows putting apis behind bitcoin paywalls.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x]  x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
