### PR TITLE
localproxy: init at 3.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15645,6 +15645,8 @@
   spalf = {
     email = "tom@tombarrett.xyz";
     name = "tom barrett";
+    github = "70m6";
+    githubId = 105207964;
   };
   spease = {
     email = "peasteven@gmail.com";

--- a/pkgs/applications/networking/localproxy/default.nix
+++ b/pkgs/applications/networking/localproxy/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, openssl
+, protobuf3_19
+, catch2
+, boost181
+, icu
+}:
+let
+  boost = boost181.override { enableStatic = true; };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "localproxy";
+  version = "3.1.0";
+
+    src = fetchFromGitHub {
+      owner = "aws-samples";
+      repo = "aws-iot-securetunneling-localproxy";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-ec72bvBkRBj4qlTNfzNPeQt02OfOPA8y2PoejHpP9cY=";
+    };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ openssl protobuf3_19 catch2 boost icu ];
+
+  # causes redefinition of _FORTIFY_SOURCE
+  hardeningDisable = [ "fortify3" ];
+
+    meta = with lib; {
+      description = "AWS IoT Secure Tunneling Local Proxy Reference Implementation C++";
+      homepage = "https://github.com/aws-samples/aws-iot-securetunneling-localproxy";
+      license = licenses.asl20;
+      maintainers = with maintainers; [spalf];
+      platforms = platforms.unix;
+    };
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10265,6 +10265,8 @@ with pkgs;
 
   lmp = callPackage ../tools/security/lmp { };
 
+  localproxy = callPackage ../applications/networking/localproxy { };
+
   localstack = with python3Packages; toPythonApplication localstack;
 
   localtime = callPackage ../tools/system/localtime { };


### PR DESCRIPTION
###### Description of changes

added the localproxy binary from aws
one thing to note, the repo suggests protobuf 3.17, although that seems to be deprecated by nixpkgs
I tested it using 3.19, and looked to have no issues 

This PR closes #137163

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

