### PR TITLE
virtiofsd: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/servers/misc/virtiofsd/default.nix
+++ b/pkgs/servers/misc/virtiofsd/default.nix
@@ -2,25 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "virtiofsd";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchFromGitLab {
     owner = "virtio-fs";
     repo = "virtiofsd";
     rev = "v${version}";
-    sha256 = "/KL1LH/3txWrZPjvuYmSkNb93euB+Whd2YofIuf/cMg=";
+    sha256 = "sha256-YihxXoWcJHy7IT27x9TOM46R66IfosLz8ZKFsWCL3K0=";
   };
 
-  patches = [
-    # fixes SIGSYS when seccomp filtering is on
-    # https://gitlab.com/virtio-fs/virtiofsd/-/issues/104
-    (fetchpatch {
-      url = "https://gitlab.com/virtio-fs/virtiofsd/-/commit/a9141cae72e6785ca10a758c22c7a5690a1fc955.patch";
-      hash = "sha256-uO8nVdNMGOkd3ThTTw23BykDP9w4I+lEx91447zxcgo=";
-    })
-  ];
-
-  cargoHash = "sha256-EkDop9v75IIIWEK+QI5v58lO20RxgJab/scFmn26idU=";
+  cargoHash = "sha256-lNtZFcbOITP9S7N/EevMs2XZcDnF5JDbGNPyn5r5Q0Q=";
 
   LIBCAPNG_LIB_PATH = "${lib.getLib libcap_ng}/lib";
   LIBCAPNG_LINK_TYPE =

--- a/pkgs/servers/misc/virtiofsd/default.nix
+++ b/pkgs/servers/misc/virtiofsd/default.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage rec {
     owner = "virtio-fs";
     repo = "virtiofsd";
     rev = "v${version}";
-    sha256 = "sha256-YihxXoWcJHy7IT27x9TOM46R66IfosLz8ZKFsWCL3K0=";
+    hash = "sha256-YihxXoWcJHy7IT27x9TOM46R66IfosLz8ZKFsWCL3K0=";
   };
 
   cargoHash = "sha256-lNtZFcbOITP9S7N/EevMs2XZcDnF5JDbGNPyn5r5Q0Q=";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
