### PR TITLE
nixos/gitlab: ensure service started again after dependency restarts

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -1635,7 +1635,7 @@ in {
         "gitlab-config.service"
         "gitlab-db-config.service"
       ] ++ optional (cfg.databaseHost == "") "postgresql.service";
-      wantedBy = [ "gitlab.target" ];
+      requiredBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
       environment = gitlabEnv;
       path = with pkgs; [


### PR DESCRIPTION
Upstreaming of flyingcircusio/fc-nixos#707 which is running fine in production for several months now.

###### Description of changes

When a dependency, like postgresql.service or redis-gitlab.service, had been stopped and started at switch-to-configuration time, gitlab.service and its helper units had been stopped but not started again:
`gitlab.service` has a `BindsTo=postgresql.service` dependency. This means, that it gets stopped when its dependency service postgresql is stopped. But there is no dependency pulling it back to be started again.
`multi-user.target` only has a `Wants` relation to gitlab.target, but once gitlab.target has been successfully started once and is not stopped/ restarted again, it does not cause all its dependencies to stay activated the whole time.

This commit fixes this by upgrading the dependy relationship of gitlab.service towards gitlab.target from a "Wants" to a "Requires". It should be enough to do this for this single unit part of gitlab.target only, as all other units wantedBy gitlab.target are pulled in by gitlab.service as well or have bindsTo relations.

Let me know whether I shall add test coverage for the case of dependency stop and start. Constructing a case where a dependency is stopped and started can certainly be done in a NixOS VM test, but I'd like to know whether such an additional test case is desired before approaching thos and potentially blowing up the test runtime any further.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - not significant enough
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
