### PR TITLE
xdg-terminal-exec: Init at 75fa03c9df3c96e16223f23b09f4d47e58a51233

### DIFF
--- a/pkgs/applications/terminal-emulators/xdg-terminal-exec/default.nix
+++ b/pkgs/applications/terminal-emulators/xdg-terminal-exec/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, bash }:
+stdenv.mkDerivation rec {
+  pname = "xdg-terminal-exec";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Vladimir-csp";
+    repo = "xdg-terminal-exec";
+    rev = "75fa03c9df3c96e16223f23b09f4d47e58a51233";
+    hash = "sha256-6ESW54MH/iV9PB93J5d1QYbR1l4SSrHxs0uQdUFYuCg=";
+  };
+
+  preInstall = ''
+  substituteInPlace xdg-terminal-exec \
+    --replace "#!/bin/sh" "${bash}"
+  '';
+  installPhase = ''
+  mkdir -p $out/bin/
+  cp xdg-terminal-exec $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Proposal for XDG terminal execution utility";
+    homepage = "https://github.com/Vladimir-csp/xdg-terminal-exec";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.sents ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/terminal-emulators/xdg-terminal-exec/default.nix
+++ b/pkgs/applications/terminal-emulators/xdg-terminal-exec/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, bash }:
 stdenv.mkDerivation rec {
   pname = "xdg-terminal-exec";
-  version = "0.1.0";
+  version = "unstable-2023-05-12";
 
   src = fetchFromGitHub {
     owner = "Vladimir-csp";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2924,6 +2924,8 @@ with pkgs;
 
   x3270 = callPackage ../applications/terminal-emulators/x3270 { };
 
+  xdg-terminal-exec = callPackage ../applications/terminal-emulators/xdg-terminal-exec { };
+
   xterm = callPackage ../applications/terminal-emulators/xterm { };
 
   xtermcontrol = callPackage ../applications/terminal-emulators/xtermcontrol { };


### PR DESCRIPTION
As mentioned in https://gitlab.gnome.org/GNOME/glib/-/issues/338 this is a temporary solution to enable users to set their prefered terminal emulator for glib.

xdg-terminal-exec requires .desktop like files in a new `$XDG_DATA_DIR/xdg-terminals`,
but adding these files for all of our terminal emulators would be some more work.
As this is only supposed to be a temporary solution I'm not sure it's worth the effort,
although it did take 12 years for a temporary solution to emerge.

In the meantime users can just add their required terminals in `$HOME/.local/share/xdg-terminals`


Homepage: https://github.com/Vladimir-csp/xdg-terminal-exec

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
