### PR TITLE
jupyter-console: expose as a tool for launching kernels

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/clojupyter/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/clojupyter/default.nix
@@ -8,8 +8,11 @@
 , imagemagick
 }:
 
-# To test:
-# $(nix-build --no-out-link -E 'with import <nixpkgs> {}; jupyter.override { definitions = { clojure = clojupyter.definition; }; }')/bin/jupyter-notebook
+# Jupyter console:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel clojupyter.definition'
+
+# Jupyter notebook:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter.override { definitions.clojure = clojupyter.definition; }'
 
 let
   cljdeps = import ./deps.nix { inherit pkgs; };

--- a/pkgs/applications/editors/jupyter-kernels/iruby/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/iruby/default.nix
@@ -2,16 +2,41 @@
 , bundlerApp
 }:
 
-bundlerApp {
-  pname = "iruby";
-  gemdir = ./.;
-  exes = [ "iruby" ];
+# Jupyter console:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel iruby.definition'
 
-  meta = with lib; {
-    description = "Ruby kernel for Jupyter";
-    homepage    = "https://github.com/SciRuby/iruby";
-    license     = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
-    platforms   = platforms.unix;
+# Jupyter notebook:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter.override { definitions.iruby = iruby.definition; }'
+
+let
+  self = bundlerApp {
+    pname = "iruby";
+    gemdir = ./.;
+    exes = [ "iruby" ];
+
+    passthru = {
+      definition = {
+        displayName = "IRuby";
+        argv = [
+          "${self}/bin/iruby"
+          "kernel"
+          "{connection_file}"
+        ];
+        language = "ruby";
+        logo32 = null;
+        logo64 = null;
+      };
+    };
+
+    meta = {
+      description = "Ruby kernel for Jupyter";
+      homepage    = "https://github.com/SciRuby/iruby";
+      license     = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ costrouc thomasjm ];
+      platforms   = lib.platforms.unix;
+    };
   };
-}
+
+in
+
+self

--- a/pkgs/applications/editors/jupyter-kernels/octave/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/octave/default.nix
@@ -7,8 +7,11 @@
 , python3
 }:
 
-# To test:
-# $(nix-build -E 'with import <nixpkgs> {}; jupyter.override { definitions = { octave = octave-kernel.definition; }; }')/bin/jupyter-notebook
+# Jupyter console:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel octave-kernel.definition'
+
+# Jupyter notebook:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter.override { definitions.octave = octave-kernel.definition; }'
 
 let
   kernel = callPackage ./kernel.nix {

--- a/pkgs/applications/editors/jupyter-kernels/wolfram/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/wolfram/default.nix
@@ -2,8 +2,12 @@
 , wolfram-engine
 }:
 
-# To test:
-# $(nix-build -E 'with import ./. {}; jupyter.override { definitions = { wolfram = wolfram-for-jupyter-kernel.definition; }; }')/bin/jupyter-notebook
+# Jupyter console:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel wolfram-for-jupyter-kernel.definition'
+
+# Jupyter notebook:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter.override { definitions.wolfram = wolfram-for-jupyter-kernel.definition; }'
+
 let kernel = callPackage ./kernel.nix {};
 in {
   definition = {

--- a/pkgs/applications/editors/jupyter/console.nix
+++ b/pkgs/applications/editors/jupyter/console.nix
@@ -1,0 +1,37 @@
+{ python3
+, jupyter-kernel
+, lib
+}:
+
+let
+  mkConsole = {
+    definitions ? jupyter-kernel.default
+    , kernel ? null
+  }:
+    (python3.buildEnv.override {
+      extraLibs = [ python3.pkgs.jupyter-console ];
+      makeWrapperArgs = [
+        "--set JUPYTER_PATH ${jupyter-kernel.create { inherit definitions; }}"
+      ] ++ lib.optionals (kernel != null) [
+        "--add-flags --kernel"
+        "--add-flags ${kernel}"
+      ];
+    }).overrideAttrs (oldAttrs: {
+      # To facilitate running nix run .#jupyter-console
+      meta = oldAttrs.meta // { mainProgram = "jupyter-console"; };
+    });
+
+in
+
+{
+  # Build a console derivation with an arbitrary set of definitions, and an optional kernel to use.
+  # If the kernel argument is not supplied, Jupyter console will pick a kernel to run from the ones
+  # available on the system.
+  inherit mkConsole;
+
+  # An ergonomic way to start a console with a single kernel.
+  withSingleKernel = definition: mkConsole {
+    definitions = lib.listToAttrs [(lib.nameValuePair definition.language definition)];
+    kernel = definition.language;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9663,6 +9663,8 @@ with pkgs;
     };
   };
 
+  jupyter-console = callPackage ../applications/editors/jupyter/console.nix { };
+
   jupyter-kernel = callPackage ../applications/editors/jupyter/kernel.nix { };
 
   justify = callPackage ../tools/text/justify { };


### PR DESCRIPTION
###### Description of changes

This PR exposes the Jupyter Console as a top-level attribute, with functions for launching either:
1. A console derivation with many kernels available, similar to how the `jupyter` derivation works for the notebook, or
2. A console derivation with a single kernel which it starts automatically.

The console is nice for playing with Jupyter kernels in a more easy and lightweight way than the notebook or Jupyter lab, since it opens in the terminal and doesn't require UI interaction or creating notebook files.

This PR also updates the instructions in several of the `pkgs/applications/editors/jupyter-kernels/*` files to be more modern and ergonomic.

I'm open to suggestions on how `withSingleKernel` is named or exposed to the user.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
