### PR TITLE
bash: disable parallel building on darwin

### DIFF
--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -90,7 +90,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = lib.optional interactive readline;
 
-  enableParallelBuilding = true;
+  # parallel building on darwin can result in
+  # libintl.h not being put in place early enough
+  enableParallelBuilding = !stdenv.isDarwin;
 
   makeFlags = lib.optionals stdenv.hostPlatform.isCygwin [
     "LOCAL_LDFLAGS=-Wl,--export-all,--out-implib,libbash.dll.a"


### PR DESCRIPTION
###### Description of changes

On darwin with many CPUs building bash will sometimes fail with:

```
make[2]: warning: -j8 forced in submake: resetting jobserver mode.
cp ./libgnuintl.h.in libgnuintl.h
In file included from unwind_prot.c:51:
In file included from ./bashintl.h:30:
./include/gettext.h:27:11: fatal error: 'libintl.h' file not found
# include <libintl.h>
          ^~~~~~~~~~~
1 error generated.
clang  -DPROGRAM='"bash"' -DCONF_HOSTTYPE='"x86_64"' -DCONF_OSTYPE='"darwin19.6.0"' -DCONF_MACHTYPE='"x86_64-apple-darwin19.6.0"' -DCONF_VENDOR='"apple"' -DLOCALEDIR='"/nix/store/mfgsqk1kbd3faz18plkmjj5ng81spww6-bash-5.2-p15/share/locale"' -DPACKAGE='"bash"' -DSHELL -DHAVE_CONFIG_H -DMACOSX   -I.  -I. -I./include -I./lib -I./lib/intl -I/private/tmp/nix-build-bash-5.2-p15.drv-0/bash-5.2/lib/intl -Wno-parentheses -Wno-format-security   -g -O2 -c dispose_cmd.c
make: *** [Makefile:106: unwind_prot.o] Error 1
make: *** Waiting for unfinished jobs....
cmp libgnuintl.h libintl.h || cp libgnuintl.h libintl.h
cmp: libintl.h: No such file or directory
make[2]: Leaving directory '/private/tmp/nix-build-bash-5.2-p15.drv-0/bash-5.2/lib/intl
```

where it can be clearly seen that `libintl.h` is being put in place too late. Disabling parallelism resolves the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
