### PR TITLE
ocamlPackages: fixes for OCaml 5

### DIFF
--- a/pkgs/development/ocaml-modules/rfc7748/default.nix
+++ b/pkgs/development/ocaml-modules/rfc7748/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildDunePackage
 , fetchFromGitHub
+, fetchpatch
 , ocaml
 
 , ounit
@@ -16,6 +17,12 @@ buildDunePackage rec {
     repo = "ocaml-rfc7748";
     rev = "v${version}";
     sha256 = "sha256-mgZooyfxrKBVQFn01B8PULmFUW9Zq5HJfgHCSJSkJo4=";
+  };
+
+  # Compatibility with OCaml 5.0
+  patches = fetchpatch {
+    url = "https://github.com/burgerdev/ocaml-rfc7748/commit/f66257bae0317c7b24c4b208ee27ab6eb68460e4.patch";
+    hash = "sha256-780yy8gLOwwf7xIKIIIaoGpDPcY7+dZ0jPS4nrkH2s8=";
   };
 
   minimalOCamlVersion = "4.05";

--- a/pkgs/development/ocaml-modules/sosa/default.nix
+++ b/pkgs/development/ocaml-modules/sosa/default.nix
@@ -2,9 +2,8 @@
 , findlib, ocaml, ocamlbuild
 }:
 
-if lib.versionOlder ocaml.version "4.02"
-then throw "sosa is not available for OCaml ${ocaml.version}"
-else
+lib.throwIf (lib.versionOlder ocaml.version "4.02")
+  "sosa is not available for OCaml ${ocaml.version}"
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-sosa";
@@ -16,6 +15,13 @@ stdenv.mkDerivation rec {
     rev = "sosa.${version}";
     sha256 = "053hdv6ww0q4mivajj4iyp7krfvgq8zajq9d8x4mia4lid7j0dyk";
   };
+
+  postPatch = lib.optionalString (lib.versionAtLeast ocaml.version "4.07") ''
+    for p in functors list_of of_mutable
+    do
+      substituteInPlace src/lib/$p.ml --replace Pervasives. Stdlib.
+    done
+  '';
 
   nativeBuildInputs = [ ocaml ocamlbuild findlib ];
 

--- a/pkgs/development/ocaml-modules/xenstore-tool/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore-tool/default.nix
@@ -1,13 +1,15 @@
-{ buildDunePackage, xenstore_transport, xenstore, lwt }:
+{ buildDunePackage, camlp-streams, xenstore_transport, xenstore, lwt }:
 
 buildDunePackage {
   pname = "xenstore-tool";
 
   inherit (xenstore_transport) src version;
 
-  duneVersion = "3";
+  postPatch = ''
+    substituteInPlace cli/dune --replace 'libraries ' 'libraries camlp-streams '
+  '';
 
-  buildInputs = [ xenstore_transport xenstore lwt ];
+  buildInputs = [ camlp-streams xenstore_transport xenstore lwt ];
 
   meta = xenstore_transport.meta // {
     description = "Command line tool for interfacing with xenstore";


### PR DESCRIPTION
###### Description of changes

Minor patches to fix build with latest OCaml.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
