### PR TITLE
haskell.packages.ghc96: Build fixes

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -63,12 +63,19 @@ in {
 
   hashable-time = doJailbreak super.hashable-time;
   libmpd = doJailbreak super.libmpd;
+  lens-family-th = doJailbreak super.lens-family-th;  # template-haskell <2.19
+
   # generically needs base-orphans for 9.4 only
   base-orphans = dontCheck (doDistribute super.base-orphans);
 
   # the dontHaddock is due to a GHC panic. might be this bug, not sure.
   # https://gitlab.haskell.org/ghc/ghc/-/issues/21619
   hedgehog = dontHaddock super.hedgehog;
+
+  # Cherry-pick GHC 9.4 changes from hnix master branch
+  hnix = appendPatches [
+    ./patches/hnix-compat-for-ghc-9.4.patch
+  ] (doJailbreak super.hnix);
 
   hpack = overrideCabal (drv: {
     # Cabal 3.6 seems to preserve comments when reading, which makes this test fail

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -163,6 +163,25 @@ self: super: {
       hls-stylish-haskell-plugin = null;
     };
 
+  # Newer version of servant required for GHC 9.6
+  servant = self.servant_0_20;
+  servant-server = self.servant-server_0_20;
+  servant-client = self.servant-client_0_20;
+  servant-client-core = self.servant-client-core_0_20;
+  # Select versions compatible with servant_0_20
+  servant-docs = self.servant-docs_0_13;
+  servant-swagger = self.servant-swagger_1_2;
+  # Jailbreaks for servant <0.20
+  servant-lucid = doJailbreak super.servant-lucid;
+
+  # Jailbreak strict upper bounds: http-api-data <0.6
+  servant_0_20 = doJailbreak super.servant_0_20;
+  servant-server_0_20 = doJailbreak super.servant-server_0_20;
+  servant-client_0_20 = doJailbreak super.servant-client_0_20;
+  servant-client-core_0_20 = doJailbreak super.servant-client-core_0_20;
+  # Jailbreak strict upper bounds: doctest <0.22
+  servant-swagger_1_2 = doJailbreak super.servant-swagger_1_2;
+
   lifted-base = dontCheck super.lifted-base;
   hw-fingertree = dontCheck super.hw-fingertree;
   hw-prim = dontCheck (doJailbreak super.hw-prim);

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -222,6 +222,8 @@ self: super: {
     mfsolve                     # mtl <2.3
     cubicbezier                 # mtl <2.3
     dhall                       # template-haskell <2.20
+    env-guard                   # doctest <0.21
+    package-version             # doctest <0.21, tasty-hedgehog <1.4
   ;
 
   # Apply workaround for Cabal 3.9 bug https://github.com/haskell/cabal/issues/8455

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -194,6 +194,13 @@ self: super: {
     xmonad-contrib              # mtl >=1 && <2.3
     dbus       # template-haskell >=2.18 && <2.20, transformers <0.6, unix <2.8
     gi-cairo-connector          # mtl <2.3
+    haskintex                   # text <2
+    lens-family-th              # template-haskell <2.19
+    ghc-prof                    # base <4.18
+    profiteur                   # vector <0.13
+    mfsolve                     # mtl <2.3
+    cubicbezier                 # mtl <2.3
+    dhall                       # template-haskell <2.20
   ;
 
   # Apply workaround for Cabal 3.9 bug https://github.com/haskell/cabal/issues/8455

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -171,7 +171,9 @@ self: super: {
   rebase = doJailbreak super.rebase_1_20;
   rerebase = doJailbreak super.rerebase_1_20;
   hiedb = dontCheck super.hiedb;
-  retrie = dontCheck (super.retrie);
+  retrie = dontCheck super.retrie;
+  # https://github.com/kowainik/relude/issues/436
+  relude = dontCheck (doJailbreak super.relude);
 
   ghc-exactprint = unmarkBroken (addBuildDepends (with self.ghc-exactprint.scope; [
    HUnit Diff data-default extra fail free ghc-paths ordered-containers silently syb

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -252,9 +252,6 @@ self: super: {
     })];
   }) super.ConfigFile;
 
-  # Use newer version of warp with has the openFd signature change for
-  # compatibility with unix>=2.8.0.
-  warp = self.warp_3_3_28;
   # The curl executable is required for withApplication tests.
   warp_3_3_28 = addTestToolDepend pkgs.curl super.warp_3_3_28;
 }

--- a/pkgs/development/haskell-modules/patches/hnix-compat-for-ghc-9.4.patch
+++ b/pkgs/development/haskell-modules/patches/hnix-compat-for-ghc-9.4.patch
@@ -1,0 +1,74 @@
+From daae423d339e820e3fe8c720bd568cc49eae3fde Mon Sep 17 00:00:00 2001
+From: Rodney Lorrimar <dev@rodney.id.au>
+Date: Tue, 25 Jul 2023 16:46:36 +0800
+Subject: [PATCH] GHC 9.4 compatibility
+
+---
+ src/Nix/Fresh.hs | 2 +-
+ src/Nix/Lint.hs  | 2 +-
+ src/Nix/Utils.hs | 2 +-
+ src/Nix/Value.hs | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/Nix/Fresh.hs b/src/Nix/Fresh.hs
+index fdd20c4a..4b55de4e 100644
+--- a/src/Nix/Fresh.hs
++++ b/src/Nix/Fresh.hs
+@@ -14,7 +14,7 @@ import           Control.Monad.Catch  ( MonadCatch
+                                       , MonadMask
+                                       , MonadThrow
+                                       )
+-import           Control.Monad.Except ( MonadFix )
++import           Control.Monad.Fix    ( MonadFix )
+ import           Control.Monad.Ref    ( MonadAtomicRef(..)
+                                       , MonadRef(Ref)
+                                       )
+diff --git a/src/Nix/Lint.hs b/src/Nix/Lint.hs
+index 2c207c91..3da8c298 100644
+--- a/src/Nix/Lint.hs
++++ b/src/Nix/Lint.hs
+@@ -498,7 +498,7 @@ instance MonadThrow (Lint s) where
+   throwM e = Lint $ ReaderT $ const (throw e)
+ 
+ instance MonadCatch (Lint s) where
+-  catch _m _h = Lint $ ReaderT $ const (fail "Cannot catch in 'Lint s'")
++  catch _m _h = Lint $ ReaderT $ const (error "Cannot catch in 'Lint s'")
+ 
+ runLintM :: Options -> Lint s a -> ST s a
+ runLintM opts action =
+diff --git a/src/Nix/Utils.hs b/src/Nix/Utils.hs
+index 8f53b3a7..af370c21 100644
+--- a/src/Nix/Utils.hs
++++ b/src/Nix/Utils.hs
+@@ -67,6 +67,7 @@ import           Relude                  hiding ( pass
+ import           Data.Binary                    ( Binary )
+ import           Data.Data                      ( Data )
+ import           Codec.Serialise                ( Serialise )
++import           Control.Monad                  ( foldM )
+ import           Control.Monad.Fix              ( MonadFix(..) )
+ import           Control.Monad.Free             ( Free(..) )
+ import           Control.Monad.Trans.Control    ( MonadTransControl(..) )
+@@ -84,7 +85,6 @@ import           Lens.Family2.Stock             ( _1
+                                                 , _2
+                                                 )
+ import qualified System.FilePath              as FilePath
+-import Control.Monad.List (foldM)
+ 
+ #if ENABLE_TRACING
+ import qualified Relude.Debug                 as X
+diff --git a/src/Nix/Value.hs b/src/Nix/Value.hs
+index aafdc25a..28b9508c 100644
+--- a/src/Nix/Value.hs
++++ b/src/Nix/Value.hs
+@@ -554,7 +554,7 @@ liftNValue
+   => (forall x . u m x -> m x)
+   -> NValue t f m
+   -> NValue t f (u m)
+-liftNValue = (`hoistNValue` lift)
++liftNValue f = hoistNValue f lift
+ 
+ 
+ -- *** MonadTransUnlift
+-- 
+2.40.1
+

--- a/pkgs/development/haskell-modules/patches/hnix-compat-for-ghc-9.4.patch
+++ b/pkgs/development/haskell-modules/patches/hnix-compat-for-ghc-9.4.patch
@@ -3,6 +3,11 @@ From: Rodney Lorrimar <dev@rodney.id.au>
 Date: Tue, 25 Jul 2023 16:46:36 +0800
 Subject: [PATCH] GHC 9.4 compatibility
 
+This is commit b89eed9 from haskell-nix/hnix master branch,
+backported to 0.16.
+
+The patch should be removed once hnix-0.17 is released.
+
 ---
  src/Nix/Fresh.hs | 2 +-
  src/Nix/Lint.hs  | 2 +-


### PR DESCRIPTION
These are Haskell package overrides to make various things build under ghc962.

This branch is based on `haskell-updates` (#240387), cc: @maralorn @cdepillabout.

I am testing the build on `x86_64-linux` with this expression:

```nix
(import ./default.nix {}).haskell.packages.ghc96.ghcWithHoogle (hp: with hp; [
  turtle
  shake
  taffybar
  xmonad
  servant
  servant-lucid
  servant-swagger
])
```