### PR TITLE
rPackages.reticulate: fallback to python3 from nixpkgs

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1321,6 +1321,16 @@ let
       RGL_USE_NULL = "true";
     });
 
+    reticulate = old.reticulate.overrideAttrs (_: {
+      preConfigure = ''
+        if [ ! -z ''${python+x} ] ; then
+          substituteInPlace R/zzz.R --replace \
+            ".onLoad <- function(libname, pkgname) {" \
+            ".onLoad <- function(libname, pkgname) { Sys.setenv(RETICULATE_PYTHON='$python/bin/python');"
+        fi
+      '';
+    });
+
     Rhdf5lib = let
       hdf5 = pkgs.hdf5_1_10.overrideAttrs (attrs: {configureFlags = attrs.configureFlags ++ ["--enable-cxx"];});
     in old.Rhdf5lib.overrideAttrs (attrs: {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Reticulate sources it's python from the PATH, falling back to a set of
default search locations. This patch changes one of the search locations
to python3 from nixpkgs, guaranteeing that a suitable python will be
found. It also allows overriding to point to specific python wrappers,
e.g.,:

```
  rPackages.reticulate.overrideAttrs (_: {
    python = python3.withPackages (ps: [numpy]);
  })
```

@bcdarwin I'm not sure this is better than #244576.

@b-rodrigues fyi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
