### PR TITLE
nixos-generate-config: Add help message when `btrfs subvol` fails for non root user

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -452,7 +452,11 @@ EOF
     if ($fsType eq "btrfs") {
         my ($status, @info) = runCommand("@btrfs@ subvol show $rootDir$mountPoint");
         if ($status != 0 || join("", @info) =~ /ERROR:/) {
-            die "Failed to retrieve subvolume info for $mountPoint\n";
+            my $error = "Failed to retrieve subvolume info for $mountPoint\n";
+            if (join("", @info) =~ /Operation not permitted/ && $> != 0) {
+                die "Not permitted: ", $error, "Help: consider retrying as root\n";
+            }
+            die $error;
         }
         my @ids = join("\n", @info) =~ m/^(?!\/\n).*Subvolume ID:[ \t\n]*([0-9]+)/s;
         if ($#ids > 0) {


### PR DESCRIPTION
###### Description of changes

When I first tried running `nixos-generate-config` on my NixOS install I bumped into this error. I did not think to try as root so I decided to Google the issue.

It seems that I wasn't the only one unsure of how to fix it. There was a post on reddit asking my question. https://www.reddit.com/r/NixOS/comments/yv44zx/comment/iwr7n85/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

I hope that this improved error will reduce potential confusion.


###### Things done

N/A: this is not a change to a package