### PR TITLE
Revert "gitea: 1.19.4 -> 1.20.0"

### DIFF
--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -439,6 +439,8 @@ in
       lfs = mkIf cfg.lfs.enable {
         PATH = cfg.lfs.contentDir;
       };
+
+      packages.CHUNKED_UPLOAD_PATH = "${cfg.stateDir}/tmp/package-upload";
     };
 
     services.postgresql = optionalAttrs (usePostgresql && cfg.database.createDatabase) {

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -439,8 +439,6 @@ in
       lfs = mkIf cfg.lfs.enable {
         PATH = cfg.lfs.contentDir;
       };
-
-      packages.CHUNKED_UPLOAD_PATH = "${cfg.stateDir}/tmp/package-upload";
     };
 
     services.postgresql = optionalAttrs (usePostgresql && cfg.database.createDatabase) {
@@ -577,7 +575,7 @@ in
       '';
 
       serviceConfig = {
-        Type = "notify";
+        Type = "simple";
         User = cfg.user;
         Group = cfg.group;
         WorkingDirectory = cfg.stateDir;

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -121,10 +121,14 @@ let
       client2.succeed(f"GIT_SSH_COMMAND='{GIT_SSH_COMMAND}' git clone {REPO}")
       client2.succeed('test "$(cat repo/testfile | xargs echo -n)" = "hello world"')
 
-      server.wait_until_succeeds(
+      server.succeed(
           'test "$(curl http://localhost:3000/api/v1/repos/test/repo/commits '
           + '-H "Accept: application/json" | jq length)" = "1"'
       )
+
+      client1.shutdown()
+      client2.shutdown()
+      server.shutdown()
     '';
   });
 in

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -20,12 +20,12 @@
 
 buildGoModule rec {
   pname = "gitea";
-  version = "1.19.4";
+  version = "1.20.0";
 
   # not fetching directly from the git repo, because that lacks several vendor files for the web UI
   src = fetchurl {
     url = "https://dl.gitea.com/gitea/${version}/gitea-src-${version}.tar.gz";
-    hash = "sha256-vNMNEKMpUoVLUGwPPVhLKfElFmjCWgZHY5i1liNs+xk=";
+    hash = "sha256-ME2ZYSeaHru/7wBFBmXLpf9dKpl0WrtrmAqmzw37tq4=";
   };
 
   vendorHash = null;

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -20,12 +20,12 @@
 
 buildGoModule rec {
   pname = "gitea";
-  version = "1.20.0";
+  version = "1.19.4";
 
   # not fetching directly from the git repo, because that lacks several vendor files for the web UI
   src = fetchurl {
     url = "https://dl.gitea.com/gitea/${version}/gitea-src-${version}.tar.gz";
-    hash = "sha256-ME2ZYSeaHru/7wBFBmXLpf9dKpl0WrtrmAqmzw37tq4=";
+    hash = "sha256-vNMNEKMpUoVLUGwPPVhLKfElFmjCWgZHY5i1liNs+xk=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#243883

We made the decision in the past to share Gitea and Forgejo codebase, this means that Gitea changes in the module can be breaking for Forgejo and this PR introduced one of them alas, I revert this and will add the package bump commit, because Gitea cannot be downgraded I suppose.