### PR TITLE
Add stremio service

### DIFF
--- a/pkgs/applications/video/stremio-service/default.nix
+++ b/pkgs/applications/video/stremio-service/default.nix
@@ -1,17 +1,34 @@
-{ lib, fetchFromGitHub, rustPlatform, pkg-config, openssl, gtk3 }:
+{ lib, stdenv, fetchurl, fetchFromGitHub, rustPlatform, pkg-config, openssl, gtk3 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "stremio-service";
-  version = "6e987ff";
+  version = "0.1.8";
 
-  src = fetchFromGitHub {
-    owner = "Stremio";
-    repo = pname;
-    rev = "6e987ff193696cca4b0ce78b93e3ca43477a7c37";
-    sha256 = "sha256-G3FQhsKmyyOLsNLfzwkFB/xJTwPQGnzVC6KbrXCDtjw=";
+  src = stdenv.mkDerivation rec {
+    name = "${pname}-source-${version}";
+    src = fetchFromGitHub {
+      owner = "Stremio";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "sha256-PySvGT7Za5NeQgW1OwAo3ja9FnKrQ/ofh217RkWewW0=";
+    };
+    server-js = fetchurl {
+      url = "https://dl.strem.io/server/v4.20.2/desktop/server.js";
+      sha256 = "sha256-YtoQG8ppBVpe86DjyRKhDwmHhVRYpIOkEDuH21YseWA=";
+    };
+    installPhase = ''
+      mkdir -p $out
+      cp -R ./* $out/
+      ls -al $out/resources/bin/linux/
+      cp ${server-js} $out/resources/bin/linux/server.js
+      ls -al $out/resources/bin/linux/
+    '';
   };
-  cargoBuildFlags = "--features=offline-build";
-  cargoSha256 = "sha256-NX43rF71wq/mFJJrxImUfpbnqRA9/kGb12yAjhHseYo=";
+
+  cargoBuildFeatures = [ "offline-build" "bundled" ];
+  doCheck = false;
+  cargoCheckFeatures = [ "offline-build" "bundled" ];
+  cargoSha256 = "sha256-aHIkHw2KvveuURq5yvSLXACIinQF89ZtHuV5o2fJmks=";
   buildInputs = [ gtk3 openssl ];
   nativeBuildInputs = [ pkg-config ];
   meta = with lib; {

--- a/pkgs/applications/video/stremio-service/default.nix
+++ b/pkgs/applications/video/stremio-service/default.nix
@@ -1,22 +1,23 @@
-{ lib, fetchFromGitHub, rustPlatform }:
+{ lib, fetchFromGitHub, rustPlatform, pkg-config, openssl, gtk3 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "stremio-service";
-  version = "0.1.6";
+  version = "6e987ff";
 
   src = fetchFromGitHub {
     owner = "Stremio";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1hqps7l5qrjh9f914r5i6kmcz6f1yb951nv4lby0cjnp5l253kps";
+    rev = "6e987ff193696cca4b0ce78b93e3ca43477a7c37";
+    sha256 = "sha256-G3FQhsKmyyOLsNLfzwkFB/xJTwPQGnzVC6KbrXCDtjw=";
   };
-
-  cargoSha256 = "03wf9r2csi6jpa7v5sw5lpxkrk4wfzwmzx7k3991q3bdjzcwnnwp";
-
+  cargoBuildFlags = "--features=offline-build";
+  cargoSha256 = "sha256-NX43rF71wq/mFJJrxImUfpbnqRA9/kGb12yAjhHseYo=";
+  buildInputs = [ gtk3 openssl ];
+  nativeBuildInputs = [ pkg-config ];
   meta = with lib; {
     description = "A companion app for Stremio Web";
     homepage = "https://github.com/Stremio/stremio-service";
-    license = licenses.unlicense;
+    license = licenses.gpl2;
     maintainers = [ ];
   };
 }

--- a/pkgs/applications/video/stremio-service/default.nix
+++ b/pkgs/applications/video/stremio-service/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "stremio-service";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "Stremio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1hqps7l5qrjh9f914r5i6kmcz6f1yb951nv4lby0cjnp5l253kps";
+  };
+
+  cargoSha256 = "03wf9r2csi6jpa7v5sw5lpxkrk4wfzwmzx7k3991q3bdjzcwnnwp";
+
+  meta = with lib; {
+    description = "A companion app for Stremio Web";
+    homepage = "https://github.com/Stremio/stremio-service";
+    license = licenses.unlicense;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/applications/video/stremio-service/default.nix
+++ b/pkgs/applications/video/stremio-service/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     '';
   };
 
-  cargoBuildFeatures = [ "offline-build" "bundled" ];
+  buildFeatures = [ "offline-build" "bundled" ];
   doCheck = false;
   cargoCheckFeatures = [ "offline-build" "bundled" ];
   cargoSha256 = "sha256-aHIkHw2KvveuURq5yvSLXACIinQF89ZtHuV5o2fJmks=";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12964,6 +12964,8 @@ with pkgs;
 
   stremio = qt5.callPackage ../applications/video/stremio { };
 
+  stremio-service = qt5.callPackage ../applications/video/stremio-service { };
+
   sunwait = callPackage ../applications/misc/sunwait { };
 
   sunpaper = callPackage ../tools/X11/sunpaper { };


### PR DESCRIPTION
###### Description of changes

Aiming to add stremio-service requested by #238550
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

even with --features=offline-mode build is still failing with fetch error `Temporary failure in name resolution`

unsure how to proceed, perhaps I should run `cargo deb` rather than using `rustPlatform.buildRustPackage` not sure about syntax
```
Error: reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("dl.strem.io")), port: None, path: "/server/v4.20.2/desktop/server.js", query: None, fragment: None }, source: hyper::Error(Connect, ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: Temporary failure in name resolution" })) }
```

_update_ fixed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- added prereq built inputs
- set build flags to offline to avoid fetch in `build.rs`
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
