### PR TITLE
xeus-cling: init at 0.15.3

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/0001-Fix-bug-in-extract_filename.patch
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/0001-Fix-bug-in-extract_filename.patch
@@ -1,0 +1,50 @@
+From 8bfa594bc37630956f80496106bb1d6070035570 Mon Sep 17 00:00:00 2001
+From: thomasjm <tom@codedown.io>
+Date: Wed, 2 Aug 2023 18:26:58 -0700
+Subject: [PATCH 1/3] Fix bug in extract_filename
+
+---
+ src/main.cpp | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/main.cpp b/src/main.cpp
+index 2ee19be..57294b4 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -61,19 +61,19 @@ bool should_print_version(int argc, char* argv[])
+     return false;
+ }
+ 
+-std::string extract_filename(int argc, char* argv[])
++std::string extract_filename(int *argc, char* argv[])
+ {
+     std::string res = "";
+-    for (int i = 0; i < argc; ++i)
++    for (int i = 0; i < *argc; ++i)
+     {
+-        if ((std::string(argv[i]) == "-f") && (i + 1 < argc))
++        if ((std::string(argv[i]) == "-f") && (i + 1 < *argc))
+         {
+             res = argv[i + 1];
+-            for (int j = i; j < argc - 2; ++j)
++            for (int j = i; j < *argc - 2; ++j)
+             {
+                 argv[j] = argv[j + 2];
+             }
+-            argc -= 2;
++            *argc -= 2;
+             break;
+         }
+     }
+@@ -128,7 +128,7 @@ int main(int argc, char* argv[])
+ #endif
+     signal(SIGINT, stop_handler);
+ 
+-    std::string file_name = extract_filename(argc, argv);
++    std::string file_name = extract_filename(&argc, argv);
+ 
+     interpreter_ptr interpreter = build_interpreter(argc, argv);
+ 
+-- 
+2.40.1
+

--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/0002-Don-t-pass-extra-includes-configure-this-with-flags.patch
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/0002-Don-t-pass-extra-includes-configure-this-with-flags.patch
@@ -1,0 +1,34 @@
+From 9e6a14bb20567071883563dafb5dfaf512df6243 Mon Sep 17 00:00:00 2001
+From: thomasjm <tom@codedown.io>
+Date: Wed, 2 Aug 2023 18:27:16 -0700
+Subject: [PATCH 2/3] Don't pass extra includes; configure this with flags
+
+---
+ src/main.cpp | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/main.cpp b/src/main.cpp
+index 57294b4..0041a55 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -84,7 +84,7 @@ using interpreter_ptr = std::unique_ptr<xcpp::interpreter>;
+ 
+ interpreter_ptr build_interpreter(int argc, char** argv)
+ {
+-    int interpreter_argc = argc + 1;
++    int interpreter_argc = argc;
+     const char** interpreter_argv = new const char*[interpreter_argc];
+     interpreter_argv[0] = "xeus-cling";
+     // Copy all arguments in the new array excepting the process name.
+@@ -92,8 +92,6 @@ interpreter_ptr build_interpreter(int argc, char** argv)
+     {
+         interpreter_argv[i] = argv[i];
+     }
+-    std::string include_dir = std::string(LLVM_DIR) + std::string("/include");
+-    interpreter_argv[interpreter_argc - 1] = include_dir.c_str();
+ 
+     interpreter_ptr interp_ptr = interpreter_ptr(new xcpp::interpreter(interpreter_argc, interpreter_argv));
+     delete[] interpreter_argv;
+-- 
+2.40.1
+

--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/default.nix
@@ -1,0 +1,63 @@
+{ callPackage
+, clangStdenv
+, cling
+, fetchurl
+, lib
+, llvmPackages_9
+, makeWrapper
+, runCommand
+, stdenv
+}:
+
+# Jupyter console:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel cpp17-kernel'
+
+# Jupyter notebook:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter.override { definitions = { cpp17 = cpp17-kernel; }; }'
+
+let
+  xeus-cling = callPackage ./xeus-cling.nix {};
+
+  mkDefinition = std:
+    let
+      versionSuffix =
+        if std == "c++11" then " 11"
+        else if std == "c++14" then " 14"
+        else if std == "c++17" then " 17"
+        else if std == "c++17" then " 17"
+        else if std == "c++2a" then " 2a"
+        else throw "Unexpected C++ std for cling: ${std}";
+    in
+      {
+        displayName = "C++" + versionSuffix;
+        argv = [
+          "${xeus-cling}/bin/xcpp"
+        ]
+        ++ cling.flags
+        ++ [
+          "-resource-dir" "${cling.unwrapped}"
+          "-L" "${cling.unwrapped}/lib"
+          "-l" "${cling.unwrapped}/lib/cling.so"
+          "-std=${std}"
+          # "-v"
+          "-f" "{connection_file}"
+        ];
+        language = "cpp";
+        logo32 = fetchurl {
+          url = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/ISO_C%2B%2B_Logo.svg/32px-ISO_C%2B%2B_Logo.svg.png";
+          hash = "sha256-cr0TB8/j2mkcFhfCkz9F7ZANOuTlWA2OcWtDcXyOjHw=";
+        };
+        logo64 = fetchurl {
+          url = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/ISO_C%2B%2B_Logo.svg/64px-ISO_C%2B%2B_Logo.svg.png";
+          hash = "sha256-nZtJ4bR7GmQttvqEJC9KejOxphrjjxT36L9yOIITFLk=";
+        };
+      };
+
+in
+
+{
+  cpp11-kernel = mkDefinition "c++11";
+  cpp14-kernel = mkDefinition "c++14";
+  cpp17-kernel = mkDefinition "c++17";
+  cpp2a-kernel = mkDefinition "c++2a";
+}

--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
@@ -1,0 +1,87 @@
+{ lib
+, callPackage
+, clangStdenv
+, cmake
+, fetchFromGitHub
+, gcc
+, git
+, llvmPackages_9
+# Libraries
+, argparse
+, cling
+, cppzmq
+, libuuid
+, ncurses
+, openssl
+, pugixml
+, xeus
+, xeus-zmq
+, xtl
+, zeromq
+, zlib
+# Settings
+, debug ? false
+}:
+
+let
+  # Nixpkgs moved to argparse 3.x, but we need ~2.9
+  argparse_2_9 = argparse.overrideAttrs (oldAttrs: {
+    version = "2.9";
+
+    src = fetchFromGitHub {
+      owner = "p-ranav";
+      repo = "argparse";
+      rev = "v2.9";
+      sha256 = "sha256-vbf4kePi5gfg9ub4aP1cCK1jtiA65bUS9+5Ghgvxt/E=";
+    };
+  });
+
+in
+
+clangStdenv.mkDerivation rec {
+  pname = "xeus-cling";
+  version = "0.15.3";
+
+  src = fetchFromGitHub {
+    owner = "QuantStack";
+    repo = "xeus-cling";
+    rev = "${version}";
+    hash = "sha256-OfZU+z+p3/a36GntusBfwfFu3ssJW4Fu7SV3SMCoo1I=";
+  };
+
+  patches = [
+    ./0001-Fix-bug-in-extract_filename.patch
+    ./0002-Don-t-pass-extra-includes-configure-this-with-flags.patch
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    argparse_2_9
+    cling.unwrapped
+    cppzmq
+    libuuid
+    llvmPackages_9.llvm
+    ncurses
+    openssl
+    pugixml
+    xeus
+    xeus-zmq
+    xtl
+    zeromq
+    zlib
+  ];
+
+  cmakeFlags = lib.optionals debug [
+    "-DCMAKE_BUILD_TYPE=Debug"
+  ];
+
+  dontStrip = debug;
+
+  meta = {
+    description = "Jupyter kernel for the C++ programming language";
+    homepage = "https://github.com/jupyter-xeus/xeus-cling";
+    maintainers = with lib.maintainers; [ thomasjm ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17579,6 +17579,10 @@ with pkgs;
     jre = jre8;
   };
 
+  inherit (callPackage ../applications/editors/jupyter-kernels/xeus-cling { })
+    cpp11-kernel cpp14-kernel cpp17-kernel cpp2a-kernel;
+  xeus-cling = callPackage ../applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix { };
+
   clojure = callPackage ../development/interpreters/clojure {
     # set this to an LTS version of java
     jdk = jdk17;


### PR DESCRIPTION
###### Description of changes

The Jupyter kernel for C++ based on Cling.

~~This is a draft until I can get https://github.com/NixOS/nixpkgs/pull/247253 and https://github.com/NixOS/nixpkgs/pull/245340 merged, and then it will be ready to go.~~

There are currently 2 patches included with this PR. One has already been merged upstream and the other is in progress, so hopefully we'll have a new release soon incorporating both and then we can remove the patches.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
