### PR TITLE
Jupyter extensions: make sure to run tests (as much as possible)

### DIFF
--- a/pkgs/development/python-modules/jupyter-contrib-core/default.nix
+++ b/pkgs/development/python-modules/jupyter-contrib-core/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , jupyter-core
 , notebook
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -19,6 +20,13 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     jupyter-core
     notebook
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # This test fails upstream too
+    "tests/test_application.py"
   ];
 
   pythonImportsCheck = [ "jupyter_contrib_core" ];

--- a/pkgs/development/python-modules/jupyter-contrib-nbextensions/default.nix
+++ b/pkgs/development/python-modules/jupyter-contrib-nbextensions/default.nix
@@ -6,6 +6,9 @@
 , jupyter-highlight-selected-word
 , jupyter-nbextensions-configurator
 , lxml
+, nose
+, pytestCheckHook
+, notebook
 }:
 
 buildPythonPackage rec {
@@ -27,6 +30,20 @@ buildPythonPackage rec {
     lxml
   ];
 
+  nativeCheckInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Thoses tests fail upstream because of nbconvert being too recent
+    # https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1606
+    "tests/test_exporters.py"
+
+    # Requires to run jupyter which is not feasible here
+    "tests/test_application.py"
+  ];
+
   pythonImportsCheck = [ "jupyter_contrib_nbextensions" ];
 
   meta = with lib; {
@@ -34,5 +51,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/ipython-contrib/jupyter_contrib_nbextensions";
     license = licenses.bsd3;
     maintainers = with maintainers; [ GaetanLepage ];
+    # https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1647
+    broken = versionAtLeast notebook.version "7";
   };
 }

--- a/pkgs/development/python-modules/jupyter-highlight-selected-word/default.nix
+++ b/pkgs/development/python-modules/jupyter-highlight-selected-word/default.nix
@@ -14,6 +14,9 @@ buildPythonPackage rec {
     hash = "sha256-KgM//SIfES46uZySwNR4ZOcolnJORltvThsmEvxXoIs=";
   };
 
+  # This package does not have tests
+  doChecks = false;
+
   pythonImportsCheck = [ "jupyter_highlight_selected_word" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/jupyter-nbextensions-configurator/default.nix
+++ b/pkgs/development/python-modules/jupyter-nbextensions-configurator/default.nix
@@ -8,6 +8,9 @@
 , notebook
 , pyyaml
 , tornado
+, nose
+, pytestCheckHook
+, selenium
 }:
 
 buildPythonPackage rec {
@@ -37,6 +40,19 @@ buildPythonPackage rec {
     notebook
     pyyaml
     tornado
+  ];
+
+  nativeCheckInputs = [
+    nose
+    pytestCheckHook
+    selenium
+  ];
+
+  # Those tests fails upstream
+  disabledTestPaths = [
+    "tests/test_application.py"
+    "tests/test_jupyterhub.py"
+    "tests/test_nbextensions_configurator.py"
   ];
 
   pythonImportsCheck = [ "jupyter_nbextensions_configurator" ];

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -1,28 +1,28 @@
-{ beautifulsoup4
-, bleach
-, buildPythonPackage
-, defusedxml
-, fetchPypi
-, fetchpatch
+{ lib
 , fetchurl
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
 , hatchling
-, importlib-metadata
-, ipywidgets
+, beautifulsoup4
+, bleach
+, defusedxml
 , jinja2
 , jupyter-core
 , jupyterlab-pygments
-, lib
 , markupsafe
 , mistune
 , nbclient
 , packaging
 , pandocfilters
 , pygments
-, pyppeteer
-, pytestCheckHook
-, pythonOlder
 , tinycss2
 , traitlets
+, importlib-metadata
+, flaky
+, ipywidgets
+, pyppeteer
+, pytestCheckHook
 }:
 
 let
@@ -33,15 +33,15 @@ let
   };
 in buildPythonPackage rec {
   pname = "nbconvert";
-  version = "7.2.5";
+  version = "7.7.3";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-j9xE/X2UJNt/3G4eg0oC9rhiD/tlN2c4i+L56xb4QYQ=";
+    hash = "sha256-SlmWv1880WqgQxiXuhqkxkhCwgefQ0s9xrjEslLvM1U=";
   };
 
   # Add $out/share/jupyter to the list of paths that are used to search for
@@ -85,6 +85,7 @@ in buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
+    flaky
     ipywidgets
     pyppeteer
     pytestCheckHook

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "7.0.1";
+  version = "7.0.2";
   disabled = pythonOlder "3.8";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-LhatTmPqiffvviEu58FpP8+lq1X/73UEdTD3SvS9kmw=";
+    hash = "sha256-1w1qB0GMgpvV9UM3zpk7cQUmHZAm+dP+aOm4qhog2po=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

When introduced, those packages' tests did not have their tests run.
This PR enables them as much as possible.

Also, I updated `python3Packages.nbconvert` to its latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
