### PR TITLE
knxd: init at 0.14.59

### DIFF
--- a/pkgs/servers/knxd/default.nix
+++ b/pkgs/servers/knxd/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, indent
+, perl
+, argp-standalone
+, fmt_9
+, libev
+, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
+, withUsb ? stdenv.isLinux, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "knxd";
+  version = "0.14.59";
+
+  src = fetchFromGitHub {
+    owner = "knxd";
+    repo = "knxd";
+    rev = version;
+    hash = "sha256-m3119aD23XTViQJ2s7hwnJZ1ct4bcEFWuyUQajmqySQ=";
+  };
+
+  postPatch = ''
+    sed -i '2i echo ${version}; exit' tools/version.sh
+    sed -i '2i exit' tools/get_libfmt
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config indent perl ];
+
+  buildInputs = [ fmt_9 libev ]
+    ++ lib.optional withSystemd systemd
+    ++ lib.optional withUsb libusb1
+    ++ lib.optional stdenv.isDarwin argp-standalone;
+
+  configureFlags = lib.optional (!withSystemd) "--disable-systemd"
+    ++ lib.optional (!withUsb) "--disable-usb";
+
+  installFlags = lib.optionals withSystemd [
+    "systemdsystemunitdir=$(out)/lib/systemd/system"
+    "systemdsysusersdir=$(out)/lib/sysusers.d"
+  ];
+
+  meta = with lib; {
+    description = "Advanced router/gateway for KNX";
+    homepage = "https://github.com/knxd/knxd";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5553,6 +5553,8 @@ with pkgs;
 
   klog = qt5.callPackage ../applications/radio/klog { };
 
+  knxd = callPackage ../servers/knxd { };
+
   komga = callPackage ../servers/komga { };
 
   komorebi = callPackage ../applications/graphics/komorebi { };


### PR DESCRIPTION
###### Description of changes
[**knxd**](https://github.com/knxd/knxd) is an advanced router/gateway for KNX.

[![Packaging status](https://repology.org/badge/tiny-repos/knxd.svg)](https://repology.org/project/knxd/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
