### PR TITLE
flyctl: update to 0.1.62, disable autoupdate

### DIFF
--- a/pkgs/development/web/flyctl/default.nix
+++ b/pkgs/development/web/flyctl/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "flyctl";
-  version = "0.1.56";
+  version = "0.1.62";
 
   src = fetchFromGitHub {
     owner = "superfly";
     repo = "flyctl";
     rev = "v${version}";
-    hash = "sha256-Megf4kQ17rwvHKlREzEw7YIibtl/wol0U5bVvPuwxxI=";
+    hash = "sha256-/IIHe3OG/r/cZ4PaYZazv/aPBzyxNBCWbgkzFbJMpvc=";
   };
 
-  vendorHash = "sha256-EI1cyLCiUEkit80gh0BV6Ti8CX8KYuIqz2od7LDLTXg=";
+  vendorHash = "sha256-bjlNwhhhvwrw5GtWO8+1HV2IauqexKSb+O9WGX06qGA=";
 
   subPackages = [ "." ];
 
@@ -43,6 +43,8 @@ buildGoModule rec {
       --fish <($out/bin/flyctl completion fish) \
       --zsh <($out/bin/flyctl completion zsh)
     ln -s $out/bin/flyctl $out/bin/fly
+    # If autoupdate is true, we get into an autoupdate loop
+    $out/bin/flyctl settings autoupdate disable
   '';
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/development/web/flyctl/default.nix
+++ b/pkgs/development/web/flyctl/default.nix
@@ -25,6 +25,8 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  patches = [ ./disable-auto-update.patch ];
+
   preBuild = ''
     go generate ./...
   '';
@@ -43,8 +45,6 @@ buildGoModule rec {
       --fish <($out/bin/flyctl completion fish) \
       --zsh <($out/bin/flyctl completion zsh)
     ln -s $out/bin/flyctl $out/bin/fly
-    # If autoupdate is true, we get into an autoupdate loop
-    $out/bin/flyctl settings autoupdate disable
   '';
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/development/web/flyctl/disable-auto-update.patch
+++ b/pkgs/development/web/flyctl/disable-auto-update.patch
@@ -1,0 +1,25 @@
+From 9c76dbff982b0fd8beaffae42a6e98bc1e67f089 Mon Sep 17 00:00:00 2001
+From: Gabriel Simmer <g@gmem.ca>
+Date: Fri, 21 Jul 2023 08:16:52 +0100
+Subject: [PATCH] Disable auto update
+
+---
+ internal/config/config.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/internal/config/config.go b/internal/config/config.go
+index 1914f8e0..958baf27 100644
+--- a/internal/config/config.go
++++ b/internal/config/config.go
+@@ -141,7 +141,7 @@ func (cfg *Config) ApplyFile(path string) (err error) {
+ 		AutoUpdate   bool   `yaml:"auto_update"`
+ 	}
+ 	w.SendMetrics = true
+-	w.AutoUpdate = true
++	w.AutoUpdate = false
+ 
+ 	if err = unmarshal(path, &w); err == nil {
+ 		cfg.AccessToken = w.AccessToken
+-- 
+2.41.0
+


### PR DESCRIPTION
###### Description of changes

Current version is rather old so there is a decent version bump included.

Release notes: 

0.1.62: https://github.com/superfly/flyctl/releases/tag/v0.1.62
0.1.61: https://github.com/superfly/flyctl/releases/tag/v0.1.61
0.1.60: https://github.com/superfly/flyctl/releases/tag/v0.1.60
0.1.59: https://github.com/superfly/flyctl/releases/tag/v0.1.59
0.1.59: https://github.com/superfly/flyctl/releases/tag/v0.1.59
0.1.58: https://github.com/superfly/flyctl/releases/tag/v0.1.58
0.1.58: https://github.com/superfly/flyctl/releases/tag/v0.1.58
0.1.57: https://github.com/superfly/flyctl/releases/tag/v0.1.57
0.1.57-pre-1: https://github.com/superfly/flyctl/releases/tag/v0.1.57-pre-1

Also disabled autoupdate by default, otherwise any invocation of the CLI starts an autoupdate loop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
