### PR TITLE
ibus-engines.table-others: 1.3.15 -> 1.3.16

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-others/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-others/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "ibus-table-others";
-  version = "1.3.15";
+  version = "1.3.16";
 
   src = fetchurl {
     url = "https://github.com/moebiuscurve/ibus-table-others/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-nOj5gwhFodZv29hAN6S8EhQ+XlWp31FDOGIXtyAOM1E=";
+    hash = "sha256-TybqFQ2EgYo4zCYXwDJ0dke7HSzkZXs0lG2zR2XmlG4=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ibus ibus-table python3 ];
+  nativeBuildInputs = [ pkg-config python3 ];
+  buildInputs = [ ibus ibus-table ];
 
   preBuild = ''
     export HOME=$TMPDIR
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     homepage     = "https://github.com/moebiuscurve/ibus-table-others";
     license      = licenses.gpl3;
     platforms    = platforms.linux;
-    maintainers  = with maintainers; [ mudri ];
+    maintainers  = with maintainers; [ mudri McSinyx ];
   };
 }


### PR DESCRIPTION
###### Description of changes

[Change log](https://github.com/moebiuscurve/ibus-table-others/releases/tag/1.3.16) of ibus-table-others 1.3.16 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
