### PR TITLE
python310Packages.python-youtube: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/python-youtube/default.nix
+++ b/pkgs/development/python-modules/python-youtube/default.nix
@@ -11,19 +11,17 @@
 }:
 buildPythonPackage rec {
   pname = "python-youtube";
-  version = "0.9.0";
+  version = "0.9.1";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "sns-sdks";
     repo = "python-youtube";
     rev = "v${version}";
-    hash = "sha256-uimipYgf8nfYd1J/K6CStbzIkQiRSosu7/yOfgXYCks=";
+    hash = "sha256-PbPdvUv7I9NKW6w4OJbiUoRNVJ1SoXychSXBH/y5nzY=";
   };
 
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "poetry.masonry.api" "poetry.core.masonry.api"
     substituteInPlace pytest.ini \
       --replace "--cov=pyyoutube" "" \
       --replace "--cov-report xml" ""
@@ -45,24 +43,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     responses
-  ];
-
-  disabledTests = [
-    # On both tests, upstream compares a string to an integer
-
-    /*
-      python3.10-python-youtube> >       self.assertEqual(m.viewCount, "160361638")
-      python3.10-python-youtube> E       AssertionError: 160361638 != '160361638'
-      python3.10-python-youtube> tests/models/test_channel.py:62: AssertionError
-    */
-    "testChannelStatistics"
-
-    /*
-      python3.10-python-youtube> >       self.assertEqual(m.viewCount, "8087")
-      python3.10-python-youtube> E       AssertionError: 8087 != '8087'
-      python3.10-python-youtube> tests/models/test_videos.py:76: AssertionError
-    */
-    "testVideoStatistics"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Small follow up on https://github.com/NixOS/nixpkgs/pull/242567
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
