### PR TITLE
qmapshack: 1.16.1 → 1.17.0

### DIFF
--- a/pkgs/applications/gis/qmapshack/default.nix
+++ b/pkgs/applications/gis/qmapshack/default.nix
@@ -1,15 +1,15 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, substituteAll
+{ lib, stdenv, fetchFromGitHub, cmake, substituteAll, wrapQtAppsHook
 , qtscript, qttranslations, qtwebengine, gdal, proj, routino, quazip }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qmapshack";
-  version = "1.16.1";
+  version = "1.17.0";
 
   src = fetchFromGitHub {
     owner = "Maproom";
-    repo = pname;
+    repo = "qmapshack";
     rev = "V_${version}";
-    sha256 = "sha256-2otvRKtFb51PLrIh/Hxltp69n5nyR63HGGvk73TFjqA=";
+    hash = "sha256-qG/fiR2J5wQZaR+xvBGjdp3L7viqki2ktkzBUf6fZi8=";
   };
 
   patches = [
@@ -20,7 +20,7 @@ mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
 
   buildInputs = [ qtscript qtwebengine gdal proj routino quazip ];
 
@@ -33,8 +33,9 @@ mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/Maproom/qmapshack";
     description = "Consumer grade GIS software";
+    homepage = "https://github.com/Maproom/qmapshack";
+    changelog = "https://github.com/Maproom/qmapshack/blob/V_${version}/changelog.txt";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dotlambda sikmir ];
     platforms = with platforms; linux;

--- a/pkgs/applications/gis/qmapshack/fix-qttranslations-path.patch
+++ b/pkgs/applications/gis/qmapshack/fix-qttranslations-path.patch
@@ -1,74 +1,74 @@
 diff --git i/src/qmapshack/setup/CAppSetupLinux.cpp w/src/qmapshack/setup/CAppSetupLinux.cpp
-index 63ea06c0..3a03b816 100644
+index 7581ef32..26eba3c8 100644
 --- i/src/qmapshack/setup/CAppSetupLinux.cpp
 +++ w/src/qmapshack/setup/CAppSetupLinux.cpp
-@@ -30,7 +30,7 @@ void CAppSetupLinux::initQMapShack()
-     prepareGdal("", "");
+@@ -30,7 +30,7 @@ void CAppSetupLinux::initQMapShack() {
+   prepareGdal("", "");
  
-     // setup translators
--    QString resourceDir = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
-+    QLatin1String resourceDir = QLatin1String("@qttranslations@/translations");
-     QString translationPath = QCoreApplication::applicationDirPath();
-     translationPath.replace(QRegExp("bin$"), "share/qmapshack/translations");
-     prepareTranslator(resourceDir, "qt_");
+   // setup translators
+-  QString resourceDir = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
++  QLatin1String resourceDir = QLatin1String("@qttranslations@/translations");
+   QString translationPath = QCoreApplication::applicationDirPath();
+   translationPath.replace(QRegExp("bin$"), "share/qmapshack/translations");
+   prepareTranslator(resourceDir, "qt_");
 diff --git i/src/qmapshack/setup/CAppSetupMac.cpp w/src/qmapshack/setup/CAppSetupMac.cpp
-index ad9b21e9..9dca8a1e 100644
+index 37602802..ae4a5a23 100644
 --- i/src/qmapshack/setup/CAppSetupMac.cpp
 +++ w/src/qmapshack/setup/CAppSetupMac.cpp
-@@ -63,7 +63,7 @@ void CAppSetupMac::initQMapShack()
+@@ -56,7 +56,7 @@ void CAppSetupMac::initQMapShack() {
  
-     // setup translators
-     QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
--    prepareTranslator(translationPath, "qt_");
-+    prepareTranslator(QLatin1String("@qttranslations@/translations"), "qt_");
-     prepareTranslator(translationPath, "qmapshack_");
+   // setup translators
+   QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
+-  prepareTranslator(translationPath, "qt_");
++  prepareTranslator(QLatin1String("@qttranslations@/translations"), "qt_");
+   prepareTranslator(translationPath, "qmapshack_");
  
-     // load and apply style sheet
+   // load and apply style sheet
 diff --git i/src/qmaptool/setup/CAppSetupLinux.cpp w/src/qmaptool/setup/CAppSetupLinux.cpp
-index dea1c4f3..8da95574 100644
+index b703e7bb..637d653e 100644
 --- i/src/qmaptool/setup/CAppSetupLinux.cpp
 +++ w/src/qmaptool/setup/CAppSetupLinux.cpp
-@@ -29,7 +29,7 @@ void CAppSetupLinux::initQMapTool()
-     prepareGdal("", "");
+@@ -29,7 +29,7 @@ void CAppSetupLinux::initQMapTool() {
+   prepareGdal("", "");
  
-     // setup translators
--    QString resourceDir = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
-+    QLatin1String resourceDir = QLatin1String("@qttranslations@/translations");
-     QString translationPath = QCoreApplication::applicationDirPath();
-     translationPath.replace(QRegExp("bin$"), "share/qmaptool/translations");
-     prepareTranslator(resourceDir, "qt_");
+   // setup translators
+-  QString resourceDir = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
++  QLatin1String resourceDir = QLatin1String("@qttranslations@/translations");
+   QString translationPath = QCoreApplication::applicationDirPath();
+   translationPath.replace(QRegExp("bin$"), "share/qmaptool/translations");
+   prepareTranslator(resourceDir, "qt_");
 diff --git i/src/qmaptool/setup/CAppSetupMac.cpp w/src/qmaptool/setup/CAppSetupMac.cpp
-index 02b27e07..fae27748 100644
+index dd68b9c1..84351cf4 100644
 --- i/src/qmaptool/setup/CAppSetupMac.cpp
 +++ w/src/qmaptool/setup/CAppSetupMac.cpp
-@@ -64,7 +64,7 @@ void CAppSetupMac::initQMapTool()
+@@ -57,7 +57,7 @@ void CAppSetupMac::initQMapTool() {
  
-     // setup translators
-     QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
--    prepareTranslator(translationPath, "qt_");
-+    prepareTranslator(QLatin1String("@qttranslations@/translations"), "qt_");
-     prepareTranslator(translationPath, "qmaptool_");
+   // setup translators
+   QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
+-  prepareTranslator(translationPath, "qt_");
++  prepareTranslator(QLatin1String("@qttranslations@/translations"), "qt_");
+   prepareTranslator(translationPath, "qmaptool_");
  
-     migrateDirContent(defaultCachePath());
+   migrateDirContent(defaultCachePath());
 diff --git i/src/qmt_rgb2pct/main.cpp w/src/qmt_rgb2pct/main.cpp
-index 21267d03..d539cec8 100644
+index 589d3d52..5f7c12f8 100644
 --- i/src/qmt_rgb2pct/main.cpp
 +++ w/src/qmt_rgb2pct/main.cpp
-@@ -50,7 +50,7 @@ static void prepareTranslator(QString translationPath, QString translationPrefix
- static void loadTranslations()
- {
- #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(__FreeBSD_kernel__) || defined(__GNU__) || defined(Q_OS_CYGWIN)
--    QString resourceDir = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
-+    QLatin1String resourceDir = QLatin1String("@qttranslations@/translations");
-     QString translationPath = QCoreApplication::applicationDirPath();
-     translationPath.replace(QRegExp("bin$"), "share/" APP_STR "/translations");
-     prepareTranslator(resourceDir, "qt_");
-@@ -61,7 +61,7 @@ static void loadTranslations()
-     // os x
-     static QString relTranslationDir = "Resources/translations"; // app
-     QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
--    prepareTranslator(translationPath, "qt_");
-+    prepareTranslator(QLatin1String("@qttranslations@/translations"), "qt_");
-     prepareTranslator(translationPath, APP_STR "_");
+@@ -47,7 +47,7 @@ static void prepareTranslator(QString translationPath, QString translationPrefix
+ static void loadTranslations() {
+ #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(__FreeBSD_kernel__) || defined(__GNU__) || \
+     defined(Q_OS_CYGWIN)
+-  QString resourceDir = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
++  QLatin1String resourceDir = QLatin1String("@qttranslations@/translations");
+   QString translationPath = QCoreApplication::applicationDirPath();
+   translationPath.replace(QRegExp("bin$"), "share/" APP_STR "/translations");
+   prepareTranslator(resourceDir, "qt_");
+@@ -58,7 +58,7 @@ static void loadTranslations() {
+   // os x
+   static QString relTranslationDir = "Resources/translations";  // app
+   QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
+-  prepareTranslator(translationPath, "qt_");
++  prepareTranslator(QLatin1String("@qttranslations@/translations"), "qt_");
+   prepareTranslator(translationPath, APP_STR "_");
  #endif
  


### PR DESCRIPTION
###### Description of changes
* [Changelog](https://github.com/Maproom/qmapshack/releases/tag/V_1.17.0)
* Remove Qt's mkDerivation in favour of stdenv.mkDerivation to fix https://github.com/NixOS/nixpkgs/issues/180841

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
