### PR TITLE
trimage: init at 1.0.7-dev

### DIFF
--- a/pkgs/applications/graphics/trimage/default.nix
+++ b/pkgs/applications/graphics/trimage/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, substituteAll
+
+, python3
+, installShellFiles
+, makeWrapper
+, wrapQtAppsHook
+
+, advancecomp
+, jpegoptim
+, optipng
+, pngcrush
+}:
+
+let
+  pythonEnv = python3.withPackages (ps: with ps; [ pyqt5 ]);
+  binPath = lib.makeBinPath [
+    advancecomp
+    jpegoptim
+    optipng
+    pngcrush
+  ];
+in
+stdenv.mkDerivation {
+  pname = "trimage";
+  version = "1.0.7-dev";
+
+  src = fetchFromGitHub {
+    owner = "Kilian";
+    repo = "Trimage";
+    rev = "ad74684272a31eee6af289cc59fd90fd962d2806";
+    hash = "sha256-jdcGGTqr3f3Xnp6thYmASQYiZh9nagLUTmlFnJ5Hqmc=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    wrapQtAppsHook
+  ];
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -R trimage $out
+
+    installManPage doc/trimage.1
+    install -Dm444 desktop/trimage.desktop -t $out/share/applications
+    install -Dm444 desktop/trimage.svg -t $out/share/icons/hicolor/scalable/apps
+
+    makeWrapper ${pythonEnv}/bin/python $out/bin/trimage \
+          --add-flags "$out/trimage/trimage.py" \
+          --prefix PATH : ${binPath} \
+          "''${qtWrapperArgs[@]}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A cross-platform tool for optimizing PNG and JPG files";
+    homepage = "https://github.com/Kilian/Trimage";
+    license = lib.licenses.mit;
+    mainProgram = "trimage";
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1881,6 +1881,8 @@ with pkgs;
 
   trigger-control = callPackage ../tools/games/trigger-control { };
 
+  trimage = callPackage ../applications/graphics/trimage { inherit (qt5) wrapQtAppsHook; };
+
   ttchat = callPackage ../tools/misc/ttchat { };
 
   ukmm = callPackage ../tools/games/ukmm { };


### PR DESCRIPTION
###### Description of changes

Closes: https://github.com/NixOS/nixpkgs/issues/222054

Trimage is an image optimization utility written in Python, which uses other image optimization libraries.

The project's last release was 1.0.6 however, there has been some work on the repo since then, so I set the version as 1.0.7-dev
It seems like the project is at a standstill, so it's most likely going to stay this way.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
