### PR TITLE
prometheus-idrac-exporter: init at unstable-2023-06-29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3258,6 +3258,12 @@
       fingerprint = "6E3A FA6D 915C C2A4 D26F  C53E 7BB4 BA9C 783D 2BBC";
     }];
   };
+  codec = {
+    email = "codec@fnord.cx";
+    github = "codec";
+    githubId = 118829;
+    name = "codec";
+  };
   CodeLongAndProsper90 = {
     github = "CodeLongAndProsper90";
     githubId = 50145141;

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -36,6 +36,7 @@ let
     "fastly"
     "fritzbox"
     "graphite"
+    "idrac"
     "influxdb"
     "ipmi"
     "json"
@@ -318,6 +319,14 @@ in
       message = ''
         Scaphandre needs 'intel_rapl_common' kernel module to be enabled. Please add it in 'boot.kernelModules'.
       '';
+    } {
+      assertion = cfg.idrac.enable -> (
+        (cfg.idrac.configurationPath == null) != (cfg.idrac.configuration == null)
+      );
+      message = ''
+        Please ensure you have either `services.prometheus.exporters.idrac.configuration'
+          or `services.prometheus.exporters.idrac.configurationPath' set!
+      '';
     } ] ++ (flip map (attrNames exporterOpts) (exporter: {
       assertion = cfg.${exporter}.firewallFilter != null -> cfg.${exporter}.openFirewall;
       message = ''
@@ -325,7 +334,12 @@ in
         `openFirewall' is set to `true'!
       '';
     })) ++ config.services.prometheus.exporters.assertions;
-    warnings = config.services.prometheus.exporters.warnings;
+    warnings = [(mkIf (config.services.prometheus.exporters.idrac.enable && config.services.prometheus.exporters.idrac.configurationPath != null) ''
+        Configuration file in `services.prometheus.exporters.idrac.configurationPath` may override
+        `services.prometheus.exporters.idrac.listenAddress` and/or `services.prometheus.exporters.idrac.port`.
+        Consider using `services.prometheus.exporters.idrac.configuration` instead.
+      ''
+    )] ++ config.services.prometheus.exporters.warnings;
   }] ++ [(mkIf config.services.minio.enable {
     services.prometheus.exporters.minio.minioAddress  = mkDefault "http://localhost:9000";
     services.prometheus.exporters.minio.minioAccessKey = mkDefault config.services.minio.accessKey;

--- a/nixos/modules/services/monitoring/prometheus/exporters/idrac.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/idrac.nix
@@ -1,0 +1,69 @@
+{ config, lib, pkgs, options }:
+
+with lib;
+let
+  cfg = config.services.prometheus.exporters.idrac;
+
+  configFile = if cfg.configurationPath != null
+               then cfg.configurationPath
+               else pkgs.writeText "idrac.yml" (builtins.toJSON cfg.configuration);
+in
+{
+  port = 9348;
+  extraOpts = {
+    configurationPath = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      example = "/etc/prometheus-idrac-exporter/idrac.yml";
+      description = lib.mdDoc ''
+        Path to the service's config file. This path can either be a computed path in /nix/store or a path in the local filesystem.
+
+        The config file should NOT be stored in /nix/store as it will contain passwords and/or keys in plain text.
+
+        Mutually exclusive with `configuration` option.
+
+        Configuration reference: https://github.com/mrlhansen/idrac_exporter/#configuration
+      '';
+    };
+    configuration = mkOption {
+      type = types.nullOr types.attrs;
+      description = lib.mdDoc ''
+        Configuration for iDRAC exporter, as a nix attribute set.
+
+        Configuration reference: https://github.com/mrlhansen/idrac_exporter/#configuration
+
+        Mutually exclusive with `configurationPath` option.
+      '';
+      default = null;
+      example = {
+        timeout = 10;
+        retries = 1;
+        hosts = {
+          default = {
+            username = "username";
+            password = "password";
+          };
+        };
+        metrics = {
+          system = true;
+          sensors = true;
+          power = true;
+          sel = true;
+          storage = true;
+          memory = true;
+        };
+      };
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      LoadCredential = "configFile:${configFile}";
+      ExecStart = "${pkgs.prometheus-idrac-exporter}/bin/idrac_exporter -config %d/configFile";
+      Environment = [
+        "IDRAC_EXPORTER_LISTEN_ADDRESS=${cfg.listenAddress}"
+        "IDRAC_EXPORTER_LISTEN_PORT=${toString cfg.port}"
+      ];
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -307,6 +307,23 @@ let
       '';
     };
 
+    idrac = {
+      exporterConfig = {
+        enable = true;
+        port = 9348;
+        configuration = {
+          hosts = {
+            default = { username = "username"; password = "password"; };
+          };
+        };
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-idrac-exporter.service")
+        wait_for_open_port(9348)
+        wait_until_succeeds("curl localhost:9348")
+      '';
+    };
+
     influxdb = {
       exporterConfig = {
         enable = true;

--- a/pkgs/servers/monitoring/prometheus/idrac-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/idrac-exporter.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoModule, fetchFromGitHub, nixosTests }:
+
+buildGoModule rec {
+  pname = "idrac_exporter";
+  version = "unstable-2023-06-29";
+
+  src = fetchFromGitHub {
+    owner = "mrlhansen";
+    repo = "idrac_exporter";
+    rev = "3b311e0e6d602fb0938267287f425f341fbf11da";
+    sha256 = "sha256-N8wSjQE25TCXg/+JTsvQk3fjTBgfXTiSGHwZWFDmFKc=";
+  };
+
+  vendorHash = "sha256-iNV4VrdQONq7LXwAc6AaUROHy8TmmloUAL8EmuPtF/o=";
+
+  patches = [ ./idrac-exporter/config-from-environment.patch ];
+
+  ldflags = [ "-s" "-w" ];
+
+  doCheck = true;
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) idrac; };
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "Simple iDRAC exporter for Prometheus";
+    license = licenses.mit;
+    maintainers = with maintainers; [ codec ];
+  };
+}

--- a/pkgs/servers/monitoring/prometheus/idrac-exporter/config-from-environment.patch
+++ b/pkgs/servers/monitoring/prometheus/idrac-exporter/config-from-environment.patch
@@ -1,0 +1,100 @@
+diff --git a/internal/config/config.go b/internal/config/config.go
+index ba8f066..1c801cd 100644
+--- a/internal/config/config.go
++++ b/internal/config/config.go
+@@ -2,8 +2,11 @@ package config
+ 
+ import (
+ 	"encoding/base64"
++	"fmt"
+ 	"os"
++	"strconv"
+ 	"sync"
++
+ 	"github.com/mrlhansen/idrac_exporter/internal/logging"
+ 	"gopkg.in/yaml.v2"
+ )
+@@ -17,9 +20,9 @@ type HostConfig struct {
+ 
+ type RootConfig struct {
+ 	mutex         sync.Mutex
+-	Address       string                 `yaml:"address"`
+-	Port          uint                   `yaml:"port"`
+-	MetricsPrefix string                 `yaml:"metrics_prefix"`
++	Address       string `yaml:"address"`
++	Port          uint   `yaml:"port"`
++	MetricsPrefix string `yaml:"metrics_prefix"`
+ 	Collect       struct {
+ 		System  bool `yaml:"system"`
+ 		Sensors bool `yaml:"sensors"`
+@@ -28,9 +31,29 @@ type RootConfig struct {
+ 		Storage bool `yaml:"storage"`
+ 		Memory  bool `yaml:"memory"`
+ 	} `yaml:"metrics"`
+-	Timeout       uint                   `yaml:"timeout"`
+-	Retries       uint                   `yaml:"retries"`
+-	Hosts         map[string]*HostConfig `yaml:"hosts"`
++	Timeout uint                   `yaml:"timeout"`
++	Retries uint                   `yaml:"retries"`
++	Hosts   map[string]*HostConfig `yaml:"hosts"`
++}
++
++func getEnv(envvar string, defvalue string) string {
++	value := os.Getenv(envvar)
++	if len(value) == 0 {
++		return defvalue
++	}
++	return value
++}
++
++func getEnvUint(envvar string, defvalue uint) uint {
++	value, err := strconv.Atoi(getEnv(envvar, fmt.Sprint(defvalue)))
++	if err != nil {
++		logging.Fatalf("Failed parse integer value: %s", err)
++	}
++	if value == 0 {
++		return defvalue
++	}
++
++	return uint(value)
+ }
+ 
+ func (config *RootConfig) GetHostCfg(target string) *HostConfig {
+@@ -70,29 +93,29 @@ func ReadConfigFile(fileName string) {
+ 	}
+ 
+ 	if Config.Address == "" {
+-		Config.Address = "0.0.0.0"
++		Config.Address = getEnv("IDRAC_EXPORTER_LISTEN_ADDRESS", "0.0.0.0")
+ 	}
+ 
+ 	if Config.Port == 0 {
+-		Config.Port = 9348
++		Config.Port = getEnvUint("IDRAC_EXPORTER_LISTEN_PORT", 9348)
+ 	}
+ 
+ 	if Config.Timeout == 0 {
+-		Config.Timeout = 10
++		Config.Timeout = getEnvUint("IDRAC_EXPORTER_TIMEOUT", 10)
+ 	}
+ 
+ 	if Config.Retries == 0 {
+-		Config.Retries = 1
++		Config.Retries = getEnvUint("IDRAC_EXPORTER_RETRIES", 1)
++	}
++
++	if Config.MetricsPrefix == "" {
++		Config.MetricsPrefix = getEnv("IDRAC_EXPORTER_PREFIX", "idrac")
+ 	}
+ 
+ 	if len(Config.Hosts) == 0 {
+ 		parseError("missing section", "hosts")
+ 	}
+ 
+-	if Config.MetricsPrefix == "" {
+-		Config.MetricsPrefix = "idrac"
+-	}
+-
+ 	for k, v := range Config.Hosts {
+ 		if v.Username == "" {
+ 			parseError("missing username for host", k)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26823,6 +26823,7 @@ with pkgs;
   prometheus-gitlab-ci-pipelines-exporter = callPackage ../servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix { };
   prometheus-graphite-exporter = callPackage ../servers/monitoring/prometheus/graphite-exporter.nix { };
   prometheus-haproxy-exporter = callPackage ../servers/monitoring/prometheus/haproxy-exporter.nix { };
+  prometheus-idrac-exporter = callPackage ../servers/monitoring/prometheus/idrac-exporter.nix { };
   prometheus-influxdb-exporter = callPackage ../servers/monitoring/prometheus/influxdb-exporter.nix { };
   prometheus-ipmi-exporter = callPackage ../servers/monitoring/prometheus/ipmi-exporter.nix { };
   prometheus-jitsi-exporter = callPackage ../servers/monitoring/prometheus/jitsi-exporter.nix { };


### PR DESCRIPTION
###### Description of changes

Simple iDRAC exporter for Prometheus

https://github.com/mrlhansen/idrac_exporter/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
