### PR TITLE
[23.05] iperf: apply patch for CVE-2023-38403

### DIFF
--- a/pkgs/tools/networking/iperf/3.nix
+++ b/pkgs/tools/networking/iperf/3.nix
@@ -16,7 +16,13 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" ];
 
-  patches = lib.optionals stdenv.hostPlatform.isMusl [
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/esnet/iperf/commit/0ef151550d96cc4460f98832df84b4a1e87c65e9.patch";
+      name = "CVE-2023-38403.patch";
+      hash = "sha256-Yaup8rlljyuBK6n71YtHhFd1+WnjxfmEQpoXJulhQTs=";
+    })
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/main/iperf3/remove-pg-flags.patch?id=7f979fc51ae31d5c695d8481ba84a4afc5080efb";
       name = "remove-pg-flags.patch";


### PR DESCRIPTION
###### Description of changes

The 3.13 and 3.14 releases include a set of user visible changes. I was not sure it those were all appropriate for a backport. Feel free to close this and to cherry-pick the upgrades instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review pr 244368` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>12 packages built:</summary>
  <ul>
    <li>bcc</li>
    <li>bcc.man</li>
    <li>bpftrace</li>
    <li>bpftrace.man</li>
    <li>iperf</li>
    <li>iperf.man</li>
    <li>linuxKernel.packages.hardkernel_4_14.oci-seccomp-bpf-hook</li>
    <li>linuxKernel.packages.hardkernel_4_14.oci-seccomp-bpf-hook.man</li>
    <li>linuxKernel.packages.linux_5_4.system76-scheduler (linuxKernel.packages.linux_4_14.system76-scheduler ,linuxKernel.packages.linux_5_4_hardened.system76-scheduler ,linuxKernel.packages.linux_6_1.system76-scheduler ,linuxKernel.packages.linux_6_1_hardened.system76-scheduler ,linuxKernel.packages.linux_6_3.system76-scheduler ,linuxKernel.packages.linux_6_3_hardened.system76-scheduler ,linuxKernel.packages.linux_6_4.system76-scheduler ,linuxKernel.packages.linux_6_4_hardened.system76-scheduler ,linuxKernel.packages.linux_hardened.system76-scheduler ,linuxKernel.packages.linux_latest_libre.system76-scheduler ,linuxKernel.packages.linux_libre.system76-scheduler ,linuxKernel.packages.linux_lqx.system76-scheduler ,linuxKernel.packages.linux_testing_bcachefs.system76-scheduler ,linuxKernel.packages.linux_xanmod.system76-scheduler ,linuxKernel.packages.linux_xanmod_latest.system76-scheduler ,linuxKernel.packages.linux_xanmod_stable.system76-scheduler ,linuxKernel.packages.linux_zen.system76-scheduler)</li>
    <li>picosnitch</li>
    <li>picosnitch.dist</li>
    <li>sockdump</li>
  </ul>
</details>