### PR TITLE
perlPackages.DataUUID: Add patch for CVE-2013-4184

### DIFF
--- a/pkgs/development/perl-modules/Data-UUID-CVE-2013-4184.patch
+++ b/pkgs/development/perl-modules/Data-UUID-CVE-2013-4184.patch
@@ -1,0 +1,214 @@
+Eliminate use of state/node files in temp directory, which are a security concern due to insecure writing of State/Node files in a temporary directory, with predictable filenames, with a possible symlink attack.
+
+Fixes CVE-2013-4184
+
+https://github.com/bleargh45/Data-UUID/pull/40 by Graham TerMarsch @bleargh45
+
+
+diff --git a/Makefile.PL b/Makefile.PL
+index 4ca26af..fb1a0f0 100644
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -89,30 +89,14 @@ WriteMakefile(
+ 
+   CONFIGURE           => sub {
+     my %opt;
+-    GetOptions(\%opt, 's|state-storage-directory:s', 'd|default-umask:s',
+-        'help|?', 'man') or pod2usage(2);
++    GetOptions(\%opt, 'help|?', 'man') or pod2usage(2);
+     pod2usage(1) if $opt{help};
+     pod2usage(-verbose => 2) if $opt{man};
+ 
+     print "Configured options (run perl Makefile.PL --help for how to change this):\n";
+ 
+-    my $d = File::Spec->tmpdir;
+-    $d = $opt{s} || $d;
+-    print "\tUUID state storage: $d\n";
+-    $d =~ s/\\/\\\\/g if $^O eq 'MSWin32';
+-
+-    my $m = '0007';
+-    unless ($^O eq 'MSWin32') {
+-        $m = $opt{d} || $m;
+-        print "\tdefault umask: $m\n";
+-    }
+-
+-    chmod(0666, sprintf("%s/%s", $d, ".UUID_NODEID"));
+-    chmod(0666, sprintf("%s/%s", $d, ".UUID_STATE"));
+     return {
+-      DEFINE => '-D_STDIR=' . shell_quote(c_quote($d))
+-              . ' -D' . shell_quote("__$Config{osname}__")
+-              . ' -D_DEFAULT_UMASK=' . shell_quote($m)
++      DEFINE => ' -D' . shell_quote("__$Config{osname}__")
+            };
+   }
+ );
+@@ -127,11 +111,9 @@ Makefile.PL - configure Makefile for Data::UUID
+ 
+ perl Makefile.PL [options] [EU::MM options]
+ 
+-perl Makefile.PL -s=/var/local/lib/data-uuid -d=0007
++perl Makefile.PL
+ 
+     Options:
+-    --state-storage-directory   directory for storing library state information
+-    --default-umask             umask for files in the state storage directory
+     --help                      brief help message
+     --man                       full documentation
+ 
+@@ -141,18 +123,6 @@ Options can be abbreviated, see L<Getopt::Long/"Case and abbreviations">.
+ 
+ =over
+ 
+-=item --state-storage-directory
+-
+-Optional. Takes a string that is interpreted as directory for storing library
+-state information. Default is c:/tmp/ on Windows if it already exists, or the
+-operating system's temporary directory (see tmpdir in L<File::Spec/"METHODS">),
+-or /var/tmp as fallback.
+-
+-=item --default-umask
+-
+-Optional. Takes a string that is interpreted as umask for the files in the state
+-storage directory. Default is 0007. This is ignored on Windows.
+-
+ =item --help
+ 
+ Print a brief help message and exits.
+@@ -165,10 +135,7 @@ Prints the manual page and exits.
+ 
+ =head1 DESCRIPTION
+ 
+-B<Makefile.PL> writes the Makefile for the Data::UUID library. It is configured
+-with the options L</"--state-storage-directory"> and L</"--default-umask">.
+-Unless given, default values are used. In any case the values are printed for
+-confirmation.
++B<Makefile.PL> writes the Makefile for the Data::UUID library.
+ 
+ Additionally, the usual EU::MM options are processed, see
+ L<ExtUtils::MakeMaker/"Using Attributes and Parameters">.
+diff --git a/README b/README
+index 8aaa1c2..34d53a5 100644
+--- a/README
++++ b/README
+@@ -23,15 +23,6 @@ To install this module type the following:
+    make test
+    make install
+ 
+-NOTE: This module is designed to save its state information in a permanent 
+-storage location. The installation script (i.e. Makefile.PL) prompts for 
+-a directory name to use as a storage location for state file and defaults 
+-this directory to "/var/tmp" if no directory name is provided. 
+-The installation script will not accept names of directories that do not
+-exist, however, it will take the locations, which the installing user
+-has no write permissions to. In this case, the state information will not be
+-saved, which will maximize the chances of generating duplicate UUIDs.
+-
+ COPYRIGHT AND LICENCE
+ 
+ Copyright (C) 2001, Alexander Golomshtok
+diff --git a/UUID.h b/UUID.h
+index dc5ea28..11d6e13 100644
+--- a/UUID.h
++++ b/UUID.h
+@@ -44,23 +44,6 @@
+ #include <process.h>
+ #endif
+ 
+-#if !defined _STDIR
+-#    define  _STDIR			"/var/tmp"
+-#endif
+-#if !defined _DEFAULT_UMASK
+-#    define  _DEFAULT_UMASK		0007
+-#endif
+-
+-#define UUID_STATE			".UUID_STATE"
+-#define UUID_NODEID			".UUID_NODEID"
+-#if defined __mingw32__ || (defined _WIN32 && !defined(__cygwin__)) || defined _MSC_VER
+-#define UUID_STATE_NV_STORE		_STDIR"\\"UUID_STATE
+-#define UUID_NODEID_NV_STORE		_STDIR"\\"UUID_NODEID
+-#else
+-#define UUID_STATE_NV_STORE		_STDIR"/"UUID_STATE
+-#define UUID_NODEID_NV_STORE		_STDIR"/"UUID_NODEID
+-#endif
+-
+ #define UUIDS_PER_TICK 1024
+ #ifdef _MSC_VER
+ #define I64(C) C##i64
+@@ -134,7 +117,6 @@ typedef struct _uuid_state_t {
+ typedef struct _uuid_context_t {
+    uuid_state_t state;
+    uuid_node_t  nodeid;
+-   perl_uuid_time_t  next_save;
+ } uuid_context_t;
+ 
+ static void format_uuid_v1(
+diff --git a/UUID.xs b/UUID.xs
+index c3496a8..8191727 100644
+--- a/UUID.xs
++++ b/UUID.xs
+@@ -356,29 +356,11 @@ PREINIT:
+    UV             one = 1;
+ CODE:
+    RETVAL = (uuid_context_t *)PerlMemShared_malloc(sizeof(uuid_context_t));
+-   if ((fd = fopen(UUID_STATE_NV_STORE, "rb"))) {
+-      fread(&(RETVAL->state), sizeof(uuid_state_t), 1, fd);
+-      fclose(fd);
+-      get_current_time(&timestamp);
+-      RETVAL->next_save = timestamp;
+-   }
+-   if ((fd = fopen(UUID_NODEID_NV_STORE, "rb"))) {
+-      pid_t *hate = (pid_t *) &(RETVAL->nodeid); 
+-      fread(&(RETVAL->nodeid), sizeof(uuid_node_t), 1, fd );
+-      fclose(fd);
+-      
+-      *hate += getpid();
+-   } else {
++
+       get_random_info(seed);
+       seed[0] |= 0x80;
+       memcpy(&(RETVAL->nodeid), seed, sizeof(uuid_node_t));
+-      mask = umask(_DEFAULT_UMASK);
+-      if ((fd = fopen(UUID_NODEID_NV_STORE, "wb"))) {
+-         fwrite(&(RETVAL->nodeid), sizeof(uuid_node_t), 1, fd);
+-         fclose(fd);
+-      };
+-      umask(mask);
+-   }
++
+    errno = 0;
+ #if DU_THREADSAFE
+    MUTEX_LOCK(&instances_mutex);
+@@ -415,17 +397,6 @@ PPCODE:
+    self->state.node = self->nodeid;
+    self->state.ts   = timestamp;
+    self->state.cs   = clockseq;
+-   if (timestamp > self->next_save ) {
+-      mask = umask(_DEFAULT_UMASK);
+-      if((fd = fopen(UUID_STATE_NV_STORE, "wb"))) {
+-	 LOCK(fd);
+-         fwrite(&(self->state), sizeof(uuid_state_t), 1, fd);
+-	 UNLOCK(fd);
+-         fclose(fd);
+-      }
+-      umask(mask);
+-      self->next_save = timestamp + (10 * 10 * 1000 * 1000);
+-   }
+    ST(0) = make_ret(uuid, ix);
+    XSRETURN(1);
+ 
+@@ -585,14 +556,6 @@ CODE:
+    MUTEX_UNLOCK(&instances_mutex);
+    if (count == 0) {
+ #endif
+-      mask = umask(_DEFAULT_UMASK);
+-      if ((fd = fopen(UUID_STATE_NV_STORE, "wb"))) {
+-         LOCK(fd);
+-         fwrite(&(self->state), sizeof(uuid_state_t), 1, fd);
+-         UNLOCK(fd);
+-         fclose(fd);
+-      };
+-      umask(mask);
+       PerlMemShared_free(self);
+ #if DU_THREADSAFE
+    }
+

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6083,6 +6083,9 @@ with self; {
       url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-UUID-1.226.tar.gz";
       hash = "sha256-CT1X/6DUEalLr6+uSVaX2yb1ydAncZj+P3zyviKZZFM=";
     };
+    patches = [
+      ../development/perl-modules/Data-UUID-CVE-2013-4184.patch
+    ];
     meta = {
       description = "Globally/Universally Unique Identifiers (GUIDs/UUIDs)";
       license = with lib.licenses; [ bsd0 ];


### PR DESCRIPTION
###### Description of changes

Adds a patch from https://github.com/bleargh45/Data-UUID/pull/40 for CVE-2013-4184 to `perlPackages.DataUUID`. It removes the vulnerable state file functionality completely.

In the case of NixOS the state directory ended up being `/build/`, so saving state didn't work in our case anyway - but could maybe introduce some impurity afaik.

```
$ strace perl -MData::UUID -E 'say Data::UUID->new->create_b64()'
[..]
openat(AT_FDCWD, "/build/.UUID_NODEID", O_WRONLY|O_CREAT|O_TRUNC, 0666) = -1 ENOENT (No such file or directory)
[..]
openat(AT_FDCWD, "/build/.UUID_STATE", O_WRONLY|O_CREAT|O_TRUNC, 0666) = -1 ENOENT (No such file or directory)
```

Gentoo and Debian has marked it as unimportant since it should be mitigated by `fs.protected_symlinks=1`:

- https://bugs.gentoo.org/show_bug.cgi?id=CVE-2013-4184
- https://security-tracker.debian.org/tracker/CVE-2013-4184

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>45 packages built:</summary>
  <ul>
    <li>gscan2pdf</li>
    <li>gscan2pdf.man</li>
    <li>hydra_unstable</li>
    <li>perl534Packages.CHI</li>
    <li>perl534Packages.CHI.devdoc</li>
    <li>perl534Packages.CatalystAuthenticationCredentialHTTP</li>
    <li>perl534Packages.CatalystAuthenticationCredentialHTTP.devdoc</li>
    <li>perl534Packages.DataGUID</li>
    <li>perl534Packages.DataGUID.devdoc</li>
    <li>perl534Packages.DataUUID</li>
    <li>perl534Packages.DataUUID.devdoc</li>
    <li>perl534Packages.GrowlGNTP</li>
    <li>perl534Packages.GrowlGNTP.devdoc</li>
    <li>perl534Packages.MojoSAML</li>
    <li>perl534Packages.MojoSAML.devdoc</li>
    <li>perl534Packages.MojoUserAgentCached</li>
    <li>perl534Packages.MojoUserAgentCached.devdoc</li>
    <li>perl534Packages.Test2Harness</li>
    <li>perl534Packages.Test2Harness.devdoc</li>
    <li>perl534Packages.Test2PluginUUID</li>
    <li>perl534Packages.Test2PluginUUID.devdoc</li>
    <li>perl534Packages.Workflow</li>
    <li>perl534Packages.Workflow.devdoc</li>
    <li>perl536Packages.CHI</li>
    <li>perl536Packages.CHI.devdoc</li>
    <li>perl536Packages.CatalystAuthenticationCredentialHTTP</li>
    <li>perl536Packages.CatalystAuthenticationCredentialHTTP.devdoc</li>
    <li>perl536Packages.DataGUID</li>
    <li>perl536Packages.DataGUID.devdoc</li>
    <li>perl536Packages.DataUUID</li>
    <li>perl536Packages.DataUUID.devdoc</li>
    <li>perl536Packages.GrowlGNTP</li>
    <li>perl536Packages.GrowlGNTP.devdoc</li>
    <li>perl536Packages.MojoSAML</li>
    <li>perl536Packages.MojoSAML.devdoc</li>
    <li>perl536Packages.MojoUserAgentCached</li>
    <li>perl536Packages.MojoUserAgentCached.devdoc</li>
    <li>perl536Packages.Test2Harness</li>
    <li>perl536Packages.Test2Harness.devdoc</li>
    <li>perl536Packages.Test2PluginUUID</li>
    <li>perl536Packages.Test2PluginUUID.devdoc</li>
    <li>perl536Packages.Workflow</li>
    <li>perl536Packages.Workflow.devdoc</li>
    <li>rt</li>
    <li>slic3r</li>
  </ul>
</details>



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
