### PR TITLE
nixci: init at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15592,6 +15592,13 @@
     githubId = 219362;
     name = "Sarah Brofeldt";
   };
+  srid = {
+    email = "srid@srid.ca";
+    matrix = "@srid:matrix.org";
+    github = "srid";
+    githubId = 3998;
+    name = "Sridhar Ratnakumar";
+  };
   srounce = {
     name = "Samuel Rounce";
     email = "me@samuelrounce.co.uk";

--- a/pkgs/tools/nix/devour-flake/default.nix
+++ b/pkgs/tools/nix/devour-flake/default.nix
@@ -1,0 +1,27 @@
+{ writeShellApplication
+, fetchFromGitHub
+, nix
+}:
+
+let
+  devour-flake = fetchFromGitHub {
+    owner = "srid";
+    repo = "devour-flake";
+    rev = "v2";
+    hash = "sha256-CZedJtbZlWAbv/b/aYgOEFd9vcTBn/oJNI3p29UitLk=";
+  };
+in
+writeShellApplication {
+  name = "devour-flake";
+  runtimeInputs = [ nix ];
+  text = ''
+    FLAKE="$1"
+    shift 1 || true
+
+    nix build ${devour-flake}#default \
+      "$@" \
+      -L --no-link --print-out-paths \
+      --override-input flake "$FLAKE" \
+      | xargs cat
+  '';
+}

--- a/pkgs/tools/nix/nixci/default.nix
+++ b/pkgs/tools/nix/nixci/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv
+, rustPlatform
+, fetchCrate
+, fetchFromGitHub
+, libiconv
+, openssl
+, pkg-config
+, Security
+}:
+
+let
+  devour-flake = fetchFromGitHub {
+    owner = "srid";
+    repo = "devour-flake";
+    rev = "v2";
+    sha256 = "sha256-CZedJtbZlWAbv/b/aYgOEFd9vcTBn/oJNI3p29UitLk=";
+  };
+in rustPlatform.buildRustPackage rec {
+  pname = "nixci";
+  version = "0.1.3";
+
+  src = fetchCrate {
+    inherit version;
+    pname = "nixci";
+    hash = "sha256-sM/1G1mf+msWbG4CX/pZNt4FmSKR2hWXdcq5h7W1AM0=";
+  };
+
+  cargoHash = "sha256-PKBNQKuWV4PE7iSKr+LugayroFjDBT4/vyyjJiw/E+I=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libiconv openssl ]
+    ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  # The rust program expects an environment (at build time) that points to the
+  # devour-flake executable.
+  DEVOUR_FLAKE = lib.getExe (callPackage devour-flake { });
+
+  meta = with lib; {
+    description = "Define and build CI for Nix projects anywhere";
+    homepage = "https://github.com/srid/nixci";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ srid ];
+    mainProgram = "nixci";
+  };
+}

--- a/pkgs/tools/nix/nixci/default.nix
+++ b/pkgs/tools/nix/nixci/default.nix
@@ -1,21 +1,14 @@
 { lib, stdenv
 , rustPlatform
 , fetchCrate
-, fetchFromGitHub
 , libiconv
 , openssl
 , pkg-config
 , Security
+, devour-flake
 }:
 
-let
-  devour-flake = fetchFromGitHub {
-    owner = "srid";
-    repo = "devour-flake";
-    rev = "v2";
-    sha256 = "sha256-CZedJtbZlWAbv/b/aYgOEFd9vcTBn/oJNI3p29UitLk=";
-  };
-in rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "nixci";
   version = "0.1.3";
 
@@ -33,7 +26,7 @@ in rustPlatform.buildRustPackage rec {
 
   # The rust program expects an environment (at build time) that points to the
   # devour-flake executable.
-  DEVOUR_FLAKE = lib.getExe (callPackage devour-flake { });
+  DEVOUR_FLAKE = lib.getExe devour-flake;
 
   meta = with lib; {
     description = "Define and build CI for Nix projects anywhere";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40124,6 +40124,10 @@ with pkgs;
 
   alejandra = callPackage ../tools/nix/alejandra { };
 
+  nixci = callPackage ../tools/nix/nixci {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   nixfmt = haskellPackages.nixfmt.bin;
 
   nixpkgs-fmt = callPackage ../tools/nix/nixpkgs-fmt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -565,6 +565,8 @@ with pkgs;
 
   dec-decode = callPackage ../development/tools/dec-decode { };
 
+  devour-flake = callPackage ../tools/nix/devour-flake { };
+
   dnf5 = callPackage ../tools/package-management/dnf5 { };
 
   dsq = callPackage ../tools/misc/dsq { };


### PR DESCRIPTION
###### Description of changes

nixci: a tool to build all flake outputs

homepage: https://github.com/srid/nixci

announcement: https://discourse.nixos.org/t/nixci-define-and-build-ci-for-nix-projects-anywhere/30696/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
