### PR TITLE
python310Packages.traceback-with-variables: init at 2.0.4

### DIFF
--- a/pkgs/development/python-modules/traceback-with-variables/01-fix-test-ouput.patch
+++ b/pkgs/development/python-modules/traceback-with-variables/01-fix-test-ouput.patch
@@ -1,0 +1,52 @@
+diff --git a/tests/dumps/test_main.argparse_code_script_help.txt b/tests/dumps/test_main.argparse_code_script_help.txt
+index 83622e1..c0239c3 100644
+--- a/tests/dumps/test_main.argparse_code_script_help.txt
++++ b/tests/dumps/test_main.argparse_code_script_help.txt
+@@ -1,6 +1,6 @@
+ usage: code.py [-h]
+ --a A
+ 
+-optional arguments:
++options:
+   -h, --help  show this help message and exit
+   --a A
+diff --git a/tests/dumps/test_main.module.txt b/tests/dumps/test_main.module.txt
+index 59737d1..659b0ba 100644
+--- a/tests/dumps/test_main.module.txt
++++ b/tests/dumps/test_main.module.txt
+@@ -4,13 +4,14 @@ usage: server.py [-h]
+ [--directory DIRECTORY]
+ [port]
+ positional arguments:
+-  port                  Specify alternate port [default: 8000]
+-optional arguments:
++  port                  specify alternate port (default: 8000)
++
++options:
+   -h, --help            show this help message and exit
+-  --cgi                 Run as CGI Server
++  --cgi                 run as CGI server
+   --bind ADDRESS, -b ADDRESS
+-                        Specify alternate bind address [default: all
+-                        interfaces]
+---directory DIRECTORY, -d DIRECTORY
+-                        Specify alternative directory [default:current
+-                        directory]
++                        specify alternate bind address (default: all
++                        interfaces)
++  --directory DIRECTORY, -d DIRECTORY
++                        specify alternate directory (default: current
++                        directory)
+diff --git a/tests/dumps/test_main.simple_code_tool_help.txt b/tests/dumps/test_main.simple_code_tool_help.txt
+index 33a15dc..daecd9c 100644
+--- a/tests/dumps/test_main.simple_code_tool_help.txt
++++ b/tests/dumps/test_main.simple_code_tool_help.txt
+@@ -13,7 +13,7 @@ positional arguments:
+   script
+   script-arg
+ 
+-optional arguments:
++options:
+   -h, --help            show this help message and exit
+   --max-value-str-len MAX_VALUE_STR_LEN
+   --max-exc-str-len MAX_EXC_STR_LEN

--- a/pkgs/development/python-modules/traceback-with-variables/default.nix
+++ b/pkgs/development/python-modules/traceback-with-variables/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pytest-cov
+, ipython
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  pname = "traceback-with-variables";
+  version = "2.0.4";
+  format = "setuptools";
+  disabled = pythonAtLeast "3.11";
+
+  src = fetchFromGitHub {
+    owner = "andy-landy";
+    repo = "traceback_with_variables";
+    rev = "v${version}";
+    hash = "sha256-XxmWmGIwF+hd256XA8nWLxF5UTwZngL+0kQYfmsfYAA=";
+  };
+
+  patches = [
+    ./01-fix-test-ouput.patch
+  ];
+
+  pythonImportsCheck = [ "traceback_with_variables" ];
+
+  # warns about distutils removal in python 3.12
+  # would modify executable output and thereby fail tests
+  # can't use pytestFlagsArray as tests are a secondary command invokation
+  PYTHONWARNINGS = "ignore::DeprecationWarning";
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    ipython
+  ];
+
+  meta = with lib; {
+    description = "Adds local variables to python traceback";
+    homepage = "https://github.com/andy-landy/traceback_with_variables";
+    changelog = "https://github.com/andy-landy/traceback_with_variables/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ blaggacao ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12820,6 +12820,8 @@ self: super: with self; {
 
   traceback2 = callPackage ../development/python-modules/traceback2 { };
 
+  traceback-with-variables = callPackage ../development/python-modules/traceback-with-variables { };
+
   tracerite = callPackage ../development/python-modules/tracerite { };
 
   tracing = callPackage ../development/python-modules/tracing { };


### PR DESCRIPTION
###### Description of changes

Old, but tested library to show tracebacks with current local variables.
Used by `frappe/frappe` (which I'm in the process of packaging).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
