### PR TITLE
ldid-procursus: init at 2.1.5-procursus7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8664,6 +8664,11 @@
     githubId = 762421;
     name = "Pierre Thierry";
   };
+  keto = {
+    github = "TheRealKeto";
+    githubId = 24854941;
+    name = "Keto";
+  };
   ketzacoatl = {
     email = "ketzacoatl@protonmail.com";
     github = "ketzacoatl";

--- a/pkgs/development/tools/ldid-procursus/default.nix
+++ b/pkgs/development/tools/ldid-procursus/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, libplist
+, openssl
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ldid-procursus";
+  version = "2.1.5-procursus7";
+  src = fetchFromGitHub {
+    owner = "ProcursusTeam";
+    repo = "ldid";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-QnSmWY9zCOPYAn2VHc5H+VQXjTCyr0EuosxvKGGpDtQ=";
+  };
+  nativeBuildInputs = [ pkg-config libplist openssl ];
+  stripDebugFlags = [ "--strip-unneeded" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = with lib; {
+    description = "Put real or fake signatures in a Mach-O binary";
+    homepage = "https://github.com/ProcursusTeam/ldid";
+    maintainers = with maintainers; [ keto ];
+    platforms = platforms.unix;
+    license = licenses.agpl3Only;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41397,6 +41397,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
+  ldid-procursus = callPackage ../development/tools/ldid-procursus { };
+
   xcolor = callPackage ../tools/graphics/xcolor { };
 
   xcfun = callPackage ../development/libraries/science/chemistry/xcfun { };


### PR DESCRIPTION
###### Description of changes

While `nixpkgs` already hosts ldid, a tool made by saurik for modifying a binary's entitlements, this fork is a more up-to-date version, updated to support newer versions of Apple software releases as well as Linux.

Although the original, official packages is still maintained by saurik, he discourages contributions by having a process to submit patches missing from any kind of documentation. Adding this fork also helps with several software that the jailbreaking community depends on, such as [Theos](https://theos.dev); the aforementioned community has progressively began to consider this fork as "standard" or "mainstream" due to the openness to accept contributions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
