### PR TITLE
python310Packages.pyxnat: 1.5 -> 1.6

### DIFF
--- a/pkgs/development/python-modules/pyxnat/default.nix
+++ b/pkgs/development/python-modules/pyxnat/default.nix
@@ -1,21 +1,27 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pythonOlder
-, nose
+, pytestCheckHook
 , lxml
+, matplotlib
+, networkx
+, pandas
 , requests
 , six
 }:
 
 buildPythonPackage rec {
   pname = "pyxnat";
-  version = "1.5";
-  disabled = pythonOlder "3.7";
+  version = "1.6";
+  disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Y8mj6OfZXyE1q3C8HyVzGySuZB6rLSsL/CV/7axxaec=";
+  # PyPI dist missing test configuration files:
+  src = fetchFromGitHub {
+    owner = "pyxnat";
+    repo = "pyxnat";
+    rev = "refs/tags/${version}";
+    hash = "sha256-QejYisvQFN7CsDOx9wAgTHmRZcSEqgIr8twG4XucfZ4=";
   };
 
   propagatedBuildInputs = [
@@ -30,17 +36,37 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "pathlib>=1.0" "" \
       --replace "future>=0.16" ""
+    sed -i '/--cov/d' setup.cfg
   '';
 
-  nativeCheckInputs = [ nose ];
-  checkPhase = "nosetests pyxnat/tests";
-  doCheck = false;  # requires a docker container running an XNAT server
+  nativeCheckInputs = [
+    pytestCheckHook
+    matplotlib
+    networkx
+    pandas
+  ];
+  preCheck = ''
+    export PYXNAT_SKIP_NETWORK_TESTS=1
+  '';
+  pytestFlagsArray = [ "pyxnat" ];
+  disabledTestPaths = [
+    # try to access network even though PYXNAT_SKIP_NETWORK_TESTS is set:
+    "pyxnat/tests/pipelines_test.py"
+    "pyxnat/tests/search_test.py"
+    "pyxnat/tests/user_and_project_management_test.py"
+  ];
+  disabledTests = [
+    # try to access network even though PYXNAT_SKIP_NETWORK_TESTS is set:
+    "test_ashs_volumes"
+    "test_inspector_structure"
+  ];
 
   pythonImportsCheck = [ "pyxnat" ];
 
   meta = with lib; {
     homepage = "https://pyxnat.github.io/pyxnat";
     description = "Python API to XNAT";
+    changelog = "https://github.com/pyxnat/pyxnat/releases/tag/${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bcdarwin ];
   };


### PR DESCRIPTION
###### Description of changes

Routine update; also enabled tests and added changelog.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).