### PR TITLE
wp-notifyd: init at unstable-2023-07-24

### DIFF
--- a/pkgs/applications/audio/wp-notifyd/default.nix
+++ b/pkgs/applications/audio/wp-notifyd/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, fmt_9
+, libnotify
+, spdlog
+, wireplumber
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wp-notifyd";
+  version = "unstable-2023-07-24";
+
+  src = fetchFromGitHub {
+    owner = "LDAP";
+    repo = pname;
+    rev = "1d46728a43ca7d9f207b8309071ed8f22968e617";
+    hash = "sha256-UGz3AAFXpoEwxUk+SwD9zhVGWqpbJ6Prex1Gz9eTTDw=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    fmt_9
+    libnotify
+    spdlog
+    wireplumber
+  ];
+
+  meta = with lib; {
+    description = "A notification daemon for Wireplumber";
+    homepage = "https://github.com/LDAP/wp-notifyd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fee1-dead ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14537,6 +14537,8 @@ with pkgs;
 
   wolf-shaper = callPackage ../applications/audio/wolf-shaper { };
 
+  wp-notifyd = callPackage ../applications/audio/wp-notifyd { };
+
   wpgtk = callPackage ../tools/X11/wpgtk { };
 
   wrap = callPackage ../tools/text/wrap { };


### PR DESCRIPTION
###### Description of changes

This application sends a notification whenever a wireplumber's device's state is changed (e.g. volume)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
