### PR TITLE
apktool: 2.8.0 -> 2.8.1 and use free aapt

### DIFF
--- a/pkgs/development/tools/aapt/default.nix
+++ b/pkgs/development/tools/aapt/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenvNoCC
+, fetchzip
+, autoPatchelfHook
+, libcxx
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "aapt";
+  version = "8.0.2-9289358";
+
+  src =
+    let
+      urlAndHash =
+        if stdenvNoCC.isLinux then {
+          url = "https://dl.google.com/android/maven2/com/android/tools/build/aapt2/${version}/aapt2-${version}-linux.jar";
+          hash = "sha256-P8eVIS6zaZGPh4Z7SXUiLtZaX1YIsSmGOdvF6Xb1WHI=";
+        } else if stdenvNoCC.isDarwin then {
+          url = "https://dl.google.com/android/maven2/com/android/tools/build/aapt2/${version}/aapt2-${version}-osx.jar";
+          hash = "sha256-hDfEPk3IJt+8FbRVEiHQbn24vsuOe6m36UcQsT6tGsQ=";
+        } else throw "Unsupport platform: ${stdenvNoCC.system}";
+    in
+    fetchzip (urlAndHash // {
+      extension = "zip";
+      stripRoot = false;
+    });
+
+  nativeBuildInputs = lib.optionals stdenvNoCC.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenvNoCC.isLinux [ libcxx ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D aapt2 $out/bin/aapt2
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A build tool that compiles and packages Android app's resources";
+    homepage = "https://developer.android.com/tools/aapt2";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ linsui ];
+    platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}
+

--- a/pkgs/development/tools/apktool/default.nix
+++ b/pkgs/development/tools/apktool/default.nix
@@ -1,15 +1,21 @@
-{ lib, stdenv, fetchurl, makeWrapper, jre, build-tools }:
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, jdk_headless
+, aapt
+}:
 
 stdenv.mkDerivation rec {
   pname = "apktool";
-  version = "2.8.0";
+  version = "2.8.1";
 
   src = fetchurl {
     urls = [
       "https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${version}.jar"
       "https://github.com/iBotPeaches/Apktool/releases/download/v${version}/apktool_${version}.jar"
     ];
-    sha256 = "sha256-szEyPr8yXWPhM3WmFHkV+drASPDx+GeDgG+SWUF0jbw=";
+    hash = "sha256-e0qOFwPiKNIG2ylkS3EUFofYoRG1WwObCLAt+kQ6sPk=";
   };
 
   dontUnpack = true;
@@ -19,23 +25,20 @@ stdenv.mkDerivation rec {
   sourceRoot = ".";
 
   installPhase =
-    let
-      tools = builtins.head build-tools;
-    in ''
+    ''
       install -D ${src} "$out/libexec/apktool/apktool.jar"
       mkdir -p "$out/bin"
-      makeWrapper "${jre}/bin/java" "$out/bin/apktool" \
+      makeWrapper "${jdk_headless}/bin/java" "$out/bin/apktool" \
           --add-flags "-jar $out/libexec/apktool/apktool.jar" \
-          --prefix PATH : "${tools}/libexec/android-sdk/build-tools/${tools.version}"
+          --prefix PATH : ${lib.getBin aapt}
     '';
 
   meta = with lib; {
     description = "A tool for reverse engineering Android apk files";
-    homepage    = "https://ibotpeaches.github.io/Apktool/";
+    homepage = "https://ibotpeaches.github.io/Apktool/";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license     = licenses.asl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ offline ];
-    platforms   = with platforms; unix;
+    platforms = with platforms; unix;
   };
-
 }

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -18,7 +18,6 @@
 , dtc
 , e2fsprogs
 , enableBloat ? true
-, enableUnfree ? false
 , enjarify
 , fetchurl
 , file
@@ -174,6 +173,7 @@ python3.pkgs.buildPythonApplication rec {
       abootimg
       apksigcopier
       apksigner
+      apktool
       cbfstool
       colord
       enjarify
@@ -214,8 +214,6 @@ python3.pkgs.buildPythonApplication rec {
     ++ lib.optionals stdenv.isLinux [ oggvideotools ]
     # This doesn't work on aarch64-darwin
     ++ lib.optionals (stdenv.hostPlatform != "aarch64-darwin") [ gnumeric ]
-    # apktool depend on build-tools which requires Android SDK acceptance, therefore, the whole thing is unfree
-    ++ lib.optionals enableUnfree [ apktool ]
   ));
 
   nativeCheckInputs = with python3.pkgs; [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3055,9 +3055,7 @@ with pkgs;
 
   apksigner = callPackage ../development/tools/apksigner { };
 
-  apktool = callPackage ../development/tools/apktool {
-    inherit (androidenv.androidPkgs_9_0) build-tools;
-  };
+  apktool = callPackage ../development/tools/apktool { };
 
   appimage-run = callPackage ../tools/package-management/appimage-run { };
   appimage-run-tests = callPackage ../tools/package-management/appimage-run/test.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39811,6 +39811,8 @@ with pkgs;
 
   aaphoto = callPackage ../tools/graphics/aaphoto { };
 
+  aapt = callPackage ../development/tools/aapt { };
+
   flam3 = callPackage ../tools/graphics/flam3 { };
 
   glee = callPackage ../tools/graphics/glee { };


### PR DESCRIPTION
###### Description of changes

The android sdk is licensed under an unfree license but the aapt from Google Maven is [licensed under Apache-2.0 only](https://maven.google.com/web/index.html#com.android.tools.build:aapt2:8.0.2-9289358). So I extract it there for a free aapt package. This also decrease the closure size of apktool from 2.2G to 599.5M.

Since apktool is free now, the unfree flag in diffoscope is not needed anymore.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
