### PR TITLE
apache-jena-fuseki: 4.8.0 -> 4.9.0, add a test

### DIFF
--- a/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
+++ b/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
@@ -1,11 +1,20 @@
-{ lib, stdenv, fetchurl, java, makeWrapper }:
+{ lib
+, stdenv
+, fetchurl
+, java
+, coreutils
+, which
+, makeWrapper
+  # For the test
+, pkgs
+}:
 
 stdenv.mkDerivation rec {
   pname = "apache-jena-fuseki";
-  version = "4.8.0";
+  version = "4.9.0";
   src = fetchurl {
     url = "mirror://apache/jena/binaries/apache-jena-fuseki-${version}.tar.gz";
-    hash = "sha256-rJCY8vG1vfEGGA0gsIqNFXKl75O2Zp4zUIWSDfplpVE=";
+    hash = "sha256-t25Q0lb+ecR12cDD1p6eZnzLxW0kZpPOFGvo5YK7AlI=";
   };
   nativeBuildInputs = [
     makeWrapper
@@ -16,11 +25,16 @@ stdenv.mkDerivation rec {
     ln -s "$out"/{fuseki-backup,fuseki-server,fuseki} "$out/bin"
     for i in "$out"/bin/*; do
       wrapProgram "$i" \
-        --prefix "PATH" : "${java}/bin/" \
+        --prefix "PATH" : "${java}/bin/:${coreutils}/bin:${which}/bin" \
         --set-default "FUSEKI_HOME" "$out" \
         ;
     done
   '';
+  passthru = {
+    tests = {
+      basic-test = pkgs.callPackage ./fuseki-test.nix { };
+    };
+  };
   meta = with lib; {
     description = "SPARQL server";
     license = licenses.asl20;

--- a/pkgs/servers/nosql/apache-jena/fuseki-test.nix
+++ b/pkgs/servers/nosql/apache-jena/fuseki-test.nix
@@ -1,0 +1,18 @@
+{ lib, runCommandNoCC, apache-jena-fuseki, curl }:
+runCommandNoCC "fuseki-test-${apache-jena-fuseki.name}"
+{ nativeBuildInputs = [ curl apache-jena-fuseki ]; } ''
+  export FUSEKI_BASE="$PWD/fuseki-base"
+  mkdir -p "$FUSEKI_BASE/db"
+  FUSEKI_ARGS="--update --loc=$FUSEKI_BASE/db /dataset" fuseki start
+  fuseki status
+  for i in $(seq 120); do
+      if  curl http://127.0.0.1:3030/dataset/data; then
+          break;
+      fi
+      sleep 1
+  done
+  curl -d 'update=insert+data+{+<test://subject>+<test://predicate>+<test://object>+}' http://127.0.0.1:3030/dataset/update > /dev/null
+  curl http://127.0.0.1:3030/dataset/data | grep -C999 'test://predicate'
+  curl -d 'query=select+?s+?p+?o+where+{+?s+?p+?o+.+}' http://127.0.0.1:3030/dataset/query | grep -C999 'test://predicate'
+  touch $out
+''


### PR DESCRIPTION
###### Description of changes

Adding a minimal test showing the Fuseki starts and handles a small insert and a request. As the test is run in the minimal environment, add the missing utilities to PATH in the wrapper.

Related to report by Joeri Exelmans about Fuseki not starting as-is in minimal environments.

Related to #244442 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
