### PR TITLE
alsa-scarlett-gui: fixed desktop entry

### DIFF
--- a/pkgs/applications/audio/alsa-scarlett-gui/default.nix
+++ b/pkgs/applications/audio/alsa-scarlett-gui/default.nix
@@ -25,7 +25,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config wrapGAppsHook4 ];
   buildInputs = [ gtk4 alsa-lib ];
   postInstall = ''
-      sed -Ei "s/(Exec\s?=\s?).*/\1alsa-scarlett-gui\nTryExec=alsa-scarlett-gui/" $out/share/applications/vu.b4.${pname}.desktop
+      substituteInPlace $out/share/applications/vu.b4.${pname}.desktop \
+        --replace "Exec=/bin/alsa-scarlett-gui" "Exec=$out/bin/alsa-scarlett-gui" \
+        --replace "Icon=alsa-scarlett-gui" "Icon=$out/share/icons/hicolor/256x256/apps/alsa-scarlett-gui.png"
   '';
 
   # causes redefinition of _FORTIFY_SOURCE

--- a/pkgs/applications/audio/alsa-scarlett-gui/default.nix
+++ b/pkgs/applications/audio/alsa-scarlett-gui/default.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation rec {
   sourceRoot = "source/src";
   nativeBuildInputs = [ pkg-config wrapGAppsHook4 ];
   buildInputs = [ gtk4 alsa-lib ];
+  postInstall = ''
+      sed -Ei "s/(Exec\s?=\s?).*/\1alsa-scarlett-gui\nTryExec=alsa-scarlett-gui/" $out/share/applications/vu.b4.${pname}.desktop
+  '';
 
   # causes redefinition of _FORTIFY_SOURCE
   hardeningDisable = [ "fortify3" ];

--- a/pkgs/applications/audio/alsa-scarlett-gui/default.nix
+++ b/pkgs/applications/audio/alsa-scarlett-gui/default.nix
@@ -26,8 +26,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gtk4 alsa-lib ];
   postInstall = ''
       substituteInPlace $out/share/applications/vu.b4.${pname}.desktop \
-        --replace "Exec=/bin/alsa-scarlett-gui" "Exec=$out/bin/${pname}" \
-        --replace "Icon=alsa-scarlett-gui" "Icon=${pname}"
+        --replace "Exec=/bin/alsa-scarlett-gui" "Exec=$out/bin/${pname}"
   '';
 
   # causes redefinition of _FORTIFY_SOURCE

--- a/pkgs/applications/audio/alsa-scarlett-gui/default.nix
+++ b/pkgs/applications/audio/alsa-scarlett-gui/default.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ gtk4 alsa-lib ];
   postInstall = ''
       substituteInPlace $out/share/applications/vu.b4.${pname}.desktop \
-        --replace "Exec=/bin/alsa-scarlett-gui" "Exec=$out/bin/alsa-scarlett-gui" \
-        --replace "Icon=alsa-scarlett-gui" "Icon=$out/share/icons/hicolor/256x256/apps/alsa-scarlett-gui.png"
+        --replace "Exec=/bin/alsa-scarlett-gui" "Exec=$out/bin/${pname}" \
+        --replace "Icon=alsa-scarlett-gui" "Icon=$out/share/icons/hicolor/256x256/apps/${pname}.png"
   '';
 
   # causes redefinition of _FORTIFY_SOURCE

--- a/pkgs/applications/audio/alsa-scarlett-gui/default.nix
+++ b/pkgs/applications/audio/alsa-scarlett-gui/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
       substituteInPlace $out/share/applications/vu.b4.${pname}.desktop \
         --replace "Exec=/bin/alsa-scarlett-gui" "Exec=$out/bin/${pname}" \
-        --replace "Icon=alsa-scarlett-gui" "Icon=$out/share/icons/hicolor/256x256/apps/${pname}.png"
+        --replace "Icon=alsa-scarlett-gui" "Icon=${pname}"
   '';
 
   # causes redefinition of _FORTIFY_SOURCE


### PR DESCRIPTION
Fixed desktop entry of the app so that it shows up in the menu. 

###### Description of changes
In place search and replace was implemented in the postInstall phase using sed.

@SebTM as requested the solution now is all in one file.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).