### PR TITLE
opcua-client-gui: enable on darwin

### DIFF
--- a/pkgs/development/python-modules/asyncua/default.nix
+++ b/pkgs/development/python-modules/asyncua/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , aiofiles
 , aiosqlite
 , buildPythonPackage
@@ -58,6 +59,17 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "asyncua"
+  ];
+
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # Failed: DID NOT RAISE <class 'asyncio.exceptions.TimeoutError'>
+    "test_publish"
+    # OSError: [Errno 48] error while attempting to bind on address ('127.0.0.1',...
+    "test_anonymous_rejection"
+    "test_certificate_handling_success"
+    "test_encrypted_private_key_handling_success"
+    "test_encrypted_private_key_handling_success_with_cert_props"
+    "test_encrypted_private_key_handling_failure"
   ];
 
   meta = with lib; {

--- a/pkgs/misc/opcua-client-gui/default.nix
+++ b/pkgs/misc/opcua-client-gui/default.nix
@@ -1,22 +1,32 @@
 { lib
-, python3
+, stdenv
+, python3Packages
 , fetchFromGitHub
 , makeDesktopItem
 , copyDesktopItems
+, desktopToDarwinBundle
+, wrapQtAppsHook
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "opcua-client-gui";
   version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = "FreeOpcUa";
-    repo = pname;
+    repo = "opcua-client-gui";
     rev = version;
     hash = "sha256-0BH1Txr3z4a7iFcsfnovmBUreXMvIX2zpZa8QivQVx8=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  nativeBuildInputs = [ copyDesktopItems wrapQtAppsHook ]
+    ++ lib.optionals stdenv.isDarwin [ desktopToDarwinBundle ];
+
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
     pyqt5
     asyncua
     opcua-widgets
@@ -43,7 +53,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = with lib; {
     description = "OPC UA GUI Client";
     homepage = "https://github.com/FreeOpcUa/opcua-client-gui";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ janik ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33609,7 +33609,7 @@ with pkgs;
 
   opcr-policy = callPackage ../development/tools/opcr-policy { };
 
-  opcua-client-gui = callPackage ../misc/opcua-client-gui { };
+  opcua-client-gui = libsForQt5.callPackage ../misc/opcua-client-gui { };
 
   open-policy-agent = callPackage ../development/tools/open-policy-agent { };
 


### PR DESCRIPTION
###### Description of changes
* enable on darwin
* add missed `copyDesktopItems` and `wrapQtAppsHook`
* fix `asyncua` build on darwin (disable some tests)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
