### PR TITLE
Revert "nixos/boot/stage-1: chase symlinks when copying binaries"

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -102,7 +102,7 @@ let
 
       copy_bin_and_libs () {
         [ -f "$out/bin/$(basename $1)" ] && rm "$out/bin/$(basename $1)"
-        cp -pdvH $1 $out/bin
+        cp -pdv $1 $out/bin
       }
 
       # Copy BusyBox.


### PR DESCRIPTION
Reverts NixOS/nixpkgs#244177

See: https://github.com/NixOS/nixpkgs/pull/244177#issuecomment-1643032271