### PR TITLE
nixos/nix-daemon: change regular if to mkIf

### DIFF
--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -168,14 +168,16 @@ in
 
     systemd.packages = [ nixPackage ];
 
-    systemd.tmpfiles =
-      if (isNixAtLeast "2.8") then {
+    systemd.tmpfiles = mkMerge [
+      (mkIf (isNixAtLeast "2.8") {
         packages = [ nixPackage ];
-      } else {
+      })
+      (mkIf (!isNixAtLeast "2.8") {
         rules = [
           "d /nix/var/nix/daemon-socket 0755 root root - -"
         ];
-      };
+      })
+    ];
 
     systemd.sockets.nix-daemon.wantedBy = [ "sockets.target" ];
 


### PR DESCRIPTION
###### Description of changes

I think there's a mistake at [nixos/modules/services/system/nix-daemon.nix line 171](https://github.com/NixOS/nixpkgs/blob/a8ba422f71f83858209f2312e942e71f5c8f7cd3/nixos/modules/services/system/nix-daemon.nix#L171) since af8206f8011d8568d34d19428e288b7ebaa4d36b.
It uses a regular if statement even though the condition uses `config`, which could lead to infinite recursion.


```nix
cfg = config.nix;
nixPackage = cfg.package.out;
isNixAtLeast = versionAtLeast (getVersion nixPackage);

...;

systemd.tmpfiles =
  if (isNixAtLeast "2.8") then {  # Problem here
    packages = [ nixPackage ];
  } else {
    rules = [
      "d /nix/var/nix/daemon-socket 0755 root root - -"
    ];
  };
```

So I changed it to `mkMerge` and 2 `mkIf`.

Am I correct? I asked in Matrix but got no response, so I figured I'll just create a PR.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
