### PR TITLE
nixos/kmscon: use upstream service file

### DIFF
--- a/nixos/modules/services/ttys/kmscon.nix
+++ b/nixos/modules/services/ttys/kmscon.nix
@@ -67,36 +67,24 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # Largely copied from unit provided with kmscon source
-    systemd.units."kmsconvt@.service".text = ''
-      [Unit]
-      Description=KMS System Console on %I
-      Documentation=man:kmscon(1)
-      After=systemd-user-sessions.service
-      After=plymouth-quit-wait.service
-      After=systemd-logind.service
-      After=systemd-vconsole-setup.service
-      Requires=systemd-logind.service
-      Before=getty.target
-      Conflicts=getty@%i.service
-      OnFailure=getty@%i.service
-      IgnoreOnIsolate=yes
-      ConditionPathExists=/dev/tty0
+    systemd.packages = [ pkgs.kmscon ];
 
-      [Service]
-      ExecStart=
-      ExecStart=${pkgs.kmscon}/bin/kmscon "--vt=%I" ${cfg.extraOptions} --seats=seat0 --no-switchvt --configdir ${configDir} --login -- ${pkgs.shadow}/bin/login -p ${autologinArg}
-      UtmpIdentifier=%I
-      TTYPath=/dev/%I
-      TTYReset=yes
-      TTYVHangup=yes
-      TTYVTDisallocate=yes
+    systemd.services."kmsconvt@" = {
+      after = [ "systemd-logind.service" "systemd-vconsole-setup.service" ];
+      requires = [ "systemd-logind.service" ];
 
-      X-RestartIfChanged=false
-    '';
+      serviceConfig.ExecStart = [
+        ""
+        ''
+          ${pkgs.kmscon}/bin/kmscon "--vt=%I" ${cfg.extraOptions} --seats=seat0 --no-switchvt --configdir ${configDir} --login -- ${pkgs.shadow}/bin/login -p ${autologinArg}
+        ''
+      ];
+
+      restartIfChanged = false;
+      aliases = [ "autovt@.service" ];
+    };
 
     systemd.suppressedSystemUnits = [ "autovt@.service" ];
-    systemd.units."kmsconvt@.service".aliases = [ "autovt@.service" ];
 
     systemd.services.systemd-vconsole-setup.enable = false;
     systemd.services.reload-systemd-vconsole-setup.enable = false;


### PR DESCRIPTION
###### Description of changes

Use the upstream [kmsconvt@.service](https://github.com/Aetf/kmscon/blob/develop/docs/kmsconvt%40.service.in) file instead of manually copying it.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).