### PR TITLE
frr: fix cross compilation and add advanced options

### DIFF
--- a/pkgs/servers/frr/clippy-helper.nix
+++ b/pkgs/servers/frr/clippy-helper.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, frr_source
+, frr_version
+
+# build time
+, autoreconfHook
+, flex
+, bison
+, pkg-config
+, libelf
+, perl
+, python3
+
+}:
+
+stdenv.mkDerivation rec {
+  pname = "frr-clippy-helper";
+  version = frr_version;
+
+  src = frr_source;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
+    perl
+    pkg-config
+  ];
+
+  buildInputs = [
+    libelf
+    python3
+  ];
+
+  configureFlags = [
+    "--enable-clippy-only"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp lib/clippy $out/bin
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://frrouting.org/";
+    description = "FRR routing daemon suite: CLI helper tool clippy";
+    longDescription = ''
+      This small tool is used to support generating CLI code for FRR. It is split out here,
+      to support cross-compiling, because it needs to be compiled with the build system toolchain
+      and not the target host one.
+    '';
+    license = with licenses; [ gpl2Plus lgpl21Plus ];
+    maintainers = with maintainers; [ thillux ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/frr/clippy-helper.nix
+++ b/pkgs/servers/frr/clippy-helper.nix
@@ -1,9 +1,9 @@
 { lib
 , stdenv
-, frr_source
-, frr_version
+, frrSource
+, frrVersion
 
-# build time
+  # build time
 , autoreconfHook
 , flex
 , bison
@@ -16,9 +16,9 @@
 
 stdenv.mkDerivation rec {
   pname = "frr-clippy-helper";
-  version = frr_version;
+  version = frrVersion;
 
-  src = frr_source;
+  src = frrSource;
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/servers/frr/default.nix
+++ b/pkgs/servers/frr/default.nix
@@ -30,8 +30,45 @@
 , nettools
 , nixosTests
 
-# options
+# general options
 , snmpSupport ? true
+, rpkiSupport ? true
+, numMultipath ? 64
+, watchfrrSupport ? true
+, cumulusSupport ? false
+, datacenterSupport ? true
+, rtadvSupport ? true
+, irdpSupport ? true
+, routeReplacementSupport ? true
+
+# routing daemon options
+, bgpdSupport ? true
+, ripdSupport ? true
+, ripngdSupport ? true
+, ospfdSupport ? true
+, ospf6dSupport ? true
+, ldpdSupport ? true
+, nhrpdSupport ? true
+, eigrpdSupport ? true
+, babeldSupport ? true
+, isisdSupport ? true
+, pimdSupport ? true
+, pim6dSupport ? true
+, sharpdSupport ? true
+, fabricdSupport ? true
+, vrrpdSupport ? true
+, pathdSupport ? true
+, bfddSupport ? true
+, pbrdSupport ? true
+, staticdSupport ? true
+
+# BGP options
+, bgpAnnounce ? true
+, bgpBmp ? true
+, bgpVnc ? true
+
+# OSPF options
+, ospfApi ? true
 }:
 
 assert snmpSupport -> stdenv.buildPlatform.canExecute stdenv.hostPlatform;
@@ -90,15 +127,50 @@ stdenv.mkDerivation rec {
     "--enable-configfile-mask=0640"
     "--enable-group=frr"
     "--enable-logfile-mask=0640"
-    "--enable-multipath=64"
-    (lib.strings.enableFeature snmpSupport "snmp")
+    "--enable-multipath=${toString numMultipath}"
     "--enable-user=frr"
     "--enable-vty-group=frrvty"
     "--localstatedir=/run/frr"
     "--sbindir=$(out)/libexec/frr"
     "--sysconfdir=/etc/frr"
-    "--enable-rpki"
     "--with-clippy=${clippy-helper}/bin/clippy"
+    # general options
+    (lib.strings.enableFeature snmpSupport "snmp")
+    (lib.strings.enableFeature rpkiSupport "rpki")
+    (lib.strings.enableFeature watchfrrSupport "watchfrr")
+    (lib.strings.enableFeature rtadvSupport "rtadv")
+    (lib.strings.enableFeature irdpSupport "irdp")
+    (lib.strings.enableFeature routeReplacementSupport "rr-semantics")
+    # routing protocols
+    (lib.strings.enableFeature bgpdSupport "bgpd")
+    (lib.strings.enableFeature ripdSupport "ripd")
+    (lib.strings.enableFeature ripngdSupport "ripngd")
+    (lib.strings.enableFeature ospfdSupport "ospfd")
+    (lib.strings.enableFeature ospf6dSupport "ospf6d")
+    (lib.strings.enableFeature ldpdSupport "ldpd")
+    (lib.strings.enableFeature nhrpdSupport "nhrpd")
+    (lib.strings.enableFeature eigrpdSupport "eigrpd")
+    (lib.strings.enableFeature babeldSupport "babeld")
+    (lib.strings.enableFeature isisdSupport "isisd")
+    (lib.strings.enableFeature pimdSupport "pimd")
+    (lib.strings.enableFeature pim6dSupport "pim6d")
+    (lib.strings.enableFeature sharpdSupport "sharpd")
+    (lib.strings.enableFeature fabricdSupport "fabricd")
+    (lib.strings.enableFeature vrrpdSupport "vrrpd")
+    (lib.strings.enableFeature pathdSupport "pathd")
+    (lib.strings.enableFeature bfddSupport "bfdd")
+    (lib.strings.enableFeature pbrdSupport "pbrd")
+    (lib.strings.enableFeature staticdSupport "staticd")
+    # BGP options
+    (lib.strings.enableFeature bgpAnnounce "bgp-announce")
+    (lib.strings.enableFeature bgpBmp "bgp-bmp")
+    (lib.strings.enableFeature bgpVnc "bgp-vnc")
+    # OSPF options
+    (lib.strings.enableFeature ospfApi "ospfapi")
+    # Cumulus options
+    (lib.strings.enableFeature cumulusSupport "cumulus")
+    # Datacenter options
+    (lib.strings.enableFeature datacenterSupport "datacenter")
   ];
 
   postPatch = ''

--- a/pkgs/servers/frr/default.nix
+++ b/pkgs/servers/frr/default.nix
@@ -213,7 +213,7 @@ stdenv.mkDerivation rec {
       private clouds.
     '';
     license = with licenses; [ gpl2Plus lgpl21Plus ];
-    maintainers = with maintainers; [ woffs ];
+    maintainers = with maintainers; [ woffs thillux ];
     platforms = platforms.unix;
   };
 


### PR DESCRIPTION
###### Description of changes

FRR did not cross-compile from x86-64 to aarch64, because the cli interface helper clippy, needs to be compiled with the build host toolchain. After some failed experiments inside default.nix, I concluded, that it would we cleaner to add a small helper package, which can the be built with the native toolchain and reference clippy from there. As this is frr internal, I did not expose it to all-packages.nix.

SNMP is used with net-snmp-config to obtain the compilation flags. It did not get this working without binfmt, as it either is called in the native form and returns e.g. x86-64 libs, which do no link on aarch64 or it is in aarch64 form, which does not execute without binfmt. Therefore I made snmp support conditional on a working host or binfmt toolchain.

For networking purposes the exposed options of the package where to small, I added most networking relevant options, like route replacement semantics and made it possible to disable most of the daemons if hardening is a need (e.g. only BGP supported). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
