### PR TITLE
libavif: build gdk-pixbuf loader and thumbnailer

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -143,8 +143,9 @@ stdenv.mkDerivation (finalAttrs: {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     };
 
-    # gdk_pixbuf_moduledir variable from gdk-pixbuf-2.0.pc
-    moduleDir = "lib/gdk-pixbuf-2.0/2.10.0/loaders";
+    # gdk_pixbuf_binarydir and gdk_pixbuf_moduledir variables from gdk-pixbuf-2.0.pc
+    binaryDir = "lib/gdk-pixbuf-2.0/2.10.0";
+    moduleDir = "${finalAttrs.passthru.binaryDir}/loaders";
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/libavif/default.nix
+++ b/pkgs/development/libraries/libavif/default.nix
@@ -8,7 +8,14 @@
 , libjpeg
 , dav1d
 , libyuv
+, gdk-pixbuf
+, makeWrapper
 }:
+
+let
+  gdkPixbufModuleDir = "${placeholder "out"}/${gdk-pixbuf.moduleDir}";
+  gdkPixbufModuleFile = "${placeholder "out"}/${gdk-pixbuf.binaryDir}/avif-loaders.cache";
+in
 
 stdenv.mkDerivation rec {
   pname = "libavif";
@@ -29,14 +36,18 @@ stdenv.mkDerivation rec {
     "-DAVIF_CODEC_DAV1D=ON" # best decoder (fast)
     "-DAVIF_CODEC_AOM_DECODE=OFF"
     "-DAVIF_BUILD_APPS=ON"
+    "-DAVIF_BUILD_GDK_PIXBUF=ON"
   ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
+    gdk-pixbuf
+    makeWrapper
   ];
 
   buildInputs = [
+    gdk-pixbuf
     libaom
     zlib
     libpng
@@ -44,6 +55,23 @@ stdenv.mkDerivation rec {
     dav1d
     libyuv
   ];
+
+  postPatch = ''
+    substituteInPlace contrib/gdk-pixbuf/avif.thumbnailer.in \
+      --replace '@CMAKE_INSTALL_FULL_BINDIR@/gdk-pixbuf-thumbnailer' "$out/libexec/gdk-pixbuf-thumbnailer-avif"
+  '';
+
+  env.PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = gdkPixbufModuleDir;
+
+  postInstall = ''
+    GDK_PIXBUF_MODULEDIR=${gdkPixbufModuleDir} \
+    GDK_PIXBUF_MODULE_FILE=${gdkPixbufModuleFile} \
+    gdk-pixbuf-query-loaders --update-cache
+
+    mkdir -p "$out/bin"
+    makeWrapper ${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer "$out/libexec/gdk-pixbuf-thumbnailer-avif" \
+      --set GDK_PIXBUF_MODULE_FILE ${gdkPixbufModuleFile}
+  '';
 
   meta = with lib; {
     description  = "C implementation of the AV1 Image File Format";

--- a/pkgs/development/libraries/webp-pixbuf-loader/default.nix
+++ b/pkgs/development/libraries/webp-pixbuf-loader/default.nix
@@ -11,10 +11,7 @@
 
 let
   inherit (gdk-pixbuf) moduleDir;
-
-  # turning lib/gdk-pixbuf-#.#/#.#.#/loaders into lib/gdk-pixbuf-#.#/#.#.#/loaders.cache
-  # removeSuffix is just in case moduleDir gets a trailing slash
-  loadersPath = (lib.strings.removeSuffix "/" gdk-pixbuf.moduleDir) + ".cache";
+  loadersPath = "${gdk-pixbuf.binaryDir}/webp-loaders.cache";
 in
 stdenv.mkDerivation rec {
   pname = "webp-pixbuf-loader";
@@ -47,7 +44,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # It looks for gdk-pixbuf-thumbnailer in this package's bin rather than the gdk-pixbuf bin. We need to patch that.
     substituteInPlace webp-pixbuf.thumbnailer.in \
-      --replace "@bindir@/gdk-pixbuf-thumbnailer" "$out/bin/webp-thumbnailer"
+      --replace "@bindir@/gdk-pixbuf-thumbnailer" "$out/libexec/gdk-pixbuf-thumbnailer-webp"
   '';
 
   postInstall = ''
@@ -58,7 +55,7 @@ stdenv.mkDerivation rec {
     # It assumes gdk-pixbuf-thumbnailer can find the webp loader in the loaders.cache referenced by environment variable, breaking containment.
     # So we replace it with a wrapped executable.
     mkdir -p "$out/bin"
-    makeWrapper "${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer" "$out/bin/webp-thumbnailer" \
+    makeWrapper "${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer" "$out/libexec/gdk-pixbuf-thumbnailer-webp" \
       --set GDK_PIXBUF_MODULE_FILE "$out/${loadersPath}"
   '';
 


### PR DESCRIPTION
Resurrecting https://github.com/NixOS/nixpkgs/pull/102189

Upstream now ships a `.thumbnailer` which we just have to patch a little. I mostly followed the approach of `webp-pixbuf-loader` and added an `avif-thumbnailer`.

I kept the loader in `out` rather than a separate output because 1. it doesn't seem to increase the size that much, and 2. doing the latter means that the `.thumbnailer` also has to live in the loader output (to avoid cyclic references with `out`), which means it won't work "out of the box".

I also specialised `loaders.cache` to `webp-loaders.cache` and `avif-loaders.cache` to avoid collisions when installing multiple loaders into a profile. I can do `librsvg` too but it's a bit more of a hassle so I thought I'd ask first.

Tested `webp-pixbuf-loader` + `libavif` in my user profile with thunar/tumbler's DesktopThumbnailer enabled; both types of thumbnails are rendered correctly.

Closes https://github.com/NixOS/nixpkgs/pull/102189

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
