### PR TITLE
mcumgr: init at unstable-2022-10-04

### DIFF
--- a/pkgs/tools/admin/mcumgr/default.nix
+++ b/pkgs/tools/admin/mcumgr/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub, testers, mcumgr }:
+
+buildGoModule rec {
+  pname = "mcumgr";
+  version = "unstable-2022-10-04";
+
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "mynewt-mcumgr-cli";
+    rev = "5c56bd24066c780aad5836429bfa2ecc4f9a944c";
+    hash = "sha256-WyaDnCRyZRwOkZyzNp1ouhNY5HuAvU6U3yUjiB5m+uE=";
+  };
+
+  vendorHash = "sha256-EPwV47zeBqxQPtD9QeQTKB64PmMt4HYseg38cI/owwE=";
+
+  postPatch = ''
+    substituteInPlace mcumgr/mcumgr.go \
+      --replace 'VersionString: "0.0.0-dev"' 'VersionString: "${version}"'
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = mcumgr;
+    command = "mcumgr version";
+    inherit version;
+  };
+
+  meta = {
+    description = "Tool to communicate with and manage remote devices running an mcumgr server";
+    homepage = "https://github.com/apache/mynewt-mcumgr-cli/";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ pkharvey ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1776,6 +1776,8 @@ with pkgs;
 
   mbidled = callPackage ../tools/networking/mbidled { };
 
+  mcumgr = callPackage ../tools/admin/mcumgr { };
+
   metapixel = callPackage ../tools/graphics/metapixel { };
 
   memos = callPackage ../servers/memos { };


### PR DESCRIPTION
###### Description of changes

Adds mcumgr, a program for flashing devices with mcuboot 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
