### PR TITLE
fanout: init at unstable-2023-07-21

### DIFF
--- a/pkgs/os-specific/linux/fanout/default.nix
+++ b/pkgs/os-specific/linux/fanout/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, kernel, kmod }:
+
+stdenv.mkDerivation rec {
+  pname = "fanout";
+  version = "unstable-2022-10-17-${kernel.version}";
+
+  src = fetchFromGitHub {
+    owner = "bob-linuxtoys";
+    repo = "fanout";
+    rev = "69b1cc69bf425d1a5f83b4e84d41272f1caa0144";
+    hash = "sha256-Q19c88KDFu0A6MejZgKYei9J2693EjRkKtR9hcRcHa0=";
+  };
+
+  preBuild = ''
+    substituteInPlace Makefile --replace "modules_install" "INSTALL_MOD_PATH=$out modules_install"
+  '';
+
+  patches = [
+    ./remove_auto_mknod.patch
+  ];
+
+  hardeningDisable = [ "format" "pic" ];
+
+  nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  meta = with lib; {
+    description = "Kernel-based publish-subscribe system";
+    homepage = "https://github.com/bob-linuxtoys/fanout";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ therishidesai ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/fanout/remove_auto_mknod.patch
+++ b/pkgs/os-specific/linux/fanout/remove_auto_mknod.patch
@@ -1,0 +1,13 @@
+diff --git a/fanout.c b/fanout.c
+index f5d2a55..87125f4 100644
+--- a/fanout.c
++++ b/fanout.c
+@@ -13,7 +13,7 @@
+ /* Comment out to forgo the creation of /dev entries
+  * The companion udev rules 'fanout.rules' sets the special file mode
+  */
+-#define DEV_MKNOD
++// #define DEV_MKNOD
+ 
+ #include <linux/kernel.h>
+ #include <linux/module.h>

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -349,6 +349,8 @@ in {
 
     evdi = callPackage ../os-specific/linux/evdi { };
 
+    fanout = callPackage ../os-specific/linux/fanout { };
+
     fwts-efi-runtime = callPackage ../os-specific/linux/fwts/module.nix { };
 
     gcadapter-oc-kmod = callPackage ../os-specific/linux/gcadapter-oc-kmod { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the [fanout](https://github.com/bob-linuxtoys/fanout/tree/master) kernel module into linuxPackages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
