### PR TITLE
tree-sitter: Improve update script, update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bash.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bash.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-bash",
-  "rev": "b6667bed364733c8a8f8e5973749f86cfa04ba2a",
-  "date": "2021-03-04T14:15:26-08:00",
-  "path": "/nix/store/nvlvdv02wdy4dq4w19bvzq6nlkgvpj20-tree-sitter-bash",
-  "sha256": "18c030bb65r50i6z37iy7jb9z9i8i36y7b08dbc9bchdifqsijs5",
+  "rev": "1b0321ee85701d5036c334a6f04761cdc672e64c",
+  "date": "2023-07-10T13:54:29+01:00",
+  "path": "/nix/store/k8k35fjd574fajfry1yvjkh294ai1iay-tree-sitter-bash",
+  "sha256": "09xbrzcllywwp067ws822plwjiwvgp43prnf11mbr3da6rmn7rmr",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/polarmutex/tree-sitter-beancount",
-  "rev": "6d580bc408741ce2ba1a566c972e9ff414c65456",
-  "date": "2023-01-27T21:26:56-05:00",
-  "path": "/nix/store/8sfwfmc20bs3vmfns5qb82jf63h625hb-tree-sitter-beancount",
-  "sha256": "0q4f1qqd8m7x4qxj4bpwgk8fxksh60n1m4payvhd0y0xrrhb06v8",
+  "rev": "358e5ecbb87109eef7fd596ea518a4ff74cb9b31",
+  "date": "2023-07-02T15:37:32-04:00",
+  "path": "/nix/store/h24aaxhp4hhp7f21by7shjvx7v4k513z-tree-sitter-beancount",
+  "sha256": "1pa673dzsv41rxlqb2a5w7r31rw9z3m6a54yx22wm75cwr9hagxz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "7a47daeaf0d410dd1a91c97b274bb7276dd96605",
-  "date": "2022-09-15T09:14:12+01:00",
-  "path": "/nix/store/sscjjlp833rqqvfpgh84wsnq59jmy90c-tree-sitter-c-sharp",
-  "sha256": "0lijbi5q49g50ji00p2lb45rvd76h07sif3xjl9b31yyxwillr6l",
+  "rev": "1648e21b4f087963abf0101ee5221bb413107b07",
+  "date": "2023-06-22T09:32:56+02:00",
+  "path": "/nix/store/7lzn4y3dbwka0hvhj8b37vl3w7241fc2-tree-sitter-c-sharp",
+  "sha256": "0x9jigiapwbcf5k2y7bkam4i0rkcblprjvr2m86qbmrd1yvhgyas",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "a015709e7d1bb4f823a2fc53175e0cbee96c1c3e",
-  "date": "2023-05-22T07:31:22+02:00",
-  "path": "/nix/store/mrl2pdg4jxn4hcyz6lpsnl47m0fxqwl8-tree-sitter-c",
-  "sha256": "086cz0ky1f0ds14v9m8nif57cil9ssvqym8c51la7qv4329dgs5b",
+  "rev": "475dc3bb849e26623df274e388776e7607a5e481",
+  "date": "2023-07-21T12:39:30-04:00",
+  "path": "/nix/store/vfw6vj9bwzmfp1k81b2rxmimqlxsg4fl-tree-sitter-c",
+  "sha256": "1kmw7jk8p93605rq9iz00jqkq8lgmvq7abvlry0p5qrbm7n5hgj9",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/uyha/tree-sitter-cmake",
-  "rev": "399605a02bcd5daa309ce63a6459c600dce3473f",
-  "date": "2023-02-05T17:55:52+01:00",
-  "path": "/nix/store/myib3gz6xjmp68mq0cc1gxmfkdh3hz2y-tree-sitter-cmake",
-  "sha256": "00zs5s2dvyqki7ghmhp5n9ssrjbsaklzvzg5rvh6fikxyk4wm77f",
+  "rev": "3dfc596025431b21e839d392c171f6f97c2a4258",
+  "date": "2023-06-28T14:34:24+00:00",
+  "path": "/nix/store/kbvsn46ksr5w8vqmk3jc3zj5rmrpv03p-tree-sitter-cmake",
+  "sha256": "0i8vsvkkas1fnn35na68gq5xq2y3xvhv2bk9q6x8c1bzsqm6rcsa",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-comment",
-  "rev": "f08e7d44b2923e9da2bf487a2f365d08677d368e",
-  "date": "2023-04-10T20:11:04-05:00",
-  "path": "/nix/store/swaxl1n782g3gvvbxj0d659krb2zrxaw-tree-sitter-comment",
-  "sha256": "1r9bzf6fxc2cjb8ndrkvirpqgk9wixandcsp2311dxvyfk3phy5z",
+  "rev": "ef429992748f89e176243411e94b8ffc8777d118",
+  "date": "2023-06-03T20:48:17-05:00",
+  "path": "/nix/store/0kg71dvg10f1m2f08z1b2wh1ap4w4hw6-tree-sitter-comment",
+  "sha256": "1d5g69i8jplyg888yr7wzjb46cqnchwf4kdzgb83him7cwfx9wax",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-commonlisp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-commonlisp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-commonlisp",
-  "rev": "c7e814975ab0d0d04333d1f32391c41180c58919",
-  "date": "2022-01-28T21:33:11+01:00",
-  "path": "/nix/store/1696bj1f92y8vqfk71cha8bzk9cx9rls-tree-sitter-commonlisp",
-  "sha256": "1hq3pwrp8509scgn983g0mi8pjy2q21pms30xlc3q7yyjxvpsw7b",
+  "rev": "338db38330f0d25cba8e2c6428240ebc5e020264",
+  "date": "2023-06-17T07:20:59+03:00",
+  "path": "/nix/store/k2lhjjqnwpp8372s626b2ficj5s6f7hq-tree-sitter-commonlisp",
+  "sha256": "03cfswsx0fansfdkp32a4lxhagbwwfj01p5fybqv3ap47yg72c4r",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "70aed2e9e83eb7320ab7c454d3084300bf587037",
-  "date": "2023-05-09T10:48:30+02:00",
-  "path": "/nix/store/v44wqlm6vlz3rw9v402hxykz6fvc4n22-tree-sitter-cpp",
-  "sha256": "1h2g7jy0znnzqrfgjnkz33hys4wcgxj6cqk3zcyb1zs77nmwn16y",
+  "rev": "cbb9974efde90cbdc5d1027c97882df737aa3601",
+  "date": "2023-07-18T17:47:27-04:00",
+  "path": "/nix/store/ggpqznnvdga5wkifixsglms5lbrjzn09-tree-sitter-cpp",
+  "sha256": "10n6b0hzm75c43cpp5k1s7s2mxc712rdx24rcp8hz9ydwnljps8h",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-css",
-  "rev": "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51",
-  "date": "2022-08-31T10:51:16-07:00",
-  "path": "/nix/store/a91kqixk4gmh40ak98jjnfrlzm3ngvax-tree-sitter-css",
-  "sha256": "05875jmkkklx0b5g1h4qc8cbgcj8mr1n8slw7hsn0wssn7yn42z5",
+  "rev": "5f2c94b897601b4029fedcce7db4c6d76ce8a128",
+  "date": "2023-07-10T20:01:23-04:00",
+  "path": "/nix/store/4fqf7ca6l5z1g8z8ybgxkxm51h4s3j7b-tree-sitter-css",
+  "sha256": "0fjl8gisfg0c7a78y9v0lbqssak9adqj114p92hpmb24xffv240w",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "9c20a3120c405db9efda9349cd005c29f2aace3c",
-  "date": "2023-05-22T10:54:56+02:00",
-  "path": "/nix/store/zzix5y046a7vj6s16cdkp0v2fhfr24fq-tree-sitter-cuda",
-  "sha256": "0z9va82k7n8rlnk6g9q52sxaw2lcb05arl3l5dqmji5s53sq5q1c",
+  "rev": "7ac4ac5f4b8dd39d46c927a9a853aae984cba2ae",
+  "date": "2023-07-19T08:05:29-03:00",
+  "path": "/nix/store/fzzf090dfk4wx3ji1bg2n0vsshhhv59p-tree-sitter-cuda",
+  "sha256": "0ysbfxak0ljqz86v972fpwlc9hsiqd8lvdiz23fhjwrlsl1ai39g",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/usernobody14/tree-sitter-dart",
-  "rev": "1a525edd89026cc6f0a954b4718ce20fd7e45b15",
-  "date": "2023-05-23T15:35:37-06:00",
-  "path": "/nix/store/kv98km1sar3gxlzi3inyqln7i9701wgi-tree-sitter-dart",
-  "sha256": "0i2d6khh7gv48fpnc0f550gyxpzm328b8065sri7lhab0rjf17ai",
+  "rev": "e398400a0b785af3cf571f5a57eccab242f0cdf9",
+  "date": "2023-06-13T09:16:30-06:00",
+  "path": "/nix/store/y90zd30jnvknsmwh1328wjhnqnqvshjn-tree-sitter-dart",
+  "sha256": "05868i5156y1fd0l14q1fq2ykp7srrkwhs3d6jks7bbrahj6lcgq",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-devicetree.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-devicetree.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/joelspadin/tree-sitter-devicetree",
-  "rev": "59faca63ab28d8aa8b79416bfcbe5b935f3fa604",
-  "date": "2023-04-23T12:18:55-05:00",
-  "path": "/nix/store/m39bl3vasy0b1r0qzdn8flb480ys8laq-tree-sitter-devicetree",
-  "sha256": "11r46v3zw03p1fldhawn9zwyzpi7h57pjw9sydwq7b1fgdmdxvn7",
+  "rev": "d2cc332aeb814ea40e1e34ed6b9446324b32612a",
+  "date": "2023-04-23T16:45:10-05:00",
+  "path": "/nix/store/f9xds4w4splaw90r8c95hy1gx8qdhl9g-tree-sitter-devicetree",
+  "sha256": "0dmgijl3sbl8rpx6z5c4ybkxdl93vzhqxckjxrrbq02zjgm8cf48",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dockerfile.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dockerfile.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/camdencheek/tree-sitter-dockerfile",
-  "rev": "d34a0cebd094e830bdd2106a28cb2f1fb22401d8",
-  "date": "2022-01-27T11:20:14-07:00",
-  "path": "/nix/store/3whf6fv79zqk5w0d6jbzfgs5jzm4cll4-tree-sitter-dockerfile",
-  "sha256": "0kf4c4xs5naj8lpcmr3pbdvwj526wl9p6zphxxpimbll7qv6qfnd",
+  "rev": "c0a9d694d9bf8ab79a919f5f9c7bc9c169caf321",
+  "date": "2023-07-06T08:25:44-06:00",
+  "path": "/nix/store/zq0q0dxvqvqlrvr8h720lmngj43rmz2z-tree-sitter-dockerfile",
+  "sha256": "1v6xxyr2z4dggw7amzi9h15fb5052kkcg62a87m748rps71wpnkl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elisp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elisp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/wilfred/tree-sitter-elisp",
-  "rev": "1991465e2722dd36c06e03dc7de6bc5d7da89d51",
-  "date": "2023-03-28T08:47:56-07:00",
-  "path": "/nix/store/mbb6q2yma6vszbzpw5hbpzf0iwg9y7vi-tree-sitter-elisp",
-  "sha256": "1m6lb60mlyk38pizcncp58f69kyf36b47rxnysf1l4193nscjqw6",
+  "rev": "e5524fdccf8c22fc726474a910e4ade976dfc7bb",
+  "date": "2023-06-03T14:06:46-07:00",
+  "path": "/nix/store/v8kv31llmwn39xlmn0fcil6kij7iqcvy-tree-sitter-elisp",
+  "sha256": "1wyzfb27zgpvm4110jgv0sl598mxv5dkrg2cwjw3p9g2bq9mav5d",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elixir-lang/tree-sitter-elixir",
-  "rev": "869dff3ceb8823ca4b17ca33b663667c8e41e8ba",
-  "date": "2023-03-14T10:58:34+01:00",
-  "path": "/nix/store/d8k07yvr8q14rc21fvhcnqrlpcwhlnmk-tree-sitter-elixir",
-  "sha256": "0m10vykaj36yxk0wwh0vk0pzvpdmac4apgihmxn3j0dwwgirchf0",
+  "rev": "2616034f78ffa83ca6a521ebd7eee1868cb5c14c",
+  "date": "2023-07-16T00:33:57+02:00",
+  "path": "/nix/store/qkxw17ai691b239ndcxr3j3ghq52cvll-tree-sitter-elixir",
+  "sha256": "0pv32ynys0fnk2x2c8g8qpys1w5mx6nnrq8flh17ascnh9wfm3r9",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elm-tooling/tree-sitter-elm",
-  "rev": "692c50c0b961364c40299e73c1306aecb5d20f40",
-  "date": "2023-04-15T15:07:51+02:00",
-  "path": "/nix/store/hmjs76plv6a64c2mgfxq79mh0ak2a45a-tree-sitter-elm",
-  "sha256": "0y5mz26ax2gzlv8cbrncn4bip9gin330a2zmynq9f1yfwv4nxfnh",
+  "rev": "73edfcdc3bb2ddfc731cd5d63e6cb287a18da90d",
+  "date": "2023-06-25T16:18:54+02:00",
+  "path": "/nix/store/lis6an738n9cg6ws0pvh1dn79hjw1p4d-tree-sitter-elm",
+  "sha256": "06z5akxb1l25gwdcgkvx890iflgl0c051f96yki0crgdh4svgw6i",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gdscript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gdscript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/prestonknopp/tree-sitter-gdscript",
-  "rev": "fbbe22c7e3f8191f65df8cfb4cc8c6137eedb09a",
-  "date": "2023-02-08T15:20:29-08:00",
-  "path": "/nix/store/62skx6k41f6k95qf32b7yjd9m516z3lk-tree-sitter-gdscript",
-  "sha256": "0f4g5vnls2rkwnry47cvpmhsymf1s109sbzdf4x7h94k58f5ggw4",
+  "rev": "03f20b94707a21bed90bb95101684bc4036139ce",
+  "date": "2023-06-20T16:09:39-07:00",
+  "path": "/nix/store/kgz2cl3makaywjxjq0z3yi0j19fmkqy5-tree-sitter-gdscript",
+  "sha256": "0smllcgikk7ji3vkjasnk4jn2yxarp1k6x6kb00zfg1x1d3knvwa",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glimmer.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glimmer.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/alexlafroscia/tree-sitter-glimmer",
-  "rev": "a23d28de811976f3ca310df735fe09a5d2de16ab",
-  "date": "2022-06-24T09:27:51-04:00",
-  "path": "/nix/store/m0hr0x0s3j7r6dn1kv6c77c9qbl4ggkw-tree-sitter-glimmer",
-  "sha256": "07dzpjyc644clh2x3r48w3mi3i68pkac5mwzha2iaxly9fndm0zk",
+  "rev": "d3031a8294bf331600d5046b1d14e690a0d8ba0c",
+  "date": "2023-04-24T10:59:03+00:00",
+  "path": "/nix/store/bv9kdsria41p6gxxvg5rxxqapjwqifvi-tree-sitter-glimmer",
+  "sha256": "18laj57m1w6l2zkmm505xpl33a124dqaw1w68ir18qrhf50fvxv2",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "190c86e633e6a6dfdb8a96f8b8460e347ff93f1c",
-  "date": "2023-05-20T13:31:53+02:00",
-  "path": "/nix/store/hj5f27mzk311bbjb448azsw2wwrax171-tree-sitter-glsl",
-  "sha256": "0ag7w0cp22253hzlm9017fsxmryhn8b8m0vrpsmh5kd05xss413k",
+  "rev": "2a56fb7bc8bb03a1892b4741279dd0a8758b7fb3",
+  "date": "2023-07-19T08:05:10-03:00",
+  "path": "/nix/store/092h59rarsqj2w6qhn06zc1n2avil7cb-tree-sitter-glsl",
+  "sha256": "17ixsi2m3k97n85k3wmnhggnj9b7z8j7sagi5jcp0k9a4nm96z2n",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "64457ea6b73ef5422ed1687178d4545c3e91334a",
-  "date": "2022-12-08T10:45:14+01:00",
-  "path": "/nix/store/4kdv3qc219w96wcciypw0znkv2izbpd2-tree-sitter-go",
-  "sha256": "16d32m78y8jricba9xav35c9y0k2r29irj5xyqgq24323yln9jnz",
+  "rev": "8c8007eaee47702bb0291a3c7aeb004909baab4d",
+  "date": "2023-07-11T19:07:25-04:00",
+  "path": "/nix/store/6c75bf78cf9srg7dkka50lvyc5pr081d-tree-sitter-go",
+  "sha256": "018d4j21lrqxxnif9q77arj564792m3w0bl4r4r7qj8phh7azj9b",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "c5cb0c860a399308305f44792bc4853737c40c07",
-  "date": "2023-05-06T16:49:31+02:00",
-  "path": "/nix/store/hh393wfdf43mghdgslq9315cqry1gim6-tree-sitter-haskell",
-  "sha256": "0an4d5q0vjl9amk4cwhs9d9cb3i4d1n20hzda165b88cq720lk7m",
+  "rev": "ba0bfb0e5d8e9e31c160d287878c6f26add3ec08",
+  "date": "2023-06-25T00:05:32+02:00",
+  "path": "/nix/store/3j06cjbifdx4msk5vjvpzj2ykrpcdbba-tree-sitter-haskell",
+  "sha256": "0zba3zy60yab4gy3rrx37l07ys3ybvqq5wadq63cv7yf4b88a8v5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MichaHoffmann/tree-sitter-hcl",
-  "rev": "6b74f88b3d396e0f101c93f807e0b3667cd3e3a2",
-  "date": "2022-12-02T21:24:38+01:00",
-  "path": "/nix/store/nn324j92ywapf4smjhkjyljlf6f5f96q-tree-sitter-hcl",
-  "sha256": "1dm129c91qyg955mpxy408wa7cmxyvh5n79c8rlb3yhc77f4z2px",
+  "rev": "becebebd3509c02e871c99be55556269be1def1b",
+  "date": "2023-04-09T14:24:54+02:00",
+  "path": "/nix/store/mbcjbkif51ayq0v2xd8i5n50bv6701d1-tree-sitter-hcl",
+  "sha256": "1bg9k1dcz4anc6zg3j8j5nrws0j8vc735gdmk0356rd1bgwrl78r",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-heex",
-  "rev": "881f1c805f51485a26ecd7865d15c9ef8d606a78",
-  "date": "2022-09-24T18:53:08-07:00",
-  "path": "/nix/store/vb6x1b9lc90ys55cwshdz5dxmwvzyjvv-tree-sitter-heex",
-  "sha256": "00330rgg67fq0d9gk1yswj78d9mn1jvvjmmy1k7cxpvm5993p3sw",
+  "rev": "2e1348c3cf2c9323e87c2744796cf3f3868aa82a",
+  "date": "2022-11-17T08:07:19-08:00",
+  "path": "/nix/store/30cgqfkhyd9qfpi8hv636l3xwckhjfzc-tree-sitter-heex",
+  "sha256": "04yzzqfxinsh62l7750grflxg809m8y3qlbmc1vknk2xk34l9d78",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-html",
-  "rev": "86c253e675e7fdd1c0482efe0706f24bafbc3a7d",
-  "date": "2023-04-17T11:50:54+02:00",
-  "path": "/nix/store/a046axd86r1bd974b7c3ylyni4b90wma-tree-sitter-html",
-  "sha256": "12brygy11q1gkbpj9m4alg91jji6avc5j71lwv3m773c94jpbqlq",
+  "rev": "e5d7d7decbbdec5a4c90bbc69436b3828f5646e7",
+  "date": "2023-07-10T14:25:09-04:00",
+  "path": "/nix/store/fv14r2cf4i369jfjb74d7y3cbxyyg762-tree-sitter-html",
+  "sha256": "0ghgv712gq9bdaa4msz347cffgdbb5fc6a13q73dl9gwdjx0zl4c",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "09d650def6cdf7f479f4b78f595e9ef5b58ce31e",
-  "date": "2022-09-19T09:37:51+02:00",
-  "path": "/nix/store/478mfssm2335hdflgba22n4f0dir7xmr-tree-sitter-java",
-  "sha256": "0440xh8x8rkbdlc1f1ail9wzl4583l29ic43x9lzl8290bm64q5l",
+  "rev": "6c8329e2da78fae78e87c3c6f5788a2b005a4afc",
+  "date": "2023-07-15T02:55:20-04:00",
+  "path": "/nix/store/8z4cp60lgasz2yjn10vdg1i7w5saia0w-tree-sitter-java",
+  "sha256": "167za768zaqhmkgmqw5i6dpiglydrjprxz7r0zb6hbb5i22ks2m4",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "5720b249490b3c17245ba772f6be4a43edb4e3b7",
-  "date": "2023-02-24T13:50:01+01:00",
-  "path": "/nix/store/ddv5a3159sgib21v066wrfpb8lvlnb85-tree-sitter-javascript",
-  "sha256": "19bbxpg98bzbg7rh7y4kcfzg8lv7yp00pv1mqfyy913dfx4hnadd",
+  "rev": "f772967f7b7bc7c28f845be2420a38472b16a8ee",
+  "date": "2023-07-11T11:08:25-04:00",
+  "path": "/nix/store/dm7m3mswqhkp0rblndwib9in9cx6dlmj-tree-sitter-javascript",
+  "sha256": "0vp7z57scpbcvyxpya06lnpz9f5kjdb66wjlkrp684xwjjgq1wxd",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-json",
-  "rev": "40a81c01a40ac48744e0c8ccabbaba1920441199",
-  "date": "2023-04-21T17:11:30-07:00",
-  "path": "/nix/store/9wcmgficprni47bm3qj9k18bhmjqi6hx-tree-sitter-json",
-  "sha256": "0zji769g3nikqlwn0vb0h93908a7w59da4jf807r9g2s6fvmz4vx",
+  "rev": "ca3f8919800e3c1ad4508de3bfd7b0b860ce434f",
+  "date": "2023-07-10T15:59:29-04:00",
+  "path": "/nix/store/3pkcya9skyx0k9k54sbp1sbqk9gpzwr4-tree-sitter-json",
+  "sha256": "038zdq2zf4phk082lrw466qd9fbkn1017n3nj53fbp1m8rmxwakk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-julia",
-  "rev": "e2f449e2bcc95f1d07ceb62d67f986005f73a6be",
-  "date": "2023-02-03T12:13:41-05:00",
-  "path": "/nix/store/wlmmi1411yhfirxhpnwdrm18ksm8rkyh-tree-sitter-julia",
-  "sha256": "1gwfy5hx168bgcdpzhvb5vjqal4mg3zksw7r4cmzyy31gfyc8yb5",
+  "rev": "d68ded9d5131878a2a06211ef0b47b72e70c6c08",
+  "date": "2023-07-13T13:46:19-05:00",
+  "path": "/nix/store/5zpxm9vbbqpwnq8ahbfkjwgw3ldfzgzw-tree-sitter-julia",
+  "sha256": "1kcbcv73qzzc7ijv897njyd30y4jar1z2g3q8bnn5drqh3v9kydw",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-kotlin.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-kotlin.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/fwcd/tree-sitter-kotlin",
-  "rev": "607af7be5606ad6580246cd9c68fc615e1ad97fd",
-  "date": "2021-10-12T01:11:47+02:00",
-  "path": "/nix/store/49cvpcypxjzpb0srcpd383ay9f0g19dy-tree-sitter-kotlin",
-  "sha256": "1sisvx7cp95d309ykhimn8bhbwd1lzcwrpz3s0mdsb2i44p69469",
+  "rev": "2878163ee7cad7eaebd3df1729e86610891fe0ee",
+  "date": "2023-07-07T00:53:58+02:00",
+  "path": "/nix/store/r760sz64q71a44b2ff8fibcn6njs82p3-tree-sitter-kotlin",
+  "sha256": "1pci8ki98yfgskz8jjm4ryi8v7p606gfic6xwl5ckw7v0yaql685",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/latex-lsp/tree-sitter-latex",
-  "rev": "8c75e93cd08ccb7ce1ccab22c1fbd6360e3bcea6",
-  "date": "2022-10-26T10:55:26+02:00",
-  "path": "/nix/store/zhx1vnr3xdrb0ry6kfjsfrzs6c3nf8i9-tree-sitter-latex",
-  "sha256": "0lc42x604f04x3kkp88vyqa5dx90wqyisiwl7nn861lyxl6phjnf",
+  "rev": "2ae2021d7b224fb6aa57b760e0d146059f943bb8",
+  "date": "2023-06-11T10:01:52+02:00",
+  "path": "/nix/store/hwbr6yzkfl1g9wljb4x8xk8d8ly7x8xv-tree-sitter-latex",
+  "sha256": "0qbfjj6h9f3l347z9mg00hsq00khb4v31yk1y73hnfg7kxn07pgg",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MunifTanjim/tree-sitter-lua",
-  "rev": "dcc44f7473ecec4d7b99af0a9529705d98a769f1",
-  "date": "2023-05-13T02:02:51+06:00",
-  "path": "/nix/store/079khfz0609hqllhwp08c2y96j2jkbwr-tree-sitter-lua",
-  "sha256": "13rmng6y6q653s0yk1ahbppjmxwcbr80h5kgr53q43bq9khjrjxx",
+  "rev": "7268c1cea5df56ac0c779cd37d6631d4e6f41d4f",
+  "date": "2023-06-21T11:52:03+06:00",
+  "path": "/nix/store/z95jvy6hs1ack82sm51c5fy1skkrrjd6-tree-sitter-lua",
+  "sha256": "1m1h0jdjppdf1m1sp14axam4gsz8asas57l0g06kd2jasmn4gd0s",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "fa6bfd51727e4bef99f7eec5f43947f73d64ea7d",
-  "date": "2023-03-06T00:22:35+01:00",
-  "path": "/nix/store/8biwal105haahabfl6q01q2dm3danjzn-tree-sitter-markdown",
-  "sha256": "0wryvq7153a3jx9qs1plm5crlgd88sm1ymlqc3gs09mr2n456z9z",
+  "rev": "936cc84289f6de83c263ae8e659fb342867ceb16",
+  "date": "2023-06-23T15:14:06+02:00",
+  "path": "/nix/store/bax6q39341bl548jirx11938ksc204cr-tree-sitter-markdown",
+  "sha256": "0hrn71rl973z0ynwqxhgrjamr1ramfwgkdsrfq60x99fzfrmjfkw",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nickel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nickel.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nickel-lang/tree-sitter-nickel",
-  "rev": "3a794388773f2424a97b2186828aa3fac4c66ce6",
-  "date": "2023-05-17T14:02:29+02:00",
-  "path": "/nix/store/m4siaf1k6xbr3smyyjm7f047szzp99sw-tree-sitter-nickel",
-  "sha256": "1m28gjdamysxr9grjzwpmj1qiniff4vy1nka9i3zjyskbm71pf1l",
+  "rev": "e1d9337864d209898a08c26b8cd4c2dd14c15148",
+  "date": "2023-06-30T12:17:41+02:00",
+  "path": "/nix/store/bjmb99x4hdldkf6xhydcap40mp3qr2p1-tree-sitter-nickel",
+  "sha256": "08rsarbf38rbhy1xwjxa9kvp67n76fff4fisfhq5dqj9v6k43ia5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "02878b40ac77d2889833519c6b6e9e63cfc690e6",
-  "date": "2023-03-11T16:31:57-06:00",
-  "path": "/nix/store/mlasmj51yygqms5fwsd34fjb2h16q8q0-tree-sitter-nix",
-  "sha256": "1y737sif7hjnssif28xn16paf1kpamgsqh82k4j6grzbp11j4kpl",
+  "rev": "66e3e9ce9180ae08fc57372061006ef83f0abde7",
+  "date": "2023-07-13T16:23:24+12:00",
+  "path": "/nix/store/s4wax7d0axrm8npq02lk4n1g75hzjhp0-tree-sitter-nix",
+  "sha256": "06671j6kx0b5z35mkmyygvxmjd8af9ac7kbl0w1bfwk177arz3zs",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ocaml",
-  "rev": "de07323343946c32759933cb3b7c78e821098cad",
-  "date": "2022-12-14T19:50:15+01:00",
-  "path": "/nix/store/h6h50380i2gp7j00i525vgs9llv58jzs-tree-sitter-ocaml",
-  "sha256": "021vnbpzzb4cca3ncd4qhzy583vynhndn3qhwayxrpgdl61m44i6",
+  "rev": "694c57718fd85d514f8b81176038e7a4cfabcaaf",
+  "date": "2023-07-17T22:31:47+02:00",
+  "path": "/nix/store/2nq7apr98j81va00y74mfhcrqqdb7gwh-tree-sitter-ocaml",
+  "sha256": "03zqsdm6yy7g3ml0lganh4qg6vfc301255kg756y1icclgdfywcg",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/milisims/tree-sitter-org",
-  "rev": "081179c52b3e8175af62b9b91dc099d010c38770",
-  "date": "2022-10-21T23:23:29-04:00",
-  "path": "/nix/store/7jy3jqyd02kryfgz16k3zxg2kmjz0wqf-tree-sitter-org",
-  "sha256": "0h9krbaq9j6ijf86sg0w221s0zbpbx5f7m1l0whzjahbrqpnqgxl",
+  "rev": "64cfbc213f5a83da17632c95382a5a0a2f3357c1",
+  "date": "2023-06-19T18:05:11-04:00",
+  "path": "/nix/store/9hdl3i24q6af6wxmkg89ww4rwkl45la7-tree-sitter-org",
+  "sha256": "1l62p4a3b22pa7b5mzmy497pk5b8w01hx6zinfwpbnzg2rjdwkgz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ganezdragon/tree-sitter-perl",
-  "rev": "60aa138f9e1db15becad53070f4d5898b0e8a98c",
-  "date": "2023-04-13T01:12:55+05:30",
-  "path": "/nix/store/dd6ymbx86sw0g6dp1lns65avs50kr9kr-tree-sitter-perl",
-  "sha256": "1br66y8prhq7k7fi50sl8v51y8s29wf590g44kh5a574dx51960s",
+  "rev": "4a023763f54dec0a6f986f5bd238af788a3f0584",
+  "date": "2023-07-14T19:13:01+05:30",
+  "path": "/nix/store/wwqsrdl1vjzgissq5x1aya3pwlmschiy-tree-sitter-perl",
+  "sha256": "0nqj127pz857zkvi84dh5d69w8ih6qyj2bg452ynxwhw35gz6qpj",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/rolandwalker/tree-sitter-pgn",
-  "rev": "e26ee30850f0cb81541480cf1e2c70385bdb013a",
-  "date": "2021-08-25T17:57:38-04:00",
-  "path": "/nix/store/fj882ab2hl3qrz45zvq366na6d2gqv8v-tree-sitter-pgn",
-  "sha256": "1c4602jmq3p7p7splzip76863l1z3rgbjlbksqv0diqjxp7c42gq",
+  "rev": "8212ded2e48bcac54e6a94d479a28bdd94fe5ceb",
+  "date": "2023-03-25T09:32:49-04:00",
+  "path": "/nix/store/iw86nbbxvn95fk6m44slckimnh58lckk-tree-sitter-pgn",
+  "sha256": "15prgza1c1adx12qxs0kg7gxq24dk5z9h2nqqckmrpsvxlc1h21m",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "1a40581b7a899201d7c2b4684ee34490bc306bd6",
-  "date": "2023-03-14T02:52:52-07:00",
-  "path": "/nix/store/nxhb4hdr16bfylq1jkzjznh65bkd0g8x-tree-sitter-php",
-  "sha256": "1hm7mpv0sggqzgbixh4r3bpap3dsh1zsy6msyknhdpkhblch4a5m",
+  "rev": "d43130fd1525301e9826f420c5393a4d169819fc",
+  "date": "2023-07-10T15:57:45-04:00",
+  "path": "/nix/store/ivsakk25vyv8zlilpifszaa1lkxijiqy-tree-sitter-php",
+  "sha256": "1lz6hz9rw251a6zdy6vpbxalk7g07cqjdvjgxxz5j55dx9r1yxd0",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "62827156d01c74dc1538266344e788da74536b8a",
-  "date": "2023-02-28T17:23:11+01:00",
-  "path": "/nix/store/vnh5j5nb3crn0zfc71i35fig0blsilsl-tree-sitter-python",
-  "sha256": "038l9zdn821s2igwfiwxq2ajkc1d66iri4zj9afazbma7kh5fnw5",
+  "rev": "7c8930b6388b5590ebef248853f144185a9eda1d",
+  "date": "2023-07-12T12:57:25-04:00",
+  "path": "/nix/store/86w2mv1qz966qifc3q3r9waccq88096w-tree-sitter-python",
+  "sha256": "0s70iq1gdxdypwjdw1cc1q0nrqfgzqf7fj91k2mm245gr2hwq1g9",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-treesitter/tree-sitter-query",
-  "rev": "e97504446f14f529d5a8e649667d3d60391e4dfd",
-  "date": "2023-03-09T05:33:03-08:00",
-  "path": "/nix/store/3p8d4hl2bnm1fzn0nx7zc62l73118vm2-tree-sitter-query",
-  "sha256": "0xd00idgmyr55yd10xaxma1pwahlvn7gqy78zf8zknfbqvd3rzqs",
+  "rev": "3a9808b22742d5bd906ef5d1a562f2f1ae57406d",
+  "date": "2023-05-14T17:44:40+00:00",
+  "path": "/nix/store/6wmfwch55yp9gy00j5pbr7z3qz46cb6k-tree-sitter-query",
+  "sha256": "0pwb8k69w1a8d8gx4j2a9aa727rq05y9698hrrrpqayk857wbpp4",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-regex",
-  "rev": "e1cfca3c79896ff79842f057ea13e529b66af636",
-  "date": "2022-01-03T09:37:11-08:00",
-  "path": "/nix/store/24lr7jzznsd3z7cld007aww25kbwcf51-tree-sitter-regex",
-  "sha256": "0j6j0h8ciyhgmcq9iy3843anyfvd7s0biqzgbsqgwbgbqbg2nfwl",
+  "rev": "2354482d7e2e8f8ff33c1ef6c8aa5690410fbc96",
+  "date": "2023-07-19T17:58:43-04:00",
+  "path": "/nix/store/bvsgqya54sh9qxcida01iwcsl5schqhh-tree-sitter-regex",
+  "sha256": "1b5sbjzdhkvpqaq2jsb347mrspjzmif9sqmvs82mp2g08bmr122z",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-rst",
-  "rev": "25e6328872ac3a764ba8b926aea12719741103f1",
-  "date": "2022-08-26T17:09:42-05:00",
-  "path": "/nix/store/y831a05hzw8dsajijwkahgwwcf4ima8l-tree-sitter-rst",
-  "sha256": "0f53jmpjh2kcl9srwwwb7a5k24729ig96m87qjj99myqfnzahw43",
+  "rev": "a41a933524a54de1ba3ac4f5336b6eeb46deac15",
+  "date": "2023-06-17T23:27:56-05:00",
+  "path": "/nix/store/n96jkzb0a7v8s6620wpgf83cbphjz5jn-tree-sitter-rst",
+  "sha256": "1pdf98cq11qdl15kx4cak22fxwiy1vwcifdik7hsj5zizkv5gr5h",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "fe6a2d634da0e16b11b5aa255cc3df568a4572fd",
-  "date": "2021-03-03T16:54:30-08:00",
-  "path": "/nix/store/ragrvqj7hm98r74v5b3fljvc47gd3nhj-tree-sitter-ruby",
-  "sha256": "0m3h4928rbs300wcb6776h9r88hi32rybbhcaf6rdympl5nzi83v",
+  "rev": "f257f3f57833d584050336921773738a3fd8ca22",
+  "date": "2023-06-12T13:35:19-07:00",
+  "path": "/nix/store/naixdym86w0qf53nwvfhn5kmcyn9cq1a-tree-sitter-ruby",
+  "sha256": "0pqcjggdshdmgvnmp9vlsxxgajz1r8c26ipdnjqa2zdvxvs98inh",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "5aefc0ae4c174fa74d6e973faefa28692e081954",
-  "date": "2023-05-23T22:52:07-04:00",
-  "path": "/nix/store/2gag459nfdm3c0p1a79wj9m3mnpzqn83-tree-sitter-scala",
-  "sha256": "064hch4v9pkl2ylkb6imfxz0a5dfl6rc37m76rxcdzmiwcr7fmfw",
+  "rev": "d42d40c7adbc638cf9fb571a5bc984715bf083c2",
+  "date": "2023-06-09T23:29:41-04:00",
+  "path": "/nix/store/8791ad93fs48q44b594z4rjcxb9sibvf-tree-sitter-scala",
+  "sha256": "0n7vqv3hc93g6jsk9x65ihsi7q10fz11z1v70a7zqbydzxxw06vz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/6cdh/tree-sitter-scheme",
-  "rev": "6abcfe33d976ebe3e244ca80273c7e8a070441b5",
-  "date": "2023-04-22T18:14:27+08:00",
-  "path": "/nix/store/18v6jgrcfdl3sgg7p02dpzkc3lj9mpn6-tree-sitter-scheme",
-  "sha256": "0iazh55cmznw2mkffnzwkpq4f8vkb1hxiapkgflmcnaq9wb6jp7a",
+  "rev": "ca8af220aaf2a80aaf609bfb0df193817e4f064b",
+  "date": "2023-07-07T09:51:33+08:00",
+  "path": "/nix/store/yj9c6fxmmdkzmz9fdy7gpqi9p7phwyhr-tree-sitter-scheme",
+  "sha256": "1qvys6bka0jhgl831w4svj6vfm42hn4yns64s77wfn51rl5lbrlv",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-smithy.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-smithy.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/indoorvivants/tree-sitter-smithy",
-  "rev": "084537ae85d186448c447de959a4955c0b855d2b",
-  "date": "2022-10-09T13:04:45+01:00",
-  "path": "/nix/store/4r9gfwad9f769y0ivivprlpqjbq8di8s-tree-sitter-smithy",
-  "sha256": "17l94ay7vv2b1iihnzssbw3i027yvk5a44waqlyzgf2bkqk7iqs0",
+  "rev": "cf8c7eb9faf7c7049839585eac19c94af231e6a0",
+  "date": "2023-01-31T21:16:56+00:00",
+  "path": "/nix/store/y5j99bx1b6h25k1lnzs6s4gkg0mhll06-tree-sitter-smithy",
+  "sha256": "0k7gfpa3pcj1ji34k0kwk1xbadkgjadfg36xfwns1fmlwzmr7jnx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/derekstride/tree-sitter-sql",
-  "rev": "63a6bad6d4ca2192cf252e10db73627414546732",
-  "date": "2023-05-23T15:22:05+00:00",
-  "path": "/nix/store/wkbdy34zr3ccs0pf0is1xc5223k3riai-tree-sitter-sql",
-  "sha256": "1g7ldcvwmw5rp97i12drcr26b8biczpphhgl08c4gack787sxgrk",
+  "rev": "9fc30c949f29747d34c254677d039c9df3c521b4",
+  "date": "2023-07-14T15:05:24+00:00",
+  "path": "/nix/store/9nbpqlagwrajarb8sf6kxx0dn5mrp28p-tree-sitter-sql",
+  "sha256": "1ls7zhwhm35zhhvgk2gjpmvji6w6ps1dvdwq3a8fcgnvr1nm49hk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-supercollider.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-supercollider.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/madskjeldgaard/tree-sitter-supercollider",
-  "rev": "90c6d9f777d2b8c4ce497c48b5f270a44bcf3ea0",
-  "date": "2022-04-14T11:41:40+02:00",
-  "path": "/nix/store/hzdm20x9fpc8bqd6bphq1akbdmdcpq7s-tree-sitter-supercollider",
-  "sha256": "1g0q32crsnzxnwh5bjfjm0dkxpnvdj76idjc8s4ba7hinwa8jpv0",
+  "rev": "3b35bd0fded4423c8fb30e9585c7bacbcd0e8095",
+  "date": "2023-05-30T21:04:53+02:00",
+  "path": "/nix/store/fzb78sqxbxcyldz5m7yx6zirxsvxn5cc-tree-sitter-supercollider",
+  "sha256": "0ib8mja321zwbw59i45xa66p39gikn8n1pihhv26hm5xgdkwwr4r",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-surface",
-  "rev": "21b7676859c1187645a27ff301f76738af5dfd44",
-  "date": "2021-08-15T10:33:50-07:00",
-  "path": "/nix/store/7i1klj80jbcvwgad7nrbcs7hvn68f125-tree-sitter-surface",
-  "sha256": "122v1d2zb0w2k5h7xqgm1c42rwfrp59dzyb2lly7kxmylyazmshy",
+  "rev": "f4586b35ac8548667a9aaa4eae44456c1f43d032",
+  "date": "2022-01-18T18:13:51-08:00",
+  "path": "/nix/store/l1nzhnhw1219140vzwvillawr7m9sz22-tree-sitter-surface",
+  "sha256": "085yvq2m4dbhhn51ndhzvgfmpp3hqiwk1a39xpjy4lxgrhbyjzqn",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/Himujjal/tree-sitter-svelte",
-  "rev": "be7f2e7db1fc19f0852265ec60923fc058380739",
-  "date": "2023-04-03T22:59:58+05:30",
-  "path": "/nix/store/lqqls8g9zhiv2v32if429cwycn092zq6-tree-sitter-svelte",
-  "sha256": "1kp91sarydq41zznwxwxdv2i2pflgzhmpfv0iqgq47fma9bcv2wy",
+  "rev": "697bb515471871e85ff799ea57a76298a71a9cca",
+  "date": "2023-04-03T23:16:54+05:30",
+  "path": "/nix/store/hv4q2pczrg0r7ryxjhiwsy8nz13spkyb-tree-sitter-svelte",
+  "sha256": "0n6apwzvj7y63f5dys3n73b4rwh4cs8hds8baxqkc1fk890l15ac",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "286e90c32060032225f636a573d0e999f7766c97",
-  "date": "2023-04-21T18:31:50-07:00",
-  "path": "/nix/store/cf6q6c3mclp70bplsdykgxbpjrnb2yh2-tree-sitter-typescript",
-  "sha256": "06kq9c26my2h53fv7qlmkpaia21ahbyd0lsrn9l4hric7b3ca3wn",
+  "rev": "b1bf4825d9eaa0f3bdeb1e52f099533328acfbdf",
+  "date": "2023-07-19T03:17:33-04:00",
+  "path": "/nix/store/c858575avx33nmi4annm51fhasv43xm9-tree-sitter-typescript",
+  "sha256": "1r74108lxyp8hsq0pysy0na4kgn06b4xk4yrlq77fw8jr6vs54m1",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-verilog",
-  "rev": "4457145e795b363f072463e697dfe2f6973c9a52",
-  "date": "2022-09-07T16:11:11-07:00",
-  "path": "/nix/store/z29mm9c88dd2iybsy648wh4m6z593kvk-tree-sitter-verilog",
-  "sha256": "0lfw8p04c85xyd85jfi3gajzrzsl5xcgc44nwxa43x4g3d7f104p",
+  "rev": "22f9b845c77c52b86b21adaebe689864957f4e31",
+  "date": "2023-07-07T16:24:25-07:00",
+  "path": "/nix/store/skj346knwyzsm802i59sx0xam7qaj7s9-tree-sitter-verilog",
+  "sha256": "00pr3w4qf2s7lqp2pfa3yl6jzvs4a663adw1kfqs0wq5s1khhz2z",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-wing.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-wing.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/winglang/wing",
-  "rev": "e578973d6f60091ba3458095edceb37bae2d04e2",
-  "date": "2023-06-27T12:28:26+00:00",
-  "path": "/nix/store/ppjabjz0dgmsr3k0wm07z7391vz7m120-wing",
-  "sha256": "0089rxdzxi43qal2310dpyzw1a3zl08qbm5b8md8cgwmvycija9a",
+  "rev": "23712eff9768576bdd852cb9b989a9cd44af014a",
+  "date": "2023-07-21T11:28:29-04:00",
+  "path": "/nix/store/nzylbi0v96ky8v6lzpy8xmrc5j19wvc2-wing",
+  "sha256": "0c11d5s6b7jfv99hdw9fy8ns5pddajm7pdwcbhhan21pjfa9qsi1",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
###### Description of changes

There are lots of tree-sitter grammars that don't have tagged releases that are compatible with the recent versions of neovim in nixpkgs, so we should be using HEAD for them.

1. Improve update script to fall back to HEAD when latest tag is older than `MIN_TIMESTAMP` (currently set to last neovim release). This basically automates the work in #242138.
2. Update grammars

Shoutout to @DPDmancul for opening #242138 PR. I was concerned that their changes are going to get overwritten next time the update script is run, so I updated the script to automate that work. Hopefully it's good enough!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
