### PR TITLE
pspp: 1.4.1 -> 1.6.2

### DIFF
--- a/pkgs/applications/science/math/pspp/default.nix
+++ b/pkgs/applications/science/math/pspp/default.nix
@@ -1,23 +1,28 @@
 { lib, stdenv, fetchurl, libxml2, readline, zlib, perl, cairo, gtk3, gsl
-, pkg-config, gtksourceview, pango, gettext, dconf
+, pkg-config, gtksourceview4, pango, gettext, dconf
 , makeWrapper, gsettings-desktop-schemas, hicolor-icon-theme
-, texinfo, ssw, python3
+, texinfo, ssw, python3, iconv
 }:
 
 stdenv.mkDerivation rec {
   pname = "pspp";
-  version = "1.4.1";
+  version = "1.6.2";
 
   src = fetchurl {
     url = "mirror://gnu/pspp/${pname}-${version}.tar.gz";
-    sha256 = "0lqrash677b09zxdlxp89z6k02y4i23mbqg83956dwl69wc53dan";
+    sha256 = "sha256-cylMovWy9/xBu/i3jFiIyAdfQ8YJf9SCq7BPhasIR7Y=";
   };
 
   nativeBuildInputs = [ pkg-config texinfo python3 makeWrapper ];
   buildInputs = [ libxml2 readline zlib perl cairo gtk3 gsl
-    gtksourceview pango gettext
-    gsettings-desktop-schemas hicolor-icon-theme ssw
-  ];
+                  gtksourceview4 pango gettext
+                  gsettings-desktop-schemas hicolor-icon-theme ssw iconv
+                ];
+
+  C_INCLUDE_PATH =
+    "${libxml2.dev}/include/libxml2/:" +
+    lib.makeSearchPathOutput "dev" "include" buildInputs;
+  LIBRARY_PATH = lib.makeLibraryPath buildInputs;
 
   doCheck = false;
 


### PR DESCRIPTION
Note: needs ssw >= 0.7

I have created another PR (#245214) for ssw: 0.6 -> 0.8, then only pspp 1.6.2 builds.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
---

----

Without below lines, I got some errors.

```nix
C_INCLUDE_PATH =                                       
  "${libxml2.dev}/include/libxml2/:" +                 
  lib.makeSearchPathOutput "dev" "include" buildInputs;
LIBRARY_PATH = lib.makeLibraryPath buildInputs;        
```

The error without above lines was: 

```c
> ./src/output/spv/spv.h:24:10: fatal error: libxml/tree.h: No such file or directory
>    24 | [#include] <libxml/tree.h>
>       |          ^~~~~~~~~~~~~~~
> compilation terminated.
```

Please correct me if its weird or wrong.
It did build on my end successfully.

You can go through [INSTALL](https://git.savannah.gnu.org/cgit/pspp.git/plain/INSTALL) for notes on building.
