### PR TITLE
nixos/nextcloud: Move database options into freeForm settings

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -527,6 +527,9 @@
   "module-services-nextcloud-basic-usage": [
     "index.html#module-services-nextcloud-basic-usage"
   ],
+  "module-services-nextcloud-external-database": [
+    "index.html#module-services-nextcloud-external-database"
+  ],
   "module-services-nextcloud-pitfalls-during-upgrade": [
     "index.html#module-services-nextcloud-pitfalls-during-upgrade"
   ],

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -446,7 +446,7 @@ In addition to numerous new and updated packages, this release has the following
 - The `services.mastodon` module now supports connection to a remote `PostgreSQL` database.
 
 - [`services.nextcloud.database.createLocally`](#opt-services.nextcloud.database.createLocally) now uses socket authentication and is no longer compatible with password authentication.
-  - If you want the module to manage the database for you, unset [`services.nextcloud.config.dbpassFile`](#opt-services.nextcloud.config.dbpassFile) (and [`services.nextcloud.config.dbhost`](#opt-services.nextcloud.config.dbhost), if it's set).
+  - If you want the module to manage the database for you, unset `services.nextcloud.config.dbpassFile` and `services.nextcloud.config.dbhost`.
   - If you want to use password authentication **and** create the database locally, you will have to use [`services.mysql`](#opt-services.mysql.enable) to set it up.
 
 - [`services.nextcloud.config.objectstore.s3.sseCKeyFile`](#opt-services.nextcloud.config.objectstore.s3.sseCKeyFile) is a new option to enable server-side encryption with customer provided keys (SSE-C) for your S3 in Nextcloud.

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -704,7 +704,7 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
 - `services.networkmanager.extraConfig` was renamed to `services.networkmanager.settings` and changed to use the ini type instead of using a multiline string.
 
 - `services.nextcloud.config.dbport` option of the Nextcloud module was removed to match upstream.
-  The port can be specified in [`services.nextcloud.config.dbhost`](#opt-services.nextcloud.config.dbhost).
+  The port can be specified in [`services.nextcloud.settings.dbhost`](#opt-services.nextcloud.settings.dbhost).
 
 - `services.kavita` now uses the free-form option `services.kavita.settings` for the application settings file.
   The options `services.kavita.ipAdresses` and `services.kavita.port` now exist at `services.kavita.settings.IpAddresses`

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -248,6 +248,15 @@
   instead of the python tester launcher. You can still refer to the python
   launcher via `python3Packages.toPythonApplication python3Packages.playwright`
 
+- `services.nextcloud` has the following options of the `config` namespace moved into [`services.nextcloud.settings`](#opt-services.nextcloud.settings) and renamed to match the name from Nextcloud's `config.php`:
+  - `dbtype` -> [`dbtype`](#opt-services.nextcloud.settings.dbtype),
+  - `dbname` -> [`dbname`](#opt-services.nextcloud.settings.dbname),
+  - `dbuser` -> [`dbuser`](#opt-services.nextcloud.settings.dbuser),
+  - `dbhost` -> [`dbhost`](#opt-services.nextcloud.settings.dbhost) and
+  - `dbtableprefix` -> [`dbtableprefix`](#opt-services.nextcloud.settings.dbtableprefix).
+ Database password should now be supplied as `dbpass` variable via
+ [`secretFile`](#opt-services.nextcloud.secretFile).
+
 - The representation of the flags attributes as shell/environment variables for most Python building setup hooks are now the same as `stdenv.mkDerivation` and other build helpers -- they are space-separated environment variables when `__structuredAttrs = false` and Bash arrays when `__structuredAttrs = true`, and are concatenated to the command without Bash-evaluation. The following behaviour changes are introduced during the conversion:
 
   - The following flags are no longer Bash-expanded before concatenated to the command:
@@ -267,7 +276,7 @@
 
 - `ps3-disc-dumper` was updated to 4.2.5, which removed the CLI project and now exclusively offers the GUI
 
-- [](#opt-services.nextcloud.config.dbtype) is unset by default, the previous default was `sqlite`.
+- [](#opt-services.nextcloud.settings.dbtype) is unset by default, the previous default was `sqlite`.
   This was done because `sqlite` is not a reasonable default since it's
   [not recommended by upstream](https://docs.nextcloud.com/server/30/admin_manual/installation/system_requirements.html)
   and thus doesn't qualify as default.

--- a/nixos/modules/services/web-apps/nextcloud-notify_push.nix
+++ b/nixos/modules/services/web-apps/nextcloud-notify_push.nix
@@ -8,6 +8,7 @@
 
 let
   cfg = config.services.nextcloud.notify_push;
+  cfgD = config.services.nextcloud.notify_push.database;
   cfgN = config.services.nextcloud;
 in
 {
@@ -56,97 +57,118 @@ in
           This is useful when nextcloud's domain is not a static IP address and when the reverse proxy cannot be bypassed because the backend connection is done via unix socket.
         '';
       };
-    }
-    // (lib.genAttrs
-      [
-        "dbtype"
-        "dbname"
-        "dbuser"
-        "dbpassFile"
-        "dbhost"
-        "dbport"
-        "dbtableprefix"
-      ]
-      (
-        opt:
-        options.services.nextcloud.config.${opt}
-        // {
-          default = config.services.nextcloud.config.${opt};
-          defaultText = lib.literalExpression "config.services.nextcloud.config.${opt}";
-        }
-      )
-    );
 
-  config = lib.mkIf cfg.enable {
-    systemd.services = {
-      nextcloud-notify_push = {
-        description = "Push daemon for Nextcloud clients";
-        documentation = [ "https://github.com/nextcloud/notify_push" ];
-        after = [
-          "phpfpm-nextcloud.service"
-          "redis-nextcloud.service"
-        ];
-        wantedBy = [ "multi-user.target" ];
-        environment = {
-          NEXTCLOUD_URL = cfg.nextcloudUrl;
-          SOCKET_PATH = cfg.socketPath;
-          DATABASE_PREFIX = cfg.dbtableprefix;
-          LOG = cfg.logLevel;
-        };
-        script =
-          let
-            dbType = if cfg.dbtype == "pgsql" then "postgresql" else cfg.dbtype;
-            dbUser = lib.optionalString (cfg.dbuser != null) cfg.dbuser;
-            dbPass = lib.optionalString (cfg.dbpassFile != null) ":$DATABASE_PASSWORD";
-            dbHostHasPrefix = prefix: lib.hasPrefix prefix (toString cfg.dbhost);
-            isPostgresql = dbType == "postgresql";
-            isMysql = dbType == "mysql";
-            isSocket = (isPostgresql && dbHostHasPrefix "/") || (isMysql && dbHostHasPrefix "localhost:/");
-            dbHost = lib.optionalString (cfg.dbhost != null) (
-              if isSocket then lib.optionalString isMysql "@localhost" else "@${cfg.dbhost}"
-            );
-            dbOpts = lib.optionalString (cfg.dbhost != null && isSocket) (
-              if isPostgresql then
-                "?host=${cfg.dbhost}"
-              else if isMysql then
-                "?socket=${lib.removePrefix "localhost:" cfg.dbhost}"
-              else
-                throw "unsupported dbtype"
-            );
-            dbName = lib.optionalString (cfg.dbname != null) "/${cfg.dbname}";
-            dbUrl = "${dbType}://${dbUser}${dbPass}${dbHost}${dbName}${dbOpts}";
-          in
-          lib.optionalString (cfg.dbpassFile != null) ''
-            export DATABASE_PASSWORD="$(<"$CREDENTIALS_DIRECTORY/dbpass")"
-          ''
-          + ''
-            export DATABASE_URL="${dbUrl}"
-            exec ${cfg.package}/bin/notify_push '${cfgN.datadir}/config/config.php'
+      database = {
+        dbtype = lib.mkOption {
+          type = lib.types.enum [ "sqlite" "pgsql" "mysql" ];
+          default = cfgN.settings.dbtype;
+          defaultText = lib.literalExpression ''
+            config.services.nextcloud.settings.dbtype
           '';
-        serviceConfig = {
-          User = "nextcloud";
-          Group = "nextcloud";
-          RuntimeDirectory = [ "nextcloud-notify_push" ];
-          Restart = "on-failure";
-          RestartSec = "5s";
-          Type = "notify";
-          LoadCredential = lib.optional (cfg.dbpassFile != null) "dbpass:${cfg.dbpassFile}";
+          description = "Database type.";
+        };
+        dbname = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = cfgN.settings.dbname;
+          defaultText = lib.literalExpression ''
+            config.services.nextcloud.settings.dbname
+          '';
+          description = "Database name.";
+        };
+        dbuser = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = cfgN.settings.dbuser;
+          defaultText = lib.literalExpression ''
+            config.services.nextcloud.settings.dbuser
+          '';
+          description = "Database user.";
+        };
+        dbhost = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = cfgN.settings.dbhost;
+          defaultText = lib.literalExpression ''
+            config.services.nextcloud.settings.dbhost
+          '';
+          description = ''
+            Database host (+port) or socket path. Defaults to the correct unix socket
+            instead if [](#opt-services.nextcloud.database.createLocally) is true and
+            [](#opt-services.nextcloud.settings.dbtype) is either `pgsql` or
+            `mysql`.
+          '';
+        };
+        dbtableprefix = lib.mkOption {
+          type = lib.types.str;
+          default = cfgN.settings.dbtableprefix;
+          defaultText = lib.literalExpression ''
+            config.services.nextcloud.settings.dbtableprefix
+          '';
+          description = "Table prefix in Nextcloud database.";
+        };
+        dbpassFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            The full path to a file that contains the database password.
+          '';
         };
       };
+    };
 
-      nextcloud-notify_push_setup = {
-        wantedBy = [ "multi-user.target" ];
-        requiredBy = [ "nextcloud-notify_push.service" ];
-        after = [ "nextcloud-notify_push.service" ];
-        serviceConfig = {
-          Type = "oneshot";
-          User = "nextcloud";
-          Group = "nextcloud";
-          ExecStart = "${lib.getExe cfgN.occ} notify_push:setup ${cfg.nextcloudUrl}/push";
-          LoadCredential = config.systemd.services.nextcloud-cron.serviceConfig.LoadCredential;
-          RestartMode = "direct";
-          Restart = "on-failure";
-        };
+  config = lib.mkIf cfg.enable {
+    systemd.services.nextcloud-notify_push = {
+      description = "Push daemon for Nextcloud clients";
+      documentation = [ "https://github.com/nextcloud/notify_push" ];
+      after = [
+        "phpfpm-nextcloud.service"
+        "redis-nextcloud.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        NEXTCLOUD_URL = cfg.nextcloudUrl;
+        SOCKET_PATH = cfg.socketPath;
+        DATABASE_PREFIX = cfgD.dbtableprefix;
+        LOG = cfg.logLevel;
+      };
+      postStart = ''
+        ${cfgN.occ}/bin/nextcloud-occ notify_push:setup ${cfg.nextcloudUrl}/push
+      '';
+      script =
+        let
+          dbType = if cfgD.dbtype == "pgsql" then "postgresql" else cfgD.dbtype;
+          dbUser = lib.optionalString (cfgD.dbuser != null) cfgD.dbuser;
+          dbPass = lib.optionalString (cfgD.dbpassFile != null) ":$DATABASE_PASSWORD";
+          dbHostHasPrefix = prefix: lib.hasPrefix prefix (toString cfgD.dbhost);
+          isPostgresql = dbType == "postgresql";
+          isMysql = dbType == "mysql";
+          isSocket = (isPostgresql && dbHostHasPrefix "/") || (isMysql && dbHostHasPrefix "localhost:/");
+          dbHost = lib.optionalString (cfgD.dbhost != null) (
+            if isSocket then lib.optionalString isMysql "@localhost" else "@${cfgD.dbhost}"
+          );
+          dbOpts = lib.optionalString (cfgD.dbhost != null && isSocket) (
+            if isPostgresql then
+              "?host=${cfgD.dbhost}"
+            else if isMysql then
+              "?socket=${lib.removePrefix "localhost:" cfgD.dbhost}"
+            else
+              throw "unsupported dbtype"
+          );
+          dbName = lib.optionalString (cfgD.dbname != null) "/${cfgD.dbname}";
+          dbUrl = "${dbType}://${dbUser}${dbPass}${dbHost}${dbName}${dbOpts}";
+        in
+        lib.optionalString (dbPass != "") ''
+          export DATABASE_PASSWORD="$(<"${cfgD.dbpassFile}")"
+        ''
+        + ''
+          export DATABASE_URL="${dbUrl}"
+          exec ${cfg.package}/bin/notify_push '${cfgN.datadir}/config/config.php'
+        '';
+      serviceConfig = {
+        User = "nextcloud";
+        Group = "nextcloud";
+        RuntimeDirectory = [ "nextcloud-notify_push" ];
+        Restart = "on-failure";
+        RestartSec = "5s";
+        Type = "notify";
       };
     };
 

--- a/nixos/modules/services/web-apps/nextcloud.md
+++ b/nixos/modules/services/web-apps/nextcloud.md
@@ -16,7 +16,7 @@ and optionally supports
 [`services.nginx`](#opt-services.nginx.enable)).
 
 For the database, you can set
-[`services.nextcloud.config.dbtype`](#opt-services.nextcloud.config.dbtype) to
+[`services.nextcloud.settings.dbtype`](#opt-services.nextcloud.settings.dbtype) to
 either `sqlite` (the default), `mysql`, or `pgsql`. The simplest is `sqlite`,
 which will be automatically created and managed by the application. For the
 last two, you can easily create a local database by setting
@@ -32,10 +32,8 @@ A very basic configuration may look like this:
     enable = true;
     hostName = "nextcloud.tld";
     database.createLocally = true;
-    config = {
-      dbtype = "pgsql";
-      adminpassFile = "/path/to/admin-pass-file";
-    };
+    config.adminpassFile = "/path/to/admin-pass-file";
+    settings.dbtype = "pgsql";
   };
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];
@@ -55,6 +53,25 @@ it's needed to add them to
 
 Auto updates for Nextcloud apps can be enabled using
 [`services.nextcloud.autoUpdateApps`](#opt-services.nextcloud.autoUpdateApps.enable).
+
+## Configure external database {#module-services-nextcloud-external-database}
+
+External databases can be configured through `dbtype`, `dbhost`, `dbuser`,
+`dbname`, `dbtableprefix` inside the
+[`services.nextcloud.settings`](#opt-services.nextcloud.settings) scope.
+Specifying `dbpass` is done via [`services.nextcloud.secretFile`](#opt-services.nextcloud.secretFile),
+for example:
+```nix
+{ pkgs, ... }:
+{
+  services.nextcloud.secretFile = "/etc/nextcloud-secret-file";
+}
+environment.etc."nextcloud-secret-file".text = ''
+  {
+    "dbpass": "secret"
+  }
+'';
+```
 
 ## Common problems {#module-services-nextcloud-pitfalls-during-upgrade}
 
@@ -156,8 +173,7 @@ Auto updates for Nextcloud apps can be enabled using
     Cannot decode /run/secrets/nextcloud_secrets, because: Syntax error
     ```
 
-    This can happen if [](#opt-services.nextcloud.secretFile) or
-    [](#opt-services.nextcloud.config.dbpassFile) are managed by
+    This can happen if [](#opt-services.nextcloud.secretFile) is managed by
     [sops-nix](https://github.com/Mic92/sops-nix/).
 
     Here, `/run/secrets/nextcloud_secrets` is a symlink to

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -59,7 +59,7 @@ runTest (
 
           services.nextcloud = {
             enable = true;
-            config.dbtype = "sqlite";
+            settings.dbtype = "sqlite";
             datadir = "/var/lib/nextcloud-data";
             autoUpdateApps = {
               enable = true;

--- a/nixos/tests/nextcloud/with-mysql-and-memcached.nix
+++ b/nixos/tests/nextcloud/with-mysql-and-memcached.nix
@@ -27,7 +27,7 @@ runTest (
               redis = false;
               memcached = true;
             };
-            config.dbtype = "mysql";
+            settings.dbtype = "mysql";
           };
 
           services.memcached.enable = true;

--- a/nixos/tests/nextcloud/with-objectstore.nix
+++ b/nixos/tests/nextcloud/with-objectstore.nix
@@ -36,7 +36,7 @@ runTest (
           networking.firewall.allowedTCPPorts = [ 9000 ];
           environment.systemPackages = [ pkgs.minio-client ];
 
-          services.nextcloud.config.dbtype = "sqlite";
+          services.nextcloud.settings.dbtype = "sqlite";
 
           services.nextcloud.config.objectstore.s3 = {
             enable = true;

--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -36,7 +36,7 @@ runTest (
               redis = true;
               memcached = false;
             };
-            config.dbtype = "pgsql";
+            settings.dbtype = "pgsql";
             notify_push = {
               enable = true;
               bendDomainToLocalhost = true;


### PR DESCRIPTION
###### Description of changes

As a continuation of https://github.com/NixOS/nixpkgs/pull/212430 and to meet [RFC42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) requirements, move several database configuration options from `services.nextcloud.config` into `services.nextcloud.settings`:

- config.dbtype -> settings.dbtype
- config.dbname -> settings.dbname
- .config.dbuser -> settings.dbuser
- config.dbpassFile -> settings -> dbpass
- config.dbhost -> settings.dbhost
- config.dbtableprefix -> settings.dbtableprefix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
