### PR TITLE
qmltermwidget: 2018-11-24 -> unstable-2022-01-09

### DIFF
--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -1,26 +1,35 @@
-{ lib, stdenv, fetchFromGitHub, qtbase, qtquick1, qmake, qtmultimedia, utmp, fetchpatch }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, qtbase
+, qtquick1
+, qmake
+, qtmultimedia
+, utmp
+}:
 
 stdenv.mkDerivation {
-  version = "2018-11-24";
-  pname = "qmltermwidget-unstable";
+  pname = "qmltermwidget";
+  version = "unstable-2022-01-09";
 
   src = fetchFromGitHub {
     repo = "qmltermwidget";
     owner = "Swordfish90";
-    rev = "48274c75660e28d44af7c195e79accdf1bd44963";
-    sha256 = "028nb1xp84jmakif5mmzx52q3rsjwckw27jdpahyaqw7j7i5znq6";
+    rev = "63228027e1f97c24abb907550b22ee91836929c5";
+    hash = "sha256-aVaiRpkYvuyomdkQYAgjIfi6a3wG2a6hNH1CfkA2WKQ=";
   };
 
-  buildInputs = [ qtbase qtquick1 qtmultimedia ]
-                ++ lib.optional stdenv.isDarwin utmp;
   nativeBuildInputs = [ qmake ];
 
+  buildInputs = [
+    qtbase
+    qtquick1
+    qtmultimedia
+  ] ++ lib.optional stdenv.isDarwin utmp;
+
   patches = [
-    (fetchpatch {
-      name = "fix-missing-includes.patch";
-      url = "https://github.com/Swordfish90/qmltermwidget/pull/27/commits/485f8d6d841b607ba49e55a791f7f587e4e193bc.diff";
-      sha256 = "186s8pv3642vr4lxsds919h0y2vrkl61r7wqq9mc4a5zk5vprinj";
-    })
+    # Some files are copied twice to the output which makes the build fails
+    ./do-not-copy-artifacts-twice.patch
   ];
 
   postPatch = ''
@@ -28,7 +37,7 @@ stdenv.mkDerivation {
       --replace '$$[QT_INSTALL_QML]' "/$qtQmlPrefix/"
   '';
 
-  installFlags = [ "INSTALL_ROOT=$(out)" ];
+  installFlags = [ "INSTALL_ROOT=${placeholder "out"}" ];
 
   dontWrapQtApps = true;
 

--- a/pkgs/development/libraries/qmltermwidget/do-not-copy-artifacts-twice.patch
+++ b/pkgs/development/libraries/qmltermwidget/do-not-copy-artifacts-twice.patch
@@ -1,0 +1,10 @@
+diff --git a/qmltermwidget.pro b/qmltermwidget.pro
+index c9594a9..aa1a804 100644
+--- a/qmltermwidget.pro
++++ b/qmltermwidget.pro
+@@ -62,4 +62,4 @@ kblayouts2.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/kb-layouts/historic
+ scrollbar.files = $$PWD/src/QMLTermScrollbar.qml
+ scrollbar.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
+ 
+-INSTALLS += target qmldir assets colorschemes colorschemes2 kblayouts kblayouts2 scrollbar
++INSTALLS += target qmldir assets


### PR DESCRIPTION
###### Description of changes

Update `qmltermwidget` to the latest git version.
This will hopefully fix `cool-retro-term`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
