### PR TITLE
protobuf3: 21.12 -> 23.4

### DIFF
--- a/pkgs/development/libraries/abseil-cpp/202301.nix
+++ b/pkgs/development/libraries/abseil-cpp/202301.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, gtest
 , static ? stdenv.hostPlatform.isStatic
 , cxxStandard ? null
 }:
@@ -18,12 +19,18 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
+    "-DABSL_BUILD_TEST_HELPERS=ON"
+    "-DABSL_USE_EXTERNAL_GOOGLETEST=ON"
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
   ] ++ lib.optionals (cxxStandard != null) [
     "-DCMAKE_CXX_STANDARD=${cxxStandard}"
   ];
 
+  strictDeps = true;
+
   nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ gtest ];
 
   meta = with lib; {
     description = "An open-source collection of C++ code designed to augment the C++ standard library";

--- a/pkgs/development/libraries/protobuf/3.23.nix
+++ b/pkgs/development/libraries/protobuf/3.23.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic-v3-cmake.nix ({
+  version = "3.23.4";
+  sha256 = "sha256-eI+mrsZAOLEsdyTC3B+K+GjD3r16CmPx1KJ2KhCwFdg=";
+} // args)

--- a/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
@@ -72,12 +72,10 @@ let
       zlib
     ];
 
-    # After 3.20, CMakeLists.txt can now be found at the top-level, however
-    # a stub cmake/CMakeLists.txt still exists for compatibility with previous build assumptions
-    cmakeDir = "../cmake";
+    cmakeDir = if lib.versionOlder version "3.22" then "../cmake" else null;
     cmakeFlags = [
       "-Dprotobuf_ABSL_PROVIDER=package"
-      ] ++ lib.optionals (!stdenv.targetPlatform.isStatic) [
+    ] ++ lib.optionals (!stdenv.targetPlatform.isStatic) [
       "-Dprotobuf_BUILD_SHARED_LIBS=ON"
     ]
     # Tests fail to build on 32-bit platforms; fixed in 3.22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24162,8 +24162,9 @@ with pkgs;
 
   prospector = callPackage ../development/tools/prospector { };
 
-  protobuf = protobuf3_21;
+  protobuf = protobuf3_23;
 
+  protobuf3_23 = callPackage ../development/libraries/protobuf/3.23.nix { };
   protobuf3_21 = callPackage ../development/libraries/protobuf/3.21.nix {
     abseil-cpp = abseil-cpp_202103;
   };


### PR DESCRIPTION
###### Description of changes

https://github.com/protocolbuffers/protobuf/releases/tag/v23.4

v22 is also not packaged, but since it hasn't been added so far I think we can leave a gap.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
