### PR TITLE
python311Packages.iocextract: 1.15.2 -> 1.16.0

### DIFF
--- a/pkgs/development/python-modules/iocextract/default.nix
+++ b/pkgs/development/python-modules/iocextract/default.nix
@@ -4,11 +4,12 @@
 , pytestCheckHook
 , pythonOlder
 , regex
+, requests
 }:
 
 buildPythonPackage rec {
   pname = "iocextract";
-  version = "1.15.2";
+  version = "1.16.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -17,11 +18,12 @@ buildPythonPackage rec {
     owner = "InQuest";
     repo = "python-iocextract";
     rev = "refs/tags/v${version}";
-    hash = "sha256-l0TGi3Y3/Dcwyp80eRWYYlDaDDJdpc31fcxdYEVvQas=";
+    hash = "sha256-jwMu4G146FpH6aFCiZK9tI/3CKnZYC2RCtO9QXXaquQ=";
   };
 
   propagatedBuildInputs = [
     regex
+    requests
   ];
 
   nativeCheckInputs = [
@@ -34,6 +36,11 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "tests.py"
+  ];
+
+  disabledTests = [
+    # AssertionError: 'http://exampledotcom/test' != 'http://example.com/test'
+    "test_refang_data"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/InQuest/python-iocextract/compare/refs/tags/v1.15.2...v1.16.0

Changelog: https://github.com/InQuest/python-iocextract/releases/tag/v1.16.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
