### PR TITLE
firefox: remove app.partner.nixos

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -187,7 +187,6 @@ let
       # These values are exposed through telemetry
       "app.distributor" = "nixos";
       "app.distributor.channel" = "nixpkgs";
-      "app.partner.nixos" = "nixos";
     };
   });
 


### PR DESCRIPTION
###### Description of changes
This causes a bug in Thunderbird. The url of the startpage is `https://live.thunderbird.net/%APP%/start?locale=%LOCALE%&version=%VERSION%&channel=%CHANNEL%&os=%OS%&buildid=%APPBUILDID%`. In the url the `%CHANNEL%` is `default` by default. But if the partner is set to nixos it [becomes](https://searchfox.org/mozilla-central/source/toolkit/modules/UpdateUtils.sys.mjs#47) `default-cck-nixos`. Therefore the [startpage](https://live.thunderbird.net/thunderbird/start?locale=en-US&version=115.0&channel=default-cck-nixos&os=Linux) is redirected to [the daily page](https://start.thunderbird.net/en-US/daily/) so that the users see Thunderbird DAILY on the startpage. The [default channel url](https://live.thunderbird.net/thunderbird/start?locale=en-US&version=115.0&channel=default&os=Linux) is redirected to the correct [release page](https://start.thunderbird.net/en-US/release/). The same happens to the changelog url in the About dialogue which should be redirected to the [release note](https://www.thunderbird.net/en-US/thunderbird/115.0/releasenotes/) but currently it's the [daily page](https://start.thunderbird.net/en-US/daily/).

It's seems firefox is not affected so this is mostly a bug of the thunderbird website. The website is pretty buggy anyway that it displays BETA on [the release page of Chinese edition](https://start.thunderbird.net/zh-CN/release/).

We can also change the urls instead but I thought this is a easier workaround. The `app.partner` is not set in [Archlinux](https://gitlab.archlinux.org/archlinux/packaging/packages/thunderbird/-/blob/main/distribution.ini) and [Gentoo](https://github.com/gentoo/gentoo/blob/master/mail-client/thunderbird/files/distribution.ini) so I thought it's OK to remove it. And it seems we shouldn't set this since it's for [modified releases](https://firefox-source-docs.mozilla.org/taskcluster/partner-repacks.html) while the NixOS release is official branded.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
