### PR TITLE
mqtt_cpp: init at 13.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15560,6 +15560,10 @@
     githubId = 7669898;
     name = "Katharina Fey";
   };
+  spalf = {
+    email = "tom@tombarrett.xyz";
+    name = "tom barrett";
+  };
   spease = {
     email = "peasteven@gmail.com";
     github = "spease";

--- a/pkgs/development/libraries/mqtt_cpp/default.nix
+++ b/pkgs/development/libraries/mqtt_cpp/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  boost,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mqtt_cpp";
+  version = "13.2.1";
+
+  src = fetchFromGitHub {
+    owner = "redboltz";
+    repo = "mqtt_cpp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-E5dMZ0uJ1AOwiGTxD4qhbO72blplmXHh1gTYGE34H+0=";
+  };
+
+  nativeBuildInputs = [cmake];
+
+  buildInputs = [boost];
+
+  meta = with lib; {
+    description = "MQTT client/server for C++14 based on Boost.Asio";
+    homepage = "https://github.com/redboltz/mqtt_cpp";
+    license = licenses.boost;
+    maintainers = with maintainers; [spalf];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10563,6 +10563,8 @@ with pkgs;
 
   mpw = callPackage ../tools/security/mpw { };
 
+  mqtt_cpp = callPackage ../development/libraries/mqtt_cpp { };
+
   mr = callPackage ../applications/version-management/mr { };
 
   mrsh = callPackage ../shells/mrsh { };


### PR DESCRIPTION
###### Description of changes

added new package:
https://github.com/redboltz/mqtt_cpp

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


I bulit another tool depending on this, looked to work well.