### PR TITLE
octave-kernel: fix broken logo path and modernize meta

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/octave/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/octave/default.nix
@@ -42,7 +42,7 @@ rec {
     dontInstall = true;
 
     buildPhase = ''
-      convert ./libgui/src/icons/logo.png -resize ${size}x${size} $out
+      convert ./libgui/src/icons/octave/128x128/logo.png -resize ${size}x${size} $out
     '';
   };
 

--- a/pkgs/applications/editors/jupyter-kernels/octave/kernel.nix
+++ b/pkgs/applications/editors/jupyter-kernels/octave/kernel.nix
@@ -18,11 +18,11 @@ buildPythonPackage rec {
   # There appears to be a similar problem with metakernel's tests
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "A Jupyter kernel for Octave.";
     homepage = "https://github.com/Calysto/octave_kernel";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ thomasjm ];
-    platforms = platforms.all;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ thomasjm ];
+    platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes

This kernel is currently broken due to a change in the path to the logo PNG upstream. This PR fixes it and also modernizes the `meta` field slightly.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

