### PR TITLE
jesec-rtorrent: Add patch to prevent segfault

### DIFF
--- a/pkgs/applications/networking/p2p/jesec-rtorrent/avoid-stack-overflow-for-lockfile-buf.patch
+++ b/pkgs/applications/networking/p2p/jesec-rtorrent/avoid-stack-overflow-for-lockfile-buf.patch
@@ -1,0 +1,30 @@
+From dd4a96073d4a60ca8fff55be6ea6b17018de96a8 Mon Sep 17 00:00:00 2001
+From: Varun Madiath <git@madiathv.com>
+Date: Wed, 19 Jul 2023 15:30:57 -0400
+Subject: [PATCH] utils: lockfile: avoid stack overflow for lockfile buffer
+
+Original patch by @cyphar was submitted to rakshasa/rtorrent at
+https://github.com/rakshasa/rtorrent/pull/1169.
+
+Observed the segfault on nixos-unstable.
+---
+ src/utils/lockfile.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/utils/lockfile.cc b/src/utils/lockfile.cc
+index 76e4b8f..441f5c8 100644
+--- a/src/utils/lockfile.cc
++++ b/src/utils/lockfile.cc
+@@ -75,7 +75,8 @@ Lockfile::try_lock() {
+   int  pos = ::gethostname(buf, 255);
+ 
+   if (pos == 0) {
+-    ::snprintf(buf + std::strlen(buf), 255, ":+%i\n", ::getpid());
++    ssize_t len = std::strlen(buf);
++    ::snprintf(buf + len, 255 - len, ":+%i\n", ::getpid());
+     ssize_t __attribute__((unused)) result = ::write(fd, buf, std::strlen(buf));
+   }
+ 
+-- 
+2.41.0
+

--- a/pkgs/applications/networking/p2p/jesec-rtorrent/default.nix
+++ b/pkgs/applications/networking/p2p/jesec-rtorrent/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-i7c1jSawHshj1kaXl8tdpelIKU24okeg9K5/+ht6t2k=";
   };
 
+  patches = [
+    ./avoid-stack-overflow-for-lockfile-buf.patch
+  ];
+
   passthru = {
     inherit libtorrent;
   };


### PR DESCRIPTION
###### Description of changes

I've submitted the attached patch upstream. https://github.com/jesec/rtorrent/pull/67
This prevents a core dump that started to happen recently (I updated last about a week ago).

As mentioned, the original patch is from: https://github.com/rakshasa/rtorrent/pull/1169.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
