### PR TITLE
nixos/nextcloud: Move objectstore options into settings

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -276,6 +276,20 @@
   to review the new defaults and description of
   [](#opt-services.nextcloud.poolSettings).
 
+- Nextcloud's object store configuration is now done inside the free form settings type. All configuration options of the namespace `config.objectstore.s3` need to be moved to the [](#opt-services.nextcloud.settings.objectstore.arguments) option.
+  Note that two option names should be renamed: useSsl -> use_ssl and usePathStyle -> use_path_style.
+  Further instead of using secretFile and sseCKeyFile inside the objectstore scope, put both secrets
+  into the JSON-file specified in the secretFile options. This file should contain both secrets in this format:
+  {
+    "objectstore": {
+      "arguments": {
+        "secret": "mysecret123",
+        "sse_c_key": "mysecret123"
+      }
+    }
+  }
+  Additionally set settings.objectstore.class = "\\OC\\Files\\ObjectStore\\S3" in S3 should be used.
+
 - The `services.locate` module does no longer support findutil's `locate` due to its inferior performance compared to `mlocate` and `plocate`. The new default is `plocate`.
   As the `service.locate.localuser` option only applied when using findutil's `locate`, it has also been removed.
 

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -154,24 +154,7 @@ let
 
   overrideConfig = let
     c = cfg.config;
-    requiresReadSecretFunction = c.dbpassFile != null || c.objectstore.s3.enable;
-    objectstoreConfig = let s3 = c.objectstore.s3; in optionalString s3.enable ''
-      'objectstore' => [
-        'class' => '\\OC\\Files\\ObjectStore\\S3',
-        'arguments' => [
-          'bucket' => '${s3.bucket}',
-          'autocreate' => ${boolToString s3.autocreate},
-          'key' => '${s3.key}',
-          'secret' => nix_read_secret('s3_secret'),
-          ${optionalString (s3.hostname != null) "'hostname' => '${s3.hostname}',"}
-          ${optionalString (s3.port != null) "'port' => ${toString s3.port},"}
-          'use_ssl' => ${boolToString s3.useSsl},
-          ${optionalString (s3.region != null) "'region' => '${s3.region}',"}
-          'use_path_style' => ${boolToString s3.usePathStyle},
-          ${optionalString (s3.sseCKeyFile != null) "'sse_c_key' => nix_read_secret('s3_sse_c_key'),"}
-        ],
-      ]
-    '';
+    requiresReadSecretFunction = c.dbpassFile != null;
     showAppStoreSetting = cfg.appstoreEnable != null || cfg.extraApps != {};
     renderedAppStoreSetting =
       let
@@ -230,7 +213,6 @@ let
       ${optionalString (c.dbtableprefix != null) "'dbtableprefix' => '${toString c.dbtableprefix}',"}
       ${optionalString (c.dbpassFile != null) "'dbpassword' => nix_read_secret('dbpass'),"}
       'dbtype' => '${c.dbtype}',
-      ${objectstoreConfig}
     ];
 
     $CONFIG = array_replace_recursive($CONFIG, nix_decode_json_file(
@@ -275,6 +257,53 @@ in {
     (mkRenamedOptionModule
       [ "services" "nextcloud" "config" "trustedProxies" ] [ "services" "nextcloud" "settings" "trusted_proxies" ])
     (mkRenamedOptionModule ["services" "nextcloud" "extraOptions" ] [ "services" "nextcloud" "settings" ])
+
+    (mkRenamedOptionModule ["services" "nextcloud" "config" "objectstore" "bucket" ] [ "services" "nextcloud" "settings" "objectstore" "arguments" ])
+    (mkRenamedOptionModule ["services" "nextcloud" "config" "objectstore" "autocreate" ] [ "services" "nextcloud" "settings" "objectstore" "autocreate" ])
+    (mkRenamedOptionModule ["services" "nextcloud" "config" "objectstore" "key" ] [ "services" "nextcloud" "settings" "objectstore" "key" ])
+    (mkRenamedOptionModule ["services" "nextcloud" "config" "objectstore" "hostname" ] [ "services" "nextcloud" "settings" "objectstore" "hostname" ])
+    (mkRenamedOptionModule ["services" "nextcloud" "config" "objectstore" "port" ] [ "services" "nextcloud" "settings" "objectstore" "port" ])
+    (mkRenamedOptionModule ["services" "nextcloud" "config" "objectstore" "useSsl" ] [ "services" "nextcloud" "settings" "objectstore" "use_ssl" ])
+    (mkRenamedOptionModule ["services" "nextcloud" "config" "objectstore" "region" ] [ "services" "nextcloud" "settings" "objectstore" "region" ])
+    (mkRenamedOptionModule ["services" "nextcloud" "config" "objectstore" "usePathStyle" ] [ "services" "nextcloud" "settings" "objectstore" "use_path_style" ])
+    (mkRenamedOptionModule ["services" "nextcloud" "config" "objectstore" ] [ "services" "nextcloud" "settings" "objectstore" ])
+    (mkRemovedOptionModule [ "services" "nextcloud" "config" "objectstore" "enable" ] ''
+      Please move all configuration options from config.objectstore into settings.objectstore.arguments.
+      Note that two option names should be renamed: useSsl -> use_ssl and usePathStyle -> use_path_style.
+      Further instead of using secretFile and sseCKeyFile inside the objectstore scope, put both secrets
+      into the file specified in secretFile. This JSON-file should contain both secrets in this format:
+      {
+        "objectstore": {
+          "arguments": {
+            "secret": "mysecret123",
+            "sse_c_key": "mysecret123"
+          }
+        }
+      }
+      Additionally set settings.objectstore.class = "\\OC\\Files\\ObjectStore\\S3" in S3 should be used.
+    '')
+    (mkRemovedOptionModule [ "services" "nextcloud" "config" "objectstore" "secretFile" ] ''
+      Specify this objectstore secret using the secretFile option. Inside this JSON-file the secret is set
+      in this format:
+      {
+        "objectstore": {
+          "arguments": {
+            "secret": "mysecret123"
+          }
+        }
+      }
+    '')
+    (mkRemovedOptionModule [ "services" "nextcloud" "config" "objectstore" "sseCKeyFile" ] ''
+      Specify this objectstore secret using the secretFile option. Inside this JSON-file the secret is set
+      in this format:
+      {
+        "objectstore": {
+          "arguments": {
+            "sse_c_key": "mysecret123"
+          }
+        }
+      }
+    '')
   ];
 
   options.services.nextcloud = {
@@ -541,107 +570,6 @@ in {
           set only in the initial setup of Nextcloud by the systemd service `nextcloud-setup.service`.
         '';
       };
-      objectstore = {
-        s3 = {
-          enable = mkEnableOption ''
-            S3 object storage as primary storage.
-
-            This mounts a bucket on an Amazon S3 object storage or compatible
-            implementation into the virtual filesystem.
-
-            Further details about this feature can be found in the
-            [upstream documentation](https://docs.nextcloud.com/server/22/admin_manual/configuration_files/primary_storage.html)
-          '';
-          bucket = mkOption {
-            type = types.str;
-            example = "nextcloud";
-            description = ''
-              The name of the S3 bucket.
-            '';
-          };
-          autocreate = mkOption {
-            type = types.bool;
-            description = ''
-              Create the objectstore if it does not exist.
-            '';
-          };
-          key = mkOption {
-            type = types.str;
-            example = "EJ39ITYZEUH5BGWDRUFY";
-            description = ''
-              The access key for the S3 bucket.
-            '';
-          };
-          secretFile = mkOption {
-            type = types.str;
-            example = "/var/nextcloud-objectstore-s3-secret";
-            description = ''
-              The full path to a file that contains the access secret.
-            '';
-          };
-          hostname = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            example = "example.com";
-            description = ''
-              Required for some non-Amazon implementations.
-            '';
-          };
-          port = mkOption {
-            type = types.nullOr types.port;
-            default = null;
-            description = ''
-              Required for some non-Amazon implementations.
-            '';
-          };
-          useSsl = mkOption {
-            type = types.bool;
-            default = true;
-            description = ''
-              Use SSL for objectstore access.
-            '';
-          };
-          region = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            example = "REGION";
-            description = ''
-              Required for some non-Amazon implementations.
-            '';
-          };
-          usePathStyle = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''
-              Required for some non-Amazon S3 implementations.
-
-              Ordinarily, requests will be made with
-              `http://bucket.hostname.domain/`, but with path style
-              enabled requests are made with
-              `http://hostname.domain/bucket` instead.
-            '';
-          };
-          sseCKeyFile = mkOption {
-            type = types.nullOr types.path;
-            default = null;
-            example = "/var/nextcloud-objectstore-s3-sse-c-key";
-            description = ''
-              If provided this is the full path to a file that contains the key
-              to enable [server-side encryption with customer-provided keys][1]
-              (SSE-C).
-
-              The file must contain a random 32-byte key encoded as a base64
-              string, e.g. generated with the command
-
-              ```
-              openssl rand 32 | base64
-              ```
-
-              [1]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html
-            '';
-          };
-        };
-      };
     };
 
     enableImagemagick = mkEnableOption ''
@@ -820,6 +748,79 @@ in {
               Only has an effect in Nextcloud 23 and later.
             '';
           };
+          objectstore = {
+            class = mkOption {
+              type = types.str;
+              example = "\\OC\\Files\\ObjectStore\\S3";
+              description = ''
+                The object store class to be used.
+              '';
+            };
+            arguments = {
+              bucket = mkOption {
+                type = types.str;
+                example = "nextcloud";
+                description = ''
+                  The name of the S3 bucket.
+                '';
+              };
+              autocreate = mkOption {
+                type = types.bool;
+                description = ''
+                  Create the objectstore if it does not exist.
+                '';
+              };
+              key = mkOption {
+                type = types.str;
+                example = "EJ39ITYZEUH5BGWDRUFY";
+                description = ''
+                  The access key for the S3 bucket.
+                '';
+              };
+              hostname = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                example = "example.com";
+                description = ''
+                  Required for some non-Amazon implementations.
+                '';
+              };
+              port = mkOption {
+                type = types.nullOr types.port;
+                default = null;
+                description = ''
+                  Required for some non-Amazon implementations.
+                '';
+              };
+              use_ssl = mkOption {
+                type = types.bool;
+                default = true;
+                description = ''
+                  Use SSL for objectstore access.
+                '';
+              };
+              region = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                example = "REGION";
+                description = ''
+                  Required for some non-Amazon implementations.
+                '';
+              };
+              use_path_style = mkOption {
+                type = types.bool;
+                default = false;
+                description = ''
+                  Required for some non-Amazon S3 implementations.
+
+                  Ordinarily, requests will be made with
+                  `http://bucket.hostname.domain/`, but with path style
+                  enabled requests are made with
+                  `http://hostname.domain/bucket` instead.
+                '';
+              };
+            };
+          };
         };
       };
       default = {};
@@ -914,6 +915,17 @@ in {
         ++ (optional (versionOlder cfg.package.version "30") (upgradeWarning 29 "24.11"))
         ++ (optional (versionOlder cfg.package.version "31") (upgradeWarning 30 "25.05"))
         ;
+
+      assertions = [
+        {
+          assertion = builtins.hasAttr "objectstore.arguments.secret" cfg.settings != true;
+          message = ''It's discouraged to specify the objectstore secret inside the settings option. The secret will be copied into the Nix store and world-readable. Please use secretFile option to specify the objectstore secret.'';
+        }
+        {
+          assertion = builtins.hasAttr "objectstore.arguments.sse_c_key" cfg.settings != true;
+          message = ''It's discouraged to specify the objectstore sse_c_key inside the settings option. The secret will be copied into the Nix store and world-readable. Please use secretFile option to specify the objectstore sse_c_key.'';
+        }
+      ];
 
       services.nextcloud.package = with pkgs;
         mkDefault (

--- a/nixos/tests/nextcloud/with-objectstore.nix
+++ b/nixos/tests/nextcloud/with-objectstore.nix
@@ -38,17 +38,21 @@ runTest (
 
           services.nextcloud.config.dbtype = "sqlite";
 
-          services.nextcloud.config.objectstore.s3 = {
-            enable = true;
-            bucket = "nextcloud";
-            autocreate = true;
-            key = accessKey;
-            secretFile = "${pkgs.writeText "secretKey" secretKey}";
-            hostname = "nextcloud";
-            useSsl = false;
-            port = 9000;
-            usePathStyle = true;
-            region = "us-east-1";
+          services.nextcloud = {
+            settings.objectstore = {
+              class = "\\OC\\Files\\ObjectStore\\S3";
+              arguments = {
+                bucket = "nextcloud";
+                autocreate = true;
+                key = accessKey;
+                hostname = "nextcloud";
+                use_ssl = false;
+                port = 9000;
+                use_path_style = true;
+                region = "us-east-1";
+              };
+            };
+            secretFile = "/etc/nextcloud-secrets.json";
           };
 
           services.minio = {
@@ -57,6 +61,19 @@ runTest (
             consoleAddress = "0.0.0.0:9001";
             inherit rootCredentialsFile;
           };
+
+          # This file is meant to contain secret options which should
+          # not go into the nix store. Here it is just used to set the
+          # objectstore secret.
+          environment.etc."nextcloud-secrets.json".text = ''
+            {
+              "objectstore": {
+                "arguments": {
+                  "secret": "${secretKey}"
+                }
+              }
+            }
+          '';
         };
     };
 


### PR DESCRIPTION
###### Description of changes

Migrate objectstore configuration form:

```
services.nextcloud.config.objectstore.s3 = {
  enable = true;
  bucket = "nextcloud";
  autocreate = true;
  key = accessKey;
  secretFile = "${pkgs.writeText "secretKey" "mysecret123"}";
  hostname = "nextcloud";
  useSsl = false;
  port = 9000;
  usePathStyle = true;
  region = "us-east-1";
};
```

to 

```
services.nextcloud = {
  settings.objectstore = {
    class = "\\OC\\Files\\ObjectStore\\S3";
    arguments = {
      bucket = "nextcloud";
      autocreate = true;
      key = "12345678910";
      hostname = "nextcloud";
      use_ssl = false;
      port = 9000;
      use_path_style = true;
      region = "us-east-1";
    };
  };
  secretFile = "/etc/nextcloud-secrets.json";
};

environment.etc."nextcloud-secrets.json".text = ''
  {
    "objectstore": {
      "secret": "mysecret123"
    }
  }
'';
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
