### PR TITLE
comic-mandown: init at 1.5.0

### DIFF
--- a/pkgs/by-name/co/comic-mandown/package.nix
+++ b/pkgs/by-name/co/comic-mandown/package.nix
@@ -1,0 +1,17 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+
+, withGUI ? true
+}:
+let
+  mandown' = python3Packages.mandown.overrideAttrs (prev: {
+    propagatedBuildInputs = prev.propagatedBuildInputs ++ lib.optionals withGUI prev.passthru.optional-dependencies.gui;
+  });
+  mandownApp = python3Packages.toPythonApplication mandown';
+in
+mandownApp // {
+  meta = mandownApp.meta // {
+    mainProgram = "mandown";
+  };
+}

--- a/pkgs/development/python-modules/comicon/default.nix
+++ b/pkgs/development/python-modules/comicon/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, ebooklib
+, lxml
+, pillow
+, pypdf
+}:
+
+buildPythonPackage rec {
+  pname = "comicon";
+  version = "1.0.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "potatoeggy";
+    repo = "comicon";
+    rev = "v${version}";
+    hash = "sha256-D6nK+GlcG/XqMTH7h7mJcbZCRG2xDHRsnooSTtphDNs=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    ebooklib
+    lxml
+    pillow
+    pypdf
+  ];
+
+  pythonImportsCheck = [ "comicon" ];
+
+  meta = with lib; {
+    description = "Lightweight comic converter library between CBZ, PDF, and EPUB";
+    homepage = "https://github.com/potatoeggy/comicon";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ Scrumplex ];
+  };
+}

--- a/pkgs/development/python-modules/ebooklib/default.nix
+++ b/pkgs/development/python-modules/ebooklib/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, lxml
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "ebooklib";
+  version = "0.18";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "aerkalov";
+    repo = "ebooklib";
+    rev = "v${version}";
+    hash = "sha256-Ciks/eeRpkqkWnyLgyHC+x/dSOcj/ZT45KUElKqv1F8=";
+  };
+
+  propagatedBuildInputs = [
+    lxml
+    six
+  ];
+
+  pythonImportsCheck = [ "ebooklib" ];
+
+  meta = with lib; {
+    description = "Python E-book library for handling books in EPUB2/EPUB3  format";
+    homepage = "https://github.com/aerkalov/ebooklib";
+    changelog = "https://github.com/aerkalov/ebooklib/blob/${src.rev}/CHANGES.txt";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ Scrumplex ];
+  };
+}

--- a/pkgs/development/python-modules/mandown/default.nix
+++ b/pkgs/development/python-modules/mandown/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, beautifulsoup4
+, comicon
+, feedparser
+, filetype
+, lxml
+, natsort
+, pillow
+, python-slugify
+, requests
+, typer
+, pyside6
+}:
+
+buildPythonPackage rec {
+  pname = "mandown";
+  version = "1.5.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "potatoeggy";
+    repo = "mandown";
+    rev = "v${version}";
+    hash = "sha256-ph+1bb1jhqqDE2d4F8lTf7LAzN7DWpDTGn8qhCiccKA=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    comicon
+    feedparser
+    filetype
+    lxml
+    natsort
+    pillow
+    python-slugify
+    requests
+    typer
+  ];
+
+  passthru.optional-dependencies = {
+    gui = [
+      pyside6
+    ];
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace 'typer = "^0.7.0"' 'typer = "^0"'
+  '';
+
+  pythonImportsCheck = [ "mandown" ];
+
+  meta = with lib; {
+    description = "Comic/manga/webtoon downloader and CBZ/EPUB/MOBI/PDF converter";
+    homepage = "https://github.com/potatoeggy/mandown";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ Scrumplex ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1825,6 +1825,8 @@ self: super: with self; {
     inherit (pkgs) secp256k1;
   };
 
+  comicon = callPackage ../development/python-modules/comicon { };
+
   connect-box = callPackage ../development/python-modules/connect_box { };
 
   connection-pool = callPackage ../development/python-modules/connection-pool { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6429,6 +6429,8 @@ self: super: with self; {
 
   managesieve = callPackage ../development/python-modules/managesieve { };
 
+  mandown = callPackage ../development/python-modules/mandown { };
+
   manhole = callPackage ../development/python-modules/manhole { };
 
   manimpango = callPackage ../development/python-modules/manimpango {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3352,6 +3352,8 @@ self: super: with self; {
 
   ebaysdk = callPackage ../development/python-modules/ebaysdk { };
 
+  ebooklib = callPackage ../development/python-modules/ebooklib { };
+
   ec2instanceconnectcli = callPackage ../tools/virtualization/ec2instanceconnectcli { };
 
   eccodes = toPythonModule (pkgs.eccodes.override {


### PR DESCRIPTION

###### Description of changes

- python3Packages.ebooklib: init at 0.18
- python3Packages.comicon: init at 1.0.0
- comic-mandown: init at 1.5.0

Mandown is a comic downloader and a CBZ, EPUB, MOBI, and/or PDF converter.

https://github.com/potatoeggy/mandown

mandown needs comicon: https://github.com/potatoeggy/comicon

comicon needs ebooklib: https://github.com/aerkalov/ebooklib

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
