### PR TITLE
searxng: unstable-2023-06-26 -> unstable-2023-07-19, freeze version

### DIFF
--- a/pkgs/servers/web-apps/searxng/default.nix
+++ b/pkgs/servers/web-apps/searxng/default.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "searxng";
-  version = "unstable-2023-06-26";
+  version = "unstable-2023-07-19";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "da7c30291dcf53cc5b3d98f9aada5615cd1593a9";
-    sha256 = "sha256-kbNw/YgcBZNkmn2nmsnEnc9Y8MJg3zGFdW1x9GIo+dM=";
+    rev = "a446dea1bb492eac417de9a900fae7cdf94aeec0";
+    sha256 = "sha256-iZDaKCkDlp3O3IixWdXVykNRIxas+irG0dWAOU4wycI=";
   };
 
   postPatch = ''

--- a/pkgs/servers/web-apps/searxng/default.nix
+++ b/pkgs/servers/web-apps/searxng/default.nix
@@ -18,9 +18,22 @@ python3.pkgs.buildPythonApplication rec {
     sed -i 's/==.*$//' requirements.txt
   '';
 
-  preBuild = ''
-    export SEARX_DEBUG="true";
-  '';
+  preBuild =
+    let
+      versionString = lib.concatStringsSep "." (builtins.tail (lib.splitString "-" version));
+      commitAbbrev = builtins.substring 0 8 src.rev;
+    in
+    ''
+      export SEARX_DEBUG="true";
+
+      cat > searx/version_frozen.py <<EOF
+      VERSION_STRING="${versionString}+${commitAbbrev}"
+      VERSION_TAG="${versionString}+${commitAbbrev}"
+      DOCKER_TAG="${versionString}-${commitAbbrev}"
+      GIT_URL="https://github.com/searxng/searxng"
+      GIT_BRANCH="master"
+      EOF
+    '';
 
   propagatedBuildInputs = with python3.pkgs; [
     babel


### PR DESCRIPTION
###### Description of changes

Upstream changes: https://github.com/searxng/searxng/compare/da7c30291dcf53cc5b3d98f9aada5615cd1593a9..a446dea1bb492eac417de9a900fae7cdf94aeec0

This also includes the exact version used to build SearXNG in the final package, see https://github.com/searxng/searxng/issues/2563#issuecomment-1643602674.

Deployed to https://sx.catgirl.cloud with https://git.catgirl.cloud/999eagle/dotfiles-nix/-/commit/64024c59839358fe04a187a5c03fdef3c646b081.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
