### PR TITLE
openxray: 1144-december-2021-rc1 -> 2188-november-2023-rc1

### DIFF
--- a/pkgs/games/openxray/default.nix
+++ b/pkgs/games/openxray/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , glew
 , freeimage
@@ -18,25 +17,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openxray";
-  version = "1747-january-2023-rc3";
+  version = "2088-august-2023-rc1";
 
   src = fetchFromGitHub {
     owner = "OpenXRay";
     repo = "xray-16";
     rev = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-ip9CruOWk5T/dBDMcn9aOHbYaaZ+7VJw9U5GayiE7AE=";
+    hash = "sha256-f9EheVp05BAjjk3FIJjHVfm0piYiMYZJ9U156g2vhac=";
   };
-
-  patches = [
-    # Fix OpenGL shader lookup & linking
-    # Remove when in a tag
-    (fetchpatch {
-      name = "0001-openxray-Fix-resource-linking-again.patch";
-      url = "https://github.com/OpenXRay/xray-16/commit/88d2302b490ff62344c5ab4f8ba77260402cf4f4.patch";
-      hash = "sha256-JvOwnqTThYB41ndpGrW1jVUp7rcysCTHNCEyq1fTlrY=";
-    })
-  ];
 
   strictDeps = true;
 

--- a/pkgs/games/openxray/default.nix
+++ b/pkgs/games/openxray/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, gitUpdater
 , cmake
 , glew
 , freeimage
@@ -17,14 +18,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openxray";
-  version = "2088-august-2023-rc1";
+  version = "2188-november-2023-rc1";
 
   src = fetchFromGitHub {
     owner = "OpenXRay";
     repo = "xray-16";
     rev = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-f9EheVp05BAjjk3FIJjHVfm0piYiMYZJ9U156g2vhac=";
+    hash = "sha256-rRxw/uThACmT2qI8NUwJU+WbJ3BWUss6CH13R5aaHco=";
   };
 
   strictDeps = true;
@@ -64,6 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     wrapProgram $out/bin/xr_3da ${toString finalAttrs.makeWrapperArgs}
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
     mainProgram = "xr_3da";

--- a/pkgs/games/openxray/default.nix
+++ b/pkgs/games/openxray/default.nix
@@ -4,7 +4,6 @@
 , gitUpdater
 , cmake
 , glew
-, freeimage
 , liblockfile
 , openal
 , libtheora
@@ -37,7 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     glew
-    freeimage
     liblockfile
     openal
     libtheora

--- a/pkgs/games/openxray/default.nix
+++ b/pkgs/games/openxray/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , glew
 , freeimage
@@ -15,17 +16,29 @@
 , makeWrapper
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openxray";
-  version = "1144-december-2021-rc1";
+  version = "1747-january-2023-rc3";
 
   src = fetchFromGitHub {
     owner = "OpenXRay";
     repo = "xray-16";
-    rev = version;
+    rev = finalAttrs.version;
     fetchSubmodules = true;
-    sha256 = "07qj1lpp21g4p583gvz5h66y2q71ymbsz4g5nr6dcys0vm7ph88v";
+    hash = "sha256-ip9CruOWk5T/dBDMcn9aOHbYaaZ+7VJw9U5GayiE7AE=";
   };
+
+  patches = [
+    # Fix OpenGL shader lookup & linking
+    # Remove when in a tag
+    (fetchpatch {
+      name = "0001-openxray-Fix-resource-linking-again.patch";
+      url = "https://github.com/OpenXRay/xray-16/commit/88d2302b490ff62344c5ab4f8ba77260402cf4f4.patch";
+      hash = "sha256-JvOwnqTThYB41ndpGrW1jVUp7rcysCTHNCEyq1fTlrY=";
+    })
+  ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
@@ -56,13 +69,13 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    mainProgram = "xray-16";
+    mainProgram = "xr_3da";
     description = "Improved version of the X-Ray Engine, the game engine used in the world-famous S.T.A.L.K.E.R. game series by GSC Game World";
     homepage = "https://github.com/OpenXRay/xray-16/";
     license = licenses.unfree // {
       url = "https://github.com/OpenXRay/xray-16/blob/${version}/License.txt";
     };
     maintainers = with maintainers; [ OPNA2608 ];
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38074,7 +38074,11 @@ with pkgs;
 
   openxcom = callPackage ../games/openxcom { SDL = SDL_compat; };
 
-  openxray = callPackage ../games/openxray { };
+  openxray = callPackage ../games/openxray {
+    # Builds with Clang, but hits an assertion failure unless GCC is used
+    # https://github.com/OpenXRay/xray-16/issues/1224
+    stdenv = gccStdenv;
+  };
 
   orthorobot = callPackage ../games/orthorobot { love = love_0_10; };
 


### PR DESCRIPTION
###### Description of changes

- bump to ~~`2088-august-2023-rc1`~~ `2188-november-2023-rc1` tag
- enable on aarch64-linux
  - I lack a system to test this properly: it should build, but requires OpenGL 4.1 which none of my ARM systems support
    - to be more specific, my hardware runs into this upstream issue if I try to fake my way past the OpenGL version requirement: https://github.com/OpenXRay/xray-16/issues/1296
- enable on x86_64 & aarch64 Darwin (can only test x86_64-darwin myself though)
  - I run into https://github.com/OpenXRay/xray-16/issues/1224 when using Clang, so need to force GCC stdenv.
    Based on the reports in that ticket also being on Ubuntu & FreeBSD w/ Clang, just hardcoding `gccStdenv` in general for now.
  - GCC build throw `runtime error: locale::facet::_S_create_c_locale name not valid` on startup, which is related to some locale interplay between GCC and Darwin AFAIU?
    Worked around by forcing `LC_ALL=C` in the wrapper, which at least lets it launch for now.

![image](https://github.com/NixOS/nixpkgs/assets/23431373/311035f6-3f03-47dc-938b-23dc8f042cfb)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
