### PR TITLE
screentest: init at unstable-2021-05-10

### DIFF
--- a/pkgs/by-name/sc/screentest/package.nix
+++ b/pkgs/by-name/sc/screentest/package.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, intltool
+, pkg-config
+, gtk2
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "screentest";
+  version = "unstable-2021-05-10";
+
+  src = fetchFromGitHub {
+    owner = "TobiX";
+    repo = "screentest";
+    rev = "780e6cbbbbd6ba93e246e7747fe593b40c4e2747";
+    hash = "sha256-TJ47c77vQ/aRBJ2uEiFLuAR4dd4CMEo+iAAx0HCFbmA=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    intltool
+    pkg-config
+  ];
+
+  buildInputs = [ gtk2 ];
+
+  meta = with lib; {
+    description = "A simple screen testing tool";
+    homepage = "https://github.com/TobiX/screentest";
+    changelog = "https://github.com/TobiX/screentest/blob/${finalAttrs.src.rev}/NEWS";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ evils ];
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
###### Description of changes

add screentest, a utility for displaying several monitor test patterns
(including solid subpixel colours in unstable)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).