### PR TITLE
alire: init at 1.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1505,6 +1505,13 @@
       fingerprint = "DD52 6BC7 767D BA28 16C0 95E5 6840 89CE 67EB B691";
     }];
   };
+  atalii = {
+    email = "taliauster@gmail.com";
+    github = "atalii";
+    githubId = 120901234;
+    name = "tali auster";
+    matrix = "@atalii:matrix.org";
+  };
   ataraxiasjel = {
     email = "nix@ataraxiadev.com";
     github = "AtaraxiaSjel";

--- a/pkgs/development/tools/build-managers/alire/default.nix
+++ b/pkgs/development/tools/build-managers/alire/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gprbuild
+, gnat
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "alire";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "alire-project";
+    repo = "alire";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-rwNiSXOIIQR1I8wwp1ROVOfEChT6SCa5c6XnTRqekDc=";
+
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ gprbuild gnat ];
+
+  # on HEAD (roughly 2c4e5a3), alire provides a dev/build.sh script. for now,
+  # just use gprbuild.
+  buildPhase = ''
+    runHook preBuild
+
+    gprbuild -j$NIX_BUILD_CORES -P alr_env
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r ./bin $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A source-based package manager for the Ada and SPARK programming languages";
+    homepage = "https://alire.ada.dev";
+    changelog = "https://github.com/alire-project/alire/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ atalii ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -234,6 +234,8 @@ with pkgs;
 
   align = callPackage ../tools/text/align { };
 
+  alire = callPackage ../development/tools/build-managers/alire { };
+
   althttpd = callPackage ../servers/althttpd { };
 
   amqpcat = callPackage ../development/tools/amqpcat { };


### PR DESCRIPTION
###### Description of changes

I've added a package for [Alire](https://alire.ada.dev/). This is a first step to getting a pleasant Ada development experience on NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

