### PR TITLE
libreoffice-fresh: strip away BUILDCONFIG, reduce runtime closure size by ~20%

### DIFF
--- a/pkgs/applications/office/libreoffice/0001-Strip-away-BUILDCONFIG.patch
+++ b/pkgs/applications/office/libreoffice/0001-Strip-away-BUILDCONFIG.patch
@@ -1,0 +1,32 @@
+From 982d38084f08950863b55043f36ce5548bd73635 Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Mon, 24 Jul 2023 19:12:25 +0200
+Subject: [PATCH] Strip away BUILDCONFIG
+
+The `BuildConfig` field in `libsofficeapp.so` includes the entire
+`PKG_CONFIG_PATH` and subsequently references to a lot of `dev` outputs
+of library dependencies blowing up the closure.
+
+Since this is not strictly needed and the inputs are comprehensible via
+`nix derivation show`, this doesn't bring a real benefit in the case of
+nixpkgs anyways.
+---
+ desktop/source/lib/init.cxx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/desktop/source/lib/init.cxx b/desktop/source/lib/init.cxx
+index 8d830c0cbd00..fbdc86aa7115 100644
+--- a/desktop/source/lib/init.cxx
++++ b/desktop/source/lib/init.cxx
+@@ -7097,7 +7097,7 @@ static char* lo_getVersionInfo(SAL_UNUSED_PARAMETER LibreOfficeKit* /*pThis*/)
+         "\"ProductVersion\": \"%PRODUCTVERSION\", "
+         "\"ProductExtension\": \"%PRODUCTEXTENSION\", "
+         "\"BuildId\": \"%BUILDID\", "
+-        "\"BuildConfig\": \""  BUILDCONFIG  "\" "
++        "\"BuildConfig\": \"removed to avoid runtime dependencies against dev outputs of each dependency. Use 'nix derivation show' against the package to find out details about BuildConfig.\" "
+         "}"));
+ }
+ 
+-- 
+2.40.1
+

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -214,6 +214,22 @@ in
     tar -xf ${srcs.translations}
   '';
 
+  # Remove build config to reduce the amount of `-dev` outputs in the
+  # runtime closure. This was introduced in upstream commit
+  # cbfac11330882c7d0a817b6c37a08b2ace2b66f4, so the patch doesn't apply
+  # for 7.4.
+  patches = lib.optionals (lib.versionAtLeast version "7.5") [
+    ./0001-Strip-away-BUILDCONFIG.patch
+  ];
+
+  # libreoffice tries to reference the BUILDCONFIG (e.g. PKG_CONFIG_PATH)
+  # in the binary causing the closure size to blow up because of many unnecessary
+  # dependencies to dev outputs. This behavior was patched away in nixpkgs
+  # (see above), make sure these don't leak again by accident.
+  disallowedRequisites = lib.concatMap
+    (x: lib.optional (x?dev) x.dev)
+    buildInputs;
+
   ### QT/KDE
   #
   # configure.ac assumes that the first directory that contains headers and


### PR DESCRIPTION

###### Description of changes
In v7.5.x a change was introduced that writes the BUILDCONFIG into `$out/lib/libreoffice/program/libsofficeapp.so` including the `PKG_CONFIG_PATH` containing references to all `dev` outputs of library dependencies:

    $ strings $(nix-build -A libreoffice-fresh)/lib/libreoffice/program/libsofficeapp.so|grep PKG_CONFIG_PATH
    [...], "BuildConfig": "[...] 'PKG_CONFIG_PATH=[...]'"

This isn't really needed because this information can also be obtained by `nix derivation show`. Also, this causes a 20% larger runtime-closure because of all the dev dependencies being referenced by the output and thus downloaded whenever libreoffice is substituted somewhere. The actual numbers look like this:

    $ nix path-info -Sh ./result-old
    /nix/store/3mzrqh4gg7v27vdrrap9dj3x8myysmyf-libreoffice-7.5.4.1-wrapped	  2.0G
    $ nix path-info -Sh ./result
    /nix/store/g5y60s0a2q2v6r58xcayv62z7fjfi816-libreoffice-7.5.4.1-wrapped	  1.6G

Only `libreoffice-fresh` is affected, `pkgs.libreoffice` isn't because it still points to 7.4 whereas the problematic change was introduced in 7.5.

To make sure this doesn't get reintroduced by accident, the derivation also prohibits now to reference any dev output from a build input.

[1] https://gerrit.libreoffice.org/c/core/+/141197

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
