### PR TITLE
Add pipInstallFlags to all pip install invocations in python hooks

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
@@ -1,6 +1,8 @@
 # Setup hook to use for pip projects
 echo "Sourcing pip-build-hook"
 
+declare -a pipInstallFlags
+
 pipBuildPhase() {
     echo "Executing pipBuildPhase"
     runHook preBuild
@@ -25,7 +27,7 @@ pipShellHook() {
       export PYTHONPATH="$tmp_path/@pythonSitePackages@:$PYTHONPATH"
       mkdir -p "$tmp_path/@pythonSitePackages@"
       @pythonInterpreter@ -m pip install -e . --prefix "$tmp_path" \
-         --no-build-isolation >&2
+         --no-build-isolation $pipInstallFlags >&2
     fi
 
     runHook postShellHook

--- a/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
@@ -1,6 +1,8 @@
 # Setup hook for setuptools.
 echo "Sourcing setuptools-build-hook"
 
+declare -a pipInstallFlags
+
 setuptoolsBuildPhase() {
     echo "Executing setuptoolsBuildPhase"
     local args
@@ -33,7 +35,7 @@ setuptoolsShellHook() {
         export PYTHONPATH="$tmp_path/@pythonSitePackages@:$PYTHONPATH"
         mkdir -p "$tmp_path/@pythonSitePackages@"
         eval "@pythonInterpreter@ -m pip install -e . --prefix $tmp_path \
-          --no-build-isolation >&2"
+          --no-build-isolation $pipInstallFlags >&2"
 
         # Process pth file installed in tmp path. This allows one to
         # actually import the editable installation. Note site.addsitedir


### PR DESCRIPTION
###### Description of changes
Resolves #172936

The pipInstallFlags environment variable was only being passed to the `pip-install-hook`. This causes other invocations of pip (like in `setup-tools-build-hook` and `pip-build`hook`) to effectively ignore the pipInstallFlags argument to the buildPythonPackage function. 

This PR resolves the issue by adding the install flags to every pip invocation in the python hooks
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
