### PR TITLE
python310Packages.opentelemetry: unified the source code

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -61,7 +61,7 @@ let
       description = "OpenTelemetry Python API";
       changelog = "https://github.com/open-telemetry/opentelemetry-python/releases/tag/${self.src.rev}";
       license = licenses.asl20;
-      maintainers = teams.deshaw.members;
+      maintainers = teams.deshaw.members ++ [ maintainers.natsukium ];
     };
   };
 in self

--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -17,13 +17,15 @@ let
     version = "1.18.0";
     disabled = pythonOlder "3.7";
 
+    # to avoid breakage, every package in opentelemetry-python must inherit this version, src, and meta
     src = fetchFromGitHub {
       owner = "open-telemetry";
       repo = "opentelemetry-python";
       rev = "refs/tags/v${self.version}";
-      hash = "sha256-h6XDzM29wYiC51S7OpBXvWFCfZ7DmIyGMG2pFjJV7pI=";
-      sparseCheckout = [ "/${self.pname}" ];
-    } + "/${self.pname}";
+      hash = "sha256-8xf4TqEkBeueejQBckFGwBNN4Gyo+/7/my6Z1Mnei5Q=";
+    };
+
+    sourceRoot = "source/opentelemetry-api";
 
     format = "pyproject";
 
@@ -55,8 +57,9 @@ let
     passthru.tests.${self.pname} = self.overridePythonAttrs { doCheck = true; };
 
     meta = with lib; {
-      homepage = "https://opentelemetry.io";
+      homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api";
       description = "OpenTelemetry Python API";
+      changelog = "https://github.com/open-telemetry/opentelemetry-python/releases/tag/${self.src.rev}";
       license = licenses.asl20;
       maintainers = teams.deshaw.members;
     };

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-common/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-common/default.nix
@@ -1,26 +1,20 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , hatchling
+, opentelemetry-api
 , opentelemetry-proto
 , opentelemetry-sdk
 , opentelemetry-test-utils
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-api) version src;
   pname = "opentelemetry-exporter-otlp-proto-common";
-  version = "1.18.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-HNlkbDyYnr0/lDeY1xt0pRxqk+977ljgPdfJzAxL3AQ=";
-    sparseCheckout = [ "/exporter/${pname}" ];
-  } + "/exporter/${pname}";
+  sourceRoot = "source/exporter/opentelemetry-exporter-otlp-proto-common";
 
   format = "pyproject";
 
@@ -40,10 +34,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.common" ];
 
-  meta = with lib; {
+  meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-common";
     description = "OpenTelemetry Protobuf encoding";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
@@ -1,29 +1,23 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , backoff
 , googleapis-common-protos
 , grpcio
 , hatchling
+, opentelemetry-api
 , opentelemetry-test-utils
 , opentelemetry-exporter-otlp-proto-common
 , pytest-grpc
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-api) version src;
   pname = "opentelemetry-exporter-otlp-proto-grpc";
-  version = "1.18.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-feAmPL/G3ABIY5tBODlMJIBzxqg6Bl7imJB2EYtEp2o=";
-    sparseCheckout = [ "/exporter/${pname}" ];
-  } + "/exporter/${pname}";
+  sourceRoot = "source/exporter/opentelemetry-exporter-otlp-proto-grpc";
 
   format = "pyproject";
 
@@ -49,10 +43,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.grpc" ];
 
-  meta = with lib; {
+  meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-grpc";
     description = "OpenTelemetry Collector Protobuf over gRPC Exporter";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-http/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-http/default.nix
@@ -1,10 +1,10 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , backoff
 , googleapis-common-protos
 , hatchling
+, opentelemetry-api
 , opentelemetry-exporter-otlp-proto-common
 , opentelemetry-test-utils
 , requests
@@ -12,18 +12,12 @@
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-api) version src;
   pname = "opentelemetry-exporter-otlp-proto-http";
-  version = "1.18.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-r4jvIhRM9E4CuZyS/XvvYO+F9cPxip8ab57CUfip47Q=";
-    sparseCheckout = [ "/exporter/${pname}" ];
-  } + "/exporter/${pname}";
+  sourceRoot = "source/exporter/opentelemetry-exporter-otlp-proto-http";
 
   format = "pyproject";
 
@@ -46,10 +40,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.http" ];
 
-  meta = with lib; {
+  meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http";
     description = "OpenTelemetry Collector Protobuf over HTTP Exporter";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp/default.nix
@@ -1,26 +1,20 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , backoff
 , hatchling
+, opentelemetry-api
 , opentelemetry-exporter-otlp-proto-grpc
 , opentelemetry-exporter-otlp-proto-http
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-api) version src;
   pname = "opentelemetry-exporter-otlp";
-  version = "1.18.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-ph9ahT6M8UBvuUJjk6nug68Ou/D7XuuXkfnKHEdD8x8=";
-    sparseCheckout = [ "/exporter/${pname}" ];
-  } + "/exporter/${pname}";
+  sourceRoot = "source/exporter/opentelemetry-exporter-otlp";
 
   format = "pyproject";
 
@@ -39,10 +33,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.exporter.otlp" ];
 
-  meta = with lib; {
+  meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp";
     description = "OpenTelemetry Collector Exporters";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , hatchling
 , opentelemetry-api
 , opentelemetry-sdk
@@ -10,18 +9,12 @@
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-api) version src;
   pname = "opentelemetry-exporter-prometheus";
-  version = "1.18.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-vWVLUt3Ett04kqUyoTOBNvRj51/M35X83saBBxeOTZI=";
-    sparseCheckout = [ "/exporter/${pname}" ];
-  } + "/exporter/${pname}";
+  sourceRoot = "source/exporter/opentelemetry-exporter-prometheus";
 
   format = "pyproject";
 
@@ -42,10 +35,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.exporter.prometheus" ];
 
-  meta = with lib; {
+  meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-prometheus";
     description = "Prometheus Metric Exporter for OpenTelemetry";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-aiohttp-client/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-aiohttp-client/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , hatchling
 , opentelemetry-api
 , opentelemetry-instrumentation
@@ -12,21 +11,13 @@
 , pytestCheckHook
 , aiohttp
 }:
-let
-  pname = "opentelemetry-instrumentation-aiohttp-client";
-  version = "0.39b0";
-in
+
 buildPythonPackage {
-  inherit pname version;
+  inherit (opentelemetry-instrumentation) version src;
+  pname = "opentelemetry-instrumentation-aiohttp-client";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python-contrib";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-HFDebR3d1osFAIlNuIbs5s+uPeTTJ1xkz+BpE5BpciU=";
-    sparseCheckout = [ "/instrumentation/${pname}" ];
-  } + "/instrumentation/${pname}";
+  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-aiohttp-client";
 
   format = "pyproject";
 
@@ -54,10 +45,8 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "opentelemetry.instrumentation.aiohttp_client" ];
 
-  meta = with lib; {
+  meta = opentelemetry-instrumentation.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-aiohttp-client";
     description = "OpenTelemetry Instrumentation for aiohttp-client";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ happysalada ];
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-asgi/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-asgi/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , asgiref
 , hatchling
 , opentelemetry-api
@@ -12,18 +11,12 @@
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-asgi";
-  version = "0.39b0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python-contrib";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-BfNrbOQwyApdcKOVGF0LqzWOxzLkHZYiYdYVVPkGmdQ=";
-    sparseCheckout = [ "/instrumentation/${pname}" ];
-  } + "/instrumentation/${pname}";
+  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-asgi";
 
   format = "pyproject";
 
@@ -46,10 +39,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.instrumentation.asgi" ];
 
-  meta = with lib; {
+  meta = opentelemetry-instrumentation.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-asgi";
     description = "ASGI instrumentation for OpenTelemetry";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , django
 , hatchling
 , opentelemetry-api
@@ -14,18 +13,12 @@
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-django";
-  version = "0.39b0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python-contrib";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-5tyLFQTYuJBFAFZirqsaHXCw72Q3TigDctZZFi/2zdI=";
-    sparseCheckout = [ "/instrumentation/${pname}" ];
-  } + "/instrumentation/${pname}";
+  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-django";
 
   format = "pyproject";
 
@@ -50,10 +43,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.instrumentation.django" ];
 
-  meta = with lib; {
+  meta = opentelemetry-instrumentation.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-django";
     description = "OpenTelemetry Instrumentation for Django";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , hatchling
 , opentelemetry-api
 , opentelemetry-instrumentation
@@ -13,18 +12,12 @@
 , grpcio
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-grpc";
-  version = "0.39b0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python-contrib";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-DkDAE0MsF9HdywxlFzqJaqNor4O/jpnSqINsKTuiVqU=";
-    sparseCheckout = [ "/instrumentation/${pname}" ];
-  } + "/instrumentation/${pname}";
+  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-grpc";
 
   format = "pyproject";
 
@@ -52,10 +45,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.instrumentation.grpc" ];
 
-  meta = with lib; {
+  meta = opentelemetry-instrumentation.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-grpc";
     description = "OpenTelemetry Instrumentation for grpc";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ happysalada ];
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-wsgi/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-wsgi/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , hatchling
 , opentelemetry-api
 , opentelemetry-instrumentation
@@ -11,18 +10,12 @@
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-wsgi";
-  version = "0.39b0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python-contrib";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-DBZGXY8Y208YC/guk0qUB04UA/JFAtiv3kjsikskTRs=";
-    sparseCheckout = [ "/instrumentation/${pname}" ];
-  } + "/instrumentation/${pname}";
+  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-wsgi";
 
   format = "pyproject";
 
@@ -44,10 +37,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.instrumentation.wsgi" ];
 
-  meta = with lib; {
+  meta = opentelemetry-instrumentation.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-wsgi";
     description = "WSGI Middleware for OpenTelemetry";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -16,13 +16,15 @@ buildPythonPackage rec {
   version = "0.39b0";
   disabled = pythonOlder "3.7";
 
+  # to avoid breakage, every package in opentelemetry-python-contrib must inherit this version, src, and meta
   src = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-python-contrib";
     rev = "refs/tags/v${version}";
-    hash = "sha256-+zk76A640nyd1L0I55JrMMs7EnQ+SPQdYGAFIyQFc6E=";
-    sparseCheckout = [ "/${pname}" ];
-  } + "/${pname}";
+    hash = "sha256-MPBOdurEQhA9BPRgVftejjtkvN/zRQEJDjQcS2QW3xc=";
+  };
+
+  sourceRoot = "source/opentelemetry-instrumentation";
 
   format = "pyproject";
 
@@ -47,6 +49,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation";
     description = "Instrumentation Tools & Auto Instrumentation for OpenTelemetry Python";
+    changelog = "https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/${src.rev}";
     license = licenses.asl20;
     maintainers = teams.deshaw.members;
   };

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage rec {
     description = "Instrumentation Tools & Auto Instrumentation for OpenTelemetry Python";
     changelog = "https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = teams.deshaw.members;
+    maintainers = teams.deshaw.members ++ [ maintainers.natsukium ];
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-proto/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-proto/default.nix
@@ -1,24 +1,18 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , hatchling
+, opentelemetry-api
 , protobuf
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-api) version src;
   pname = "opentelemetry-proto";
-  version = "1.18.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-6iB+QlBUqRvIJ9p38NYgP4icW2rYs1P3bNCxI95cOvs=";
-    sparseCheckout = [ "/${pname}" ];
-  } + "/${pname}";
+  sourceRoot = "source/opentelemetry-proto";
 
   format = "pyproject";
 
@@ -36,10 +30,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.proto" ];
 
-  meta = with lib; {
+  meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-proto";
     description = "OpenTelemetry Python Proto";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-sdk/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-sdk/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , flaky
 , hatchling
 , opentelemetry-api
@@ -14,17 +13,11 @@
 
 let
   self = buildPythonPackage {
+    inherit (opentelemetry-api) version src;
     pname = "opentelemetry-sdk";
-    version = "1.18.0";
     disabled = pythonOlder "3.7";
 
-    src = fetchFromGitHub {
-      owner = "open-telemetry";
-      repo = "opentelemetry-python";
-      rev = "refs/tags/v${self.version}";
-      hash = "sha256-YMFSmzuvm/VA9Fpe7pbF9mnGQHOQpobWMb1iGRt+d3w=";
-      sparseCheckout = [ "/${self.pname}" ];
-    } + "/${self.pname}";
+    sourceRoot = "source/opentelemetry-sdk";
 
     format = "pyproject";
 
@@ -56,11 +49,9 @@ let
     # Enable tests via passthru to avoid cyclic dependency with opentelemetry-test-utils.
     passthru.tests.${self.pname} = self.overridePythonAttrs { doCheck = true; };
 
-    meta = with lib; {
-      homepage = "https://opentelemetry.io";
-      description = "OpenTelemetry Python API and SDK";
-      license = licenses.asl20;
-      maintainers = teams.deshaw.members;
+    meta = opentelemetry-api.meta // {
+      homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-sdk";
+      description = "OpenTelemetry Python SDK";
     };
   };
 in self

--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
@@ -1,23 +1,17 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , hatchling
+, opentelemetry-api
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-api) version src;
   pname = "opentelemetry-semantic-conventions";
-  version = "1.18.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-82L/tDoWgu0r+Li3CS3hjVR99DQQmA5yt3y85+37imI=";
-    sparseCheckout = [ "/${pname}" ];
-  } + "/${pname}";
+  sourceRoot = "source/opentelemetry-semantic-conventions";
 
   format = "pyproject";
 
@@ -31,10 +25,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.semconv" ];
 
-  meta = with lib; {
+  meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions";
     description = "OpenTelemetry Semantic Conventions";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
@@ -2,25 +2,18 @@
 , callPackage
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , asgiref
 , hatchling
 , opentelemetry-api
 , opentelemetry-sdk
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-api) version src;
   pname = "opentelemetry-test-utils";
-  version = "1.18.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-WRcKTE3eVqOSQUi5gZ3du+RGw8CrMazXHrctdrjgzHo=";
-    sparseCheckout = [ "/tests/${pname}" ];
-  } + "/tests/${pname}";
+  sourceRoot = "source/tests/opentelemetry-test-utils";
 
   format = "pyproject";
 
@@ -36,10 +29,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.test" ];
 
-  meta = with lib; {
+  meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/tests/opentelemetry-test-utils";
     description = "Test utilities for OpenTelemetry unit tests";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-util-http/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-util-http/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchFromGitHub
 , hatchling
 , opentelemetry-instrumentation
 , opentelemetry-sdk
@@ -10,18 +9,12 @@
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
+  inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-util-http";
-  version = "0.39b0";
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "open-telemetry";
-    repo = "opentelemetry-python-contrib";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-C20/M5wimQec/8tTKx7+jkIYgfgNPtU9lkPKliIM3Uk=";
-    sparseCheckout = [ "/util/${pname}" ];
-  } + "/util/${pname}";
+  sourceRoot = "source/util/opentelemetry-util-http";
 
   format = "pyproject";
 
@@ -42,10 +35,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "opentelemetry.util.http" ];
 
-  meta = with lib; {
+  meta = opentelemetry-instrumentation.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/util/opentelemetry-util-http";
     description = "Web util for OpenTelemetry";
-    license = licenses.asl20;
-    maintainers = teams.deshaw.members;
   };
 }


### PR DESCRIPTION
###### Description of changes

It was pointed out on [matrix](https://matrix.to/#/!VjfUzaKsXokUdnQcvP:nixos.org/$9DnbZKGlZacc8xm4umLfG1rsOYnd1VW8f28E6J2sEWM?via=nixos.org&via=matrix.org&via=nixos.dev) that each module under `open-telemetry/opentelemetry-python` is packaged separately and, therefore, fragile to version updates.

In this PR, I unified the `version`, `src`, and `meta` using the core package, `opentelemetry-api`, as the source.

I also added myself as a maintainer to make it easier to notice changes related to opentelemetry-api.

I hope we can package them in a better way.

Also, I will work on `opentelemetry-python-contrib` after this PR and #245028 are done.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
