### PR TITLE
netdata: 1.40.1 -> 1.41.0

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -17,14 +17,14 @@
 
 stdenv.mkDerivation rec {
   # Don't forget to update go.d.plugin.nix as well
-  version = "1.40.1";
+  version = "1.41.0";
   pname = "netdata";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "netdata";
     rev = "v${version}";
-    sha256 = "sha256-4bYCsEeB0kEYtVFVXymFv7ELUo9RXoKbPjOlDKav8Rg=";
+    sha256 = "sha256-MZQ1ZTghH4bN7kCMqbyQlAGSgE70sYJxjiamTTH/6ds=";
     fetchSubmodules = true;
   };
 
@@ -49,11 +49,6 @@ stdenv.mkDerivation rec {
     # required to prevent plugins from relying on /etc
     # and /var
     ./no-files-in-etc-and-var.patch
-    # The current IPC location is unsafe as it writes
-    # a fixed path in /tmp, which is world-writable.
-    # Therefore we put it into `/run/netdata`, which is owned
-    # by netdata only.
-    ./ipc-socket-in-run.patch
 
     # Avoid build-only inputs in closure leaked by configure command:
     #   https://github.com/NixOS/nixpkgs/issues/175693#issuecomment-1143344162

--- a/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
+++ b/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
@@ -1,8 +1,8 @@
 diff --git a/collectors/Makefile.am b/collectors/Makefile.am
-index 24e4c3f09..b3c354943 100644
+index 2aec3dd3e..27385ec28 100644
 --- a/collectors/Makefile.am
 +++ b/collectors/Makefile.am
-@@ -30,7 +30,7 @@ usercustompluginsconfigdir=$(configdir)/custom-plugins.d
+@@ -31,7 +31,7 @@ usercustompluginsconfigdir=$(configdir)/custom-plugins.d
  usergoconfigdir=$(configdir)/go.d
  
  # Explicitly install directories to avoid permission issues due to umask
@@ -62,7 +62,7 @@ index c8144c137..f8aaa89b6 100644
 +no-install-exec-local:
  	$(INSTALL) -d $(DESTDIR)$(userstatsdconfigdir)
 diff --git a/health/Makefile.am b/health/Makefile.am
-index ea1b6e961..071fdd564 100644
+index 20e000860..add0137b3 100644
 --- a/health/Makefile.am
 +++ b/health/Makefile.am
 @@ -19,7 +19,7 @@ dist_userhealthconfig_DATA = \
@@ -75,10 +75,10 @@ index ea1b6e961..071fdd564 100644
  
  healthconfigdir=$(libconfigdir)/health.d
 diff --git a/system/Makefile.am b/system/Makefile.am
-index 13466639d..e7cc7acea 100644
+index 54e9278c8..e7cc7acea 100644
 --- a/system/Makefile.am
 +++ b/system/Makefile.am
-@@ -21,11 +21,9 @@ include $(top_srcdir)/build/subst.inc
+@@ -21,12 +21,9 @@ include $(top_srcdir)/build/subst.inc
  SUFFIXES = .in
  
  dist_config_SCRIPTS = \
@@ -87,10 +87,11 @@ index 13466639d..e7cc7acea 100644
  
  dist_config_DATA = \
 -    .install-type \
+-    netdata-updater.conf \
      $(NULL)
  
  libconfigvnodesdir=$(libconfigdir)/vnodes
-@@ -45,7 +43,7 @@ libsysrunitdir=$(libsysdir)/runit
+@@ -46,7 +43,7 @@ libsysrunitdir=$(libsysdir)/runit
  libsyssystemddir=$(libsysdir)/systemd
  
  # Explicitly install directories to avoid permission issues due to umask
@@ -112,6 +113,3 @@ index be2c545c3..55f373114 100644
  	$(INSTALL) -d $(DESTDIR)$(usersslconfigdir)
  
  dist_noinst_DATA = \
--- 
-2.40.1
-

--- a/pkgs/tools/system/netdata/skip-CONFIGURE_COMMAND.patch
+++ b/pkgs/tools/system/netdata/skip-CONFIGURE_COMMAND.patch
@@ -1,16 +1,16 @@
 Shrink closure size by avoiding paths embedded from configure call.
 
 https://github.com/NixOS/nixpkgs/issues/175693
+diff --git a/daemon/buildinfo.c b/daemon/buildinfo.c
+index 56cde84fc..011e7579d 100644
 --- a/daemon/buildinfo.c
 +++ b/daemon/buildinfo.c
-@@ -247,7 +247,9 @@ void print_build_info(void) {
-     char *prebuilt_distro = NULL;
-     get_install_type(&install_type, &prebuilt_arch, &prebuilt_distro);
+@@ -1040,7 +1040,7 @@ static void build_info_set_status(BUILD_INFO_SLOT slot, bool status) {
  
--    printf("Configure options: %s\n", CONFIGURE_COMMAND);
-+    // To minimize closure size do not persist configure options
-+    // with build-time inputs.
-+    printf("Configure options: REMOVED\n");
+ __attribute__((constructor)) void initialize_build_info(void) {
+     build_info_set_value(BIB_PACKAGING_NETDATA_VERSION, program_version);
+-    build_info_set_value(BIB_PACKAGING_CONFIGURE_OPTIONS, CONFIGURE_COMMAND);
++    build_info_set_value(BIB_PACKAGING_CONFIGURE_OPTIONS, "REMOVED FOR CLOSURE SIZE REASONS");
  
-     if (install_type == NULL) {
-         printf("Install type: unknown\n");
+ #ifdef COMPILED_FOR_LINUX
+     build_info_set_status(BIB_FEATURE_BUILT_FOR, true);


### PR DESCRIPTION
###### Description of changes

https://github.com/netdata/netdata/releases/tag/v1.41.0

Reflowed & updated 2 patches:

- etc/var one
- skip configure one

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
