### PR TITLE
linux: expose `KBUILD_IMAGE` as a property of the kernel

### DIFF
--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -48,6 +48,7 @@ rec {
     isRiscV64      = { cpu = { family = "riscv"; bits = 64; }; };
     isRx           = { cpu = { family = "rx"; }; };
     isSparc        = { cpu = { family = "sparc"; }; };
+    isSparc64      = { cpu = { family = "sparc"; bits = 64; }; };
     isWasm         = { cpu = { family = "wasm"; }; };
     isMsp430       = { cpu = { family = "msp430"; }; };
     isVc4          = { cpu = { family = "vc4"; }; };

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -14,7 +14,6 @@ rec {
       baseConfig = "defconfig";
       # Build whatever possible as a module, if not stated in the extra config.
       autoModules = true;
-      target = "bzImage";
     };
   };
 
@@ -27,7 +26,6 @@ rec {
       name = "PowerNV";
 
       baseConfig = "powernv_defconfig";
-      target = "vmlinux";
       autoModules = true;
       # avoid driver/FS trouble arising from unusual page size
       extraConfig = ''
@@ -384,7 +382,6 @@ rec {
         # which our initrd builder can't currently do easily.
         USB_XHCI_TEGRA m
       '';
-      target = "Image";
     };
     gcc = {
       arch = "armv8-a";
@@ -534,7 +531,6 @@ rec {
   riscv-multiplatform = {
     linux-kernel = {
       name = "riscv-multiplatform";
-      target = "Image";
       autoModules = true;
       baseConfig = "defconfig";
       DTB = true;

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -894,7 +894,8 @@ let
 
       EFI_STUB            = yes; # EFI bootloader in the bzImage itself
       EFI_GENERIC_STUB_INITRD_CMDLINE_LOADER =
-          whenOlder "6.2" (whenAtLeast "5.8" yes); # initrd kernel parameter for EFI
+        whenOlder "6.2" (whenAtLeast "5.8" yes); # initrd kernel parameter for EFI
+      EFI_ZBOOT = whenAtLeast "6.1" yes; # Generic compression support for EFI payloads
       CGROUPS             = yes; # used by systemd
       FHANDLE             = yes; # used by systemd
       SECCOMP             = yes; # used by systemd >= 231

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -106,6 +106,41 @@ let
     ia32Emulation = true;
   } // features) kernelPatches;
 
+
+  # Legacy compatibility layer for
+  # systems relying on `installTarget`
+  # being a property of the platform.
+  defaultKernelInstallTargets = [
+    stdenv.hostPlatform.linux-kernel.installTarget or
+    (defaultMapImageToTargets.${stdenv.hostPlatform.linux-kernel.target or "vmlinux"})
+  ];
+
+  # Default kernel target in the case no install target or kernelTarget is mentioned
+  # We aim to derive the "best" kernel given the current constraints.
+  defaultKernelTarget =
+  if stdenv.hostPlatform.isx86
+    then "bzImage"
+  else if stdenv.hostPlatform.isAarch64
+    then "Image.gz"
+  else if (stdenv.hostPlatform.isAarch || stdenv.hostPlatform.isArmv7)
+    then "vmlinuz"
+  else if stdenv.hostPlatform.isMips
+    then "vmlinux"
+  else if stdenv.hostPlatform.isRiscV
+    then "Image.xz"
+  else if stdenv.hostPlatform.isSparc64
+    then "Image.gz"
+  else if stdenv.hostPlatform.isSparc
+    then "vmlinux"
+  else if stdenv.hostPlatform.isS390
+    then "bzImage"
+  else if stdenv.hostplatform.isLoongArch64
+    then "Image.gz"
+  else "vmlinux";
+
+  finalKernelTarget = if kernelTarget == null then defaultKernelTarget else kernelTarget;
+  finalInstallTargets = if installTargets != [] then defaultKernelInstallTargets else installTargets;
+
   commonStructuredConfig = import ./common-config.nix {
     inherit lib stdenv version;
 
@@ -207,6 +242,9 @@ let
 
   kernel = (callPackage ./manual-config.nix { inherit lib stdenv buildPackages; }) (basicArgs // {
     inherit kernelPatches randstructSeed extraMakeFlags extraMeta configfile;
+    kernelTarget = finalKernelTarget;
+    # kernelTarget has precedence
+    installTargets = if installTargets != [ ] then finalInstallTargets else [ ];
     pos = builtins.unsafeGetAttrPos "version" args;
 
     config = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };
@@ -215,6 +253,10 @@ let
   passthru = basicArgs // {
     features = kernelFeatures;
     inherit commonStructuredConfig structuredExtraConfig extraMakeFlags isZen isHardened isLibre;
+
+    kernelTarget = if kernelTarget == null then defaultKernelTarget else kernelTarget;
+    installTargets = if installTargets != [] then defaultKernelInstallTargets else installTargets;
+
     isXen = lib.warn "The isXen attribute is deprecated. All Nixpkgs kernels that support it now have Xen enabled." true;
 
     # Adds dependencies needed to edit the config:

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -1,3 +1,12 @@
+let
+  # Map of images representations to legacy Makefile targets.
+  defaultMapImageToTargets = {
+    "uImage" = "uinstall";
+    "zImage" = "zinstall";
+    "Image.gz" = "zinstall";
+    "vmlinux" = "install";
+  };
+in
 { buildPackages
 , callPackage
 , perl
@@ -57,6 +66,11 @@
 # easy overrides to stdenv.hostPlatform.linux-kernel members
 , autoModules ? stdenv.hostPlatform.linux-kernel.autoModules or true
 , preferBuiltin ? stdenv.hostPlatform.linux-kernel.preferBuiltin or false
+, kernelTarget ? null
+# FIXME: this should go whenever we can rely on KBUILD_IMAGE to install
+# our kernel targets, MIPS is probably the only recent kernel in-tree
+# which does not support that yet.
+, installTargets ? [ ]
 , kernelArch ? stdenv.hostPlatform.linuxArch
 , kernelTests ? []
 , nixosTests

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -30,6 +30,16 @@ in lib.makeOverridable ({
   src,
   # a list of { name=..., patch=..., extraConfig=...} patches
   kernelPatches ? [],
+  # KBUILD_IMAGE
+  kernelTarget ? null,
+  # a list of install targets, e.g. :
+  # - uinstall for uImage, U-Boot wrapped image
+  # - zinstall for zImage, self-extracting images
+  # - install, the generic binary image
+  # those targets are legacy and are present
+  # only for compatibility with old kernels or MIPS for now.
+  # prefer KBUILD_IMAGE instead.
+  installTargets ? [],
   # The kernel .config file
   configfile,
   # Manually specified nixexpr representing the config
@@ -296,12 +306,7 @@ stdenv.mkDerivation ({
   '';
 
   # Some image types need special install targets (e.g. uImage is installed with make uinstall)
-  installTargets = [
-    (kernelConf.installTarget or (
-      /**/ if target == "uImage" then "uinstall"
-      else if target == "zImage" || target == "Image.gz" then "zinstall"
-      else "install"))
-  ];
+  installTargets = if installTargets == [ ] then [ "install" ] else installTargets;
 
   postInstall = optionalString isModular ''
     if [ -z "''${dontStrip-}" ]; then

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -337,7 +337,8 @@ stdenv.mkDerivation ({
         cp -HR $buildRoot/$f $dev/lib/modules/${modDirVersion}/build/$f
       fi
     done
-    ln -s $dev/lib/modules/${modDirVersion}/build/vmlinux $dev
+    mkdir $debug/
+    ln -s $dev/lib/modules/${modDirVersion}/build/vmlinux $debug
 
     # !!! No documentation on how much of the source tree must be kept
     # If/when kernel builds fail due to missing files, you can add
@@ -429,5 +430,5 @@ stdenv.mkDerivation ({
 } // optionalAttrs (pos != null) {
   inherit pos;
 } // optionalAttrs isModular {
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "debug" ];
 }))


### PR DESCRIPTION
###### Description of changes

Instead of the platform, see `lib/systems/examples.nix` for examples (no pun intended).

Nowadays, most architectures supports `KBUILD_IMAGE` which is
set by the architecture-specific Makefile or can be overriden by the user

Before that, we were using Makefile install targets such as "uinstall" for uImage,
"zinstall" for zImage, etc.

This PR aims multiple delicate things:

- Expose `KBUILD_IMAGE` knob to build kernel with a desired image using the vanilla `install` Makefile target.
- Do not break backward compatibility with `lib/systems/examples.nix` until we phase them out by keeping an override knob for Makefile install targets and passing the legacy ones.
- Drop `installTarget` for `x86`, `aarch64-multiplatform`, `riscv64` as a first "target" in this PR.

Once, we are able to do this, phase 2 is to move up the knob into NixOS to offer the capability to choose the kernel image to advanced users, i.e. compressed or non-compressed kernel.

Phase 3 is to deprecate `lib/systems/examples.nix` when nixos-hardware is ready to receive them, we will do it with a proper deprecation notice, etc.

In the meantime, grabbing https://github.com/NixOS/nixpkgs/pull/239721 is interesting to test the effects of this PR for platforms that supports UEFI.

Expected results after some work:

- people can enjoy compressed kernels in NixOS on UEFI-enabled platforms.
- people can build kernels with less override shenigans.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
