### PR TITLE
Jetbrains with plugins: build fix

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -97,20 +97,20 @@ let
       };
     });
 
-    buildDataSpell = { pname, version, src, license, description, wmClass, buildNumber, ... }:
-      (mkJetBrainsProduct {
-        inherit pname version src wmClass jdk buildNumber;
-        product = "DataSpell";
-        meta = with lib; {
-          homepage = "https://www.jetbrains.com/dataspell/";
-          inherit description license platforms;
-          longDescription = ''
-            DataSpell is a new IDE from JetBrains built for Data Scientists.
-            Mainly it integrates Jupyter notebooks in the IntelliJ platform.
-          '';
-          maintainers = with maintainers; [ leona ];
-        };
-      });
+  buildDataSpell = { pname, version, src, license, description, wmClass, buildNumber, ... }:
+    (mkJetBrainsProduct {
+      inherit pname version src wmClass jdk buildNumber;
+      product = "DataSpell";
+      meta = with lib; {
+        homepage = "https://www.jetbrains.com/dataspell/";
+        inherit description license platforms;
+        longDescription = ''
+          DataSpell is a new IDE from JetBrains built for Data Scientists.
+          Mainly it integrates Jupyter notebooks in the IntelliJ platform.
+        '';
+        maintainers = with maintainers; [ leona ];
+      };
+    });
 
   buildGateway = { pname, version, src, license, description, wmClass, buildNumber, product, ... }:
     (mkJetBrainsProduct {

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -132,6 +132,10 @@ let
     (mkJetBrainsProduct {
       inherit pname version src wmClass jdk buildNumber;
       product = "Goland";
+      extraWrapperArgs = [
+        # fortify source breaks build since delve compiles with -O0
+        ''--prefix CGO_CPPFLAGS " " "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"''
+      ];
       meta = with lib; {
         homepage = "https://www.jetbrains.com/go/";
         inherit description license platforms;
@@ -148,9 +152,6 @@ let
         interp="$(cat $NIX_CC/nix-support/dynamic-linker)"
         patchelf --set-interpreter $interp $out/goland/plugins/go-plugin/lib/dlv/linux/dlv
         chmod +x $out/goland/plugins/go-plugin/lib/dlv/linux/dlv
-        # fortify source breaks build since delve compiles with -O0
-        wrapProgram $out/bin/goland \
-          --prefix CGO_CPPFLAGS " " "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"
       '';
     });
 

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -100,11 +100,6 @@ rec {
         let
           pluginCmdsLines = map (plugin: "ln -s ${plugin} \"$out\"/${meta.mainProgram}/plugins/${baseNameOf plugin}") plugins;
           pluginCmds = builtins.concatStringsSep "\n" pluginCmdsLines;
-          extraBuildPhase = rec {
-            goland = ''
-              sed "s|${ide}|$out|" -i $out/bin/.goland-wrapped
-            '';
-          };
         in
         ''
           cp -r ${ide} $out
@@ -118,6 +113,6 @@ rec {
             -i $(realpath $out/bin/${meta.mainProgram}) \
             -i $(realpath $out/bin/${meta.mainProgram}-remote-dev-server)
           autoPatchelf $out/${meta.mainProgram}/bin
-        '' + (extraBuildPhase."${ide.meta.mainProgram}" or "");
+        '';
     };
 }

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -101,9 +101,6 @@ rec {
           pluginCmdsLines = map (plugin: "ln -s ${plugin} \"$out\"/${meta.mainProgram}/plugins/${baseNameOf plugin}") plugins;
           pluginCmds = builtins.concatStringsSep "\n" pluginCmdsLines;
           extraBuildPhase = rec {
-            clion = ''
-              sed "s|${ide}|$out|" -i $out/bin/.clion-wrapped
-            '';
             goland = ''
               sed "s|${ide}|$out|" -i $out/bin/.goland-wrapped
             '';

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -68,6 +68,8 @@ rec {
   # Only use if you know what youre doing
   raw = { inherit files byId byName; };
 
+  tests = callPackage ./tests.nix {};
+
   addPlugins = ide: unprocessedPlugins:
     let
 

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -117,7 +117,9 @@ rec {
           do
             ln -s "$plugin" -t $out/${meta.mainProgram}/plugins/
           done
-          sed "s|${ide.outPath}|$out|" -i $out/bin/${meta.mainProgram}
+          sed "s|${ide.outPath}|$out|" \
+            -i $(realpath $out/bin/${meta.mainProgram}) \
+            -i $(realpath $out/bin/${meta.mainProgram}-remote-dev-server)
           autoPatchelf $out/${meta.mainProgram}/bin
         '' + (extraBuildPhase."${ide.meta.mainProgram}" or "");
     };

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -244,6 +244,33 @@
       },
       "name": "csv-editor"
     },
+    "12062": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-community",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "webstorm"
+      ],
+      "builds": {
+        "223.8836.1185": "https://plugins.jetbrains.com/files/12062/256327/keymap-vscode-223.7571.113.zip",
+        "231.9011.35": "https://plugins.jetbrains.com/files/12062/307834/keymap-vscode-231.8109.91.zip",
+        "231.9225.12": "https://plugins.jetbrains.com/files/12062/307834/keymap-vscode-231.8109.91.zip",
+        "231.9225.15": "https://plugins.jetbrains.com/files/12062/307834/keymap-vscode-231.8109.91.zip",
+        "231.9225.16": "https://plugins.jetbrains.com/files/12062/307834/keymap-vscode-231.8109.91.zip",
+        "231.9225.18": "https://plugins.jetbrains.com/files/12062/307834/keymap-vscode-231.8109.91.zip",
+        "231.9225.21": "https://plugins.jetbrains.com/files/12062/307834/keymap-vscode-231.8109.91.zip",
+        "231.9225.23": "https://plugins.jetbrains.com/files/12062/307834/keymap-vscode-231.8109.91.zip"
+      },
+      "name": "vscode-keymap"
+    },
     "12559": {
       "compatible": [
         "clion",
@@ -383,6 +410,8 @@
   "files": {
     "https://plugins.jetbrains.com/files/10037/358810/CSVEditor-3.2.1-231.zip": "sha256-JC/NOICLHf1gc4wTarDPw7lYfGHOkCOlG194yt18xOA=",
     "https://plugins.jetbrains.com/files/10037/358812/CSVEditor-3.2.1-223.zip": "sha256-l8xq7XXQheZYcP+kdnLXAO7FhfPJYwIh+ZffbttBI9s=",
+    "https://plugins.jetbrains.com/files/12062/256327/keymap-vscode-223.7571.113.zip": "sha256-MlWTPLA6517inAtiOdJDUeUMyHczXzeUIe4dfASLzsM=",
+    "https://plugins.jetbrains.com/files/12062/307834/keymap-vscode-231.8109.91.zip": "sha256-OqK3HmcksgNlrADv7Ld91VCW+uzTOVWtcXcRC60IKfw=",
     "https://plugins.jetbrains.com/files/12559/257029/keymap-eclipse-223.7571.125.zip": "sha256-0hMn8Qt+xJjB9HnYz7OMw8xmI0FxDFy+lYfXHURhTKY=",
     "https://plugins.jetbrains.com/files/12559/307825/keymap-eclipse-231.8109.91.zip": "sha256-8jUsRK4evNMzjuWQIjIMrvQ0sIXPoY1C/buu1nod5X8=",
     "https://plugins.jetbrains.com/files/13017/257030/keymap-visualStudio-223.7571.125.zip": "sha256-YiJALivO1a+I4bCtZEv68PZ21Vydk5UW6gAgErj28DQ=",

--- a/pkgs/applications/editors/jetbrains/plugins/tests.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/tests.nix
@@ -1,0 +1,26 @@
+{ jetbrains, writeText }:
+
+{
+  # Check to see if the process for adding plugins is breaking anything, instead of the plugins themselves
+  default =
+    let
+      modify-ide = ide: jetbrains.plugins.addPlugins ide [ ];
+      ides = with jetbrains; map modify-ide [
+        clion
+        datagrip
+        dataspell
+        goland
+        idea-community
+        idea-ultimate
+        mps
+        phpstorm
+        pycharm-community
+        pycharm-professional
+        rider
+        ruby-mine
+        webstorm
+      ];
+      paths = builtins.concatStringsSep " " ides;
+    in
+    writeText "jb-ides" paths;
+}


### PR DESCRIPTION
###### Description of changes

Due to a lack of tests, a patch broke jetbrains ides with declarative plugins. This PR fixes that and adds a simple test to prevent this happening in the future.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).