### PR TITLE
sbt: 1.9.2 -> 1.9.3

### DIFF
--- a/pkgs/development/tools/build-managers/sbt/default.nix
+++ b/pkgs/development/tools/build-managers/sbt/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sbt";
-  version = "1.9.2";
+  version = "1.9.3";
 
   src = fetchurl {
     url = "https://github.com/sbt/sbt/releases/download/v${finalAttrs.version}/sbt-${finalAttrs.version}.tgz";
-    hash = "sha256-XdQ69GFnoboN9jhZv65uNS++1SXnZiLY69yJFCIlMrI=";
+    hash = "sha256-nM+UTsyzPGaDDvn/nUbDQCdBzcbYgyUQRSYdsz50joI=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

https://github.com/sbt/sbt/releases/tag/v1.9.3

<details>
<summary>Build log on `x86_64-linux`</summary>

```
$ nix-build -A sbt
this derivation will be built:
  /nix/store/y7q5y2xjrxclszqgsz6rr7k7wxcypmws-sbt-1.9.3.drv
these 12 paths will be fetched (382.32 MiB download, 621.27 MiB unpacked):
  /nix/store/zfihhh057nj7grqy148bm1gxslxbkmln-at-spi2-core-2.48.3
  /nix/store/s4a3cb4w53pi92ciiwzf61nq2rmr8c1s-auto-patchelf-hook
  /nix/store/1lyz93i3n2hp9whal1pfspka314525f9-cups-2.4.6-lib
  /nix/store/bxic6j2whyg3z4h2x3xjyqgp7fl83bnp-gcc-wrapper-12.3.0
  /nix/store/v11kw0qj6rrf26b49k094d1la47i6xvh-gconf-3.2.6
  /nix/store/n2l6v5c6rrlrnaw8c2phw95c2fq00bq8-gnome-vfs-2.24.4
  /nix/store/ccrwazlrwckvic16mi64z75cppx0ll3h-gtk+3-3.24.38
  /nix/store/kjqqffw83zh7zvilg82v0f1rxnqrx020-openjdk-19.0.2+7
  /nix/store/daihizmbqdwn1yzb0lj3y812v1v4xnbj-python3-3.10.12-env
  /nix/store/v43i840aawx4w6yyms86nxpc6yncclw1-python3.10-pyelftools-0.29
  /nix/store/7aprjn0yf6p06krg4087sxvilfp4c8yy-stdenv-linux
  /nix/store/41d6dz6cj7kj52gfmbyqwhp4hkvbrmfg-systemd-253.6
copying path '/nix/store/1lyz93i3n2hp9whal1pfspka314525f9-cups-2.4.6-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/bxic6j2whyg3z4h2x3xjyqgp7fl83bnp-gcc-wrapper-12.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/v11kw0qj6rrf26b49k094d1la47i6xvh-gconf-3.2.6' from 'https://cache.nixos.org'...
copying path '/nix/store/v43i840aawx4w6yyms86nxpc6yncclw1-python3.10-pyelftools-0.29' from 'https://cache.nixos.org'...
copying path '/nix/store/41d6dz6cj7kj52gfmbyqwhp4hkvbrmfg-systemd-253.6' from 'https://cache.nixos.org'...
copying path '/nix/store/7aprjn0yf6p06krg4087sxvilfp4c8yy-stdenv-linux' from 'https://cache.nixos.org'...
copying path '/nix/store/daihizmbqdwn1yzb0lj3y812v1v4xnbj-python3-3.10.12-env' from 'https://cache.nixos.org'...
copying path '/nix/store/s4a3cb4w53pi92ciiwzf61nq2rmr8c1s-auto-patchelf-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/n2l6v5c6rrlrnaw8c2phw95c2fq00bq8-gnome-vfs-2.24.4' from 'https://cache.nixos.org'...
copying path '/nix/store/zfihhh057nj7grqy148bm1gxslxbkmln-at-spi2-core-2.48.3' from 'https://cache.nixos.org'...
copying path '/nix/store/ccrwazlrwckvic16mi64z75cppx0ll3h-gtk+3-3.24.38' from 'https://cache.nixos.org'...
copying path '/nix/store/kjqqffw83zh7zvilg82v0f1rxnqrx020-openjdk-19.0.2+7' from 'https://cache.nixos.org'...
building '/nix/store/y7q5y2xjrxclszqgsz6rr7k7wxcypmws-sbt-1.9.3.drv'...
unpacking sources
unpacking source archive /nix/store/yjz623q281amcj242nzjj2w1j43fryqn-sbt-1.9.3.tgz
source root is sbt
setting SOURCE_DATE_EPOCH to timestamp 1690177671 of file sbt/conf/sbtopts
patching sources
updateAutotoolsGnuConfigScriptsPhase
configuring
no configure script, doing nothing
building
no Makefile or custom buildPhase, doing nothing
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3
shrinking /nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3/share/sbt/bin/sbtn-x86_64-pc-linux
shrinking /nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3/share/sbt/bin/sbtn-aarch64-pc-linux
checking for references to /build/ in /nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3...
patching script interpreter paths in /nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3
/nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3/share/sbt/bin/sbt: interpreter directive changed from "#!/usr/bin/env bash" to "/nix/store/p6dlr3skfhxpyphipg2bqnj52999banh-bash-5.2-p15/bin/bash"
stripping (with command strip and flags -S -p) in  /nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3/bin
automatically fixing dependencies for ELF files
{'append_rpaths': [],
 'ignore_missing': [],
 'libs': [PosixPath('/nix/store/s4a3cb4w53pi92ciiwzf61nq2rmr8c1s-auto-patchelf-hook/lib'),
          PosixPath('/nix/store/0kp5iizg5gnxm3flx8q74w0kbalad1x8-binutils-wrapper-2.40/lib'),
          PosixPath('/nix/store/f03dll3arwa0pzp4r5c93wxrrqjqx217-patchelf-0.15.0/lib'),
          PosixPath('/nix/store/ihh5h6znyiyy7lmkkf9bj7k7gqwiq77b-update-autotools-gnu-config-scripts-hook/lib'),
          PosixPath('/nix/store/h9lc1dpi14z7is86ffhl3ld569138595-audit-tmpdir.sh/lib'),
          PosixPath('/nix/store/m54bmrhj6fqz8nds5zcj97w9s9bckc9v-compress-man-pages.sh/lib'),
          PosixPath('/nix/store/wgrbkkaldkrlrni33ccvm3b6vbxzb656-make-symlinks-relative.sh/lib'),
          PosixPath('/nix/store/5yzw0vhkyszf2d179m0qfkgxmp5wjjx4-move-docs.sh/lib'),
          PosixPath('/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh/lib'),
          PosixPath('/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh/lib'),
          PosixPath('/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh/lib'),
          PosixPath('/nix/store/bxsly8a56yb8kyrq03s82a3vyc8fqrb3-multiple-outputs.sh/lib'),
          PosixPath('/nix/store/nf1lkdrhapsx5lr6diyxyjr7pb7r20gr-patch-shebangs.sh/lib'),
          PosixPath('/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh/lib'),
          PosixPath('/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh/lib'),
          PosixPath('/nix/store/ngg1cv31c8c7bcm2n8ww4g06nq7s4zhm-set-source-date-epoch-to-latest.sh/lib'),
          PosixPath('/nix/store/a9ndjg0b1ivi0av9m93vfkrndp7fqbw1-strip.sh/lib'),
          PosixPath('/nix/store/bxic6j2whyg3z4h2x3xjyqgp7fl83bnp-gcc-wrapper-12.3.0/lib'),
          PosixPath('/nix/store/kcp78dk7h5gcs7d4qss7rbz3skxhzdnn-binutils-wrapper-2.40/lib'),
          PosixPath('/nix/store/1x1q5sqa0ilbi8fz7aayk02pjy5g7jhh-gcc-12.3.0/lib'),
          PosixPath('/nix/store/2fpmbk0g0ggm9zq89af7phvvvv8dnm7n-gcc-12.3.0-lib/lib'),
          PosixPath('/nix/store/0rnx7rc87hwkbrhsys7mgwq4jw6pz7ma-zlib-1.2.13-dev/lib'),
          PosixPath('/nix/store/5p62fc7h9ij36fqsxlbq73mbwdhnmbkv-zlib-1.2.13/lib'),
          PosixPath('/nix/store/s4a3cb4w53pi92ciiwzf61nq2rmr8c1s-auto-patchelf-hook/lib'),
          PosixPath('/nix/store/0kp5iizg5gnxm3flx8q74w0kbalad1x8-binutils-wrapper-2.40/lib'),
          PosixPath('/nix/store/f03dll3arwa0pzp4r5c93wxrrqjqx217-patchelf-0.15.0/lib'),
          PosixPath('/nix/store/ihh5h6znyiyy7lmkkf9bj7k7gqwiq77b-update-autotools-gnu-config-scripts-hook/lib'),
          PosixPath('/nix/store/h9lc1dpi14z7is86ffhl3ld569138595-audit-tmpdir.sh/lib'),
          PosixPath('/nix/store/m54bmrhj6fqz8nds5zcj97w9s9bckc9v-compress-man-pages.sh/lib'),
          PosixPath('/nix/store/wgrbkkaldkrlrni33ccvm3b6vbxzb656-make-symlinks-relative.sh/lib'),
          PosixPath('/nix/store/5yzw0vhkyszf2d179m0qfkgxmp5wjjx4-move-docs.sh/lib'),
          PosixPath('/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh/lib'),
          PosixPath('/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh/lib'),
          PosixPath('/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh/lib'),
          PosixPath('/nix/store/bxsly8a56yb8kyrq03s82a3vyc8fqrb3-multiple-outputs.sh/lib'),
          PosixPath('/nix/store/nf1lkdrhapsx5lr6diyxyjr7pb7r20gr-patch-shebangs.sh/lib'),
          PosixPath('/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh/lib'),
          PosixPath('/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh/lib'),
          PosixPath('/nix/store/ngg1cv31c8c7bcm2n8ww4g06nq7s4zhm-set-source-date-epoch-to-latest.sh/lib'),
          PosixPath('/nix/store/a9ndjg0b1ivi0av9m93vfkrndp7fqbw1-strip.sh/lib'),
          PosixPath('/nix/store/bxic6j2whyg3z4h2x3xjyqgp7fl83bnp-gcc-wrapper-12.3.0/lib'),
          PosixPath('/nix/store/kcp78dk7h5gcs7d4qss7rbz3skxhzdnn-binutils-wrapper-2.40/lib'),
          PosixPath('/nix/store/1x1q5sqa0ilbi8fz7aayk02pjy5g7jhh-gcc-12.3.0/lib'),
          PosixPath('/nix/store/2fpmbk0g0ggm9zq89af7phvvvv8dnm7n-gcc-12.3.0-lib/lib'),
          PosixPath('/nix/store/0rnx7rc87hwkbrhsys7mgwq4jw6pz7ma-zlib-1.2.13-dev/lib'),
          PosixPath('/nix/store/5p62fc7h9ij36fqsxlbq73mbwdhnmbkv-zlib-1.2.13/lib')],
 'paths': [PosixPath('/nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3')],
 'recursive': True,
 'runtime_dependencies': []}
setting interpreter of /nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3/share/sbt/bin/sbtn-x86_64-pc-linux
searching for dependencies of /nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3/share/sbt/bin/sbtn-x86_64-pc-linux
    libstdc++.so.6 -> found: /nix/store/2fpmbk0g0ggm9zq89af7phvvvv8dnm7n-gcc-12.3.0-lib/lib
    libz.so.1 -> found: /nix/store/5p62fc7h9ij36fqsxlbq73mbwdhnmbkv-zlib-1.2.13/lib
setting RPATH to: /nix/store/2fpmbk0g0ggm9zq89af7phvvvv8dnm7n-gcc-12.3.0-lib/lib:/nix/store/5p62fc7h9ij36fqsxlbq73mbwdhnmbkv-zlib-1.2.13/lib
skipping /nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3/share/sbt/bin/sbtn-aarch64-pc-linux because its architecture (AArch64) differs from target (x64)
auto-patchelf: 0 dependencies could not be satisfied
/nix/store/wv8a74s4p3g2y6rxp5nb3mfg1v5v3801-sbt-1.9.3
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
