### PR TITLE
libsForQt5.qttools: Add option for building qdoc

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qttools-QT_HOST_DATA-refs.patch
+++ b/pkgs/development/libraries/qt-5/modules/qttools-QT_HOST_DATA-refs.patch
@@ -1,0 +1,39 @@
+From 985a5b530e27372a0766ce897c621026928abfbb Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Wed, 7 Aug 2024 22:16:42 +0200
+Subject: [PATCH] Patch QT_HOST_DATA references
+
+---
+ src/linguist/linguist.pro                           | 2 +-
+ src/qtattributionsscanner/qtattributionsscanner.pro | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/linguist/linguist.pro b/src/linguist/linguist.pro
+index 7638c7710..bd8798818 100644
+--- a/src/linguist/linguist.pro
++++ b/src/linguist/linguist.pro
+@@ -47,7 +47,7 @@ contains(CMAKE_BIN_DIR, "^\\.\\./.*") {
+ load(qt_build_paths)
+ 
+ cmake_linguist_config_file.input = $$PWD/Qt5LinguistToolsConfig.cmake.in
+-cmake_linguist_config_version_file.input = $$[QT_HOST_DATA/src]/mkspecs/features/data/cmake/Qt5ConfigVersion.cmake.in
++cmake_linguist_config_version_file.input = @qtbaseDev@/mkspecs/features/data/cmake/Qt5ConfigVersion.cmake.in
+ cmake_linguist_macros_file.input = $$PWD/Qt5LinguistToolsMacros.cmake
+ CMAKE_PACKAGE_VERSION = $$MODULE_VERSION
+ cmake_linguist_config_file.output = $$MODULE_BASE_OUTDIR/lib/cmake/Qt5LinguistTools/Qt5LinguistToolsConfig.cmake
+diff --git a/src/qtattributionsscanner/qtattributionsscanner.pro b/src/qtattributionsscanner/qtattributionsscanner.pro
+index d645a22a9..5d4239f83 100644
+--- a/src/qtattributionsscanner/qtattributionsscanner.pro
++++ b/src/qtattributionsscanner/qtattributionsscanner.pro
+@@ -51,7 +51,7 @@ load(qt_build_paths)
+ equals(QMAKE_HOST.os, Windows): CMAKE_BIN_SUFFIX = ".exe"
+ 
+ cmake_qattributionsscanner_config_file.input = $$PWD/Qt5AttributionsScannerTools.cmake.in
+-cmake_qattributionsscanner_config_version_file.input = $$[QT_HOST_DATA/src]/mkspecs/features/data/cmake/Qt5ConfigVersion.cmake.in
++cmake_qattributionsscanner_config_version_file.input = @qtbaseDev@/mkspecs/features/data/cmake/Qt5ConfigVersion.cmake.in
+ CMAKE_PACKAGE_VERSION = $$MODULE_VERSION
+ cmake_qattributionsscanner_config_file.output = $$MODULE_BASE_OUTDIR/lib/cmake/Qt5AttributionsScannerTools/Qt5AttributionsScannerToolsConfig.cmake
+ cmake_qattributionsscanner_config_version_file.output = $$MODULE_BASE_OUTDIR/lib/cmake/Qt5AttributionsScannerTools/Qt5AttributionsScannerToolsConfigVersion.cmake
+-- 
+2.44.1
+

--- a/pkgs/development/libraries/qt-5/modules/qttools-QT_HOST_DATA-refs.patch
+++ b/pkgs/development/libraries/qt-5/modules/qttools-QT_HOST_DATA-refs.patch
@@ -1,12 +1,13 @@
-From 985a5b530e27372a0766ce897c621026928abfbb Mon Sep 17 00:00:00 2001
+From b54dd2923448f2ae7402cf2364f40337d6c3cb6d Mon Sep 17 00:00:00 2001
 From: OPNA2608 <opna2608@protonmail.com>
-Date: Wed, 7 Aug 2024 22:16:42 +0200
+Date: Wed, 7 Aug 2024 22:47:00 +0200
 Subject: [PATCH] Patch QT_HOST_DATA references
 
 ---
  src/linguist/linguist.pro                           | 2 +-
+ src/qdoc/qdoc.pro                                   | 2 +-
  src/qtattributionsscanner/qtattributionsscanner.pro | 2 +-
- 2 files changed, 2 insertions(+), 2 deletions(-)
+ 3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/linguist/linguist.pro b/src/linguist/linguist.pro
 index 7638c7710..bd8798818 100644
@@ -21,6 +22,19 @@ index 7638c7710..bd8798818 100644
  cmake_linguist_macros_file.input = $$PWD/Qt5LinguistToolsMacros.cmake
  CMAKE_PACKAGE_VERSION = $$MODULE_VERSION
  cmake_linguist_config_file.output = $$MODULE_BASE_OUTDIR/lib/cmake/Qt5LinguistTools/Qt5LinguistToolsConfig.cmake
+diff --git a/src/qdoc/qdoc.pro b/src/qdoc/qdoc.pro
+index db4b25cf1..19592d50b 100644
+--- a/src/qdoc/qdoc.pro
++++ b/src/qdoc/qdoc.pro
+@@ -151,7 +151,7 @@ load(qt_build_paths)
+ equals(QMAKE_HOST.os, Windows): CMAKE_BIN_SUFFIX = ".exe"
+ 
+ cmake_qdoc_config_file.input = $$PWD/Qt5DocToolsConfig.cmake.in
+-cmake_qdoc_config_version_file.input = $$[QT_HOST_DATA/src]/mkspecs/features/data/cmake/Qt5ConfigVersion.cmake.in
++cmake_qdoc_config_version_file.input = @qtbaseDev@/mkspecs/features/data/cmake/Qt5ConfigVersion.cmake.in
+ CMAKE_PACKAGE_VERSION = $$MODULE_VERSION
+ cmake_qdoc_config_file.output = $$MODULE_BASE_OUTDIR/lib/cmake/Qt5DocTools/Qt5DocToolsConfig.cmake
+ cmake_qdoc_config_version_file.output = $$MODULE_BASE_OUTDIR/lib/cmake/Qt5DocTools/Qt5DocToolsConfigVersion.cmake
 diff --git a/src/qtattributionsscanner/qtattributionsscanner.pro b/src/qtattributionsscanner/qtattributionsscanner.pro
 index d645a22a9..5d4239f83 100644
 --- a/src/qtattributionsscanner/qtattributionsscanner.pro

--- a/pkgs/development/libraries/qt-5/modules/qttools-libclang-main-header.patch
+++ b/pkgs/development/libraries/qt-5/modules/qttools-libclang-main-header.patch
@@ -1,0 +1,34 @@
+From a1fb301a0b9b59f420454be1ebeb05ce0547da2c Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Fri, 6 Sep 2024 14:20:05 +0200
+Subject: [PATCH] Patch includedir for libclang main header
+
+---
+ src/qdoc/configure.pri | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/qdoc/configure.pri b/src/qdoc/configure.pri
+index 4f3d77603..8fe8bc439 100644
+--- a/src/qdoc/configure.pri
++++ b/src/qdoc/configure.pri
+@@ -71,7 +71,7 @@ defineTest(qtConfTest_libclang) {
+             LLVM_INSTALL_DIR = $$system("$$candidate --prefix 2>$$QMAKE_SYSTEM_NULL_DEVICE")
+             !isEmpty(LLVM_INSTALL_DIR) {
+                 CLANG_INCLUDEPATH = $$system("$$candidate --includedir 2>/dev/null")
+-                LIBCLANG_MAIN_HEADER = $$CLANG_INCLUDEPATH/clang-c/Index.h
++                LIBCLANG_MAIN_HEADER = @libclangDev@/include/clang-c/Index.h
+                 !exists($$LIBCLANG_MAIN_HEADER) {
+                     !isEmpty(LLVM_INSTALL_DIR): \
+                         qtLog("Cannot find libclang's main header file, candidate: $${LIBCLANG_MAIN_HEADER}.")
+@@ -121,7 +121,7 @@ defineTest(qtConfTest_libclang) {
+         return(false)
+     }
+ 
+-    LIBCLANG_MAIN_HEADER = $$CLANG_INCLUDEPATH/clang-c/Index.h
++    LIBCLANG_MAIN_HEADER = @libclangDev@/include/clang-c/Index.h
+     !exists($$LIBCLANG_MAIN_HEADER) {
+         !isEmpty(LLVM_INSTALL_DIR): \
+             qtLog("Cannot find libclang's main header file, candidate: $${LIBCLANG_MAIN_HEADER}.")
+-- 
+2.44.1
+

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -1,17 +1,17 @@
-{ qtModule, stdenv, lib, qtbase, qtdeclarative }:
+{ qtModule, stdenv, lib, qtbase, qtdeclarative, substituteAll }:
 
 qtModule {
   pname = "qttools";
   propagatedBuildInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 
-  # fixQtBuiltinPaths overwrites a builtin path we should keep
-  postPatch = ''
-    sed -i "src/linguist/linguist.pro" \
-        -e '/^cmake_linguist_config_version_file.input =/ s|$$\[QT_HOST_DATA.*\]|${lib.getDev qtbase}|'
-    sed -i "src/qtattributionsscanner/qtattributionsscanner.pro" \
-        -e '/^cmake_qattributionsscanner_config_version_file.input =/ s|$$\[QT_HOST_DATA.*\]|${lib.getDev qtbase}|'
-  '';
+  patches = [
+    # fixQtBuiltinPaths overwrites builtin paths we should keep
+    (substituteAll {
+      src = ./qttools-QT_HOST_DATA-refs.patch;
+      qtbaseDev = lib.getDev qtbase;
+    })
+  ];
 
   devTools = [
     "bin/qcollectiongenerator"

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -9,14 +9,16 @@
 
 qtModule {
   pname = "qttools";
-  propagatedBuildInputs = [
-    qtbase
-    qtdeclarative
-  ];
+
   outputs = [
     "out"
     "dev"
     "bin"
+  ];
+
+  propagatedBuildInputs = [
+    qtbase
+    qtdeclarative
   ];
 
   patches = [

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -5,6 +5,7 @@
   qtbase,
   qtdeclarative,
   substituteAll,
+  llvmPackages,
 }:
 
 qtModule {
@@ -14,6 +15,11 @@ qtModule {
     "out"
     "dev"
     "bin"
+  ];
+
+  buildInputs = with llvmPackages; [
+    libclang
+    libllvm
   ];
 
   propagatedBuildInputs = [
@@ -26,6 +32,11 @@ qtModule {
     (substituteAll {
       src = ./qttools-QT_HOST_DATA-refs.patch;
       qtbaseDev = lib.getDev qtbase;
+    })
+
+    (substituteAll {
+      src = ./qttools-libclang-main-header.patch;
+      libclangDev = lib.getDev llvmPackages.libclang;
     })
   ];
 

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -1,9 +1,23 @@
-{ qtModule, stdenv, lib, qtbase, qtdeclarative, substituteAll }:
+{
+  qtModule,
+  stdenv,
+  lib,
+  qtbase,
+  qtdeclarative,
+  substituteAll,
+}:
 
 qtModule {
   pname = "qttools";
-  propagatedBuildInputs = [ qtbase qtdeclarative ];
-  outputs = [ "out" "dev" "bin" ];
+  propagatedBuildInputs = [
+    qtbase
+    qtdeclarative
+  ];
+  outputs = [
+    "out"
+    "dev"
+    "bin"
+  ];
 
   patches = [
     # fixQtBuiltinPaths overwrites builtin paths we should keep
@@ -32,11 +46,11 @@ qtModule {
     "bin/qthelpconverter"
     "bin/lprodump"
     "bin/qdistancefieldgenerator"
-  ] ++ lib.optionals stdenv.isDarwin [
-    "bin/macdeployqt"
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [ "bin/macdeployqt" ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && qtdeclarative != null) ''-DNIXPKGS_QMLIMPORTSCANNER="${qtdeclarative.dev}/bin/qmlimportscanner"'';
+  env.NIX_CFLAGS_COMPILE = lib.optionalString (
+    stdenv.isDarwin && qtdeclarative != null
+  ) ''-DNIXPKGS_QMLIMPORTSCANNER="${qtdeclarative.dev}/bin/qmlimportscanner"'';
 
   setupHook = ../hooks/qttools-setup-hook.sh;
 }


### PR DESCRIPTION
###### Description of changes

Mirroring what's been done on qt6Packages.qttools, hide this behind a `withClang` option.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  Tested new `qdoc` binary.
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
