### PR TITLE
csvs-to-sqlite: 1.2 -> 1.3

### DIFF
--- a/pkgs/tools/misc/csvs-to-sqlite/default.nix
+++ b/pkgs/tools/misc/csvs-to-sqlite/default.nix
@@ -1,35 +1,34 @@
-{ lib, python3, fetchFromGitHub }:
+{ lib, python3, fetchFromGitHub, fetchpatch }:
 
-let
-  # csvs-to-sqlite is currently not compatible with Click 8. See the following
-  # https://github.com/simonw/csvs-to-sqlite/issues/80
-  #
-  # Workaround the issue by providing click 7 explicitly.
-  python = python3.override {
-    packageOverrides = self: super: {
-      # Use click 7
-      click = super.click.overridePythonAttrs (old: rec {
-        version = "7.1.2";
-        src = old.src.override {
-          inherit version;
-          hash = "sha256-0rUlXHxjSbwb0eWeCM0SrLvWPOZJ8liHVXg6qU37axo=";
-        };
-      });
-    };
-  };
-in with python.pkgs; buildPythonApplication rec {
+with python3.pkgs; buildPythonApplication rec {
   pname = "csvs-to-sqlite";
-  version = "1.2";
+  version = "1.3";
   format = "setuptools";
-
-  disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = pname;
     rev = version;
-    hash = "sha256-ZG7Yto8q9QNNJPB/LMwzucLfCGiqwBd3l0ePZs5jKV0";
+    hash = "sha256-wV6htULG3lg2IhG2bXmc/9vjcK8/+WA7jm3iJu4ZoOE=";
   };
+
+  patches = [
+    # https://github.com/simonw/csvs-to-sqlite/pull/92
+    (fetchpatch {
+      name = "pandas2-compatibility-1.patch";
+      url = "https://github.com/simonw/csvs-to-sqlite/commit/fcd5b9c7485bc7b95bf2ed9507f18a60728e0bcb.patch";
+      hash = "sha256-ZmaNWxsqeNw5H5gAih66DLMmzmePD4no1B5mTf8aFvI=";
+    })
+    (fetchpatch {
+      name = "pandas2-compatibility-2.patch";
+      url = "https://github.com/simonw/csvs-to-sqlite/commit/3d190aa44e8d3a66a9a3ca5dc11c6fe46da024df.patch";
+      hash = "sha256-uYUH0Mhn6LIf+AHcn6WuCo5zFuSNWOZBM+AoqkmMnSI=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
 
   propagatedBuildInputs = [
     click
@@ -39,8 +38,18 @@ in with python.pkgs; buildPythonApplication rec {
     six
   ];
 
+  pythonRelaxDeps = [
+    "click"
+  ];
+
   nativeCheckInputs = [
+    cogapp
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Test needs to be adjusted for click >= 8.
+    "test_if_cog_needs_to_be_run"
   ];
 
   meta = with lib; {
@@ -49,5 +58,4 @@ in with python.pkgs; buildPythonApplication rec {
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };
-
 }


### PR DESCRIPTION
https://github.com/simonw/csvs-to-sqlite/releases/tag/1.3

1. Remove pin on click 7, because except for one unit test that checks the help output too strictly, the app still works with click 8.

2. Pull in patches that make the app compatible with pandas 2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
