### PR TITLE
python3Packages.numpy: mass-rebuild clean up

### DIFF
--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -39,7 +39,7 @@ let
       };
     };
   };
-in buildPythonPackage (rec {
+in buildPythonPackage rec {
   pname = "numpy";
   version = "1.24.2";
   format = "setuptools";
@@ -91,6 +91,9 @@ in buildPythonPackage (rec {
   nativeBuildInputs = [ gfortran cython ];
   buildInputs = [ blas lapack ];
 
+  # Causes `error: argument unused during compilation: '-fno-strict-overflow'` due to `-Werror`.
+  hardeningDisable = lib.optionals stdenv.cc.isClang [ "strictoverflow" ];
+
   # we default openblas to build with 64 threads
   # if a machine has more than 64 threads, it will segfault
   # see https://github.com/xianyi/OpenBLAS/issues/2993
@@ -137,7 +140,4 @@ in buildPythonPackage (rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fridh ];
   };
-} // lib.optionalAttrs stdenv.cc.isClang {
-  # Causes `error: argument unused during compilation: '-fno-strict-overflow'` due to `-Werror`.
-  hardeningDisable = [ "strictoverflow" ];
-})
+}

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -51,33 +51,31 @@ in buildPythonPackage rec {
     hash = "sha256-ADqfUw6IDLLNF3y6GvciC5qkLe+cSvwqL8Pua+frKyI=";
   };
 
-  patches = lib.optionals python.hasDistutilsCxxPatch [
-    # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
-    # Patching of numpy.distutils is needed to prevent it from undoing the
-    # patch to distutils.
-    ./numpy-distutils-C++.patch
-  ]
-  ++ lib.optionals stdenv.cc.isClang [
+  patches = [
     # f2py.f90mod_rules generates code with invalid function pointer conversions, which are
     # clang 16 makes an error by default.
     (fetchpatch {
       url = "https://github.com/numpy/numpy/commit/609fee4324f3521d81a3454f5fcc33abb0d3761e.patch";
       hash = "sha256-6Dbmf/RWvQJPTIjvchVaywHGcKCsgap/0wAp5WswuCo=";
     })
-  ]
-  ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+
     # Backport from 1.25. `platform.machine` returns `arm64` on aarch64-darwin, which causes
     # differing results between `_selected_real_kind_func` and Fortran’s `selected_real_kind`.
     (fetchpatch {
       url = "https://github.com/numpy/numpy/commit/afcedf4b63f4a94187e6995c2adea0da3bb18e83.patch";
       hash = "sha256-cxBoimX5a9wC2qUIGAo5o/M2E9+eV63bV2/wLmfDYKg=";
     })
-  ]
-  ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+
     # Disable `numpy/core/tests/test_umath.py::TestComplexFunctions::test_loss_of_precision[complex256]`
     # on x86_64-darwin because it fails under Rosetta 2 due to issues with trig functions and
     # 80-bit long double complex numbers.
     ./disable-failing-long-double-test-Rosetta-2.patch
+  ]
+  # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
+  # Patching of numpy.distutils is needed to prevent it from undoing the
+  # patch to distutils.
+  ++ lib.optionals python.hasDistutilsCxxPatch [
+    ./numpy-distutils-C++.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
