### PR TITLE
planner: init at 0.14.91

### DIFF
--- a/pkgs/applications/office/planner/default.nix
+++ b/pkgs/applications/office/planner/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, desktop-file-utils
+, gsettings-desktop-schemas
+, glib
+, gtk3
+, libgda
+, libxml2
+, libxslt
+, makeWrapper
+, meson
+, ninja
+, pkg-config
+, shared-mime-info
+}:
+
+stdenv.mkDerivation rec {
+  pname = "planner";
+  version = "0.14.91";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
+    repo = "planner";
+    rev = version;
+    hash = "sha256-LxctZv/CKolJ1I4Hql20E+/+p+ZoJLR1eZe34HPMqvY=";
+  };
+
+  postPatch = ''
+    patchShebangs \
+      meson_post_install.sh \
+      tools/strip_trailing_white_space.sh \
+      tests/python/task-test.py
+  '';
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    makeWrapper
+    meson
+    ninja
+    pkg-config
+    shared-mime-info
+  ];
+
+  buildInputs = [
+    libgda
+    libxml2
+    libxslt
+    glib
+    gsettings-desktop-schemas
+    gtk3
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/planner \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/planner-${version}"
+  '';
+
+  meta = {
+    description = "Project management tool for the GNOME desktop";
+    homepage = "https://wiki.gnome.org/Apps/Planner";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ amiloradovsky ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1354,7 +1354,6 @@ mapAliases ({
   pixie = throw "pixie has been removed: abandoned by upstream"; # Added 2022-04-21
   pkgconfig = pkg-config; # Added 2018-02-02, moved to aliases.nix 2021-01-18
   pkgconfigUpstream = throw "'pkgconfigUpstream' has been renamed to/replaced by 'pkg-configUpstream'"; # Converted to throw 2022-02-22
-  planner = throw "planner has been removed from nixpkgs, as it is no longer developed and still uses python2/PyGTK"; # Added 2021-02-02
   pleroma-otp = pleroma; # Added 2021-07-10
   plexpy = throw "'plexpy' has been renamed to/replaced by 'tautulli'"; # Converted to throw 2022-02-22
   pltScheme = racket; # just to be sure

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32215,6 +32215,8 @@ with pkgs;
 
   pixinsight = libsForQt5.callPackage ../applications/graphics/pixinsight { };
 
+  planner = callPackage ../applications/office/planner { };
+
   please-cli = callPackage ../applications/misc/please-cli { };
 
   protonup-qt = python3Packages.callPackage ../applications/misc/protonup-qt { };


### PR DESCRIPTION
###### Description of changes

Planner has been removed 2+ years ago, because it wasn't maintained for a long time, but now it seems to be maintained again and doesn't pull up the ancient dependencies anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
