### PR TITLE
qgnomeplatform: 0.8.4 → 0.9.1

### DIFF
--- a/nixos/modules/config/qt.nix
+++ b/nixos/modules/config/qt.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.qt;
 
-  isQGnome = cfg.platformTheme == "gnome" && builtins.elem cfg.style ["adwaita" "adwaita-dark"];
+  isQGnome = cfg.platformTheme == "gnome" && builtins.elem cfg.style ["adwaita" "adwaita-dark" "none"];
   isQtStyle = cfg.platformTheme == "gtk2" && !(builtins.elem cfg.style ["adwaita" "adwaita-dark"]);
   isQt5ct = cfg.platformTheme == "qt5ct";
   isLxqt = cfg.platformTheme == "lxqt";
@@ -80,6 +80,7 @@ in
           "gtk2"
           "motif"
           "plastique"
+          "none"
         ];
         example = "adwaita";
         relatedPackages = [
@@ -96,6 +97,8 @@ in
             [adwaita](https://github.com/FedoraQt/adwaita-qt)
           - `cleanlooks`, `gtk2`, `motif`, `plastique`: Use styles from
             [qtstyleplugins](https://github.com/qt/qtstyleplugins)
+          - `none`: Don't set QT_STYLE_OVERRIDE, can be useful when
+            theme engine handles the style for you
         '';
       };
     };
@@ -105,7 +108,7 @@ in
 
     environment.variables = {
       QT_QPA_PLATFORMTHEME = cfg.platformTheme;
-      QT_STYLE_OVERRIDE = mkIf (! (isQt5ct || isLxqt || isKde)) cfg.style;
+      QT_STYLE_OVERRIDE = mkIf (!(isQt5ct || isLxqt || isKde) && (cfg.style != "none")) cfg.style;
     };
 
     environment.profileRelativeSessionVariables = let

--- a/nixos/modules/config/qt.nix
+++ b/nixos/modules/config/qt.nix
@@ -62,7 +62,7 @@ in
           Selects the platform theme to use for Qt applications.
 
           The options are
-          - `gtk`: Use GTK theme with [qtstyleplugins](https://github.com/qt/qtstyleplugins)
+          - `gtk2`: Use GTK theme with [qtstyleplugins](https://github.com/qt/qtstyleplugins)
           - `gnome`: Use GNOME theme with [qgnomeplatform](https://github.com/FedoraQt/QGnomePlatform)
           - `lxqt`: Use LXQt style set using the [lxqt-config-appearance](https://github.com/lxqt/lxqt-config)
              application.

--- a/nixos/modules/config/qt.nix
+++ b/nixos/modules/config/qt.nix
@@ -18,6 +18,8 @@ let
       pkgs.adwaita-qt
       pkgs.qgnomeplatform-qt6
       pkgs.adwaita-qt6
+      # https://github.com/FedoraQt/QGnomePlatform/commit/2c3bd4019b61e1abf46bdcc547cf4683e7b9e5ba
+      pkgs.libsForQt5.qqc2-desktop-style
     ]
     else if isQtStyle then [ pkgs.libsForQt5.qtstyleplugins pkgs.qt6Packages.qt6gtk2 ]
     else if isQt5ct then [ pkgs.libsForQt5.qt5ct pkgs.qt6Packages.qt6ct ]

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -356,7 +356,7 @@ in
       qt = {
         enable = mkDefault true;
         platformTheme = mkDefault "gnome";
-        style = mkDefault "adwaita";
+        style = mkDefault "none";
       };
 
       networking.networkmanager.enable = mkDefault true;

--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -9,8 +9,9 @@
 , glib
 , gtk3
 , qtbase
+, qt5
 , qtwayland
-, pantheon
+, cinnamon
 , substituteAll
 , gsettings-desktop-schemas
 , useQt6 ? false
@@ -18,20 +19,21 @@
 
 stdenv.mkDerivation rec {
   pname = "qgnomeplatform";
-  version = "0.8.4";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "FedoraQt";
     repo = "QGnomePlatform";
     rev = version;
-    sha256 = "sha256-DaIBtWmce+58OOhqFG5802c3EprBAtDXhjiSPIImoOM=";
+    sha256 = "sha256-X+iJIbZL4/jKECIg2gTcenjzMA9nMy6gO6rNrAiVsKI=";
   };
 
   patches = [
-    # Hardcode GSettings schema path to avoid crashes from missing schemas
+    # Hardcode GSettings schema path
     (substituteAll {
       src = ./hardcode-gsettings.patch;
       gds_gsettings_path = glib.getSchemaPath gsettings-desktop-schemas;
+      cinnamon_gsettings_path = glib.getSchemaPath cinnamon.cinnamon-desktop;
     })
   ];
 
@@ -46,6 +48,7 @@ stdenv.mkDerivation rec {
     qtbase
     qtwayland
   ] ++ lib.optionals (!useQt6) [
+    qt5.qtquickcontrols2
     adwaita-qt
   ] ++ lib.optionals useQt6 [
     adwaita-qt6

--- a/pkgs/development/libraries/qgnomeplatform/hardcode-gsettings.patch
+++ b/pkgs/development/libraries/qgnomeplatform/hardcode-gsettings.patch
@@ -1,25 +1,32 @@
-diff --git a/src/common/gnomesettings.cpp b/src/common/gnomesettings.cpp
-index 717cc9b..ee255ea 100644
---- a/src/common/gnomesettings.cpp
-+++ b/src/common/gnomesettings.cpp
-@@ -150,10 +150,18 @@ GnomeSettingsPrivate::GnomeSettingsPrivate(QObject *parent)
-     : GnomeSettings(parent)
-     , m_usePortal(checkUsePortalSupport())
-     , m_canUseFileChooserPortal(!m_usePortal)
--    , m_gnomeDesktopSettings(g_settings_new("org.gnome.desktop.wm.preferences"))
--    , m_settings(g_settings_new("org.gnome.desktop.interface"))
-     , m_fallbackFont(new QFont(QLatin1String("Sans"), 10))
- {
-+    g_autoptr(GSettingsSchemaSource) schemaSource = nullptr;
-+    g_autoptr(GSettingsSchema) gnomeDesktopSchema = nullptr;
-+    g_autoptr(GSettingsSchema) settingsSchema = nullptr;
-+
-+    schemaSource = g_settings_schema_source_new_from_directory("@gds_gsettings_path@", g_settings_schema_source_get_default(), true, nullptr);
-+    gnomeDesktopSchema = g_settings_schema_source_lookup(schemaSource, "org.gnome.desktop.wm.preferences", false);
-+    m_gnomeDesktopSettings = g_settings_new_full(gnomeDesktopSchema, nullptr, nullptr);
-+    settingsSchema = g_settings_schema_source_lookup(schemaSource, "org.gnome.desktop.interface", false);
-+    m_settings = g_settings_new_full(settingsSchema, nullptr, nullptr);
-+
-     gtk_init(nullptr, nullptr);
+diff --git a/src/common/gsettingshintprovider.cpp b/src/common/gsettingshintprovider.cpp
+index ed71c56..d49ace4 100644
+--- a/src/common/gsettingshintprovider.cpp
++++ b/src/common/gsettingshintprovider.cpp
+@@ -26,9 +26,9 @@
  
-     // Set log handler to suppress false GtkDialog warnings
+ Q_LOGGING_CATEGORY(QGnomePlatformGSettingsHintProvider, "qt.qpa.qgnomeplatform.gsettingshintprovider")
+ 
+-static GSettings *loadGSettingsSchema(const QString &schema)
++static GSettings *loadGSettingsSchema(const QString &schemaSource, const QString &schema)
+ {
+-    GSettingsSchemaSource *source = g_settings_schema_source_get_default();
++    GSettingsSchemaSource *source = g_settings_schema_source_new_from_directory(schemaSource.toLatin1(), g_settings_schema_source_get_default(), TRUE, nullptr);
+     GSettingsSchema *gschema = nullptr;
+ 
+     gschema = g_settings_schema_source_lookup(source, schema.toLatin1(), TRUE);
+@@ -43,12 +43,12 @@ static GSettings *loadGSettingsSchema(const QString &schema)
+ 
+ GSettingsHintProvider::GSettingsHintProvider(QObject *parent)
+     : HintProvider(parent)
+-    , m_gnomeDesktopSettings(loadGSettingsSchema(QLatin1String("org.gnome.desktop.wm.preferences")))
+-    , m_settings(loadGSettingsSchema(QLatin1String("org.gnome.desktop.interface")))
++    , m_gnomeDesktopSettings(loadGSettingsSchema(QLatin1String("@gds_gsettings_path@"), QLatin1String("org.gnome.desktop.wm.preferences")))
++    , m_settings(loadGSettingsSchema(QLatin1String("@gds_gsettings_path@"), QLatin1String("org.gnome.desktop.interface")))
+ {
+     // Check if this is a Cinnamon session to use additionally a different setting scheme
+     if (qgetenv("XDG_CURRENT_DESKTOP").toLower() == QStringLiteral("x-cinnamon")) {
+-        m_cinnamonSettings = loadGSettingsSchema(QLatin1String("org.cinnamon.desktop.interface"));
++        m_cinnamonSettings = loadGSettingsSchema(QLatin1String("@cinnamon_gsettings_path@"), QLatin1String("org.cinnamon.desktop.interface"));
+     }
+ 
+     // Do not continue on missing GSettings


### PR DESCRIPTION
Not tested but open an early draft to avoid duplicate work...

### Debug

```
$ QT_LOGGING_RULES="qt.qpa.qgnomeplatform*=true" some-application
```

Specifically, if cursor theme not working on Qt apps, then you might mess up one of the following:

```
$ echo $XCURSOR_THEME
$ cat ~/.local/share/icons/default/index.theme
$ cat ~/.icons/default/index.theme
```

Specifically, if you have unexpected mixed light/dark view, try restart the app

### To test

Still testing... I guess, we need to test a matrix of:

- GNOME Wayland, GNOME X11, Cinnamon, Pantheon, random other desktop
- Qt5 app, Qt6 app
- QT_STYLE_OVERRIDE is adwaita, QT_STYLE_OVERRIDE is adwaita-dark, none
- Adwaita, Adwaita-dark, random light theme, random dark theme as GTK theme
- No support `org.freedesktop.appearance.color-scheme`, no preference, prefer light, prefer dark

? :upside_down_face: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
