### PR TITLE
samba: 4.17.7 -> 4.18.5

### DIFF
--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ldb";
-  version = "2.6.2";
+  version = "2.7.2";
 
   src = fetchurl {
     url = "mirror://samba/ldb/${pname}-${version}.tar.gz";
-    hash = "sha256-XLxjw1KTwjSzn5S6n/yonW0HiSXX+QIfgIZz3t8tkl4=";
+    hash = "sha256-Ju5y1keFTmYtmWQ+srLTQWVavzH0mQg41mUPtc+SCcg=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -51,11 +51,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "samba";
-  version = "4.17.7";
+  version = "4.18.5";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${pname}-${version}.tar.gz";
-    hash = "sha256-lcnBa2VKiM+u/ZWAUt1XPi+F7N8RTk7Owxh1N6CU2Rk=";
+    hash = "sha256-CVJWrDMuHZ+/m3/3gj+SoyM9PtZYzn/JszkFwiQ/RH8=";
   };
 
   outputs = [ "out" "dev" "man" ];

--- a/pkgs/servers/samba/build-find-pre-built-heimdal-build-tools-in-case-of-.patch
+++ b/pkgs/servers/samba/build-find-pre-built-heimdal-build-tools-in-case-of-.patch
@@ -1,4 +1,4 @@
-From 9287fcfc36ed9f2bb936ec2253244f60df80711f Mon Sep 17 00:00:00 2001
+From 7e3c8ba66b86a21fe8e5bd9a595dd6fc03fa26d4 Mon Sep 17 00:00:00 2001
 From: Pascal Bach <pascal.bach@nextrem.ch>
 Date: Wed, 22 Sep 2021 09:42:42 +0200
 Subject: [PATCH] build: find pre-built heimdal build tools in case of embedded
@@ -34,13 +34,10 @@ BUG: https://bugzilla.samba.org/show_bug.cgi?id=14164
 Signed-off-by: Uri Simchoni <uri@samba.org>
 Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
 [Bachp: rebased for version 4.15.0]
-
-# Conflicts:
-#	wscript_configure_system_heimdal
+[Mats: rebased for version 4.18.5]
 ---
  wscript_configure_embedded_heimdal | 11 +++++++++++
- wscript_configure_system_heimdal   | 11 -----------
- 2 files changed, 11 insertions(+), 11 deletions(-)
+ 1 file changed, 11 insertions(+)
 
 diff --git a/wscript_configure_embedded_heimdal b/wscript_configure_embedded_heimdal
 index 6066f2b39d7..e92cabad65f 100644
@@ -61,35 +58,6 @@ index 6066f2b39d7..e92cabad65f 100644
 +
 +check_system_heimdal_binary("compile_et")
 +check_system_heimdal_binary("asn1_compile")
-diff --git a/wscript_configure_system_heimdal b/wscript_configure_system_heimdal
-index 6033dad08dc..c0a9bb95e87 100644
---- a/wscript_configure_system_heimdal
-+++ b/wscript_configure_system_heimdal
-@@ -37,14 +37,6 @@ def check_system_heimdal_lib(name, functions='', headers='', onlyif=None):
-     conf.define('USING_SYSTEM_%s' % name.upper(), 1)
-     return True
- 
--def check_system_heimdal_binary(name):
--    if conf.LIB_MAY_BE_BUNDLED(name):
--        return False
--    if not conf.find_program(name, var=name.upper()):
--        return False
--    conf.define('USING_SYSTEM_%s' % name.upper(), 1)
--    return True
--
- check_system_heimdal_lib("com_err", "com_right_r com_err", "com_err.h")
- 
- if check_system_heimdal_lib("roken", "rk_socket_set_reuseaddr", "roken.h"):
-@@ -86,9 +78,6 @@ finally:
- #if conf.CHECK_BUNDLED_SYSTEM('tommath', checkfunctions='mp_init', headers='tommath.h'):
- #    conf.define('USING_SYSTEM_TOMMATH', 1)
- 
--check_system_heimdal_binary("compile_et")
--check_system_heimdal_binary("asn1_compile")
--
- conf.env.KRB5_VENDOR = 'heimdal'
- conf.define('USING_SYSTEM_KRB5', 1)
- conf.define('USING_SYSTEM_HEIMDAL', 1)
 -- 
-2.37.3
+2.41.0
 


### PR DESCRIPTION
###### Description of changes

Updates `ldb` and `samba` to the latest versions fixing numerous bugs and security issues, including:
- [CVE-2023-34967](https://www.samba.org/samba/security/CVE-2023-34967.html)
- [CVE-2022-2127](https://www.samba.org/samba/security/CVE-2022-2127.html)
- [CVE-2023-34968](https://www.samba.org/samba/security/CVE-2023-34968.html)
- [CVE-2023-34966](https://www.samba.org/samba/security/CVE-2023-34966.html)
- [CVE-2023-3347](https://www.samba.org/samba/security/CVE-2023-3347.html)

Release notes:
https://www.samba.org/samba/history/samba-4.18.5.html
https://www.samba.org/samba/history/samba-4.18.4.html
https://www.samba.org/samba/history/samba-4.18.3.html
https://www.samba.org/samba/history/samba-4.18.2.html
https://www.samba.org/samba/history/samba-4.18.1.html
https://www.samba.org/samba/history/samba-4.18.0.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
