### PR TITLE
lib/modules/mk*Module: give resulting modules meaningful keys

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1049,7 +1049,8 @@ let
   */
   mkRemovedOptionModule = optionName: replacementInstructions:
     { options, ... }:
-    { options = setAttrByPath optionName (mkOption {
+    { key = "lib/modules.nix#mkRemovedOptionModule-${showOption optionName}";
+      options = setAttrByPath optionName (mkOption {
         visible = false;
         apply = x: throw "The option `${showOption optionName}' can no longer be used since it's been removed. ${replacementInstructions}";
       });
@@ -1134,6 +1135,7 @@ let
   mkMergedOptionModule = from: to: mergeFn:
     { config, options, ... }:
     {
+      key = "lib/modules.nix#mkMergedOptionModule-${lib.concatMapStringsSep "-" showOption from}-to-${showOption to}";
       options = foldl' recursiveUpdate {} (map (path: setAttrByPath path (mkOption {
         visible = false;
         # To use the value in mergeFn without triggering errors
@@ -1224,6 +1226,7 @@ let
       toType = let opt = attrByPath to {} options; in opt.type or (types.submodule {});
     in
     {
+      key = "lib/modules.nix#doRename-${showOption from}-to-${showOption to}";
       options = setAttrByPath from (mkOption {
         inherit visible;
         description = "Alias of {option}`${showOption to}`.";

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -167,6 +167,11 @@ checkConfigError 'Module ..*disable-module-bad-key.nix. contains a disabledModul
 checkConfigOutput '^true$' 'config.positive.enable' ./disable-module-with-toString-key.nix
 checkConfigOutput '^false$' 'config.negative.enable' ./disable-module-with-toString-key.nix
 
+# Check whether disabling inline modules defined using lib.mk*Module via key works
+checkConfigOutput '^true$' 'config.group.enable' ./disable-removed-option-module.nix
+checkConfigError 'The option .group-a. does not exist.' 'config.group-b.enable' ./disable-renamed-option-module.nix
+checkConfigError 'The option .old-enable-a. does not exist.' 'config.new-enable' ./disable-merged-option-module.nix
+
 # Check _module.args.
 set -- config.enable ./declare-enable.nix ./define-enable-with-custom-arg.nix
 checkConfigError 'while evaluating the module argument .*custom.* in .*define-enable-with-custom-arg.nix.*:' "$@"

--- a/lib/tests/modules/alias-with-priority-can-override.nix
+++ b/lib/tests/modules/alias-with-priority-can-override.nix
@@ -19,21 +19,12 @@ with lib;
         Some descriptive text
       '';
     };
-
-    # mkAliasOptionModule sets warnings, so this has to be defined.
-    warnings = mkOption {
-      internal = true;
-      default = [];
-      type = types.listOf types.str;
-      example = [ "The `foo' service is deprecated and will go away soon!" ];
-      description = ''
-        This option allows modules to show warnings to users during
-        the evaluation of the system configuration.
-      '';
-    };
   };
 
   imports = [
+    # mkAliasOptionModule sets warnings, so this has to be imported.
+    ./dummy-warnings-module.nix
+
     # Create an alias for the "enable" option.
     (mkAliasOptionModule [ "enableAlias" ] [ "enable" ])
 

--- a/lib/tests/modules/alias-with-priority.nix
+++ b/lib/tests/modules/alias-with-priority.nix
@@ -19,21 +19,12 @@ with lib;
         Some descriptive text
       '';
     };
-
-    # mkAliasOptionModule sets warnings, so this has to be defined.
-    warnings = mkOption {
-      internal = true;
-      default = [];
-      type = types.listOf types.str;
-      example = [ "The `foo' service is deprecated and will go away soon!" ];
-      description = ''
-        This option allows modules to show warnings to users during
-        the evaluation of the system configuration.
-      '';
-    };
   };
 
   imports = [
+    # mkAliasOptionModule sets warnings, so this has to be imported.
+    ./dummy-warnings-module.nix
+
     # Create an alias for the "enable" option.
     (mkAliasOptionModule [ "enableAlias" ] [ "enable" ])
 

--- a/lib/tests/modules/disable-merged-option-module.nix
+++ b/lib/tests/modules/disable-merged-option-module.nix
@@ -1,0 +1,34 @@
+{ lib, ... }:
+
+let
+  newOption =
+    { lib, ... }:
+
+    {
+      options.new-enable = lib.mkEnableOption "nothing";
+    };
+
+  mergeOptions =
+    lib.mkMergedOptionModule
+      [
+        [ "old-enable-a" ]
+        [ "old-enable-b" ]
+      ]
+      [ "new-enable" ]
+      (config: config.old-enable-a == true && config.old-enable-b == true);
+in
+
+{
+  imports = [
+    # mkMergedOptionModule would set warnings, so this needs to be imported
+    ./dummy-warnings-module.nix
+    newOption
+    mergeOptions
+  ];
+
+  disabledModules = [
+    { key = "lib/modules.nix#mkMergedOptionModule-old-enable-a-old-enable-b-to-new-enable"; }
+  ];
+
+  config.old-enable-a = true;
+}

--- a/lib/tests/modules/disable-removed-option-module.nix
+++ b/lib/tests/modules/disable-removed-option-module.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+
+let
+  optionModule =
+    { lib, ... }:
+
+    {
+      options.group.enable = lib.mkEnableOption "nothing";
+    };
+in
+
+{
+  imports = [
+    (lib.mkRemovedOptionModule [ "group" ] "This message should never show")
+    optionModule
+  ];
+
+  disabledModules = [
+    { key = "lib/modules.nix#mkRemovedOptionModule-group"; }
+  ];
+
+  config.group.enable = true;
+}

--- a/lib/tests/modules/disable-renamed-option-module.nix
+++ b/lib/tests/modules/disable-renamed-option-module.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+
+let
+  newOption =
+    { lib, ... }:
+    {
+      options.group-b.enable = lib.mkEnableOption "nothing";
+    };
+in
+
+{
+  imports = [
+    newOption
+    (lib.mkRenamedOptionModule [ "group-a" "enable" ] [ "group-b" "enable" ])
+  ];
+
+  disabledModules = [
+    { key = "lib/modules.nix#doRename-group-a.enable-to-group-b.enable"; }
+  ];
+
+  config.group-a.enable = true;
+}

--- a/lib/tests/modules/doRename-warnings.nix
+++ b/lib/tests/modules/doRename-warnings.nix
@@ -1,9 +1,10 @@
 { lib, config, ... }: {
   imports = [
+    # doRename sets warnings, so this has to be imported.
+    ./dummy-warnings-module.nix
     (lib.doRename { from = ["a" "b"]; to = ["c" "d" "e"]; warn = true; use = x: x; visible = true; })
   ];
   options = {
-    warnings = lib.mkOption { type = lib.types.listOf lib.types.str; };
     c.d.e = lib.mkOption {};
     result = lib.mkOption {};
   };

--- a/lib/tests/modules/dummy-warnings-module.nix
+++ b/lib/tests/modules/dummy-warnings-module.nix
@@ -1,0 +1,14 @@
+{ lib, ... }:
+
+{
+  options.warnings = lib.mkOption {
+    internal = true;
+    default = [];
+    type = lib.types.listOf lib.types.str;
+    example = [ "The `foo' service is deprecated and will go away soon!" ];
+    description = ''
+      This option allows modules to show warnings to users during
+      the evaluation of the system configuration.
+    '';
+  };
+}


### PR DESCRIPTION
This enables us to disable unwanted modules created in this way using `disabledModules`. This is especially useful, since it is currently impossible to disable `rename.nix` (#245265), so it is required to get rid of the offending modules individually.

Undocumented until the bike shedding about the `key` format has finished…

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
