### PR TITLE
edk2: backport OpenSSL 1.1.1t to the tree

### DIFF
--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -34,6 +34,14 @@ buildType = if stdenv.isDarwin then
   else
     "GCC5";
 
+  # OpenSSL 1.1.1t
+  vendoredOpenSSL = fetchFromGitHub {
+    owner = "openssl";
+    repo = "openssl";
+    rev = "OpenSSL_1_1_1t";
+    sha256 = "sha256-gI2+Vm67j1+xLvzBb+DF0YFTOHW7myotRsXRzluzSLY=";
+  };
+
 edk2 = buildStdenv.mkDerivation {
   pname = "edk2";
   version = "202211";
@@ -44,9 +52,18 @@ edk2 = buildStdenv.mkDerivation {
       url = "https://src.fedoraproject.org/rpms/edk2/raw/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/0021-Tweak-the-tools_def-to-support-cross-compiling.patch";
       sha256 = "sha256-E1/fiFNVx0aB1kOej2DJ2DlBIs9tAAcxoedym2Zhjxw=";
     })
+    # Apply EDK2-specific OpenSSL 1.1.1t changes
+    # Original bug: https://bugzilla.tianocore.org/show_bug.cgi?id=4342
+    (fetchpatch {
+      url = "https://bugzilla.tianocore.org/attachment.cgi?id=1330";
+      hash = "sha256-HAwa9gqTxA5+8UQf5NiRdZYSmE6ykQsDbkHFj7oLygg=";
+      # Normally, EDK2 vendors OpenSSL via Git submodules
+      # We unbundle them because fetchpatch and fetchers interaction are not ideal in nixpkgs.
+      # i.e. we cannot patch a git submodule at the right moment.
+      excludes = [ "CryptoPkg/Library/OpensslLib/openssl" ];
+    })
   ];
 
-  # submodules
   src = fetchFromGitHub {
     owner = "tianocore";
     repo = "edk2";
@@ -54,6 +71,17 @@ edk2 = buildStdenv.mkDerivation {
     fetchSubmodules = true;
     sha256 = "sha256-0jE73xPyenAcgJ1mS35oTc5cYw7jJvVYxhPdhTWpKA0=";
   };
+
+  postUnpack = ''
+    rm -rf source/CryptoPkg/Library/OpensslLib/openssl
+  '';
+
+  # Update the OpenSSL used APIs to 1.1.1t in EDK2…
+  # OpenSSL3 PoC exist: https://patchew.org/EDK2/cover.1679026329.git.yi1.li@intel.com/
+  # Unvendor only when OpenSSL3 support lands otherwise fix everything that breaks, I guess?
+  postPatch = ''
+    cp -r ${vendoredOpenSSL} CryptoPkg/Library/OpensslLib/openssl
+  '';
 
   nativeBuildInputs = [ pythonEnv ];
   depsBuildBuild = [ buildPackages.stdenv.cc buildPackages.util-linux buildPackages.bash ];


### PR DESCRIPTION
###### Description of changes

Original bug: https://bugzilla.tianocore.org/show_bug.cgi?id=4342

We decide to backport this way because we do not have a lot of choices here, upgrading will break 23.05.

Prior art: https://github.com/NixOS/nixpkgs/pull/242473#issuecomment-1646247334.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
