### PR TITLE
nixos/monado: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -77,6 +77,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [go-camo](https://github.com/cactus/go-camo), a secure image proxy server. Available as [services.go-camo](#opt-services.go-camo.enable).
 
+- [Monado](https://monado.freedesktop.org/), an open source XR runtime. Available as [services.monado](#opt-services.monado.enable).
+
 - [Clevis](https://github.com/latchset/clevis), a pluggable framework for automated decryption, used to unlock encrypted devices in initrd. Available as [boot.initrd.clevis.enable](#opt-boot.initrd.clevis.enable).
 
 - [TuxClocker](https://github.com/Lurkki14/tuxclocker), a hardware control and monitoring program. Available as [programs.tuxclocker](#opt-programs.tuxclocker.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -547,6 +547,7 @@
   ./services/hardware/lcd.nix
   ./services/hardware/lirc.nix
   ./services/hardware/nvidia-container-toolkit-cdi-generator
+  ./services/hardware/monado.nix
   ./services/hardware/nvidia-optimus.nix
   ./services/hardware/openrgb.nix
   ./services/hardware/pcscd.nix

--- a/nixos/modules/services/hardware/monado.nix
+++ b/nixos/modules/services/hardware/monado.nix
@@ -69,6 +69,7 @@ in
     };
 
     environment.systemPackages = [ cfg.package ];
+    environment.pathsToLink = [ "/share/openxr" ];
   };
 
   meta.maintainers = with lib.maintainers; [ Scrumplex ];

--- a/nixos/modules/services/hardware/monado.nix
+++ b/nixos/modules/services/hardware/monado.nix
@@ -79,6 +79,9 @@ in
         socketConfig = {
           ListenStream = "%t/monado_comp_ipc";
           RemoveOnStop = true;
+
+          # If Monado crashes while starting up, we want to close incoming OpenXR connections
+          FlushPending = true;
         };
 
         restartTriggers = [ cfg.package ];

--- a/nixos/modules/services/hardware/monado.nix
+++ b/nixos/modules/services/hardware/monado.nix
@@ -25,6 +25,8 @@ in
       source = "${cfg.package}/bin/monado-service";
     };
 
+    services.udev.packages = with pkgs; [ xr-hardware ];
+
     systemd.user = {
       services.monado = {
         description = "Monado XR runtime service module";

--- a/nixos/modules/services/hardware/monado.nix
+++ b/nixos/modules/services/hardware/monado.nix
@@ -1,0 +1,73 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  inherit (lib) mkDefault mkEnableOption mkIf mkPackageOption;
+
+  cfg = config.services.monado;
+in
+{
+  options.services.monado = {
+    enable = mkEnableOption "Monado wrapper and user service";
+
+    package = mkPackageOption pkgs "monado" { };
+  };
+
+  config = mkIf cfg.enable {
+    security.wrappers."monado-service" = {
+      setuid = false;
+      owner = "root";
+      group = "root";
+      # cap_sys_nice needed for asynchronous reprojection
+      capabilities = "cap_sys_nice+eip";
+      source = "${cfg.package}/bin/monado-service";
+    };
+
+    systemd.user = {
+      services.monado = {
+        description = "Monado XR runtime service module";
+        requires = [ "monado.socket" ];
+        conflicts = [ "monado-dev.service" ];
+
+        unitConfig.ConditionUser = "!root";
+
+        environment = {
+          # Default options
+          # https://gitlab.freedesktop.org/monado/monado/-/blob/4548e1738591d0904f8db4df8ede652ece889a76/src/xrt/targets/service/monado.in.service#L12
+          XRT_COMPOSITOR_LOG = mkDefault "debug";
+          XRT_PRINT_OPTIONS = mkDefault "on";
+          IPC_EXIT_ON_DISCONNECT = mkDefault "off";
+        };
+
+        serviceConfig = {
+          ExecStart = "${config.security.wrapperDir}/monado-service";
+          Restart = "no";
+        };
+
+        restartTriggers = [ cfg.package ];
+      };
+
+      sockets.monado = {
+        description = "Monado XR service module connection socket";
+        conflicts = [ "monado-dev.service" ];
+
+        unitConfig.ConditionUser = "!root";
+
+        socketConfig = {
+          ListenStream = "%t/monado_comp_ipc";
+          RemoveOnStop = true;
+        };
+
+        restartTriggers = [ cfg.package ];
+
+        wantedBy = [ "sockets.target" ];
+      };
+    };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ Scrumplex ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -535,6 +535,7 @@ in {
   mobilizon = handleTest ./mobilizon.nix {};
   mod_perl = handleTest ./mod_perl.nix {};
   molly-brown = handleTest ./molly-brown.nix {};
+  monado = handleTest ./monado.nix {};
   monica = handleTest ./web-apps/monica.nix {};
   mongodb = handleTest ./mongodb.nix {};
   moodle = handleTest ./moodle.nix {};

--- a/nixos/tests/monado.nix
+++ b/nixos/tests/monado.nix
@@ -1,0 +1,39 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "monado";
+
+  nodes.machine =
+    { pkgs, ... }:
+
+    {
+      hardware.opengl.enable = true;
+      users.users.alice = {
+        isNormalUser = true;
+        uid = 1000;
+      };
+
+      services.monado = {
+        enable = true;
+        defaultRuntime = true;
+      };
+      # Stop Monado from probing for any hardware
+      systemd.user.services.monado.environment.SIMULATED_ENABLE = "1";
+
+      environment.systemPackages = with pkgs; [ openxr-loader ];
+    };
+
+  testScript = { nodes, ... }:
+    let
+      userId = toString nodes.machine.users.users.alice.uid;
+      runtimePath = "/run/user/${userId}";
+    in
+    ''
+      machine.succeed("loginctl enable-linger alice")
+      machine.wait_for_unit("user@${userId}.service")
+
+      machine.wait_for_unit("monado.socket", "alice")
+      machine.systemctl("start monado.service", "alice")
+      machine.wait_for_unit("monado.service", "alice")
+
+      machine.succeed("su -- alice -c env XDG_RUNTIME_DIR=${runtimePath} openxr_runtime_list")
+    '';
+})

--- a/pkgs/applications/graphics/monado/default.nix
+++ b/pkgs/applications/graphics/monado/default.nix
@@ -41,6 +41,7 @@
 , wayland-scanner
 , libdrm
 , zlib
+, nixosTests
 # Set as 'false' to build monado without service support, i.e. allow VR
 # applications linking against libopenxr_monado.so to use OpenXR standalone
 # instead of via the monado-service program. For more information see:
@@ -136,6 +137,10 @@ stdenv.mkDerivation {
     # We don't have $HOME/.steam when building
     ./force-enable-steamvr_lh.patch
   ];
+
+  passthru.tests = {
+    basic-service = nixosTests.monado;
+  };
 
   meta = with lib; {
     description = "Open source XR runtime";

--- a/pkgs/by-name/xr/xr-hardware/package.nix
+++ b/pkgs/by-name/xr/xr-hardware/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab
+}: stdenvNoCC.mkDerivation {
+  pname = "xr-hardware";
+  version = "unstable-2023-11-08";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "monado/utilities";
+    repo = "xr-hardware";
+    rev = "9204de323210d2a5ab8635c2ee52127100de67b1";
+    hash = "sha256-ZS15WODms/WKsPu+WbfILO2BOwnxrhCY/SoF8jzOX5Q=";
+  };
+
+  installTargets = "install_package";
+  installFlagsArray = "DESTDIR=${placeholder "out"}";
+
+  meta = with lib; {
+    description = "Hardware description for XR devices";
+    homepage = "https://gitlab.freedesktop.org/monado/utilities/xr-hardware";
+    license = licenses.boost;
+    maintainers = with maintainers; [ Scrumplex ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Closes #275107

This module ensures that we have a monado.service that has CAP_SYS_NICE to utilize asynchronous reprojection. (See NixOS/nixpkgs#217119) for details about asynchronous reprojection)

This effectively shadows the unit files packaged in `monado`. Maybe it is desirable to remove those from the packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
