### PR TITLE
python310Packages.pyradiomics: init at 3.1.0

### DIFF
--- a/pkgs/development/python-modules/pyradiomics/default.nix
+++ b/pkgs/development/python-modules/pyradiomics/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, numpy
+, pykwalify
+, pywavelets
+, setuptools
+, simpleitk
+, six
+, versioneer
+}:
+
+buildPythonPackage rec {
+  pname = "pyradiomics";
+  version = "3.1.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "AIM-Harvard";
+    repo = "pyradiomics";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/qFNN63Bbq4DUZDPmwUGj1z5pY3ujsbqFJpVXbO+b8E=";
+    name = "pyradiomics";
+  };
+
+  nativeBuildInputs = [ setuptools versioneer ];
+
+  propagatedBuildInputs = [
+    numpy
+    pykwalify
+    pywavelets
+    simpleitk
+    six
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  preCheck = ''
+    rm -rf radiomics
+  '';
+  # tries to access network at collection time:
+  disabledTestPaths = [ "tests/test_wavelet.py" ];
+  # various urllib download errors and (probably related) missing feature errors:
+  disabledTests = [
+    "brain1_shape2D-original_shape2D"
+    "brain2_shape2D-original_shape2D"
+    "breast1_shape2D-original_shape2D"
+    "lung1_shape2D-original_shape2D"
+    "lung2_shape2D-original_shape2D"
+  ];
+  # note the above elements of disabledTests are patterns, not exact tests,
+  # so simply setting `disabledTests` does not suffice:
+  pytestFlagsArray = [
+    "-k '${toString (lib.intersperse "and" (lib.forEach disabledTests (t: "not ${t}")))}'"
+  ];
+
+  pythonImportsCheck = [
+    "radiomics"
+  ];
+
+  meta = with lib; {
+    homepage = "https://pyradiomics.readthedocs.io";
+    description = "Extraction of Radiomics features from 2D and 3D images and binary masks";
+    changelog = "https://github.com/AIM-Harvard/pyradiomics/releases/tag/v${version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9494,6 +9494,8 @@ self: super: with self; {
 
   pyrad = callPackage ../development/python-modules/pyrad { };
 
+  pyradiomics = callPackage ../development/python-modules/pyradiomics { };
+
   pyradios = callPackage ../development/python-modules/pyradios { };
 
   pyrainbird = callPackage ../development/python-modules/pyrainbird { };


### PR DESCRIPTION
###### Description of changes

Add pyradiomics, a Python package for extracting radiomics features from image files.

With some suggestions by @benxiao.
 
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
