### PR TITLE
Frama-C: Iron → Cobalt

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
@@ -1,23 +1,23 @@
-{ lib, buildDunePackage, fetchurl, ppxlib, alcotest
+{ lib, buildDunePackage, fetchurl, ppxlib, alcotest, mdx
 , ppx_deriving, yaml
 }:
 
 buildDunePackage rec {
   pname = "ppx_deriving_yaml";
-  version = "0.1.1";
+  version = "0.2.1";
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v${version}/ppx_deriving_yaml-${version}.tbz";
-    sha256 = "sha256-nR3568ULM6jaGG4H4+lLBTEJqh/ALHPiJxve40jPUxw=";
+    hash = "sha256-3vmay8UY7d3j96VOQ+D3oYEotzVls91F51ebXWQ/9SQ=";
   };
 
   propagatedBuildInputs = [ ppxlib ppx_deriving yaml ];
 
   doCheck = true;
   checkInputs = [ alcotest ];
+  nativeCheckInputs = [ mdx.bin ];
 
   meta = {
     description = "A YAML codec generator for OCaml";

--- a/pkgs/development/tools/analysis/frama-c/default.nix
+++ b/pkgs/development/tools/analysis/frama-c/default.nix
@@ -4,15 +4,6 @@
 , gdk-pixbuf, wrapGAppsHook
 }:
 
-let why3_1_5 = why3.overrideAttrs (o: rec {
-    version = "1.5.1";
-    src = fetchurl {
-      url = "https://why3.gitlabpages.inria.fr/releases/${o.pname}-${version}.tar.gz";
-      hash = "sha256-vNR7WeiSvg+763GcovoZBFDfncekJMeqNegP4fVw06I=";
-    };
-  }); in
-let why3 = why3_1_5; in
-
 let
   mkocamlpath = p: "${p}/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib";
   runtimeDeps = with ocamlPackages; [
@@ -45,33 +36,25 @@ in
 
 stdenv.mkDerivation rec {
   pname = "frama-c";
-  version = "26.1";
-  slang   = "Iron";
+  version = "27.1";
+  slang   = "Cobalt";
 
   src = fetchurl {
     url  = "https://frama-c.com/download/frama-c-${version}-${slang}.tar.gz";
-    hash = "sha256-UT7ajIyu8e5vzrz2oBKDDrtZqUacgUP/TRi0/kz9Qkg=";
+    hash = "sha256-WxNXShaliXHCeQm+6Urn83sX2JeFK0DHaKPU4uCeOdI=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fixes-yojson-2_1-support.patch";
-      url = "https://git.frama-c.com/pub/frama-c/-/commit/647eace02ed8dac46e75452898c3470f82576818.patch";
-      hash = "sha256-XfLi4kW1Y2MCLjHHQZAD8DvXvfZuDH3OKd9hlTV0XCw=";
-    })
-  ];
 
   postConfigure = "patchShebangs src/plugins/eva/gen-api.sh";
 
   strictDeps = true;
 
-  nativeBuildInputs = [ wrapGAppsHook ] ++ (with ocamlPackages; [ ocaml findlib dune_3 ]);
+  nativeBuildInputs = [ wrapGAppsHook ] ++ (with ocamlPackages; [ ocaml findlib dune_3 menhir ]);
 
   buildInputs = with ocamlPackages; [
     dune-site dune-configurator
     ltl2ba ocamlgraph yojson menhirLib camlzip
     lablgtk3 lablgtk3-sourceview3 coq graphviz zarith apron why3 mlgmpidl doxygen
-    ppx_deriving ppx_import ppx_deriving_yojson
+    ppx_deriving ppx_import ppx_deriving_yaml ppx_deriving_yojson
     gdk-pixbuf
   ];
 


### PR DESCRIPTION
###### Description of changes

https://github.com/patricoferris/ppx_deriving_yaml/blob/v0.2.1/CHANGES.md
https://frama-c.com/html/changelog.html#Cobalt-27.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
