### PR TITLE
vorta: strip away output dependency on `qt5.qtwayland.dev`

### DIFF
--- a/pkgs/applications/backup/vorta/default.nix
+++ b/pkgs/applications/backup/vorta/default.nix
@@ -4,6 +4,7 @@
 , wrapQtAppsHook
 , borgbackup
 , qt5
+, stdenv
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -19,6 +20,10 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
+  buildInputs = lib.optionals stdenv.isLinux [
+    qt5.qtwayland
+  ];
+
   propagatedBuildInputs = with python3Packages; [
     peewee
     pyqt5
@@ -29,8 +34,6 @@ python3Packages.buildPythonApplication rec {
     appdirs
     setuptools
     platformdirs
-  ] ++ lib.optionals stdenv.isLinux [
-    qt5.qtwayland
   ];
 
   postPatch = ''


### PR DESCRIPTION

###### Description of changes
`propagatedBuildInputs` is only required in this case to correctly build the `PYTHONPATH` for the final application. The QT hook doesn't need `qtwayland` in `propagatedBuildInputs`, `buildInputs` is sufficient for it to work.

Additionally, this causes a closure-size reduction of ~22.5% because we get rid of the dependency to the `dev` output of `qtwayland`:

    $ nix path-info -Sh ./result-old
    /nix/store/i8i4p2i3wkjv4y95pp3i421nwg0f1shh-vorta-0.8.12	775.2M
    $ nix path-info -Sh ./result-new
    /nix/store/jcyrkk89my2lh00z7dy8z19xyvlf8yhr-vorta-0.8.12	599.5M

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
