### PR TITLE
osm2pgsql: fix build

### DIFF
--- a/pkgs/tools/misc/osm2pgsql/default.nix
+++ b/pkgs/tools/misc/osm2pgsql/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , cmake
 , expat
+, fetchpatch
 , fmt
 , proj
 , bzip2
@@ -26,6 +27,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-8Jefd8dfoh/an7wd+8iTM0uOKA4UiUo8t2WzZs4r/Ck=";
   };
+
+  patches = [
+    # Fix compatiblity with fmt 10.0. Remove with the next release
+    (fetchpatch {
+      url = "https://github.com/openstreetmap/osm2pgsql/commit/37aae6c874b58cd5cd27e70b2b433d6624fd7498.patch";
+      hash = "sha256-Fv2zPqhRDoJXlqB1Q9q5iskn28iqq3TYPcdqfu/pvD4=";
+    })
+  ];
 
   postPatch = ''
     # Remove bundled libraries


### PR DESCRIPTION
###### Description of changes
Use fmt_9 (https://github.com/NixOS/nixpkgs/pull/233330#issuecomment-1610746384)
https://hydra.nixos.org/build/227867921

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
