### PR TITLE
curl: Fix cross-compilation to Windows by not forcing gssSupport

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7001,7 +7001,6 @@ with pkgs;
     idnSupport = true;
     zstdSupport = true;
   } // lib.optionalAttrs (!stdenv.hostPlatform.isStatic) {
-    gssSupport = true;
     brotliSupport = true;
   });
 


### PR DESCRIPTION
###### Description of changes

E.g. `nix build .#pkgsCross.mingwW64.curl` would fail. The params for curl already have `gssSupport = !isStatic && …` ([src](https://github.com/NixOS/nixpkgs/blob/a5872e5b1b11ac8ef7c60d39bc2ecb1fd4cd1dd7/pkgs/tools/networking/curl/default.nix#L6-L15)), so removing this doesn’t really have any effect since it’s already `true` when possible and `false` for static platforms.

###### Things done

Have additionally done `nix build .#pkgsStatic.curl .#pkgsCross.mingwW64.curl` on x86_64-linux. The drvs are unchanged before and after this:

```
nix build --print-out-paths '.?ref=master'#{curl,legacyPackages.x86_64-darwin.curl,pkgsStatic.curl} 
/nix/store/d7i0yivmb90qnihx1ja8c925lihz9d2a-curl-8.1.1-bin
/nix/store/xvfk15hqs47yykw28x13bb4dh3dr380p-curl-8.1.1-man
/nix/store/r8zjczwbpgsq190r6imb8mqkrg4dsr9w-curl-8.1.1-bin
/nix/store/5xnzx76dzjmk5nq9yrilhmf3s05syx7s-curl-8.1.1-man
/nix/store/gfvnl299dcpbaaa00h0ivdipabwidk7a-curl-static-x86_64-unknown-linux-musl-8.1.1-bin
/nix/store/mbqifyvww48ik2d29zdfq2wfiynhk1x3-curl-static-x86_64-unknown-linux-musl-8.1.1-man

nix build --print-out-paths .#{curl,legacyPackages.x86_64-darwin.curl,pkgsStatic.curl}
/nix/store/d7i0yivmb90qnihx1ja8c925lihz9d2a-curl-8.1.1-bin
/nix/store/xvfk15hqs47yykw28x13bb4dh3dr380p-curl-8.1.1-man
/nix/store/r8zjczwbpgsq190r6imb8mqkrg4dsr9w-curl-8.1.1-bin
/nix/store/5xnzx76dzjmk5nq9yrilhmf3s05syx7s-curl-8.1.1-man
/nix/store/gfvnl299dcpbaaa00h0ivdipabwidk7a-curl-static-x86_64-unknown-linux-musl-8.1.1-bin
/nix/store/mbqifyvww48ik2d29zdfq2wfiynhk1x3-curl-static-x86_64-unknown-linux-musl-8.1.1-man
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
