### PR TITLE
xeus-zmq: init at 1.1.0

### DIFF
--- a/pkgs/development/libraries/xeus-zmq/default.nix
+++ b/pkgs/development/libraries/xeus-zmq/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, clangStdenv
+, fetchFromGitHub
+, cmake
+, cppzmq
+, libuuid
+, nlohmann_json
+, openssl
+, xeus
+, xtl
+, zeromq
+}:
+
+clangStdenv.mkDerivation rec {
+  pname = "xeus-zmq";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jupyter-xeus";
+    repo = "xeus-zmq";
+    rev = "${version}";
+    hash = "sha256-j23NPgqwjQ7x4QriCb+N7CtBWhph+pCmBC0AULEDL1U=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    cppzmq
+    libuuid
+    openssl
+    xeus
+    xtl
+    zeromq
+  ];
+
+  propagatedBuildInputs = [ nlohmann_json ];
+
+  meta = {
+    description = "ZeroMQ-based middleware for xeus";
+    homepage = "https://github.com/jupyter-xeus/xeus-zmq";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ thomasjm ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20098,6 +20098,8 @@ with pkgs;
 
   xeus = callPackage ../development/libraries/xeus { };
 
+  xeus-zmq = callPackage ../development/libraries/xeus-zmq { };
+
   xmlindent = callPackage ../development/web/xmlindent { };
 
   xpwn = callPackage ../development/mobile/xpwn { };


### PR DESCRIPTION
###### Description of changes

Add the `xeus-zmq` library. 

This is the first step of packaging `xeus-cling`, the Jupyter kernel for C++. See the draft PR #244777.

Opening this per discussion in the QuantStack/Lobby room. Any chance you could review @serge-sans-paille ?

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
