### PR TITLE
das: 0.3.6 -> 0.3.8

### DIFF
--- a/pkgs/tools/security/das/default.nix
+++ b/pkgs/tools/security/das/default.nix
@@ -5,19 +5,20 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "das";
-  version = "0.3.6";
+  version = "0.3.8";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "snovvcrash";
     repo = "DivideAndScan";
     rev = "refs/tags/v${version}";
-    hash = "sha256-UFuIy19OUiS8VmmfGm0F4hI4s4BU5b4ZVh40bFGiLfk=";
+    hash = "sha256-a9gnEBTvZshw42M/GrpCgjZh6FOzL45aZqGRyeHO0ec=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'networkx = "^2.8.4"' 'networkx = "*"'
+      --replace 'networkx = "^2.8.4"' 'networkx = "*"' \
+      --replace 'pandas = "^1.4.2"' 'pandas = "*"'
   '';
 
   nativeBuildInputs = with python3.pkgs; [


### PR DESCRIPTION
###### Description of changes

https://github.com/snovvcrash/DivideAndScan/compare/v0.3.6...v0.3.8

Plus we relax the pandas constraint in preparation for updating pandas to >= 2. We can clean it up if https://github.com/snovvcrash/DivideAndScan/pull/8 is merged and released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
