### PR TITLE
gnmic: init at 0.31.3

### DIFF
--- a/pkgs/applications/networking/gnmic/default.nix
+++ b/pkgs/applications/networking/gnmic/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, buildPackages
+}:
+
+buildGoModule rec {
+  pname = "gnmic";
+  version = "0.31.3";
+
+  src = fetchFromGitHub {
+    owner = "openconfig";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-+TxOl+at/SQIC1x/LwCgk4JmvOPY2el7HE1reAkmVn8=";
+  };
+
+  vendorHash = "sha256-4cmFoDMgD9TKacZ2RD73kQKDrpN5xuSKZ4ikcWAd5Rw=";
+
+  ldflags = [
+    "-s" "-w"
+    "-X" "github.com/openconfig/gnmic/app.version=${version}"
+    "-X" "github.com/openconfig/gnmic/app.commit=${src.rev}"
+    "-X" "github.com/openconfig/gnmic/app.date=1970-01-01T00:00:00Z"
+  ];
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = let emulator = stdenv.hostPlatform.emulator buildPackages; in ''
+    installShellCompletion --cmd gnmic \
+      --bash <(${emulator} $out/bin/gnmic completion bash) \
+      --fish <(${emulator} $out/bin/gnmic completion fish) \
+      --zsh  <(${emulator} $out/bin/gnmic completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "gNMI CLI client and collector";
+    homepage = "https://gnmic.openconfig.net/";
+    changelog = "https://github.com/openconfig/gnmic/releases/tag/${src.rev}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ vincentbernat ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31212,6 +31212,8 @@ with pkgs;
 
   globe-cli = callPackage ../applications/misc/globe-cli { };
 
+  gnmic = callPackage ../applications/networking/gnmic { };
+
   gnss-sdr = callPackage ../applications/radio/gnss-sdr { };
 
   gnuradio = callPackage ../applications/radio/gnuradio/wrapper.nix {


### PR DESCRIPTION
###### Description of changes

This is a gNMI client, useful to query routers through a YANG model (instead of using SNMP for example). https://gnmic.openconfig.net

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
