### PR TITLE
nixos/stunnel: Allow "accept" _or_ "sni" in server configs

### DIFF
--- a/nixos/modules/services/networking/stunnel.nix
+++ b/nixos/modules/services/networking/stunnel.nix
@@ -7,9 +7,9 @@ let
   cfg = config.services.stunnel;
   yesNo = val: if val then "yes" else "no";
 
-  verifyRequiredField = type: field: n: c: {
-    assertion = hasAttr field c;
-    message =  "stunnel: \"${n}\" ${type} configuration - Field ${field} is required.";
+  verifyRequiredField = type: fields: n: c: {
+    assertion = any (field: hasAttr field c) fields;
+    message =  "stunnel: \"${n}\" ${type} configuration - Field ${concatStringsSep " or " fields} is required.";
   };
 
   verifyChainPathAssert = n: c: {
@@ -144,11 +144,11 @@ in
       })
 
       (mapAttrsToList verifyChainPathAssert cfg.clients)
-      (mapAttrsToList (verifyRequiredField "client" "accept") cfg.clients)
-      (mapAttrsToList (verifyRequiredField "client" "connect") cfg.clients)
-      (mapAttrsToList (verifyRequiredField "server" "accept") cfg.servers)
-      (mapAttrsToList (verifyRequiredField "server" "cert") cfg.servers)
-      (mapAttrsToList (verifyRequiredField "server" "connect") cfg.servers)
+      (mapAttrsToList (verifyRequiredField "client" ["accept"]) cfg.clients)
+      (mapAttrsToList (verifyRequiredField "client" ["connect"]) cfg.clients)
+      (mapAttrsToList (verifyRequiredField "server" ["accept" "sni"]) cfg.servers)
+      (mapAttrsToList (verifyRequiredField "server" ["cert"]) cfg.servers)
+      (mapAttrsToList (verifyRequiredField "server" ["connect"]) cfg.servers)
     ];
 
     environment.systemPackages = [ pkgs.stunnel ];


### PR DESCRIPTION
###### Description of changes

The current stunnel module requires server configs to have an `accept` field.  But there are legal stunnel configs that do not contain an `accept` field.  In particular, using [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) requires configurations without an `accept` field.

This PR loosens this requirement, allowing a config to contain _either_ the  `accept` field _or_ the `sni` field.

This PR also adds a test case for stunnel SNI functionality.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
