### PR TITLE
nixos/networkmanager: create pppd lock directory

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -461,6 +461,8 @@ in {
       "d /var/lib/NetworkManager-fortisslvpn 0700 root root -"
 
       "d /var/lib/misc 0755 root root -" # for dnsmasq.leases
+      # ppp isn't able to mkdir that directory at runtime
+      "d /run/pppd/lock 0700 root root -"
     ];
 
     systemd.services.NetworkManager = {


### PR DESCRIPTION
I digged up some 3G stick, which uses ppp to set up the connection.

It failed to spin up ppp, because ppp failed to find the directory it wants to create its lockfiles in:

```
Jul 22 16:47:49 tp ModemManager[926779]: <info>  [modem1] state changed (connected -> disconnecting)
Jul 22 16:47:49 tp ModemManager[926779]: <info>  [modem1] simple connect started...
Jul 22 16:47:49 tp ModemManager[926779]: <info>  [modem1] simple connect state (4/10): wait to get fully enabled
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1] state changed (disconnecting -> registered)
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1] simple connect state (5/10): wait after enabled
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1/bearer0] connection #11 finished: duration 1s
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1] simple connect state (6/10): register
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1] simple connect state (7/10): wait to get packet service state attached
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1] simple connect state (8/10): bearer
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1] simple connect state (9/10): connect
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1] state changed (registered -> connecting)
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1] state changed (connecting -> connected)
Jul 22 16:47:50 tp ModemManager[926779]: <info>  [modem1] simple connect state (10/10): all done
Jul 22 16:47:50 tp pppd[1576260]: Plugin /nix/store/yqdqzz6y6agcmrfj8b6pwqhjcjyb3ypr-networkmanager-1.42.6/lib/pppd/2.5.0/nm-pppd-plugin.so loaded.
Jul 22 16:47:50 tp NetworkManager[1576260]: Plugin /nix/store/yqdqzz6y6agcmrfj8b6pwqhjcjyb3ypr-networkmanager-1.42.6/lib/pppd/2.5.0/nm-pppd-plugin.so loaded.
Jul 22 16:47:50 tp pppd[1576260]: nm-ppp-plugin: initializing
Jul 22 16:47:50 tp pppd[1576260]: pppd 2.5.0 started by root, uid 0
Jul 22 16:47:50 tp pppd[1576260]: Can't create lock file /var/run/pppd/lock/LCK..ttyUSB0: No such file or directory
Jul 22 16:47:50 tp NetworkManager[1576260]: Can't create lock file /var/run/pppd/lock/LCK..ttyUSB0: No such file or directory
Jul 22 16:47:50 tp pppd[1576260]: nm-ppp-plugin: status 2 / phase 'serial connection'
Jul 22 16:47:50 tp pppd[1576260]: Exit.
Jul 22 16:47:50 tp pppd[1576260]: nm-ppp-plugin: status 0 / phase 'dead'
Jul 22 16:47:50 tp pppd[1576260]: nm-ppp-plugin: cleaning up
```

Creating the directories via tmpfiles.d got the connection to succeed, and might also fix other connections using PPP.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
