### PR TITLE
9ptls: init at 1.6.4

### DIFF
--- a/pkgs/os-specific/linux/9ptls/default.nix
+++ b/pkgs/os-specific/linux/9ptls/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, stdenv
+, tlsclient
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  inherit (tlsclient) src version enableParallelBuilding;
+  pname = "9ptls";
+
+  strictDeps = true;
+
+  buildFlags = [ "mount.9ptls" ];
+  installFlags = [ "PREFIX=$(out)" "SBIN=$(out)/bin" ];
+  installTargets = "mount.9ptls.install";
+
+  meta = with lib; {
+    description = "mount.9ptls mount helper";
+    longDescription = ''
+      mount.9ptls wraps the v9fs mount type in a dp9ik authenticated
+      tls tunnel using tlsclient.
+    '';
+    homepage = "https://git.sr.ht/~moody/tlsclient";
+    license = licenses.mit;
+    maintainers = with maintainers; [ moody ];
+    mainProgram = "mount.9ptls";
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/os-specific/linux/pam_dp9ik/default.nix
+++ b/pkgs/os-specific/linux/pam_dp9ik/default.nix
@@ -14,10 +14,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ pam ];
 
-  makeFlags = [ "pam_p9.so" ];
-  installPhase = ''
-    install -Dm755 -t $out/lib/security/ pam_p9.so
-  '';
+  buildFlags = [ "pam_p9.so" ];
+  installFlags = [ "PREFIX=$(out)" ];
+  installTargets = "pam.install";
 
   meta = with lib; {
     description = "dp9ik pam module";

--- a/pkgs/tools/admin/tlsclient/default.nix
+++ b/pkgs/tools/admin/tlsclient/default.nix
@@ -3,31 +3,28 @@
 , fetchFromSourcehut
 , pkg-config
 , openssl
-, installShellFiles
 , gitUpdater
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tlsclient";
-  version = "1.5";
+  version = "1.6.4";
 
   src = fetchFromSourcehut {
     owner = "~moody";
     repo = "tlsclient";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-9LKx9x5Kx7Mo4EL/b89Mdsdu8NqVYxohn98XnF+IWXs=";
+    hash = "sha256-36fhY9kO6tPUuRkpk3Jv9oBRYX/SnmdZg0Rzt/A6MQE=";
   };
 
   strictDeps = true;
   enableParallelBuilding = true;
-  nativeBuildInputs = [ pkg-config installShellFiles ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 
-  makeFlags = [ "tlsclient" ];
-  installPhase = ''
-    install -Dm755 -t $out/bin tlsclient
-    installManPage tlsclient.1
-  '';
+  buildFlags = [ "tlsclient" ];
+  installFlags = [ "PREFIX=$(out)" ];
+  installTargets = "tlsclient.install";
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";

--- a/pkgs/tools/admin/tlsclient/default.nix
+++ b/pkgs/tools/admin/tlsclient/default.nix
@@ -4,6 +4,7 @@
 , pkg-config
 , openssl
 , installShellFiles
+, gitUpdater
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,6 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm755 -t $out/bin tlsclient
     installManPage tlsclient.1
   '';
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
 
   meta = with lib; {
     description = "tlsclient command line utility";

--- a/pkgs/tools/admin/tlsclient/default.nix
+++ b/pkgs/tools/admin/tlsclient/default.nix
@@ -6,14 +6,14 @@
 , installShellFiles
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tlsclient";
   version = "1.5";
 
   src = fetchFromSourcehut {
     owner = "~moody";
     repo = "tlsclient";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-9LKx9x5Kx7Mo4EL/b89Mdsdu8NqVYxohn98XnF+IWXs=";
   };
 
@@ -37,4 +37,4 @@ stdenv.mkDerivation rec {
     mainProgram = "tlsclient";
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1385,6 +1385,8 @@ with pkgs;
 
   _9pfs = callPackage ../tools/filesystems/9pfs { };
 
+  _9ptls = callPackage ../os-specific/linux/9ptls { };
+
   aaa = callPackage ../tools/misc/aaa { };
 
   aardvark-dns = callPackage ../tools/networking/aardvark-dns { };


### PR DESCRIPTION
###### Description of changes

This packages up another utility that has been added to tlsclient.
Mount.9ptls allows for linux kernel v9fs mounts to be easily wrapped by
tlsclient for authenticated and encrypted mounts of 9front 9p fileservers.

While working on this I took time to try to tidy and clean up some of the other
tlsclient utilities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
