### PR TITLE
python packages: Put nose in nativeCheckInputs

### DIFF
--- a/pkgs/development/python-modules/jsonable/default.nix
+++ b/pkgs/development/python-modules/jsonable/default.nix
@@ -1,8 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
 , nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -16,9 +16,10 @@ buildPythonPackage rec {
     hash = "sha256-3FIzG2djSZOPDdoYeKqs3obQjgHrFtyp0sdBwZakkHA=";
   };
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  checkInputs = [ nose ];
+  nativeCheckInputs = [
+    nose
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "jsonable" ];
 

--- a/pkgs/development/python-modules/mwtypes/default.nix
+++ b/pkgs/development/python-modules/mwtypes/default.nix
@@ -2,8 +2,8 @@
 , buildPythonPackage
 , fetchPypi
 , jsonable
-, pytestCheckHook
 , nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -17,9 +17,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ jsonable ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  checkInputs = [ nose ];
+  nativeCheckInputs = [
+    nose
+    pytestCheckHook
+  ];
 
   disabledTests = [
     "test_normalize_path_bad_extension"

--- a/pkgs/development/python-modules/mwxml/default.nix
+++ b/pkgs/development/python-modules/mwxml/default.nix
@@ -4,8 +4,8 @@
 , jsonschema
 , mwcli
 , mwtypes
-, pytestCheckHook
 , nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -23,9 +23,10 @@ buildPythonPackage rec {
     mwtypes
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  checkInputs = [ nose ];
+  nativeCheckInputs = [
+    nose
+    pytestCheckHook
+  ];
 
   disabledTests = [
     "test_page_with_discussion"

--- a/pkgs/development/python-modules/para/default.nix
+++ b/pkgs/development/python-modules/para/default.nix
@@ -1,8 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pytestCheckHook
 , nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -14,9 +14,10 @@ buildPythonPackage rec {
     hash = "sha256-RsMjKunY6p2IbP0IzdESiSICvthkX0C2JVWXukz+8hc=";
   };
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  checkInputs = [ nose ];
+  nativeCheckInputs = [
+    nose
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "para" ];
 


### PR DESCRIPTION
###### Description of changes

As @SuperSandro2000 recommended, `nose` should be put in `nativeCheckInputs` and not `checkInputs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
