### PR TITLE
bash: fix parallel build failure on unwind_prot.o

### DIFF
--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -61,6 +61,10 @@ stdenv.mkDerivation rec {
       url = "https://cgit.freebsd.org/ports/plain/shells/bash/files/patch-configure?id=3e147a1f594751a68fea00a28090d0792bee0b51";
       sha256 = "XHFMQ6eXTReNoywdETyrfQEv1rKF8+XFbQZP4YoVKFk=";
     })
+    # Apply parallel build fix pending upstream inclusion:
+    #   https://savannah.gnu.org/patch/index.php?10373
+    # Had to fetch manually to workaround -p0 default.
+    ./parallel.patch
   ];
 
   configureFlags = [

--- a/pkgs/shells/bash/parallel.patch
+++ b/pkgs/shells/bash/parallel.patch
@@ -1,0 +1,12 @@
+From https://savannah.gnu.org/patch/index.php?10373
+  https://savannah.gnu.org/patch/download.php?file_id=54964
+--- Makefile.in
++++ Makefile.in
+@@ -1432,6 +1432,7 @@ siglist.o: bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ subst.o: bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ test.o: bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ trap.o: bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
++unwind_prot.o: bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ variables.o: bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ version.o: bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ xmalloc.o: bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h


### PR DESCRIPTION
As reported by Robert Scott in https://github.com/NixOS/nixpkgs/pull/245066 without the change `make -j8` build of `make` occasionally fails to buildin parallel. The simplest reproducer is:

    $$ ./configure
    $$ make unwind_prot.o
    ...
    In file included from unwind_prot.c:51:
    In file included from ./bashintl.h:30:
    ./include/gettext.h:27:11: fatal error: 'libintl.h' file not found
    # include <libintl.h>
              ^~~~~~~~~~~
    1 error generated.
    make: * [Makefile:106: unwind_prot.o] Error 1

The change adds missing ttransitive `${LIBINTL_H}` dependency for unwind_prot.o.

Closes #245066

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
