### PR TITLE
vector: compatibility with rust 1.71

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -45,6 +45,10 @@ rustPlatform.buildRustPackage {
     hash = "sha256-+ATOHx+LQLQV4nMdj1FRRvDTqGCTbX9kl290AbY9Vw0=";
   };
 
+  patches = [
+    ./rust-1.71-unnecessary-mut.diff
+  ];
+
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {

--- a/pkgs/tools/misc/vector/rust-1.71-unnecessary-mut.diff
+++ b/pkgs/tools/misc/vector/rust-1.71-unnecessary-mut.diff
@@ -1,0 +1,22 @@
+diff --git a/lib/vector-core/src/tls/incoming.rs b/lib/vector-core/src/tls/incoming.rs
+index 5d2fd1cdb..7992f2c2b 100644
+--- a/lib/vector-core/src/tls/incoming.rs
++++ b/lib/vector-core/src/tls/incoming.rs
+@@ -263,7 +263,7 @@ impl MaybeTlsIncomingStream<TcpStream> {
+     where
+         F: FnOnce(Pin<&mut MaybeTlsStream<TcpStream>>, &mut Context) -> Poll<io::Result<T>>,
+     {
+-        let mut this = self.get_mut();
++        let this = self.get_mut();
+         loop {
+             return match &mut this.state {
+                 StreamState::Accepted(stream) => poll_fn(Pin::new(stream), cx),
+@@ -307,7 +307,7 @@ impl AsyncWrite for MaybeTlsIncomingStream<TcpStream> {
+     }
+ 
+     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+-        let mut this = self.get_mut();
++        let this = self.get_mut();
+         match &mut this.state {
+             StreamState::Accepted(stream) => match Pin::new(stream).poll_shutdown(cx) {
+                 Poll::Ready(Ok(())) => {


### PR DESCRIPTION
###### Description of changes

In Rust 1.71, the compiler is smarter and notices two places where `mut` is unnecessary and fails vector's build. I reported it upstream at https://github.com/vectordotdev/vector/issues/17978. In the meantime, we can commit a patch so that this will continue to build once https://github.com/NixOS/nixpkgs/pull/243283 makes it to `master`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
