### PR TITLE
python311Packages.asgi-lifespan: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/asgi-lifespan/default.nix
+++ b/pkgs/development/python-modules/asgi-lifespan/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  pytestCheckHook,
+  nix-update-script,
+  starlette,
+  httpx,
+  pytest-asyncio,
+  pytest-trio,
+  pytest-cov,
+}:
+buildPythonPackage rec {
+  version = "2.1.0";
+  pname = "asgi-lifespan";
+  disabled = pythonOlder "3.7";
+
+  # PyPI tarball doesn't include tests directory
+  src = fetchFromGitHub {
+    owner = "florimondmanca";
+    repo = "asgi-lifespan";
+    rev = version;
+    hash = "sha256-Jgmd/4c1lxHM/qi3MJNN1aSSUJrI7CRNwwHrFwwcCkc=";
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    httpx
+    pytest-cov
+    pytest-asyncio
+    pytest-trio
+    starlette
+  ];
+
+  pytestFlagsArray = [
+    "tests/"
+    "--no-cov"
+  ];
+
+  pythonImportsCheck = ["asgi_lifespan"];
+
+  passthru.updateScript = nix-update-script {};
+
+  meta = with lib; {
+    description = "Programmatic startup/shutdown of ASGI apps";
+    license = licenses.mit;
+    homepage = "https://github.com/florimondmanca/asgi-lifespan";
+    maintainers = with maintainers; [emattiza];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -672,6 +672,8 @@ self: super: with self; {
 
   asgi-csrf = callPackage ../development/python-modules/asgi-csrf { };
 
+  asgi-lifespan = callPackage ../development/python-modules/asgi-lifespan {};
+
   asgineer = callPackage ../development/python-modules/asgineer { };
 
   asgiref = callPackage ../development/python-modules/asgiref { };


### PR DESCRIPTION
###### Description of changes

ASGI-Lifespan is a python library to Programmatically send startup/shutdown [lifespan](https://asgi.readthedocs.io/en/latest/specs/lifespan.html) events into [ASGI](https://asgi.readthedocs.io/) applications

Metadata

    homepage URL: https://pypi.org/project/asgi-lifespan/
    source URL: https://github.com/florimondmanca/asgi-lifespan
    license: mit
    platforms: linux, darwin

closes #244488
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
