### PR TITLE
swayosd: refactor build to install all files

### DIFF
--- a/pkgs/applications/window-managers/sway/swayosd_systemd_paths.patch
+++ b/pkgs/applications/window-managers/sway/swayosd_systemd_paths.patch
@@ -1,0 +1,24 @@
+diff --git a/data/meson.build b/data/meson.build
+index fc687a5..68decdf 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -1,5 +1,6 @@
+ datadir = get_option('datadir')
+ sysconfdir = get_option('sysconfdir')
++libdir = get_option('libdir')
+ 
+ # LICENSE
+ install_data(
+@@ -41,11 +42,7 @@ configure_file(
+ 
+ # Systemd service unit
+ systemd = dependency('systemd', required: false)
+-if systemd.found()
+-  systemd_service_install_dir = systemd.get_variable(pkgconfig :'systemdsystemunitdir')
+-else
+-  systemd_service_install_dir = join_paths(libdir, 'systemd', 'system')
+-endif
++systemd_service_install_dir = join_paths(libdir, 'systemd', 'system')
+ 
+ configure_file(
+   configuration: conf_data,


### PR DESCRIPTION
###### Description of changes

The way swayosd was build missed the systemd and dbus files. This PR use the build scripts provided by the original package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
