### PR TITLE
lib/generators/toKeyValue: add `indent` parameter

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -81,9 +81,10 @@ rec {
    */
   toKeyValue = {
     mkKeyValue ? mkKeyValueDefault {} "=",
-    listsAsDuplicateKeys ? false
+    listsAsDuplicateKeys ? false,
+    indent ? ""
   }:
-  let mkLine = k: v: mkKeyValue k v + "\n";
+  let mkLine = k: v: indent + mkKeyValue k v + "\n";
       mkLines = if listsAsDuplicateKeys
         then k: v: map (mkLine k) (if lib.isList v then v else [v])
         else k: v: [ (mkLine k v) ];


### PR DESCRIPTION
toKeyValue is generic enough that it is sometimes used as part of other format generators, where it might be useful to specify the indentation level.

Context: https://github.com/nix-community/home-manager/pull/4263#discussion_r1271283136