### PR TITLE
nixos/hyprland: apply config options to package

### DIFF
--- a/nixos/modules/programs/hyprland.nix
+++ b/nixos/modules/programs/hyprland.nix
@@ -6,10 +6,10 @@
 with lib; let
   cfg = config.programs.hyprland;
 
-  defaultHyprlandPackage = pkgs.hyprland.override {
-    enableXWayland = cfg.xwayland.enable;
-    hidpiXWayland = cfg.xwayland.hidpi;
-    nvidiaPatches = cfg.nvidiaPatches;
+  finalPortalPackage = cfg.portalPackage.override {
+    hyprland-share-picker = pkgs.hyprland-share-picker.override {
+      hyprland = cfg.finalPackage;
+    };
   };
 in
 {
@@ -25,23 +25,24 @@ in
       '';
     };
 
-    package = mkOption {
-      type = types.path;
-      default = defaultHyprlandPackage;
-      defaultText = literalExpression ''
-        pkgs.hyprland.override {
-          enableXWayland = config.programs.hyprland.xwayland.enable;
-          hidpiXWayland = config.programs.hyprland.xwayland.hidpi;
-          nvidiaPatches = config.programs.hyprland.nvidiaPatches;
-        }
-      '';
-      example = literalExpression "<Hyprland flake>.packages.<system>.default";
+    package = mkPackageOptionMD pkgs "hyprland" { };
+
+    finalPackage = mkOption {
+      type = types.package;
+      readOnly = true;
+      default = cfg.package.override {
+        enableXWayland = cfg.xwayland.enable;
+        hidpiXWayland = cfg.xwayland.hidpi;
+        nvidiaPatches = cfg.nvidiaPatches;
+      };
+      defaultText = literalExpression
+        "`wayland.windowManager.hyprland.package` with applied configuration";
       description = mdDoc ''
-        The Hyprland package to use.
-        Setting this option will make {option}`programs.hyprland.xwayland` and
-        {option}`programs.hyprland.nvidiaPatches` not work.
+        The Hyprland package after applying configuration.
       '';
     };
+
+    portalPackage = mkPackageOptionMD pkgs "xdg-desktop-portal-hyprland" { };
 
     xwayland = {
       enable = mkEnableOption (mdDoc "XWayland") // { default = true; };
@@ -57,7 +58,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ cfg.finalPackage ];
 
     fonts.enableDefaultFonts = mkDefault true;
     hardware.opengl.enable = mkDefault true;
@@ -69,13 +70,11 @@ in
 
     security.polkit.enable = true;
 
-    services.xserver.displayManager.sessionPackages = [ cfg.package ];
+    services.xserver.displayManager.sessionPackages = [ cfg.finalPackage ];
 
     xdg.portal = {
       enable = mkDefault true;
-      extraPortals = [
-        pkgs.xdg-desktop-portal-hyprland
-      ];
+      extraPortals = [ finalPortalPackage ];
     };
   };
 }


### PR DESCRIPTION
###### Description of changes
Apply config options such as `cfg.xwayland` and `cfg.nvidiaPatches` to
`cfg.package` to form `cfg.finalPackage`, which will be used in the `config`
section of the module. This is more ergonomic than expecting users to override
the package themselves, if they choose to set a different version.

It also overrides the hyprland package inside `hyprland-share-picker`, which is
used by `xdg-desktop-portal-hyprland`, so that no matter what, the Hyprland
version is consistent.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
