### PR TITLE
minosoft: init at 7ba4569

### DIFF
--- a/pkgs/games/minosoft/default.nix
+++ b/pkgs/games/minosoft/default.nix
@@ -85,7 +85,7 @@ in stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.bixilon.de/bixilon/minosoft";
     description = "An open source Minecraft re-implementation written from scratch";
     sourceProvenance = with sourceTypes; [

--- a/pkgs/games/minosoft/default.nix
+++ b/pkgs/games/minosoft/default.nix
@@ -24,7 +24,7 @@ let
 
   # build jar into fixed-output derivation (it is fetching JARs to include from the internet anyways, so it doesnt matter if its not that conform to our ideals)
   deps = stdenv.mkDerivation {
-    pname = "${pname}-deps";
+    pname = "minosoft-deps";
     inherit version src;
     nativeBuildInputs = [ gradle perl ];
     buildPhase = ''

--- a/pkgs/games/minosoft/default.nix
+++ b/pkgs/games/minosoft/default.nix
@@ -1,0 +1,101 @@
+{ lib, stdenv
+, makeWrapper
+, fetchFromGitLab
+, gradle
+, perl
+, jre
+, libpulseaudio
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+let
+  pname = "minosoft";
+  version = "7ba4569"; # there are no tags yet, so lets version this using tags for now
+
+  src = fetchFromGitLab {
+    domain = "gitlab.bixilon.de";
+    owner = "bixilon";
+    repo = "minosoft";
+    rev = "7ba45697e3586e0b6de231ed5db6d3e34cb37d82";
+    hash = "sha256-sro49mh6c20HN1ZAHp5Ukzmn5IcniuLTa0w43S8ZVNw=";
+    leaveDotGit = true; # needed by gradle scripts
+  };
+
+  # build jar into fixed-output derivation (it is fetching JARs to include from the internet anyways, so it doesnt matter if its not that conform to our ideals)
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit version src;
+    nativeBuildInputs = [ gradle perl ];
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+      # https://github.com/gradle/gradle/issues/4426
+      ${lib.optionalString stdenv.isDarwin "export TERM=dumb"}
+      gradle --no-daemon --info fatJar
+    '';
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      #find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+      #  | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+      #  | sh
+      cp -r . $out
+    '';
+    outputHashMode = "recursive";
+    outputHash = "sha256-yVlgw8zs1OD63xtCwaJpuYHr+LdxwXC0rfjR0ds7p5g=";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "minosoft";
+    desktopName = "Minosoft";
+    comment = "An open source Minecraft re-implementation written from scratch";
+    icon = "minosoft";
+    exec = "minosoft";
+    terminal = false;
+    categories = [ "Game" "AdventureGame" ];
+    keywords = [ "sandbox" "open" "source" "minecraft" ];
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname version src;
+
+  nativeBuildInputs = [ gradle perl makeWrapper copyDesktopItems ];
+
+  desktopItems = [ desktopItem ];
+
+  buildPhase = ''
+    runHook preBuild
+    ls
+    echo ${deps}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 build/libs/minosoft-fat*.jar $out/share/minosoft.jar
+    mkdir $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/minosoft \
+      --prefix LD_LIBRARY_PATH : ${libpulseaudio}/lib \
+      --add-flags "-jar $out/share/minosoft.jar"
+
+    install -Dm644 doc/img/Minosoft_logo.png \
+      $out/share/pixmaps/minosoft.png
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://gitlab.bixilon.de/bixilon/minosoft";
+    description = "An open source Minecraft re-implementation written from scratch";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ aprl ];
+    platforms = platforms.all;
+    # https://github.com/NixOS/nixpkgs/pull/99885#issuecomment-740065005
+    #broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2473,6 +2473,8 @@ with pkgs;
 
   melonDS = libsForQt5.callPackage ../applications/emulators/melonDS { };
 
+  minosoft = callPackage ../games/minosoft { };
+
   mgba = libsForQt5.callPackage ../applications/emulators/mgba { };
 
   mupen64plus = callPackage ../applications/emulators/mupen64plus { };


### PR DESCRIPTION
###### Description of changes

From the project's GitLab: "Minosoft is an open source minecraft client, written from scratch in kotlin (and java). It aims to bring more functionality and stability."

Resolves #237956 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
