### PR TITLE
ax25-apps: set localstatedir to /var/lib

### DIFF
--- a/pkgs/applications/radio/ax25-apps/default.nix
+++ b/pkgs/applications/radio/ax25-apps/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--sysconfdir=/etc"
+    "--localstatedir=/var/lib"
     "--program-transform-name=s@^call$@ax&@;s@^listen$@ax&@"
   ];
 


### PR DESCRIPTION
Relates to: https://github.com/NixOS/nixpkgs/pull/245242

Previously, `localstatedir` was being defaulting to path inside /nix/store so some AX.25 applications were not able to write their state to disk.

Heres an example of `ax25rtd` as an example of an application that needs to write it state to disk.

Previously:
```
$ strings ./result/bin/ax25rtd | grep -i var
/nix/store/89mvw2jksb0s41xggb6zjzikyjk4clfk-ax25-apps-0.0.8-rc5/var/ax25/ax25rtd/control
/nix/store/89mvw2jksb0s41xggb6zjzikyjk4clfk-ax25-apps-0.0.8-rc5/var/ax25/ax25rtd/ax25_route
/nix/store/89mvw2jksb0s41xggb6zjzikyjk4clfk-ax25-apps-0.0.8-rc5/var/ax25/ax25rtd/ip_route
```

After changes:
```
$ strings ./result/bin/ax25rtd | grep -i var
/var/lib/ax25/ax25rtd/control
/var/lib/ax25/axax25rtd/control
/var/lib/ax25/ax25rtd/ax25_route
/var/lib/ax25/ax25rtd/ip_route
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
