### PR TITLE
python310Packages.rpds-py: link to libiconv on darwin

### DIFF
--- a/pkgs/development/python-modules/rpds-py/default.nix
+++ b/pkgs/development/python-modules/rpds-py/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , buildPythonPackage
 , cargo
 , fetchPypi
@@ -6,6 +7,7 @@
 , pythonOlder
 , rustc
 , rustPlatform
+, libiconv
 }:
 
 buildPythonPackage rec {
@@ -32,6 +34,10 @@ buildPythonPackage rec {
     rustPlatform.maturinBuildHook
     cargo
     rustc
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
###### Description of changes

Resolves the following error:

```
error: could not compile `rpds-py` (lib) due to previous error
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Cargo build finished with "exit status: 101": `CARGO_ENCODED_RUSTFLAGS="-C\u{1f}target-feature=-crt-static" PYO3_ENVIRONMENT_SIGNATURE="cpython-3.10-64bit" PYO3_PYTHON="/nix/store/hqw3f4jgbinm4rzl4zm77hw9l76y6n1w-python3-3.10.12/bin/python3" PYTHON_SYS_EXECUTABLE="/nix/store/hqw3f4jgbinm4rzl4zm77hw9l76y6n1w-python3-3.10.12/bin/python3" "cargo" "rustc" "--jobs" "10" "--features" "pyo3/extension-module" "--target" "x86_64-apple-darwin" "--message-format" "json-render-diagnostics" "--frozen" "--manifest-path" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/Cargo.toml" "--release" "--lib" "--" "-C" "link-arg=-undefined" "-C" "link-arg=dynamic_lookup" "-C" "link-args=-Wl,-install_name,@rpath/rpds.cpython-310-darwin.so" "-C" "link-arg=-s"`
error: builder for '/nix/store/53gady1wy6ajj9h77rajfi133a4i5w8b-python3.10-rpds-py-0.9.2.drv' failed with exit code 1;
       last 10 log lines:
       >   = note: LC_ALL="C" PATH="/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/bin:/nix/store/hqw3f4jgbinm4rzl4zm77hw9l76y6n1w-python3-3.10.12/bin:/nix/store/qy82z64ig90sb011hnn5xcl3xz82rqzb-python3.10-pip-23.0.1/bin:/nix/store/nzsj79p2j932hc5pq54940a4b0b03yl4-python3.10-wheel-0.38.4/bin:/nix/store/l1ppwqwss8pdydik24986myxsa2ys39j-cargo-1.70.0/bin:/nix/store/d6zgxyap5k37shcibkiygvlq4l1xa1jn-maturin-1.1.0/bin:/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/bin:/nix/store/pwm09z6zk41kynyf3wwp6qbzhad88gb1-libiconv-50/bin:/nix/store/vprl8pkc8sxqla6mwk4fak13hnlz58w3-python3.10-pytest-7.2.1/bin:/nix/store/12qf8ib757q3lvyssgrx9zvrpc525k2s-clang-wrapper-11.1.0/bin:/nix/store/7xrrd4dw32qbxppffp760lqgc1rcjqlq-clang-11.1.0/bin:/nix/store/8fr8kndrn5ga5agybsnncl966spqs5fv-coreutils-9.3/bin:/nix/store/m0lwz45p47zrnxkc9mdqfbxhf8hqka6c-cctools-binutils-darwin-wrapper-11.1.0-973.0.1/bin:/nix/store/v8w96xnlhwr8z63br45j4c5q6vqafln1-cctools-binutils-darwin-11.1.0-973.0.1/bin:/nix/store/8fr8kndrn5ga5agybsnncl966spqs5fv-coreutils-9.3/bin:/nix/store/f7m3z9n581xr0phpl0qbapxgr72pvvj3-findutils-4.9.0/bin:/nix/store/bmw9iwmfzdgy64igscpks8dm3iwwgxdg-diffutils-3.10/bin:/nix/store/ix0qk306qp5cz3r2qswycch6gk123x9z-gnused-4.9/bin:/nix/store/8d74bvhwn9x8bklmkimfgg5pmgkrf5vq-gnugrep-3.11/bin:/nix/store/2ydllvmrbif46i0b395v2wghj4ny1797-gawk-5.2.2/bin:/nix/store/3n5vk8pxpickrhf9m0z2lfhp8kwk31d6-gnutar-1.34/bin:/nix/store/b4hk5mmxhvf2xa25y2dkjnn6kxqmhy42-gzip-1.12/bin:/nix/store/89wbpcimabzm0gn9lbsk8w23wn9zlq3i-bzip2-1.0.8-bin/bin:/nix/store/i33fwc5vngr6140hidnkk2kyqb6lrvm4-gnumake-4.4.1/bin:/nix/store/krj9mlsrl8l544z26680ailir2jxzfqs-bash-5.2-p15/bin:/nix/store/h95ayvh2013c61hjjawpc4ksd408avq7-patch-2.7.6/bin:/nix/store/j45hwh3aq76lg4lpwy7q5fvs8yr9nsz1-xz-5.4.3-bin/bin:/nix/store/zz8dcsg9fa77c57cd0n2bnpmnqfk2bmn-file-5.44/bin" VSLANG="1033" ZERO_AR_DATE="1" "/nix/store/12qf8ib757q3lvyssgrx9zvrpc525k2s-clang-wrapper-11.1.0/bin/cc" "-Wl,-exported_symbols_list,/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rustcGxWFmY/list" "-arch" "x86_64" "-m64" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rustcGxWFmY/symbols.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.0.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.1.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.10.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.11.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.12.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.13.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.14.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.15.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.2.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.3.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.4.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.5.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.6.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.7.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.8.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.rpds.5a1a8e0c-cgu.9.rcgu.o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/rpds.48pqxhamsmkvfdf1.rcgu.o" "-L" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps" "-L" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/release/deps" "-L" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/librpds-4a124bc6e4ab60ab.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libarchery-123b0499b5a1cf9a.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libpyo3-8f6f7c0459f4e2f2.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libmemoffset-1e5eea6a397e643a.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libparking_lot-e559879f09deef0e.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libparking_lot_core-98dd77637c83f1c1.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libcfg_if-7c2ac38a84167a5c.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libsmallvec-9d43cb63ed7e62e2.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/liblock_api-03d4893ccabd1437.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libscopeguard-12f6759c6169d57e.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libpyo3_ffi-c0fd8aa3e8dcf666.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/liblibc-b9c4a97650ec358e.rlib" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/libunindent-c2fda657a9f6a08d.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libstd-749606e3c9c473dc.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libpanic_unwind-6d0d4bc9f9ff5e0b.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libobject-e8e98cdc2d316be1.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libmemchr-dba5b24ec3def1f3.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libaddr2line-b8c221754c5a4f20.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libgimli-1179b566276f0923.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_demangle-c648ea09f81d3e29.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libstd_detect-90388e06f59159de.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libhashbrown-9d77a105715d59ff.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libminiz_oxide-48460ddb5062967f.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libadler-88bbe7a98f070681.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_alloc-02604a7475f69144.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libunwind-24738642b9f9f11e.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libcfg_if-203043354fa7bdd3.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/liblibc-c87f5a461e89dba5.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/liballoc-5cd506f86c2d7435.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_core-3e7828a39a7934ae.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libcore-47ecee688c956ec3.rlib" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-5a85a42de0691646.rlib" "-liconv" "-lSystem" "-lc" "-lm" "-L" "/nix/store/v4vxflcvkmdlbsmxzmpkfyx6hrngdl8b-rustc-1.70.0/lib/rustlib/x86_64-apple-darwin/lib" "-o" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/target/x86_64-apple-darwin/release/deps/librpds.dylib" "-Wl,-dead_strip" "-dynamiclib" "-Wl,-dylib" "-nodefaultlibs" "-undefined" "dynamic_lookup" "-Wl,-install_name,@rpath/rpds.cpython-310-darwin.so" "-s"
       >   = note: ld: warning: option -s is obsolete and being ignored
       >           ld: library not found for -liconv
       >           clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
       >
       >
       > error: could not compile `rpds-py` (lib) due to previous error
       > 💥 maturin failed
       >   Caused by: Failed to build a native library through cargo
       >   Caused by: Cargo build finished with "exit status: 101": `CARGO_ENCODED_RUSTFLAGS="-C\u{1f}target-feature=-crt-static" PYO3_ENVIRONMENT_SIGNATURE="cpython-3.10-64bit" PYO3_PYTHON="/nix/store/hqw3f4jgbinm4rzl4zm77hw9l76y6n1w-python3-3.10.12/bin/python3" PYTHON_SYS_EXECUTABLE="/nix/store/hqw3f4jgbinm4rzl4zm77hw9l76y6n1w-python3-3.10.12/bin/python3" "cargo" "rustc" "--jobs" "10" "--features" "pyo3/extension-module" "--target" "x86_64-apple-darwin" "--message-format" "json-render-diagnostics" "--frozen" "--manifest-path" "/private/tmp/nix-build-python3.10-rpds-py-0.9.2.drv-0/rpds_py-0.9.2/Cargo.toml" "--release" "--lib" "--" "-C" "link-arg=-undefined" "-C" "link-arg=dynamic_lookup" "-C" "link-args=-Wl,-install_name,@rpath/rpds.cpython-310-darwin.so" "-C" "link-arg=-s"`
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
