### PR TITLE
 nixos/nix-channel: only try to remove the nix-channel binary if it exists

### DIFF
--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -86,7 +86,7 @@ in
       '';
 
     environment.extraSetup = mkIf (!cfg.channel.enable) ''
-      rm $out/bin/nix-channel
+      rm --force $out/bin/nix-channel
     '';
 
     # NIX_PATH has a non-empty default according to Nix docs, so we don't unset

--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -3,8 +3,8 @@
   configuration to work.
 
   See also
-   - ./nix.nix
-   - ./nix-flakes.nix
+  - ./nix.nix
+  - ./nix-flakes.nix
  */
 { config, lib, ... }:
 let
@@ -28,9 +28,9 @@ in
             Whether the `nix-channel` command and state files are made available on the machine.
 
             The following files are initialized when enabled:
-             - `/nix/var/nix/profiles/per-user/root/channels`
-             - `/root/.nix-channels`
-             - `$HOME/.nix-defexpr/channels` (on login)
+              - `/nix/var/nix/profiles/per-user/root/channels`
+              - `/root/.nix-channels`
+              - `$HOME/.nix-defexpr/channels` (on login)
 
             Disabling this option will not remove the state files from the system.
           '';
@@ -48,7 +48,7 @@ in
             "nixos-config=/etc/nixos/configuration.nix"
             "/nix/var/nix/profiles/per-user/root/channels"
           ]
-          else [];
+          else [ ];
         defaultText = ''
           if nix.channel.enable
           then [


### PR DESCRIPTION
###### Description of changes

~~Since #242098 we remove the `nix-channel` binary from the system path if the nix channel is disabled. This binary is not necessarily present though, for instance when `system.disableInstallerTools` is true. So we introduce a test to check whether it exists before removing it.~~

EDIT: my analysis was wrong, I think @xaverdh below is correct. The fix remains the same though.

Ping: @roberth 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
