### PR TITLE
python311Packages.qpsolvers: init at 3.4.0

### DIFF
--- a/pkgs/development/python-modules/daqp/default.nix
+++ b/pkgs/development/python-modules/daqp/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, unittestCheckHook
+, cython
+, setuptools
+, wheel
+, numpy
+}:
+buildPythonPackage {
+  pname = "daqp";
+  version = "0.5.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "darnstrom";
+    repo = "daqp";
+    rev = "5a15a3d16731d3d50f867218c1b281567db556fd";
+    hash = "sha256-in7Ci/wM7i0csJ4XVfo1lboWOyfuuU+8E+TzGmMV3x0=";
+  };
+
+  sourceRoot = "source/interfaces/daqp-python";
+
+  postPatch = ''
+    sed -i 's|../../../daqp|../..|' setup.py
+    sed -i 's|if src_path and os.path.exists(src_path):|if False:|' setup.py
+  '';
+
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "test" "-p" "'*.py'" "-v" ];
+
+  nativeBuildInputs = [
+    cython
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  pythonImportsCheck = [ "daqp" ];
+
+  meta = with lib; {
+    description = "A dual active-set algorithm for convex quadratic programming";
+    homepage = "https://github.com/darnstrom/daqp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ renesat ];
+  };
+}

--- a/pkgs/development/python-modules/osqp/default.nix
+++ b/pkgs/development/python-modules/osqp/default.nix
@@ -14,19 +14,15 @@
 
 buildPythonPackage rec {
   pname = "osqp";
-  version = "0.6.2.post8";
+  version = "0.6.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-I9a65KNhL2DV9lLQ5fpLLq1QfKv/9dkw2CIFeubtZnc=";
+    hash = "sha256-A+Rg5oPsLOD4OTU936PEyP+lCauM9qKyr7tYb6RT4YA=";
   };
-
-  postPatch = ''
-    sed -i 's/sp.random/np.random/g' src/osqp/tests/*.py
-  '';
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
@@ -54,29 +50,8 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # Test are failing due to scipy update (removal of scipy.random in 1.9.0)
-    # Is fixed upstream but requires a new release
-    "test_feasibility_problem"
+    # Need an unfree license package - mkl
     "test_issue14"
-    "test_polish_random"
-    "test_polish_unconstrained"
-    "test_primal_and_dual_infeasible_problem"
-    "test_primal_infeasible_problem"
-    "test_solve"
-    "test_unconstrained_problem"
-    "test_update_A_allind"
-    "test_update_A"
-    "test_update_bounds"
-    "test_update_l"
-    "test_update_P_A_allind"
-    "test_update_P_A_indA"
-    "test_update_P_A_indP_indA"
-    "test_update_P_A_indP"
-    "test_update_P_allind"
-    "test_update_P"
-    "test_update_q"
-    "test_update_u"
-    "test_warm_start"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/qpsolvers/default.nix
+++ b/pkgs/development/python-modules/qpsolvers/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, unittestCheckHook
+, daqp
+, ecos
+, numpy
+, osqp
+, scipy
+, scs
+, quadprog
+}:
+buildPythonPackage rec {
+  pname = "qpsolvers";
+  version = "3.4.0";
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "qpsolvers";
+    repo = "qpsolvers";
+    rev = "v${version}";
+    hash = "sha256-GrYAhTWABBvU6rGoHi00jBa7ryjCNgzO/hQBTdSW9cg=";
+  };
+
+  pythonImportsCheck = [ "qpsolvers" ];
+
+  propagatedBuildInputs = [
+    daqp
+    ecos
+    numpy
+    osqp
+    scipy
+    scs
+  ];
+
+  nativeCheckInputs = [
+    quadprog
+    unittestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Quadratic programming solvers in Python with a unified API";
+    homepage = "https://github.com/qpsolvers/qpsolvers";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ renesat ];
+  };
+}

--- a/pkgs/development/python-modules/scs/default.nix
+++ b/pkgs/development/python-modules/scs/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , blas
@@ -11,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "scs";
-  version = "3.0.0";
+  version = "3.2.3";
 
   src = fetchFromGitHub {
     owner = "bodono";
     repo = "scs-python";
     rev = version;
-    hash = "sha256-7OgqCo21S0FDev8xv6/8iGFXg8naVi93zd8v1f9iaWw=";
+    hash = "sha256-/5yGvZy3luGQkbYcsb/6TZLYou91lpA3UKONviMVpuM=";
     fetchSubmodules = true;
   };
 
@@ -33,6 +34,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "scs" ];
+  disabledTests = lib.lists.optional (stdenv.system == "x86_64-linux") [
+    # `test/test_scs_rand.py` hang on "x86_64-linux" (https://github.com/NixOS/nixpkgs/pull/244532#pullrequestreview-1598095858)
+    "test_feasible"
+    "test_infeasibl"
+    "test_unbounded"
+  ];
 
   meta = with lib; {
     description = "Python interface for SCS: Splitting Conic Solver";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2367,6 +2367,8 @@ self: super: with self; {
 
   daphne = callPackage ../development/python-modules/daphne { };
 
+  daqp = callPackage ../development/python-modules/daqp { };
+
   dasbus = callPackage ../development/python-modules/dasbus { };
 
   dash = callPackage ../development/python-modules/dash { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10627,6 +10627,8 @@ self: super: with self; {
 
   qpageview = callPackage ../development/python-modules/qpageview { };
 
+  qpsolvers = callPackage ../development/python-modules/qpsolvers { };
+
   qrcode = callPackage ../development/python-modules/qrcode { };
 
   qreactor = callPackage ../development/python-modules/qreactor { };


### PR DESCRIPTION
###### Description of changes

qpsolvers is python library for solving quadratic programming problems. It contains wrappers for multiple solvers like osqp, cvxopt, quadprog and much more.

Metadata

    homepage URL: https://github.com/qpsolvers/qpsolvers
    source URL: https://github.com/qpsolvers/qpsolvers
    license: LGPLv3
    platforms: platform independent (python3.10)

Close #244480

Depend on #244528, #244529 and #244530



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
