### PR TITLE
audiobookshelf: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -30,6 +30,8 @@
 
 - [trust-dns](https://trust-dns.org/), a Rust based DNS server built to be safe and secure from the ground up. Available as [services.trust-dns](#opt-services.trust-dns.enable).
 
+- [audiobookshelf](https://github.com/advplyr/audiobookshelf/), a self-hosted audiobook and podcast server. Available as [services.audiobookshelf](#opt-services.audiobookshelf.enable).
+
 - [osquery](https://www.osquery.io/), a SQL powered operating system instrumentation, monitoring, and analytics.
 
 - [ebusd](https://ebusd.eu), a daemon for handling communication with eBUS devices connected to a 2-wire bus system (“energy bus” used by numerous heating systems). Available as [services.ebusd](#opt-services.ebusd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1190,6 +1190,7 @@
   ./services/web-apps/atlassian/confluence.nix
   ./services/web-apps/atlassian/crowd.nix
   ./services/web-apps/atlassian/jira.nix
+  ./services/web-apps/audiobookshelf.nix
   ./services/web-apps/bookstack.nix
   ./services/web-apps/calibre-web.nix
   ./services/web-apps/coder.nix

--- a/nixos/modules/services/web-apps/audiobookshelf.nix
+++ b/nixos/modules/services/web-apps/audiobookshelf.nix
@@ -1,0 +1,113 @@
+{ pkgs
+, lib
+, config
+, ...
+}:
+
+with lib; let
+  cfg = config.services.audiobookshelf;
+in
+
+{
+  options.services.audiobookshelf = {
+    enable = mkEnableOption (lib.mdDoc  "Audiobookshelf, self-hosted audiobook and podcast server");
+
+    host = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = lib.mdDoc ''
+        The host address that Audiobookshelf will listen on.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8000;
+      description = lib.mdDoc ''
+        The port that Audiobookshelf will listen on.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "audiobookshelf";
+      description = lib.mdDoc ''
+        User account under which Audiobookshelf runs.
+      '';
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "audiobookshelf";
+      description = lib.mdDoc ''
+        Group under which Audiobookshelf runs.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Whether to open the firewall for the port in {option}`services.audiobookshelf.port`.
+      '';
+    };
+
+    configDir = mkOption {
+      type = types.str;
+      default = "/etc/audiobookshelf";
+      description = lib.mdDoc ''
+        Configuration directory Audiobookshelf will use.
+      '';
+    };
+
+    metadataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/audiobookshelf";
+      description = lib.mdDoc ''
+        Metadata directory Audiobookshelf will use.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+
+    users.groups = mkIf (cfg.group == "audiobookshelf") {
+      audiobookshelf = { };
+    };
+
+    users.users = mkIf (cfg.user == "audiobookshelf") {
+      audiobookshelf = {
+        group = cfg.group;
+        description = "Audiobookshelf Daemon user";
+        isSystemUser = true;
+      };
+    };
+
+    systemd.services.audiobookshelf = {
+      description = "Audiobookshelf is a self-hosted audiobook and podcast server";
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Type = "simple";
+        Restart = "on-failure";
+        StateDirectory = mkIf (cfg.metadataDir == "/var/lib/audiobookshelf") "audiobookshelf";
+        ConfigurationDirectory = mkIf (cfg.configDir == "/etc/audiobookshelf") "audiobookshelf";
+        ExecStart = ''
+          ${pkgs.audiobookshelf}/bin/audiobookshelf \
+            --host ${cfg.host} \
+            --port ${toString cfg.port} \
+            --metadata ${cfg.metadataDir} \
+            --config ${cfg.configDir}
+        '';
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ dit7ya ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -115,6 +115,7 @@ in {
   atd = handleTest ./atd.nix {};
   atop = handleTest ./atop.nix {};
   atuin = handleTest ./atuin.nix {};
+  audiobookshelf = handleTest ./audiobookshelf.nix {};
   auth-mysql = handleTest ./auth-mysql.nix {};
   authelia = handleTest ./authelia.nix {};
   avahi = handleTest ./avahi.nix {};

--- a/nixos/tests/audiobookshelf.nix
+++ b/nixos/tests/audiobookshelf.nix
@@ -1,0 +1,23 @@
+import ./make-test-python.nix ({ lib, ... }:
+
+with lib;
+
+{
+  name = "audiobookshelf";
+  meta.maintainers = with maintainers; [ dit7ya ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.audiobookshelf = {
+        enable = true;
+        port = 1234;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("audiobookshelf.service")
+    machine.wait_for_open_port(1234)
+    machine.succeed("curl --fail http://localhost:1234/")
+  '';
+})

--- a/pkgs/servers/audiobookshelf/default.nix
+++ b/pkgs/servers/audiobookshelf/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, pkgs, fetchFromGitHub, runCommand, buildNpmPackage, nodejs_18, tone, ffmpeg-full, util-linux, libwebp }:
+{ lib, stdenv, pkgs, fetchFromGitHub, runCommand, buildNpmPackage, nodejs_18, tone, ffmpeg-full, util-linux, libwebp, getopt }:
 
 let
   nodejs = nodejs_18;
@@ -28,7 +28,7 @@ let
   };
 
   wrapper = import ./wrapper.nix {
-    inherit stdenv ffmpeg-full tone pname nodejs;
+    inherit stdenv ffmpeg-full tone pname nodejs getopt;
   };
 
 in buildNpmPackage {

--- a/pkgs/servers/audiobookshelf/wrapper.nix
+++ b/pkgs/servers/audiobookshelf/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, ffmpeg-full, tone, pname, nodejs }: ''
+{ stdenv, ffmpeg-full, tone, pname, nodejs, getopt }: ''
     #!${stdenv.shell}
 
     port=8000
@@ -7,7 +7,7 @@
     metadata=$(pwd)/metadata
 
     LONGOPTS=host:,port:,config:,metadata:,help
-    args=$(getopt -l "$LONGOPTS" -o h -- "$@")
+    args=$(${getopt}/bin/getopt -l "$LONGOPTS" -o h -- "$@")
 
     eval set -- "$args"
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added audiobookshelf module. Credit goes to @dit7ya , also kept them as a maintainer. Just some small modifications to work with the audiobookshelf package that was merged. Had to add getopt to the package also...

Tested working on nixos-unstable

[This is the package/module](https://github.com/NixOS/nixpkgs/pull/201552) that @dit7ya made, which can be closed by this PR.

[This was the package that was merged.](https://github.com/NixOS/nixpkgs/pull/213265)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
