### PR TITLE
[23.05] retroarch: auto-detect joypads

### DIFF
--- a/pkgs/applications/emulators/retroarch/retroarch-joypad-autoconfig.nix
+++ b/pkgs/applications/emulators/retroarch/retroarch-joypad-autoconfig.nix
@@ -1,0 +1,28 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "retroarch-joypad-autoconfig";
+  version = "1.15.0";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "retroarch-joypad-autoconfig";
+    rev = "v${version}";
+    hash = "sha256-/F2Y08uDA/pIIeLiLfOQfGVjX2pkuOqPourlx2RbZ28=";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "Joypad autoconfig files";
+    homepage = "https://www.libretro.com/";
+    license = licenses.mit;
+    maintainers = with maintainers; teams.libretro.members ++ [ ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/emulators/retroarch/wrapper.nix
+++ b/pkgs/applications/emulators/retroarch/wrapper.nix
@@ -3,16 +3,28 @@
 , makeWrapper
 , retroarch
 , symlinkJoin
+, runCommand
 , cores ? [ ]
+, settings ? { }
 }:
 
 let
+  settingsPath = runCommand "declarative-retroarch.cfg"
+    {
+      value = lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = \"${v}\"") settings);
+      passAsFile = [ "value" ];
+    }
+    ''
+      cp "$valuePath" "$out"
+    '';
+
   # All cores should be located in the same path after symlinkJoin,
   # but let's be safe here
   coresPath = lib.lists.unique (map (c: c.libretroCore) cores);
-  wrapperArgs = lib.strings.escapeShellArgs
-    (lib.lists.flatten
-      (map (p: [ "--add-flags" "-L ${placeholder "out" + p}" ]) coresPath));
+  wrapperArgs = lib.strings.escapeShellArgs (
+    (lib.lists.flatten (map (p: [ "--add-flags" "-L ${placeholder "out" + p}" ]) coresPath))
+    ++ [ "--add-flags" "--appendconfig=${settingsPath}" ]
+  );
 in
 symlinkJoin {
   name = "retroarch-with-cores-${lib.getVersion retroarch}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2500,6 +2500,9 @@ with pkgs;
       withAssets = true;
       withCoreInfo = true;
     };
+    settings = {
+      joypad_autoconfig_dir = "${retroarch-joypad-autoconfig}/share/libretro/autoconfig";
+    };
   };
 
   retroarch-assets = callPackage ../applications/emulators/retroarch/retroarch-assets.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2504,6 +2504,8 @@ with pkgs;
 
   retroarch-assets = callPackage ../applications/emulators/retroarch/retroarch-assets.nix { };
 
+  retroarch-joypad-autoconfig = callPackage ../applications/emulators/retroarch/retroarch-joypad-autoconfig.nix { };
+
   libretro = recurseIntoAttrs
     (callPackage ../applications/emulators/retroarch/cores.nix {
       retroarch = retroarchBare;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2491,9 +2491,9 @@ with pkgs;
       (builtins.attrValues libretro);
   };
 
-  wrapRetroArch = { retroarch }:
+  wrapRetroArch = { retroarch, settings ? {} }:
     callPackage ../applications/emulators/retroarch/wrapper.nix
-      { inherit retroarch; };
+      { inherit retroarch settings; };
 
   retroarch = wrapRetroArch {
     retroarch = retroarchBare.override {


### PR DESCRIPTION
###### Description of changes

Be able to use joypads out of the box. (Backported from master branch.)

Commits:

- retroarch: add support for declarative settings
- retroarch-joypad-autoconfig: init at 1.15.0
- retroarch: auto-detect joypads

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
