### PR TITLE
nixos/vte: use vte without any GUI dependencies

### DIFF
--- a/nixos/modules/config/vte.nix
+++ b/nixos/modules/config/vte.nix
@@ -1,5 +1,3 @@
-# VTE
-
 { config, pkgs, lib, ... }:
 
 with lib;
@@ -9,7 +7,7 @@ let
   vteInitSnippet = ''
     # Show current working directory in VTE terminals window title.
     # Supports both bash and zsh, requires interactive shell.
-    . ${pkgs.vte}/etc/profile.d/vte.sh
+    . ${pkgs.vte.override { gtkVersion = null; }}/etc/profile.d/vte.sh
   '';
 
 in

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -32,7 +32,8 @@ stdenv.mkDerivation rec {
   pname = "vte";
   version = "0.72.2";
 
-  outputs = [ "out" "dev" "devdoc" ];
+  outputs = [ "out" "dev" ]
+    ++ lib.optional (gtkVersion != null) "devdoc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -73,9 +74,10 @@ stdenv.mkDerivation rec {
     systemd
   ];
 
-  propagatedBuildInputs = assert (gtkVersion == "3" || gtkVersion == "4"); [
+  propagatedBuildInputs = assert (gtkVersion == "3" || gtkVersion == "4" || gtkVersion == null);
     # Required by vte-2.91.pc.
-    (if gtkVersion == "3" then gtk3 else gtk4)
+    lib.optional (gtkVersion != null) (if gtkVersion == "3" then gtk3 else gtk4)
+  ++ [
     glib
     pango
   ];
@@ -87,6 +89,9 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (gtkVersion == "4") [
     "-Dgtk3=false"
     "-Dgtk4=true"
+  ] ++ lib.optionals (gtkVersion == null) [
+    "-Dgtk3=false"
+    "-Dgtk4=false"
   ] ++ lib.optionals stdenv.isDarwin [
     # -Bsymbolic-functions is not supported on darwin
     "-D_b_symbolic_functions=false"


### PR DESCRIPTION
we just need the script, borrowed from environment.noXLibs On my system this reduced the closure size by ~100MB

 ▶ nix path-info -Sh /nix/var/nix/profiles/system-76-link/
/nix/store/adybwlzyf3qa56irabblzlyjsr74amb9-nixos-system-francium-23.11    6.5G
 ▶ nix path-info -S /nix/var/nix/profiles/system-76-link/
/nix/store/adybwlzyf3qa56irabblzlyjsr74amb9-nixos-system-francium-23.11  6956572064

 ▶ nix path-info -Sh /nix/var/nix/profiles/system-77-link/
/nix/store/wgs6wlq2i911q2r1n5fqbs9vzmp8qy26-nixos-system-francium-23.11    6.4G
 ▶ nix path-info -S /nix/var/nix/profiles/system-77-link/
/nix/store/wgs6wlq2i911q2r1n5fqbs9vzmp8qy26-nixos-system-francium-23.11  6856836056

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
