### PR TITLE
sourcery: init at 1.15.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3712,6 +3712,8 @@ let
         meta.license = lib.licenses.lgpl3Only;
       };
 
+      sourcery.sourcery = callPackage ./sourcery.sourcery { };
+
       spywhere.guides = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "guides";

--- a/pkgs/applications/editors/vscode/extensions/sourcery.sourcery/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/sourcery.sourcery/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  vscode-utils,
+  autoPatchelfHook,
+  libxcrypt-legacy,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "sourcery";
+    publisher = "sourcery";
+    version = "1.16.0";
+    hash = "sha256-SHgS2C+ElTJW4v90Wg0QcsSL2FoSz+SxZQpgq2J4JiU=";
+  };
+
+  postPatch = ''
+    pushd sourcery_binaries/install
+    rm -r win ${if stdenv.isLinux then "mac" else "linux"}
+    popd
+  '';
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    libxcrypt-legacy
+  ];
+
+  meta = {
+    changelog = "https://sourcery.ai/changelog/";
+    description = "A VSCode extension for Sourcery, an AI-powered code review and pair programming tool for Python";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=sourcery.sourcery";
+    homepage = "https://github.com/sourcery-ai/sourcery-vscode";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
+  };
+}

--- a/pkgs/by-name/so/sourcery/package.nix
+++ b/pkgs/by-name/so/sourcery/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchPypi,
+  autoPatchelfHook,
+  libxcrypt-legacy,
+}:
+
+let
+  platformInfos = {
+    "x86_64-linux" = {
+      platform = "manylinux1_x86_64";
+      hash = "sha256-gr5z8VYkuCqgmcnyA01/Ez6aX9NrKR4MgA0Bc6IHnfs=";
+    };
+    "x86_64-darwin" = {
+      platform = "macosx_10_9_universal2";
+      hash = "sha256-5LsxeozPgInUC1QAxDSlr8NIfmRSl5BN+g9/ZYAxiRE=";
+    };
+  };
+  platformInfo = platformInfos.${stdenv.system} or (throw "Unsupported platform ${stdenv.system}");
+in
+python3Packages.buildPythonApplication rec {
+  pname = "sourcery";
+  version = "1.16.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    inherit (platformInfo) platform hash;
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [ libxcrypt-legacy ];
+
+  meta = {
+    changelog = "https://sourcery.ai/changelog/";
+    description = "An AI-powered code review and pair programming tool for Python";
+    downloadPage = "https://pypi.org/project/sourcery/";
+    homepage = "https://sourcery.ai";
+    license = lib.licenses.unfree;
+    mainProgram = "sourcery";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Closes: https://github.com/NixOS/nixpkgs/issues/243774
Closes: https://github.com/NixOS/nixpkgs/issues/244143

This PR adds the Sourcery.ai Python package and the VSCode extension.
Although the repo says it's MIT licensed, the Pypi pacakge says it's proprietary (which it actually is).

For the Python package, there are only platform specific wheels available on Pypi.
I don't know which platforms are supported actually, so I'll just go with x86_64 for linux and darwin.

The VSCode extension has all platforms' sources in it, so hopefully that will work as expected.

https://github.com/NixOS/nixpkgs/issues/243774 said that the package name was `python-sourcery`, but that's another, unrelated package

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
