### PR TITLE
lxd: 5.15 -> 5.16, update URLs and statically compile tools

### DIFF
--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
       --replace "/usr/share/misc/usb.ids" "${hwdata}/share/hwdata/usb.ids"
   '';
 
-  excludedPackages = [ "test" "lxd/db/generate" ];
+  excludedPackages = [ "test" "lxd/db/generate" "lxd-agent" "lxd-migrate" ];
 
   nativeBuildInputs = [ installShellFiles pkg-config ];
   buildInputs = [
@@ -51,6 +51,11 @@ buildGoModule rec {
   preBuild = ''
     # required for go-dqlite. See: https://github.com/canonical/lxd/pull/8939
     export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
+  '';
+
+  # build static binaries: https://github.com/canonical/lxd/blob/6fd175c45e65cd475d198db69d6528e489733e19/Makefile#L43-L51
+  postBuild = ''
+    make lxd-agent lxd-migrate
   '';
 
   preCheck =

--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -21,10 +21,7 @@ buildGoModule rec {
   version = "5.15";
 
   src = fetchurl {
-    urls = [
-      "https://linuxcontainers.org/downloads/lxd/lxd-${version}.tar.gz"
-      "https://github.com/lxc/lxd/releases/download/lxd-${version}/lxd-${version}.tar.gz"
-    ];
+    url = "https://github.com/canonical/lxd/releases/download/lxd-${version}/lxd-${version}.tar.gz";
     hash = "sha256-ez/875yu0XYu5ORf4ak6RN1jWGxuGk0n9023zJkoluM=";
   };
 
@@ -52,7 +49,7 @@ buildGoModule rec {
   tags = [ "libsqlite3" ];
 
   preBuild = ''
-    # required for go-dqlite. See: https://github.com/lxc/lxd/pull/8939
+    # required for go-dqlite. See: https://github.com/canonical/lxd/pull/8939
     export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
   '';
 
@@ -78,14 +75,14 @@ buildGoModule rec {
   passthru.tests.lxd-ui = nixosTests.lxd-ui;
   passthru.ui = callPackage ./ui.nix { };
   passthru.updateScript = gitUpdater {
-    url = "https://github.com/lxc/lxd.git";
+    url = "https://github.com/canonical/lxd.git";
     rev-prefix = "lxd-";
   };
 
   meta = with lib; {
     description = "Daemon based on liblxc offering a REST API to manage containers";
-    homepage = "https://linuxcontainers.org/lxd/";
-    changelog = "https://github.com/lxc/lxd/releases/tag/lxd-${version}";
+    homepage = "https://ubuntu.com/lxd";
+    changelog = "https://github.com/canonical/lxd/releases/tag/lxd-${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ marsam adamcstephens ];
     platforms = platforms.linux;

--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -18,11 +18,11 @@
 
 buildGoModule rec {
   pname = "lxd-unwrapped";
-  version = "5.15";
+  version = "5.16";
 
   src = fetchurl {
     url = "https://github.com/canonical/lxd/releases/download/lxd-${version}/lxd-${version}.tar.gz";
-    hash = "sha256-ez/875yu0XYu5ORf4ak6RN1jWGxuGk0n9023zJkoluM=";
+    hash = "sha256-evtNPZvnx8rzr/tJkEp0E7BhUBWHBSJdMtZJQk3VZI8=";
   };
 
   vendorHash = null;

--- a/pkgs/tools/admin/lxd/ui.nix
+++ b/pkgs/tools/admin/lxd/ui.nix
@@ -33,8 +33,7 @@ mkYarnPackage rec {
 
   meta = {
     description = "Web user interface for LXD.";
-    homepage = "https://linuxcontainers.org/lxd/";
-    changelog = "https://github.com/canonical/lxd-ui";
+    homepage = "https://github.com/canonical/lxd-ui";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ jnsgruk ];
     platforms = lib.platforms.linux;

--- a/pkgs/tools/virtualization/distrobuilder/default.nix
+++ b/pkgs/tools/virtualization/distrobuilder/default.nix
@@ -38,7 +38,7 @@ buildGoModule rec {
 
   patches = [
     # go.mod update: needed to to include a newer lxd which contains
-    # https://github.com/lxc/lxd/commit/d83f061a21f509d42b7a334b97403d2a019a7b52
+    # https://github.com/canonical/lxd/commit/d83f061a21f509d42b7a334b97403d2a019a7b52
     # which is needed to fix the build w/glibc-2.36.
     (fetchpatch {
       url = "https://github.com/lxc/distrobuilder/commit/5346bcc77dd7f141a36a8da851f016d0b929835e.patch";


### PR DESCRIPTION
###### Description of changes

https://discourse.ubuntu.com/t/lxd-5-16-has-been-released/37150
https://github.com/canonical/lxd/releases/tag/lxd-5.16

- Fix URLs as LXD is no longer a part of the linuxcontainers project: https://linuxcontainers.org/lxd/
- Statically compile tools that upstream does, including:
  - lxd-agent - the LXD server distributes this to guests on creation
  - lxd-migrate - intended to be a standalone tool

This is in part preparation for https://github.com/NixOS/nixpkgs/pull/244093

Closes #245579

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
