### PR TITLE
otus-lisp: init at 2.4

### DIFF
--- a/pkgs/development/compilers/otus-lisp/default.nix
+++ b/pkgs/development/compilers/otus-lisp/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, xxd }:
+
+stdenv.mkDerivation rec {
+  pname = "otus-lisp";
+  version = "2.4";
+
+  src = fetchFromGitHub {
+    owner = "yuriy-chumak";
+    repo = "ol";
+    rev = version;
+    sha256 = "sha256-+6qH1BhvMkuG2rUOfo9qMjMjhCib9KONQTBWS27c3Ts=";
+  };
+
+  nativeBuildInputs = [ xxd ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "A purely functional dialect of Lisp";
+    homepage = "https://yuriy-chumak.github.io/ol/";
+    license = with lib.licenses; [ mit lgpl3Only ]; # dual licensed
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ nagy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3122,6 +3122,8 @@ with pkgs;
 
   owl-lisp = callPackage ../development/compilers/owl-lisp { };
 
+  otus-lisp = callPackage ../development/compilers/otus-lisp { };
+
   ascii = callPackage ../tools/text/ascii { };
 
   asciinema = callPackage ../tools/misc/asciinema { };


### PR DESCRIPTION
###### Description of changes

New package.

https://github.com/yuriy-chumak/ol

https://yuriy-chumak.github.io/ol/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).