### PR TITLE
python3Packages.cirq-core: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , pythonAtLeast
 , pythonOlder
+, pythonRelaxDepsHook
 , fetchFromGitHub
 , fetchpatch
 , duet
@@ -32,36 +33,29 @@
 
 buildPythonPackage rec {
   pname = "cirq-core";
-  version = "1.1.0";
+  version = "1.2.0";
   format = "setuptools";
 
-  # Upstream package is broken on Python 3.11 https://github.com/quantumlib/Cirq/issues/6018
-  disabled = pythonOlder "3.7" || pythonAtLeast "3.11";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "quantumlib";
     repo = "cirq";
     rev = "refs/tags/v${version}";
-    hash = "sha256-5j4hbG95KRfRQTyyZgoNp/eHIcy0FphyEhbYnzyUMO4=";
+    hash = "sha256-KEei5PJ0ammsduZVmMh2vaW3f58DYI4BCrFCl/SjUoo=";
   };
 
   sourceRoot = "source/${pname}";
 
-  patches = [
-    # https://github.com/quantumlib/Cirq/pull/5991
-    (fetchpatch {
-      url = "https://build.opensuse.org/public/source/openSUSE:Factory/python-cirq/cirq-pr5991-np1.24.patch?rev=8";
-      stripLen = 1;
-      hash = "sha256-d2FpaxM1PsPWT9ZM9v2gVrnLCy9zmvkkyAVgo85eL3U=";
-    })
-  ];
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "matplotlib~=3.0" "matplotlib" \
-      --replace "networkx~=2.4" "networkx" \
-      --replace "numpy>=1.16,<1.24" "numpy"
-  '';
+  pythonRelaxDeps = [
+    "matplotlib"
+    "networkx"
+    "numpy"
+    "duet"
+    "sortedcontainers"
+  ];
 
   propagatedBuildInputs = [
     duet
@@ -102,8 +96,8 @@ buildPythonPackage rec {
     "test_metadata_search_path"
     # Fails due pandas MultiIndex. Maybe issue with pandas version in nix?
     "test_benchmark_2q_xeb_fidelities"
-    # https://github.com/quantumlib/Cirq/pull/5991
-    "test_json_and_repr_data"
+    # Tests for some changed error handling behavior in SymPy 1.12
+    "test_custom_value_not_implemented"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/cirq-rigetti/default.nix
+++ b/pkgs/development/python-modules/cirq-rigetti/default.nix
@@ -2,6 +2,7 @@
 , cirq-core
 , requests
 , pytestCheckHook
+, pythonRelaxDepsHook
 , attrs
 , certifi
 , h11
@@ -31,23 +32,27 @@ buildPythonPackage rec {
 
   sourceRoot = "source/${pname}";
 
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
   postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "attrs~=20.3.0" "attrs" \
-      --replace "certifi~=2021.5.30" "certifi" \
-      --replace "h11~=0.9.0" "h11" \
-      --replace "httpcore~=0.11.1" "httpcore" \
-      --replace "httpx~=0.15.5" "httpx" \
-      --replace "idna~=2.10" "idna" \
-      --replace "pyjwt~=1.7.1" "pyjwt" \
-      --replace "qcs-api-client~=0.8.0" "qcs-api-client" \
-      --replace "iso8601~=0.1.14" "iso8601" \
-      --replace "rfc3986~=1.5.0" "rfc3986" \
-      --replace "pyquil~=3.0.0" "pyquil" \
-      --replace "pydantic~=1.8.2" "pydantic"
     # Remove outdated test
     rm cirq_rigetti/service_test.py
   '';
+
+  pythonRelaxDeps = [
+    "attrs"
+    "certifi"
+    "h11"
+    "httpcore"
+    "httpx"
+    "idna"
+    "pyjwt"
+    "qcs-api-client"
+    "iso8601"
+    "rfc3986"
+    "pyquil"
+    "pydantic"
+  ];
 
   propagatedBuildInputs = [
     cirq-core


### PR DESCRIPTION
###### Description of changes
Updated cirq-core to a version that is compatible with python 3.11 and numpy 1.24.
`test_custom_value_not_implemented` explicitly tests some error handling behavior in sympy that was changed in 1.12. #244787 updates sympy to 1.12, but at any rate this should not change usability of the library. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
