### PR TITLE
dq: init at 20230101

### DIFF
--- a/pkgs/tools/networking/dq/default.nix
+++ b/pkgs/tools/networking/dq/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "dq";
+  version = "20230101";
+
+  src = fetchFromGitHub {
+    owner = "janmojzis";
+    repo = "dq";
+    rev = "refs/tags/${version}";
+    hash = "sha256-K96yOonOYSsz26Bf/vx9XtWs7xyY0Dpxdd55OMbQz8k=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 dq dqcache dqcache-makekey dqcache-start -t $out/bin
+    installManPage man/*
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Recursive DNS/DNSCurve server and comandline tool";
+    homepage = "https://github.com/janmojzis/dq";
+    changelog = "https://github.com/janmojzis/dq/releases/tag/${version}";
+    license = licenses.cc0;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7206,6 +7206,8 @@ with pkgs;
 
   doggo = callPackage ../tools/networking/doggo { };
 
+  dq = callPackage ../tools/networking/dq { };
+
   dool = callPackage ../tools/system/dool { };
 
   dosfstools = callPackage ../tools/filesystems/dosfstools { };


### PR DESCRIPTION
###### Description of changes
[**dq**](https://github.com/janmojzis/dq): recursive DNS/DNSCurve server and comandline tool to debug DNS/DNSCurve.

```sh
$ result/bin/dq a nixos.org 1.1.1.1
1 nixos.org - regular DNS:
59 bytes, 1+2+0+0 records, response, noerror
query: 1 nixos.org
answer: nixos.org 20 A 18.192.231.252
answer: nixos.org 20 A 3.72.140.173
```

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
