### PR TITLE
xrootd: wrap executables with [DY]LD_LIBRARY_PATH prefix

### DIFF
--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -24,6 +24,9 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
+
+  __structuredAttrs = true;
+
   pname = "xrootd";
   version = "5.5.5";
 

--- a/pkgs/tools/networking/xrootd/fetchxrd.nix
+++ b/pkgs/tools/networking/xrootd/fetchxrd.nix
@@ -23,7 +23,7 @@
   }
   ''
     for u in $urls; do
-      xrdcp --force "$u" "$out"
+      xrdcp --verbose --force "$u" "$out"
       ret=$?
       (( ret != 0 )) || break
     done

--- a/pkgs/tools/networking/xrootd/fetchxrd.nix
+++ b/pkgs/tools/networking/xrootd/fetchxrd.nix
@@ -21,11 +21,9 @@
     inherit url;
     urls = if urls == [ ] then lib.singleton url else urls;
   }
-  # Set [DY]LD_LIBRARY_PATH to workaround #169677
-  # TODO: Remove the library path after #200830 get merged
   ''
     for u in $urls; do
-      ${lib.optionalString buildPlatform.isDarwin "DY"}LD_LIBRARY_PATH=${lib.makeLibraryPath [ xrootd ]} xrdcp --force "$u" "$out"
+      xrdcp --force "$u" "$out"
       ret=$?
       (( ret != 0 )) || break
     done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1889,7 +1889,10 @@ with pkgs;
 
   xpaste = callPackage ../tools/text/xpaste { };
 
-  xrootd = callPackage ../tools/networking/xrootd { };
+  xrootd = callPackage ../tools/networking/xrootd {
+    # Workaround systemd static build breakage
+    systemd = if systemd.meta.broken then null else systemd;
+  };
 
   yabridge = callPackage ../tools/audio/yabridge {
     wine = wineWowPackages.staging;


### PR DESCRIPTION
###### Description of changes

Executables built with XRootD (`xrootd`) libraries will complain failing to find such library at run time. Such executable includes the ones provided by the XRootD project itself, and dependent project such as CERN ROOT (`root`). (#169677)

The library-finding failure can be worked around by adding the library path to `LD_LIBRARY_PATH` (`DYLD_LIBRARY_PATH` on Darwin). This issue might be caused by the XRootD upstream, as CERN ROOT people also implement this workaround inside their `thisroot.sh` RC file.

This PR apply such wrapping to the XRootD executables to make them usable. This problem affects the current stable branch (Nixpkgs 23.05) and need to be backported.

In addition, this PR also opt-out the systemd dependency when built statically, where it is marked broken.

Cc: @veprbl

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
