### PR TITLE
treewide: mostly noop: refer to `src.name` or similar in `sourceRoot` where appropriate

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -558,7 +558,7 @@ buildPythonPackage rec {
     hash = "sha256-miW//pnOmww2i6SOGbkrAIdc/JMDT4FJLqdMFojZeoY=";
   };
 
-  sourceRoot = "source/bindings/python";
+  sourceRoot = "${src.name}/bindings/python";
 
   nativeBuildInputs = [
     cargo

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -614,13 +614,18 @@ The list of source files or directories to be unpacked or copied. One of these m
 
 ##### `sourceRoot` {#var-stdenv-sourceRoot}
 
-After running `unpackPhase`, the generic builder changes the current directory to the directory created by unpacking the sources. If there are multiple source directories, you should set `sourceRoot` to the name of the intended directory. Set `sourceRoot = ".";` if you use `srcs` and control the unpack phase yourself.
+After unpacking all of `src` and `srcs`, if neither of `sourceRoot` and `setSourceRoot` are set, `unpackPhase` of the generic builder checks that the unpacking produced a single directory and moves the current working directory into it.
 
-By default the `sourceRoot` is set to `"source"`. If you want to point to a sub-directory inside your project, you therefore need to set `sourceRoot = "source/my-sub-directory"`.
+If `unpackPhase` produces multiple source directories, you should set `sourceRoot` to the name of the intended directory.
+You can also set `sourceRoot = ".";` if you want to control it yourself in a later phase.
+
+For example, if your want your build to start in a sub-directory inside your sources, and you are using `fetchzip`-derived `src` (like `fetchFromGitHub` or similar), you need to set `sourceRoot = "${src.name}/my-sub-directory"`.
 
 ##### `setSourceRoot` {#var-stdenv-setSourceRoot}
 
 Alternatively to setting `sourceRoot`, you can set `setSourceRoot` to a shell command to be evaluated by the unpack phase after the sources have been unpacked. This command must set `sourceRoot`.
+
+For example, if you are using `fetchurl` on an archive file that gets unpacked into a single directory the name of which changes between package versions, and you want your build to start in its sub-directory, you need to set `setSourceRoot = "sourceRoot=$(echo */my-sub-directory)";`, or in the case of multiple sources, you could use something more specific, like `setSourceRoot = "sourceRoot=$(echo ${pname}-*/my-sub-directory)";`.
 
 ##### `preUnpack` {#var-stdenv-preUnpack}
 

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -162,6 +162,8 @@ The module update takes care of the new config syntax and the data itself (user 
 
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 
+- The use of `sourceRoot = "source";`, `sourceRoot = "source/subdir";`, and similar lines in package derivations using the default `unpackPhase` is deprecated as it requires `unpackPhase` to always produce a directory named "source". Use `sourceRoot = src.name`, `sourceRoot = "${src.name}/subdir";`, or `setSourceRoot = "sourceRoot=$(echo */subdir)";` or similar instead.
+
 - The `qemu-vm.nix` module by default now identifies block devices via
   persistent names available in `/dev/disk/by-*`. Because the rootDevice is
   identfied by its filesystem label, it needs to be formatted before the VM is

--- a/pkgs/applications/audio/alsa-scarlett-gui/default.nix
+++ b/pkgs/applications/audio/alsa-scarlett-gui/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ];
 
   makeFlags = [ "DESTDIR=\${out}" "PREFIX=''" ];
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
   nativeBuildInputs = [ pkg-config wrapGAppsHook4 ];
   buildInputs = [ gtk4 alsa-lib ];
   postInstall = ''

--- a/pkgs/applications/audio/miniaudicle/default.nix
+++ b/pkgs/applications/audio/miniaudicle/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${finalAttrs.src.name}/src";
 
   postPatch = ''
     echo '#define GIT_REVISION "${finalAttrs.version}-NixOS"' > git-rev.h

--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "1rasp2v1ds2aw296lbf27rzw0l9fjl0cvbvw85d5ycvh6wkm301p";
   };
 
-  sourceRoot = "source/muse3";
+  sourceRoot = "${src.name}/muse3";
 
   patches = [ ./fix-parallel-building.patch ];
 

--- a/pkgs/applications/audio/picoloop/default.nix
+++ b/pkgs/applications/audio/picoloop/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     libjack2
   ];
 
-  sourceRoot = "source/picoloop";
+  sourceRoot = "${src.name}/picoloop";
 
   makeFlags = [ "-f Makefile.PatternPlayer_debian_RtAudio_sdl20" ];
 

--- a/pkgs/applications/audio/soundkonverter/default.nix
+++ b/pkgs/applications/audio/soundkonverter/default.nix
@@ -68,7 +68,7 @@ mkDerivation rec {
   buildInputs = [ taglib ] ++ runtimeDeps;
   # encoder plugins go to ${out}/lib so they're found by kbuildsycoca5
   cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=$out" ];
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
   # add runt-time deps to PATH
   postInstall = ''
     wrapProgram $out/bin/soundkonverter --prefix PATH : ${lib.makeBinPath runtimeDeps }

--- a/pkgs/applications/audio/speech-denoiser/default.nix
+++ b/pkgs/applications/audio/speech-denoiser/default.nix
@@ -12,7 +12,7 @@ let
     pname = "rnnoise-nu";
     version = "unstable-07-10-2019";
     src = speech-denoiser-src;
-    sourceRoot = "source/rnnoise";
+    sourceRoot = "${speech-denoiser-src.name}/rnnoise";
     nativeBuildInputs = [ autoreconfHook ];
     configureFlags = [ "--disable-examples" "--disable-doc" "--disable-shared" "--enable-static" ];
     installTargets = [ "install-rnnoise-nu" ];

--- a/pkgs/applications/audio/tagutil/default.nix
+++ b/pkgs/applications/audio/tagutil/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-oY1aGl5CKVtpOfh8Wskio/huWYMiPuxWPqxlooTutcw=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/audio/yoshimi/default.nix
+++ b/pkgs/applications/audio/yoshimi/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-zFwfKy8CVecGhgr48T+eDNHfMdctfrNGenc/XJctyw8=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   postPatch = ''
     substituteInPlace Misc/Config.cpp --replace /usr $out

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/default.nix
@@ -28,7 +28,7 @@ let
     pname = "tsc";
     commit = version;
 
-    sourceRoot = "source/core";
+    sourceRoot = "${src.name}/core";
 
     recipe = writeText "recipe" ''
       (tsc
@@ -44,7 +44,7 @@ let
     pname = "tsc-dyn";
 
     nativeBuildInputs = [ rustPlatform.bindgenHook ];
-    sourceRoot = "source/core";
+    sourceRoot = "${src.name}/core";
 
     postInstall = ''
       LIB=($out/lib/libtsc_dyn.*)

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/update.py
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/update.py
@@ -96,12 +96,12 @@ if __name__ == "__main__":
         drv_path = eval_drv(
             nixpkgs,
             """
-        rustPlatform.buildRustPackage {
+        rustPlatform.buildRustPackage rec {
           pname = "tsc-dyn";
           version = "%s";
           nativeBuildInputs = [ clang ];
           src = fetchFromGitHub (lib.importJSON %s);
-          sourceRoot = "source/core";
+          sourceRoot = "${src.name}/core";
           cargoHash = lib.fakeHash;
         }
         """

--- a/pkgs/applications/emulators/basiliskii/default.nix
+++ b/pkgs/applications/emulators/basiliskii/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, autoconf, automake, pkg-config, SDL2, gtk2, mpfr }:
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "basiliskii";
   version = "unstable-2022-09-30";
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     rev = "2fa17a0783cf36ae60b77b5ed930cda4dc1824af";
     sha256 = "+jkns6H2YjlewbUzgoteGSQYWJL+OWVu178aM+BtABM=";
   };
-  sourceRoot = "source/BasiliskII/src/Unix";
+  sourceRoot = "${src.name}/BasiliskII/src/Unix";
   patches = [ ./remove-redhat-6-workaround-for-scsi-sg.h.patch ];
   nativeBuildInputs = [ autoconf automake pkg-config ];
   buildInputs = [ SDL2 gtk2 mpfr ];

--- a/pkgs/applications/emulators/basiliskii/default.nix
+++ b/pkgs/applications/emulators/basiliskii/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, autoconf, automake, pkg-config, SDL2, gtk2, mpfr }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "basiliskii";
   version = "unstable-2022-09-30";
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     rev = "2fa17a0783cf36ae60b77b5ed930cda4dc1824af";
     sha256 = "+jkns6H2YjlewbUzgoteGSQYWJL+OWVu178aM+BtABM=";
   };
-  sourceRoot = "${src.name}/BasiliskII/src/Unix";
+  sourceRoot = "${finalAttrs.src.name}/BasiliskII/src/Unix";
   patches = [ ./remove-redhat-6-workaround-for-scsi-sg.h.patch ];
   nativeBuildInputs = [ autoconf automake pkg-config ];
   buildInputs = [ SDL2 gtk2 mpfr ];
@@ -25,4 +25,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ quag ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/applications/file-managers/xplorer/default.nix
+++ b/pkgs/applications/file-managers/xplorer/default.nix
@@ -51,7 +51,7 @@ in
 rustPlatform.buildRustPackage {
   inherit version src pname;
 
-  sourceRoot = "source/src-tauri";
+  sourceRoot = "${src.name}/src-tauri";
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/applications/graphics/djv/default.nix
+++ b/pkgs/applications/graphics/djv/default.nix
@@ -56,7 +56,7 @@ let
 
     src = djvSrc;
 
-    sourceRoot = "source/etc/SuperBuild";
+    sourceRoot = "${src.name}/etc/SuperBuild";
 
     nativeBuildInputs = [ cmake ];
     buildInputs = [

--- a/pkgs/applications/graphics/imgbrd-grabber/default.nix
+++ b/pkgs/applications/graphics/imgbrd-grabber/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     ln -s $out/share/Grabber/Grabber-cli $out/bin/Grabber-cli
   '';
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   meta = with lib; {
     description = "Very customizable imageboard/booru downloader with powerful filenaming features";

--- a/pkgs/applications/graphics/pixelnuke/default.nix
+++ b/pkgs/applications/graphics/pixelnuke/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, libevent, glew, glfw }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pixelnuke";
   version = "unstable-2019-05-19";
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "03dp0p00chy00njl4w02ahxqiwqpjsrvwg8j4yi4dgckkc3gbh40";
   };
 
-  sourceRoot = "${src.name}/pixelnuke";
+  sourceRoot = "${finalAttrs.src.name}/pixelnuke";
 
   buildInputs = [ libevent glew glfw ];
 
@@ -26,4 +26,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ mrVanDalo ];
   };
-}
+})

--- a/pkgs/applications/graphics/pixelnuke/default.nix
+++ b/pkgs/applications/graphics/pixelnuke/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, libevent, glew, glfw }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "pixelnuke";
   version = "unstable-2019-05-19";
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "03dp0p00chy00njl4w02ahxqiwqpjsrvwg8j4yi4dgckkc3gbh40";
   };
 
-  sourceRoot = "source/pixelnuke";
+  sourceRoot = "${src.name}/pixelnuke";
 
   buildInputs = [ libevent glew glfw ];
 

--- a/pkgs/applications/graphics/synfigstudio/default.nix
+++ b/pkgs/applications/graphics/synfigstudio/default.nix
@@ -39,7 +39,7 @@ let
     pname = "ETL";
     inherit version src;
 
-    sourceRoot = "source/ETL";
+    sourceRoot = "${src.name}/ETL";
 
     nativeBuildInputs = [
       pkg-config
@@ -54,7 +54,7 @@ let
     pname = "synfig";
     inherit version src;
 
-    sourceRoot = "source/synfig-core";
+    sourceRoot = "${src.name}/synfig-core";
 
     configureFlags = [
       "--with-boost=${boost.dev}"
@@ -89,7 +89,7 @@ stdenv.mkDerivation {
   pname = "synfigstudio";
   inherit version src;
 
-  sourceRoot = "source/synfig-studio";
+  sourceRoot = "${src.name}/synfig-studio";
 
   postPatch = ''
     patchShebangs images/splash_screen_development.sh

--- a/pkgs/applications/graphics/vpv/default.nix
+++ b/pkgs/applications/graphics/vpv/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   cargoRoot = "src/fuzzy-finder";
   cargoDeps = rustPlatform.fetchCargoTarball {
     src = finalAttrs.src;
-    sourceRoot = "source/src/fuzzy-finder";
+    sourceRoot = "${finalAttrs.src.name}/src/fuzzy-finder";
     hash = "sha256-CDKlmwA2Wj78xPaSiYPmIJ7xmiE5Co+oGGejZU3v1zI=";
   };
 

--- a/pkgs/applications/misc/candle/default.nix
+++ b/pkgs/applications/misc/candle/default.nix
@@ -13,7 +13,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ qmake ];
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/misc/johnny-reborn/with-data.nix
+++ b/pkgs/applications/misc/johnny-reborn/with-data.nix
@@ -6,34 +6,32 @@
 , makeWrapper
 }:
 
+
+let
+  sounds = fetchFromGitHub {
+    owner = "nivs1978";
+    repo = "Johnny-Castaway-Open-Source";
+    rev = "be6afefd43a3334acc66fc9d777c162c8bfb9558";
+    hash = "sha256-rtZVCn4KbEBVwaSQ4HZhMoDEI5Q9IPj9SZywgAx0MPY=";
+  };
+
+  resources = fetchzip {
+    name = "scrantic-source";
+    url = "https://archive.org/download/johnny-castaway-screensaver/scrantic-run.zip";
+    hash = "sha256-Q9chCYReOQEmkTyIkYo+D+OXYUqxPNOOEEmiFh8yaw4=";
+    stripRoot = false;
+  };
+in
+
 stdenvNoCC.mkDerivation {
   pname = "johnny-reborn";
   inherit (johnny-reborn-engine) version;
 
-  srcs =
-    let
-      sounds = fetchFromGitHub {
-        owner = "nivs1978";
-        repo = "Johnny-Castaway-Open-Source";
-        rev = "be6afefd43a3334acc66fc9d777c162c8bfb9558";
-        hash = "sha256-rtZVCn4KbEBVwaSQ4HZhMoDEI5Q9IPj9SZywgAx0MPY=";
-      };
-
-      resources = fetchzip {
-        name = "scrantic-source";
-        url = "https://archive.org/download/johnny-castaway-screensaver/scrantic-run.zip";
-        hash = "sha256-Q9chCYReOQEmkTyIkYo+D+OXYUqxPNOOEEmiFh8yaw4=";
-        stripRoot = false;
-      };
-    in
-    [
-      sounds
-      resources
-    ];
+  srcs = [ sounds resources ];
 
   nativeBuildInputs = [ makeWrapper ];
 
-  sourceRoot = "source";
+  sourceRoot = sounds.name;
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/applications/misc/openbangla-keyboard/default.nix
+++ b/pkgs/applications/misc/openbangla-keyboard/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     postPatch = ''
       cp ${./Cargo.lock} Cargo.lock
     '';
-    sourceRoot = "source/${cargoRoot}";
+    sourceRoot = "${src.name}/${cargoRoot}";
     sha256 = "sha256-01MWuUUirsgpoprMArRp3qxKNayPHTkYWk31nXcIC34=";
   };
 

--- a/pkgs/applications/misc/pot/default.nix
+++ b/pkgs/applications/misc/pot/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-v5yx8pE8+m+5CDy7X3CwitYhFQMX8Ynt8Y2k1lEZKpg=";
   };
 
-  sourceRoot = "source/src-tauri";
+  sourceRoot = "${src.name}/src-tauri";
 
   postPatch = ''
     substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \

--- a/pkgs/applications/misc/qsudo/default.nix
+++ b/pkgs/applications/misc/qsudo/default.nix
@@ -17,7 +17,7 @@ mkDerivation rec {
     sha256 = "06kg057vwkvafnk69m9rar4wih3vq4h36wbzwbfc2kndsnn47lfl";
   };
 
-  sourceRoot = "source/src-qt5";
+  sourceRoot = "${src.name}/src-qt5";
 
   nativeBuildInputs = [
     qmake

--- a/pkgs/applications/misc/spacenav-cube-example/default.nix
+++ b/pkgs/applications/misc/spacenav-cube-example/default.nix
@@ -2,11 +2,9 @@
 
 stdenv.mkDerivation {
   pname = "spacenav-cube-example";
-  version = libspnav.version;
+  inherit (libspnav) version src;
 
-  src = libspnav.src;
-
-  sourceRoot = "source/examples/cube";
+  sourceRoot = "${libspnav.src.name}/examples/cube";
 
   buildInputs = [ libX11 mesa_glu libspnav ];
 

--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -44,7 +44,7 @@ let
 
     src = subsurfaceSrc;
 
-    sourceRoot = "source/libdivecomputer";
+    sourceRoot = "${subsurfaceSrc.name}/libdivecomputer";
 
     nativeBuildInputs = [ autoreconfHook pkg-config ];
 

--- a/pkgs/applications/misc/yubioath-flutter/helper.nix
+++ b/pkgs/applications/misc/yubioath-flutter/helper.nix
@@ -16,7 +16,7 @@ buildPythonApplication {
   pname = "yubioath-flutter-helper";
   inherit src version meta;
 
-  sourceRoot = "source/helper";
+  sourceRoot = "${src.name}/helper";
   format = "pyproject";
 
   postPatch = ''

--- a/pkgs/applications/networking/browsers/browsh/default.nix
+++ b/pkgs/applications/networking/browsers/browsh/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
 
   pname = "browsh";
 
-  sourceRoot = "source/interfacer";
+  sourceRoot = "${src.name}/interfacer";
 
   src = fetchFromGitHub {
     owner = "browsh-org";

--- a/pkgs/applications/networking/browsers/ladybird/default.nix
+++ b/pkgs/applications/networking/browsers/ladybird/default.nix
@@ -10,7 +10,7 @@
 , nixosTests
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ladybird";
   version = "unstable-2023-01-17";
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-n2mLg9wNfdMGsJuGj+ukjto9qYjGOIz4cZjgvMGQUrY=";
   };
 
-  sourceRoot = "${src.name}/Ladybird";
+  sourceRoot = "${finalAttrs.src.name}/Ladybird";
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
@@ -70,4 +70,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/applications/networking/browsers/ladybird/default.nix
+++ b/pkgs/applications/networking/browsers/ladybird/default.nix
@@ -10,7 +10,7 @@
 , nixosTests
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "ladybird";
   version = "unstable-2023-01-17";
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     hash = "sha256-n2mLg9wNfdMGsJuGj+ukjto9qYjGOIz4cZjgvMGQUrY=";
   };
 
-  sourceRoot = "source/Ladybird";
+  sourceRoot = "${src.name}/Ladybird";
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \

--- a/pkgs/applications/networking/filebrowser/default.nix
+++ b/pkgs/applications/networking/filebrowser/default.nix
@@ -12,7 +12,7 @@ let
       hash = "sha256-xhBIJcEtxDdMXSgQtLAV0UWzPtrvKEil0WV76K5ycBc=";
     };
 
-    sourceRoot = "source/frontend";
+    sourceRoot = "${src.name}/frontend";
 
     npmDepsHash = "sha256-acNIMKHc4q7eiFLPBtKZBNweEsrt+//0VR6dqwXHTvA=";
 

--- a/pkgs/applications/networking/geph/default.nix
+++ b/pkgs/applications/networking/geph/default.nix
@@ -59,7 +59,7 @@ in
       pname = "gephgui";
       inherit version src;
 
-      sourceRoot = "source/gephgui-wry/gephgui";
+      sourceRoot = "${src.name}/gephgui-wry/gephgui";
 
       postPatch = "ln -s ${./package-lock.json} ./package-lock.json";
 
@@ -79,7 +79,7 @@ in
       pname = "gephgui-wry";
       inherit version src;
 
-      sourceRoot = "source/gephgui-wry";
+      sourceRoot = "${src.name}/gephgui-wry";
 
       cargoHash = "sha256-lidlUUfHXKPUlICdaVv/SFlyyWsZ7cYHyTJ3kkMn3L4=";
 

--- a/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
@@ -14,7 +14,7 @@ in rustPlatform.buildRustPackage rec {
     hash = pinData.srcHash;
   };
 
-  sourceRoot = "source/seshat-node/native";
+  sourceRoot = "${src.name}/seshat-node/native";
 
   nativeBuildInputs = [ nodejs python3 yarn ];
   buildInputs = [ sqlcipher ] ++ lib.optional stdenv.isDarwin CoreServices;

--- a/pkgs/applications/networking/instant-messengers/jami/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/default.nix
@@ -113,7 +113,7 @@ stdenv.mkDerivation rec {
   daemon = stdenv.mkDerivation {
     pname = "jami-daemon";
     inherit src version meta;
-    sourceRoot = "source/daemon";
+    sourceRoot = "${src.name}/daemon";
 
     nativeBuildInputs = [
       autoreconfHook

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/pidgin-opensteamworks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/pidgin-opensteamworks/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VWsoyFG+Ro+Y6ngSTMQ7yBYf6awCMNOc6U0WqNeg/jU=";
   };
 
-  sourceRoot = "source/steam-mobile";
+  sourceRoot = "${src.name}/steam-mobile";
 
   installFlags = [
     "PLUGIN_DIR_PURPLE=${placeholder "out"}/lib/purple-2"

--- a/pkgs/applications/networking/kubo-migrator/all-migrations.nix
+++ b/pkgs/applications/networking/kubo-migrator/all-migrations.nix
@@ -13,7 +13,7 @@ let
   fs-repo-common = pname: version: buildGoModule {
     inherit pname version;
     inherit (kubo-migrator-unwrapped) src;
-    sourceRoot = "source/${pname}";
+    sourceRoot = "${kubo-migrator-unwrapped.src.name}/${pname}";
     vendorSha256 = null;
     # Fix build on Go 1.17 and later: panic: qtls.ClientHelloInfo doesn't match
     # See https://github.com/ipfs/fs-repo-migrations/pull/163

--- a/pkgs/applications/networking/kubo-migrator/unwrapped.nix
+++ b/pkgs/applications/networking/kubo-migrator/unwrapped.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
     hash = "sha256-y0IYSKKZlFbPrTUC6XqYKhS3a79rieNGBL58teWMlC4=";
   };
 
-  sourceRoot = "source/fs-repo-migrations";
+  sourceRoot = "${src.name}/fs-repo-migrations";
 
   vendorHash = "sha256-/DqkBBtR/nU8gk3TFqNKY5zQU6BFMc3N8Ti+38mi/jk=";
 

--- a/pkgs/applications/networking/mullvad/libwg.nix
+++ b/pkgs/applications/networking/mullvad/libwg.nix
@@ -11,7 +11,7 @@ buildGoModule {
     src
     ;
 
-  sourceRoot = "source/wireguard/libwg";
+  sourceRoot = "${mullvad.src.name}/wireguard/libwg";
 
   vendorSha256 = "QNde5BqkSuqp3VJQOhn7aG6XknRDZQ62PE3WGhEJ5LU=";
 

--- a/pkgs/applications/networking/owncloud-client/libre-graph-api-cpp-qt-client.nix
+++ b/pkgs/applications/networking/owncloud-client/libre-graph-api-cpp-qt-client.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-wbdamPi2XSLWeprrYZtBUDH1A2gdp6/5geFZv+ZqSWk=";
   };
 
-  sourceRoot = "source/client";
+  sourceRoot = "${src.name}/client";
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];
   buildInputs = [ qtbase ];

--- a/pkgs/applications/office/paperwork/openpaperwork-core.nix
+++ b/pkgs/applications/office/paperwork/openpaperwork-core.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   pname = "openpaperwork-core";
   inherit (import ./src.nix { inherit fetchFromGitLab; }) version src;
 
-  sourceRoot = "source/openpaperwork-core";
+  sourceRoot = "${src.name}/openpaperwork-core";
 
   # Python 2.x is not supported.
   disabled = !isPy3k && !isPyPy;

--- a/pkgs/applications/office/paperwork/openpaperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/openpaperwork-gtk.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   pname = "openpaperwork-gtk";
   inherit (import ./src.nix { inherit fetchFromGitLab; }) version src;
 
-  sourceRoot = "source/openpaperwork-gtk";
+  sourceRoot = "${src.name}/openpaperwork-gtk";
 
   # Python 2.x is not supported.
   disabled = !isPy3k && !isPyPy;

--- a/pkgs/applications/office/paperwork/paperwork-backend.nix
+++ b/pkgs/applications/office/paperwork/paperwork-backend.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   pname = "paperwork-backend";
   inherit (import ./src.nix { inherit fetchFromGitLab; }) version src;
 
-  sourceRoot = "source/paperwork-backend";
+  sourceRoot = "${src.name}/paperwork-backend";
 
   patches = [
     # disables a flaky test https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/issues/1035#note_1493700

--- a/pkgs/applications/office/paperwork/paperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/paperwork-gtk.nix
@@ -41,7 +41,7 @@ python3Packages.buildPythonApplication rec {
     src = sample_documents;
   };
 
-  sourceRoot = "source/paperwork-gtk";
+  sourceRoot = "${src.name}/paperwork-gtk";
 
   # Patch out a few paths that assume that we're using the FHS:
   postPatch = ''

--- a/pkgs/applications/office/paperwork/paperwork-shell.nix
+++ b/pkgs/applications/office/paperwork/paperwork-shell.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   pname = "paperwork-shell";
   inherit (import ./src.nix { inherit fetchFromGitLab; }) version src;
 
-  sourceRoot = "source/paperwork-shell";
+  sourceRoot = "${src.name}/paperwork-shell";
 
   # Python 2.x is not supported.
   disabled = !isPy3k && !isPyPy;

--- a/pkgs/applications/radio/ubertooth/default.nix
+++ b/pkgs/applications/radio/ubertooth/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "11r5ag2l5xn4pr7ycicm30w9c3ldn9yiqj1sqnjc79csxl2vrcfw";
   };
 
-  sourceRoot = "source/host";
+  sourceRoot = "${src.name}/host";
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ libbtbb libpcap libusb1 bluez ];

--- a/pkgs/applications/science/biology/muscle/default.nix
+++ b/pkgs/applications/science/biology/muscle/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-NpnJziZXga/T5OavUt3nQ5np8kJ9CFcSmwyg4m6IJsk=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   installPhase = ''
     install -m755 -D Linux/muscle $out/bin/muscle

--- a/pkgs/applications/science/biology/star/default.nix
+++ b/pkgs/applications/science/biology/star/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-58Y4lzqXwBhRlXcionUg2IhAg5znNUuyr/FsuNZd+5Q=";
   };
 
-  sourceRoot = "source/source";
+  sourceRoot = "${src.name}/source";
 
   postPatch = ''
     substituteInPlace Makefile --replace "/bin/rm" "rm"

--- a/pkgs/applications/science/biology/tandem-aligner/default.nix
+++ b/pkgs/applications/science/biology/tandem-aligner/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  sourceRoot = "source/tandem_aligner";
+  sourceRoot = "${finalAttrs.src.name}/tandem_aligner";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/applications/science/chemistry/autodock-vina/python-bindings.nix
+++ b/pkgs/applications/science/chemistry/autodock-vina/python-bindings.nix
@@ -12,7 +12,7 @@ buildPythonPackage {
 
   format = "pyproject";
 
-  sourceRoot = "source/build/python";
+  sourceRoot = "${autodock-vina.src.name}/build/python";
 
   postPatch = ''
     # wildcards are not allowed

--- a/pkgs/applications/science/logic/z3/tptp.nix
+++ b/pkgs/applications/science/logic/z3/tptp.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = z3.src;
 
-  sourceRoot = "source/examples/tptp";
+  sourceRoot = "${src.name}/examples/tptp";
 
   nativeBuildInputs = [cmake];
   buildInputs = [z3];

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     sha256 = data.repo_hash;
   };
 
-  sourceRoot = "source/workhorse";
+  sourceRoot = "${src.name}/workhorse";
 
   vendorSha256 = "sha256-lKl/V2fti0eqrEoeJNNwvJbZO7z7v+5HlES+dyxxcP4=";
   buildInputs = [ git ];

--- a/pkgs/applications/version-management/gitlint/default.nix
+++ b/pkgs/applications/version-management/gitlint/default.nix
@@ -21,7 +21,7 @@ python3.pkgs.buildPythonApplication rec {
 
   # Upstream splitted the project into gitlint and gitlint-core to
   # simplify the dependency handling
-  sourceRoot = "source/gitlint-core";
+  sourceRoot = "${src.name}/gitlint-core";
 
   nativeBuildInputs = with python3.pkgs; [
     hatch-vcs

--- a/pkgs/applications/version-management/gitqlient/default.nix
+++ b/pkgs/applications/version-management/gitqlient/default.nix
@@ -6,48 +6,52 @@
 , gitUpdater
 }:
 
-mkDerivation rec {
+let
   pname = "gitqlient";
   version = "1.5.0";
 
-  srcs = [
-    (fetchFromGitHub {
-      owner = "francescmm";
-      repo = pname;
-      rev = "v${version}";
-      sha256 = "sha256-Mq29HbmPABrRIJjWC5AAKIOKbGngeJdkZkWeJw8BFuw=";
-    })
-    (fetchFromGitHub rec {
-      owner = "francescmm";
-      repo = "AuxiliarCustomWidgets";
-      rev = "835f538b4a79e4d6bb70eef37a32103e7b2a1fd1";
-      sha256 = "sha256-b1gb/7UcLS6lI92dBfTenGXA064t4dZufs3S9lu/lQA=";
-      name = repo;
-    })
-    (fetchFromGitHub rec {
-      owner = "francescmm";
-      repo = "QLogger";
-      rev = "d1ed24e080521a239d5d5e2c2347fe211f0f3e4f";
-      sha256 = "sha256-NVlFYmm7IIkf8LhQrAYXil9kH6DFq1XjOEHQiIWmER4=";
-      name = repo;
-    })
-    (fetchFromGitHub rec {
-      owner = "francescmm";
-      repo = "QPinnableTabWidget";
-      rev = "cc937794e910d0452f0c07b4961c6014a7358831";
-      sha256 = "sha256-2KzzBv/s2t665axeBxWrn8aCMQQArQLlUBOAlVhU+wE=";
-      name = repo;
-    })
-    (fetchFromGitHub rec {
-      owner = "francescmm";
-      repo = "git";
-      rev = "b62750f4da4b133faff49e6f53950d659b18c948";
-      sha256 = "sha256-4FqA+kkHd0TqD6ZuB4CbJ+IhOtQG9uWN+qhSAT0dXGs=";
-      name = repo;
-    })
-  ];
+  main_src = fetchFromGitHub {
+    owner = "francescmm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Mq29HbmPABrRIJjWC5AAKIOKbGngeJdkZkWeJw8BFuw=";
+  };
+  aux_src = fetchFromGitHub rec {
+    owner = "francescmm";
+    repo = "AuxiliarCustomWidgets";
+    rev = "835f538b4a79e4d6bb70eef37a32103e7b2a1fd1";
+    sha256 = "sha256-b1gb/7UcLS6lI92dBfTenGXA064t4dZufs3S9lu/lQA=";
+    name = repo;
+  };
+  qlogger_src = fetchFromGitHub rec {
+    owner = "francescmm";
+    repo = "QLogger";
+    rev = "d1ed24e080521a239d5d5e2c2347fe211f0f3e4f";
+    sha256 = "sha256-NVlFYmm7IIkf8LhQrAYXil9kH6DFq1XjOEHQiIWmER4=";
+    name = repo;
+  };
+  qpinnabletab_src = fetchFromGitHub rec {
+    owner = "francescmm";
+    repo = "QPinnableTabWidget";
+    rev = "cc937794e910d0452f0c07b4961c6014a7358831";
+    sha256 = "sha256-2KzzBv/s2t665axeBxWrn8aCMQQArQLlUBOAlVhU+wE=";
+    name = repo;
+  };
+  git_src = fetchFromGitHub rec {
+    owner = "francescmm";
+    repo = "git";
+    rev = "b62750f4da4b133faff49e6f53950d659b18c948";
+    sha256 = "sha256-4FqA+kkHd0TqD6ZuB4CbJ+IhOtQG9uWN+qhSAT0dXGs=";
+    name = repo;
+  };
+in
 
-  sourceRoot = "source";
+mkDerivation rec {
+  inherit pname version;
+
+  srcs = [ main_src aux_src qlogger_src qpinnabletab_src git_src ];
+
+  sourceRoot = main_src.name;
 
   nativeBuildInputs = [
     qmake

--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -96,7 +96,7 @@ python3Packages.buildPythonApplication {
   pname = "sapling";
   inherit src version;
 
-  sourceRoot = "source/eden/scm";
+  sourceRoot = "${src.name}/eden/scm";
 
   # Upstream does not commit Cargo.lock
   cargoDeps = rustPlatform.importCargoLock {

--- a/pkgs/applications/version-management/sourcehut/builds.nix
+++ b/pkgs/applications/version-management/sourcehut/builds.nix
@@ -30,7 +30,7 @@ let
 
   buildsrht-worker = buildGoModule {
     inherit src version;
-    sourceRoot = "source/worker";
+    sourceRoot = "${src.name}/worker";
     pname = "buildsrht-worker";
     vendorHash = "sha256-y5RFPbtaGmgPpiV2Q3njeWORGZF1TJRjAbY6VgC1hek=";
   };

--- a/pkgs/applications/video/epgstation/default.nix
+++ b/pkgs/applications/video/epgstation/default.nix
@@ -49,7 +49,7 @@ buildNpmPackage rec {
     npmDepsHash = "sha256-a/cDPABWI4lPxvSOI4D90O71A9lm8icPMak/g6DPYQY=";
     npmRootPath = "";
 
-    sourceRoot = "source/client";
+    sourceRoot = "${src.name}/client";
     NODE_OPTIONS = "--openssl-legacy-provider";
   };
 

--- a/pkgs/applications/video/frigate/web.nix
+++ b/pkgs/applications/video/frigate/web.nix
@@ -7,7 +7,7 @@ buildNpmPackage {
   pname = "frigate-web";
   inherit version src;
 
-  sourceRoot = "source/web";
+  sourceRoot = "${src.name}/web";
 
   postPatch = ''
     substituteInPlace package.json \

--- a/pkgs/applications/window-managers/tinywl/default.nix
+++ b/pkgs/applications/window-managers/tinywl/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   pname = "tinywl";
   inherit (wlroots) version src;
 
-  sourceRoot = "source/tinywl";
+  sourceRoot = "${wlroots.src.name}/tinywl";
 
   nativeBuildInputs = [ pkg-config wayland-scanner ];
   buildInputs = [ libxkbcommon pixman udev wayland wayland-protocols wlroots ];

--- a/pkgs/applications/window-managers/wmderlandc/default.nix
+++ b/pkgs/applications/window-managers/wmderlandc/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, libX11, xorgproto }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "wmderlandc";
   version = "unstable-2020-07-17";
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0npmlnybblp82mfpinjbz7dhwqgpdqc1s63wc1zs8mlcs19pdh98";
   };
 
-  sourceRoot = "source/ipc-client";
+  sourceRoot = "${src.name}/ipc-client";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/window-managers/wmderlandc/default.nix
+++ b/pkgs/applications/window-managers/wmderlandc/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, libX11, xorgproto }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wmderlandc";
   version = "unstable-2020-07-17";
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0npmlnybblp82mfpinjbz7dhwqgpdqc1s63wc1zs8mlcs19pdh98";
   };
 
-  sourceRoot = "${src.name}/ipc-client";
+  sourceRoot = "${finalAttrs.src.name}/ipc-client";
 
   nativeBuildInputs = [
     cmake
@@ -29,4 +29,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ takagiy ];
   };
-}
+})

--- a/pkgs/data/themes/catppuccin-plymouth/default.nix
+++ b/pkgs/data/themes/catppuccin-plymouth/default.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-quBSH8hx3gD7y1JNWAKQdTk3CmO4t1kVo4cOGbeWlNE=";
   };
 
-  sourceRoot = "source/themes/catppuccin-${variant}";
+  sourceRoot = "${src.name}/themes/catppuccin-${variant}";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -21,8 +21,27 @@
 }:
 
 let
+
   pname = "mojave-gtk-theme";
+  version = "2023-06-13";
+
+  main_src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    hash = "sha256-0jb/VQ6Z0BGaEka57BWM0pBweP08cr4jfPRdEN/BJ1M=";
+  };
+
+  wallpapers_src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = "0c4ae6ddff7e3fab4959469461c4d4042deb1b2f";
+    hash = "sha256-7LSZSsRt6zTVPLWzuBgwRC1q1MHp5pN/pMl3x2wR8Ow=";
+    name = "wallpapers";
+  };
+
 in
+
 lib.checkListOfEnum "${pname}: button size variants" [ "standard" "small" ] buttonSizeVariants
 lib.checkListOfEnum "${pname}: button variants" [ "standard" "alt" ] buttonVariants
 lib.checkListOfEnum "${pname}: color variants" [ "light" "dark" ] colorVariants
@@ -30,29 +49,11 @@ lib.checkListOfEnum "${pname}: opacity variants" [ "standard" "solid" ] opacityV
 lib.checkListOfEnum "${pname}: theme variants" [ "default" "blue" "purple" "pink" "red" "orange" "yellow" "green" "grey" "all" ] themeVariants
 
 stdenvNoCC.mkDerivation rec {
-  inherit pname;
-  version = "2023-06-13";
+  inherit pname version;
 
-  srcs = [
-    (fetchFromGitHub {
-      owner = "vinceliuice";
-      repo = pname;
-      rev = version;
-      hash = "sha256-0jb/VQ6Z0BGaEka57BWM0pBweP08cr4jfPRdEN/BJ1M=";
-    })
-  ]
-  ++
-  lib.optional wallpapers
-    (fetchFromGitHub {
-      owner = "vinceliuice";
-      repo = pname;
-      rev = "0c4ae6ddff7e3fab4959469461c4d4042deb1b2f";
-      hash = "sha256-7LSZSsRt6zTVPLWzuBgwRC1q1MHp5pN/pMl3x2wR8Ow=";
-      name = "wallpapers";
-    })
-  ;
+  srcs = [ main_src ] ++ lib.optional wallpapers wallpapers_src;
 
-  sourceRoot = "source";
+  sourceRoot = main_src.name;
 
   nativeBuildInputs = [
     glib

--- a/pkgs/desktops/lumina/lumina-calculator/default.nix
+++ b/pkgs/desktops/lumina/lumina-calculator/default.nix
@@ -11,7 +11,7 @@ mkDerivation rec {
     sha256 = "1238d1m0mjkwkdpgq165a4ql9aql0aji5f41rzdzny6m7ws9nm2y";
   };
 
-  sourceRoot = "source/src-qt5";
+  sourceRoot = "${src.name}/src-qt5";
 
   nativeBuildInputs = [ qmake qttools ];
 

--- a/pkgs/desktops/lumina/lumina-pdf/default.nix
+++ b/pkgs/desktops/lumina/lumina-pdf/default.nix
@@ -11,7 +11,7 @@ mkDerivation rec {
     sha256 = "08caj4nashp79fbvj94rabn0iaa1hymifqmb782x03nb2vkn38r6";
   };
 
-  sourceRoot = "source/src-qt5";
+  sourceRoot = "${src.name}/src-qt5";
 
   nativeBuildInputs = [ qmake qttools ];
 

--- a/pkgs/development/compilers/llvm/13/clang/default.nix
+++ b/pkgs/development/compilers/llvm/13/clang/default.nix
@@ -10,7 +10,7 @@ let
     inherit version;
 
     inherit src;
-    sourceRoot = "source/clang";
+    sourceRoot = "${src.name}/clang";
 
     nativeBuildInputs = [ cmake python3 ]
       ++ lib.optional enableManpages python3.pkgs.sphinx

--- a/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   inherit version;
 
   inherit src;
-  sourceRoot = "source/compiler-rt";
+  sourceRoot = "${src.name}/compiler-rt";
 
   nativeBuildInputs = [ cmake python3 libllvm.dev ]
     ++ lib.optional stdenv.isDarwin xcbuild.xcrun;

--- a/pkgs/development/compilers/llvm/13/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxx/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   inherit src;
-  sourceRoot = "source/libcxx";
+  sourceRoot = "${src.name}/libcxx";
 
   outputs = [ "out" ] ++ lib.optional (!headersOnly) "dev";
 

--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   inherit src;
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/compilers/llvm/13/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/13/libunwind/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   inherit src;
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   patches = [
     ./gnu-install-dirs.patch

--- a/pkgs/development/compilers/llvm/13/lld/default.nix
+++ b/pkgs/development/compilers/llvm/13/lld/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   inherit src;
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   patches = [
     ./gnu-install-dirs.patch

--- a/pkgs/development/compilers/llvm/13/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/13/llvm/default.nix
@@ -61,7 +61,7 @@ in stdenv.mkDerivation (rec {
   inherit version;
 
   inherit src;
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   outputs = [ "out" "lib" "dev" "python" ];
 

--- a/pkgs/development/compilers/llvm/13/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/13/openmp/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   inherit src;
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [

--- a/pkgs/development/coq-modules/metalib/default.nix
+++ b/pkgs/development/coq-modules/metalib/default.nix
@@ -1,6 +1,6 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-mkCoqDerivation {
+(mkCoqDerivation {
   pname = "metalib";
   owner = "plclub";
   inherit version;
@@ -12,10 +12,10 @@ mkCoqDerivation {
   release."8.15".sha256 = "0wbp058zwa4bkdjj38aysy2g1avf9nrh8q23a3dil0q00qczi616";
   release."8.10".sha256 = "0wbypc05d2lqfm9qaw98ynr5yc1p0ipsvyc3bh1rk9nz7zwirmjs";
 
-  sourceRoot = "source/Metalib";
-
   meta = with lib; {
     license = licenses.mit;
     maintainers = [ maintainers.jwiegley ];
   };
-}
+}).overrideAttrs (oldAttrs: {
+  sourceRoot = "${oldAttrs.src.name}/Metalib";
+})

--- a/pkgs/development/embedded/fpga/tinyprog/default.nix
+++ b/pkgs/development/embedded/fpga/tinyprog/default.nix
@@ -15,7 +15,7 @@ with python3Packages; buildPythonApplication rec {
     sha256 = "0zbrvvb957z2lwbfd39ixqdsnd2w4wfjirwkqdrqm27bjz308731";
   };
 
-  sourceRoot = "source/programmer";
+  sourceRoot = "${src.name}/programmer";
 
   propagatedBuildInputs = [
     pyserial

--- a/pkgs/development/haskell-modules/configuration-tensorflow.nix
+++ b/pkgs/development/haskell-modules/configuration-tensorflow.nix
@@ -18,7 +18,7 @@ let
 
   setTensorflowSourceRoot = dir: drv:
     (overrideCabal (drv: { src = tensorflow-haskell; }) drv)
-      .overrideAttrs (_oldAttrs: {sourceRoot = "source/${dir}";});
+      .overrideAttrs (_oldAttrs: { sourceRoot = "${tensorflow-haskell.name}/${dir}"; });
 in
 {
   tensorflow-proto = doJailbreak (setTensorflowSourceRoot "tensorflow-proto" super.tensorflow-proto);

--- a/pkgs/development/interpreters/kerf/default.nix
+++ b/pkgs/development/interpreters/kerf/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     hash  = "sha256-0sU2zOk5I69lQyrn1g0qsae7S/IBT6eA/911qp0GNkk=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
   buildInputs = [ libedit zlib ncurses ]
     ++ lib.optionals stdenv.isDarwin ([
       Accelerate

--- a/pkgs/development/interpreters/wamr/default.nix
+++ b/pkgs/development/interpreters/wamr/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  sourceRoot = "source/product-mini/platforms/linux";
+  sourceRoot = "${finalAttrs.src.name}/product-mini/platforms/linux";
 
   meta = with lib; {
     description = "WebAssembly Micro Runtime";

--- a/pkgs/development/libraries/clfft/default.nix
+++ b/pkgs/development/libraries/clfft/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-yp7u6qhpPYQpBw3d+VLg0GgMyZONVII8BsBCEoRZm4w=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   postPatch = ''
     sed -i '/-m64/d;/-m32/d' CMakeLists.txt

--- a/pkgs/development/libraries/clipper2/default.nix
+++ b/pkgs/development/libraries/clipper2/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-u/4GG1A2PAlk8VEWgJX8+EnZ5hpGhu1QbvHwct58sF4=";
   };
 
-  sourceRoot = "source/CPP";
+  sourceRoot = "${src.name}/CPP";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/cxxtest/default.nix
+++ b/pkgs/development/libraries/cxxtest/default.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "19w92kipfhp5wvs47l0qpibn3x49sbmvkk91yxw6nwk6fafcdl17";
   };
 
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   nativeCheckInputs = [ python3Packages.ply ];
 

--- a/pkgs/development/libraries/dab_lib/default.nix
+++ b/pkgs/development/libraries/dab_lib/default.nix
@@ -2,7 +2,7 @@
 , faad2, fftwFloat, zlib
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "dab_lib";
   version = "unstable-2023-03-02";
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
     hash = "sha256-KSkOg0a5iq+13kClQqj+TaEP/PsLUrm8bMmiJEAZ+C4=";
   };
 
-  sourceRoot = "source/library/";
+  sourceRoot = "${src.name}/library/";
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ faad2 fftwFloat zlib ];

--- a/pkgs/development/libraries/dab_lib/default.nix
+++ b/pkgs/development/libraries/dab_lib/default.nix
@@ -2,7 +2,7 @@
 , faad2, fftwFloat, zlib
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dab_lib";
   version = "unstable-2023-03-02";
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-KSkOg0a5iq+13kClQqj+TaEP/PsLUrm8bMmiJEAZ+C4=";
   };
 
-  sourceRoot = "${src.name}/library/";
+  sourceRoot = "${finalAttrs.src.name}/library/";
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ faad2 fftwFloat zlib ];
@@ -25,4 +25,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ alexwinter ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/development/libraries/fuzzylite/default.nix
+++ b/pkgs/development/libraries/fuzzylite/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-i1txeUE/ZSRggwLDtpS8dd4uuZfHX9w3zRH0gBgGXnk=";
   };
-  sourceRoot = "source/fuzzylite";
+  sourceRoot = "${src.name}/fuzzylite";
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/libraries/herqq/default.nix
+++ b/pkgs/development/libraries/herqq/default.nix
@@ -9,7 +9,7 @@ mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  sourceRoot = "source/herqq";
+  sourceRoot = "${src.name}/herqq";
   src = fetchFromGitHub {
     owner = "ThomArmax";
     repo = "HUPnP";

--- a/pkgs/development/libraries/libclc/default.nix
+++ b/pkgs/development/libraries/libclc/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     rev = "llvmorg-${version}";
     hash = "sha256-paWwnoU3XMqreRgh9JbT1tDMTwq/ZL0ss3SJTteEGL0=";
   };
-  sourceRoot = "source/libclc";
+  sourceRoot = "${src.name}/libclc";
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/libraries/libgeotiff/default.nix
+++ b/pkgs/development/libraries/libgeotiff/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  sourceRoot = "source/libgeotiff";
+  sourceRoot = "${src.name}/libgeotiff";
 
   configureFlags = [
     "--with-jpeg=${libjpeg.dev}"

--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-TkMy2tEdG1FPPWfH/wPnVbs5kocqe4Y0jU4yvbiRZ9k=";
   };
 
-  sourceRoot = "source/libvmaf";
+  sourceRoot = "${src.name}/libvmaf";
 
   patches = [
     # Backport fix for non-Linux, non-Darwin platforms.

--- a/pkgs/development/libraries/octomap/default.nix
+++ b/pkgs/development/libraries/octomap/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-qE5i4dGugm7tR5tgDCpbla/R7hYR/PI8BzrZQ4y6Yz8=";
   };
 
-  sourceRoot = "source/octomap";
+  sourceRoot = "${src.name}/octomap";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/libraries/orocos-kdl/default.nix
+++ b/pkgs/development/libraries/orocos-kdl/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  sourceRoot = "source/orocos_kdl";
+  sourceRoot = "${src.name}/orocos_kdl";
 
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ eigen ];

--- a/pkgs/development/libraries/pico-sdk/default.nix
+++ b/pkgs/development/libraries/pico-sdk/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   # SDK contains libraries and build-system to develop projects for RP2040 chip
   # We only need to compile pioasm binary
-  sourceRoot = "source/tools/pioasm";
+  sourceRoot = "${src.name}/tools/pioasm";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/libraries/proj-datumgrid/default.nix
+++ b/pkgs/development/libraries/proj-datumgrid/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "132wp77fszx33wann0fjkmi1isxvsb0v9iw0gd9sxapa9h6hf3am";
   };
 
-  sourceRoot = "source/scripts";
+  sourceRoot = "${src.name}/scripts";
 
   buildPhase = ''
     $CC nad2bin.c -o nad2bin

--- a/pkgs/development/libraries/qrcodegen/default.nix
+++ b/pkgs/development/libraries/qrcodegen/default.nix
@@ -14,9 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-aci5SFBRNRrSub4XVJ2luHNZ2pAUegjgQ6pD9kpkaTY=";
   };
 
-  preBuild = ''
-    cd c
-  '';
+  sourceRoot = "${finalAttrs.src.name}/c";
 
   nativeBuildInputs = lib.optionals stdenv.cc.isClang [
     stdenv.cc.cc.libllvm.out

--- a/pkgs/development/libraries/qtstyleplugin-kvantum-qt4/default.nix
+++ b/pkgs/development/libraries/qtstyleplugin-kvantum-qt4/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ qmake4Hook ];
   buildInputs = [ qt4 libX11 libXext ];
 
-  sourceRoot = "source/Kvantum";
+  sourceRoot = "${src.name}/Kvantum";
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
+++ b/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (lib.versionOlder qtbase.version "6") [ qtx11extras kwindowsystem ]
     ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland;
 
-  sourceRoot = "source/Kvantum";
+  sourceRoot = "${src.name}/Kvantum";
 
   patches = [
     (fetchpatch {

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -131,7 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
       pname = "${finalAttrs.pname}-test";
       inherit (finalAttrs) version src;
 
-      sourceRoot = "source/clients/tests";
+      sourceRoot = "${finalAttrs.src.name}/clients/tests";
 
       nativeBuildInputs = [
         cmake
@@ -164,7 +164,7 @@ stdenv.mkDerivation (finalAttrs: {
       pname = "${finalAttrs.pname}-benchmark";
       inherit (finalAttrs) version src;
 
-      sourceRoot = "source/clients/rider";
+      sourceRoot = "${finalAttrs.src.name}/clients/rider";
 
       nativeBuildInputs = [
         cmake
@@ -197,7 +197,7 @@ stdenv.mkDerivation (finalAttrs: {
       pname = "${finalAttrs.pname}-samples";
       inherit (finalAttrs) version src;
 
-      sourceRoot = "source/clients/samples";
+      sourceRoot = "${finalAttrs.src.name}/clients/samples";
 
       nativeBuildInputs = [
         cmake

--- a/pkgs/development/php-packages/snuffleupagus/default.nix
+++ b/pkgs/development/php-packages/snuffleupagus/default.nix
@@ -31,7 +31,7 @@ buildPecl rec {
     session
   ];
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   configureFlags = [
     "--enable-snuffleupagus"

--- a/pkgs/development/python-modules/aardwolf/default.nix
+++ b/pkgs/development/python-modules/aardwolf/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    sourceRoot = "source/aardwolf/utils/rlers";
+    sourceRoot = "${src.name}/aardwolf/utils/rlers";
     name = "${pname}-${version}";
     hash = "sha256-JGXTCCyC20EuUX0pP3xSZG3qFB5jRL7+wW2YRC3EiCc=";
   };

--- a/pkgs/development/python-modules/acme/default.nix
+++ b/pkgs/development/python-modules/acme/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   doCheck = false;
   pythonImportsCheck = [ "acme" ];
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   meta = certbot.meta // {
     description = "ACME protocol implementation in Python";

--- a/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
   inherit (antlr4.runtime.cpp) version src;
   disabled = python.pythonOlder "3.6";
 
-  sourceRoot = "source/runtime/Python3";
+  sourceRoot = "${src.name}/runtime/Python3";
 
   # in 4.9, test was renamed to tests
   checkPhase = ''

--- a/pkgs/development/python-modules/apache-beam/default.nix
+++ b/pkgs/development/python-modules/apache-beam/default.nix
@@ -87,7 +87,7 @@ buildPythonPackage rec {
     "pyarrow"
   ];
 
-  sourceRoot = "source/sdks/python";
+  sourceRoot = "${src.name}/sdks/python";
 
   nativeBuildInputs = [
     cython

--- a/pkgs/development/python-modules/basemap-data/default.nix
+++ b/pkgs/development/python-modules/basemap-data/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   pname = "basemap-data";
   inherit (basemap) version src;
 
-  sourceRoot = "source/packages/basemap_data";
+  sourceRoot = "${src.name}/packages/basemap_data";
 
   # no tests
   doCheck = false;

--- a/pkgs/development/python-modules/basemap/default.nix
+++ b/pkgs/development/python-modules/basemap/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     hash = "sha256-oWKCUARTMCiXDp4SCOOrOUQLUDU4DIzwsmUXCXoDvx0=";
   };
 
-  sourceRoot = "source/packages/basemap";
+  sourceRoot = "${src.name}/packages/basemap";
 
   nativeBuildInputs = [
     cython

--- a/pkgs/development/python-modules/capstone/default.nix
+++ b/pkgs/development/python-modules/capstone/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   version = lib.getVersion capstone;
 
   src = capstone.src;
-  sourceRoot = "source/bindings/python";
+  sourceRoot = "${src.name}/bindings/python";
 
   postPatch = ''
     ln -s ${capstone}/lib/libcapstone${stdenv.targetPlatform.extensions.sharedLibrary} prebuilt/

--- a/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
 
-  sourceRoot = "source/certbot-dns-cloudflare";
+  sourceRoot = "${src.name}/certbot-dns-cloudflare";
 
   meta = certbot.meta // {
     description = "Cloudflare DNS Authenticator plugin for Certbot";

--- a/pkgs/development/python-modules/certbot-dns-google/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-google/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
 
-  sourceRoot = "source/certbot-dns-google";
+  sourceRoot = "${src.name}/certbot-dns-google";
 
   meta = certbot.meta // {
     description = "Google Cloud DNS Authenticator plugin for Certbot";

--- a/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
 
-  sourceRoot = "source/certbot-dns-rfc2136";
+  sourceRoot = "${src.name}/certbot-dns-rfc2136";
 
   meta = certbot.meta // {
     description = "RFC 2136 DNS Authenticator plugin for Certbot";

--- a/pkgs/development/python-modules/certbot-dns-route53/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-route53/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
 
-  sourceRoot = "source/certbot-dns-route53";
+  sourceRoot = "${src.name}/certbot-dns-route53";
 
   meta = certbot.meta // {
     description = "Route53 DNS Authenticator plugin for Certbot";

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     hash = "sha256-BQsdhlYABZtz5+SORiCVnWMZdMmiWGM9W1YLqObyFo8=";
   };
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   propagatedBuildInputs = [
     configargparse

--- a/pkgs/development/python-modules/chart-studio/default.nix
+++ b/pkgs/development/python-modules/chart-studio/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     hash = "sha256-H+p2fPBXn+VqrW63KkdmPn2xqxC9uAOzQUV1ruKEUSs=";
   };
 
-  sourceRoot = "source/packages/python/chart-studio";
+  sourceRoot = "${src.name}/packages/python/chart-studio";
 
   propagatedBuildInputs = [
     plotly

--- a/pkgs/development/python-modules/chirpstack-api/default.nix
+++ b/pkgs/development/python-modules/chirpstack-api/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     hash = "sha256-69encHMk0eXE2Av87ysKvxoiXog5o68qCUlOx/lgHFU=";
   };
 
-  sourceRoot = "source/python/src";
+  sourceRoot = "${src.name}/python/src";
 
   propagatedBuildInputs = [
     google-api-core

--- a/pkgs/development/python-modules/cirq-aqt/default.nix
+++ b/pkgs/development/python-modules/cirq-aqt/default.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   pname = "cirq-aqt";
   inherit (cirq-core) version src meta;
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   postPatch = ''
     substituteInPlace requirements.txt \

--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     hash = "sha256-5j4hbG95KRfRQTyyZgoNp/eHIcy0FphyEhbYnzyUMO4=";
   };
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   patches = [
     # https://github.com/quantumlib/Cirq/pull/5991

--- a/pkgs/development/python-modules/cirq-google/default.nix
+++ b/pkgs/development/python-modules/cirq-google/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   pname = "cirq-google";
   inherit (cirq-core) version src meta;
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   postPatch = ''
     substituteInPlace requirements.txt \

--- a/pkgs/development/python-modules/cirq-ionq/default.nix
+++ b/pkgs/development/python-modules/cirq-ionq/default.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   pname = "cirq-ionq";
   inherit (cirq-core) version src meta;
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   postPatch = ''
     substituteInPlace requirements.txt \

--- a/pkgs/development/python-modules/cirq-pasqal/default.nix
+++ b/pkgs/development/python-modules/cirq-pasqal/default.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   pname = "cirq-pasqal";
   inherit (cirq-core) version src meta;
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   postPatch = ''
     substituteInPlace requirements.txt \

--- a/pkgs/development/python-modules/cirq-rigetti/default.nix
+++ b/pkgs/development/python-modules/cirq-rigetti/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   postPatch = ''
     substituteInPlace requirements.txt \

--- a/pkgs/development/python-modules/cirq-web/default.nix
+++ b/pkgs/development/python-modules/cirq-web/default.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
   pname = "cirq-web";
   inherit (cirq-core) version src meta;
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   propagatedBuildInputs = [
     cirq-core

--- a/pkgs/development/python-modules/ctranslate2/default.nix
+++ b/pkgs/development/python-modules/ctranslate2/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   # https://github.com/OpenNMT/CTranslate2/tree/master/python
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   nativeBuildInputs = [
     pybind11

--- a/pkgs/development/python-modules/dask-gateway/default.nix
+++ b/pkgs/development/python-modules/dask-gateway/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     hash = "sha256-+YCHIfNq8E2rXO8b91Q1D21dVzNWnJZIKZeY4AETa7s=";
   };
 
-  sourceRoot = "source/dask-gateway";
+  sourceRoot = "${src.name}/dask-gateway";
 
   nativeBuildInputs = [ setuptools ];
 

--- a/pkgs/development/python-modules/edlib/default.nix
+++ b/pkgs/development/python-modules/edlib/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage {
 
   disabled = pythonOlder "3.6";
 
-  sourceRoot = "source/bindings/python";
+  sourceRoot = "${edlib.src.name}/bindings/python";
 
   preBuild = ''
     ln -s ${edlib.src}/edlib .

--- a/pkgs/development/python-modules/extractcode/7z.nix
+++ b/pkgs/development/python-modules/extractcode/7z.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "02qinla281fc6pmg5xzsrmqnf9js76f2qcbf98zq7m2dkn70as4w";
   };
 
-  sourceRoot = "source/builtins/extractcode_7z-linux";
+  sourceRoot = "${src.name}/builtins/extractcode_7z-linux";
 
   propagatedBuildInputs = [
     plugincode

--- a/pkgs/development/python-modules/extractcode/libarchive.nix
+++ b/pkgs/development/python-modules/extractcode/libarchive.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     sha256 = "02qinla281fc6pmg5xzsrmqnf9js76f2qcbf98zq7m2dkn70as4w";
   };
 
-  sourceRoot = "source/builtins/extractcode_libarchive-linux";
+  sourceRoot = "${src.name}/builtins/extractcode_libarchive-linux";
 
   preBuild = ''
     pushd src/extractcode_libarchive/lib

--- a/pkgs/development/python-modules/flatbuffers/default.nix
+++ b/pkgs/development/python-modules/flatbuffers/default.nix
@@ -6,7 +6,7 @@
 buildPythonPackage rec {
   inherit (flatbuffers) pname version src;
 
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   # flatbuffers needs VERSION environment variable for setting the correct
   # version, otherwise it uses the current date.

--- a/pkgs/development/python-modules/gb-io/default.nix
+++ b/pkgs/development/python-modules/gb-io/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     hash = "sha256-lPnOFbEJgcaPPl9bTngugubhW//AUFp9RAjyiFHxC70=";
   };
 
-  sourceRoot = "source";
+  sourceRoot = src.name;
 
   nativeBuildInputs = [
     setuptools-rust

--- a/pkgs/development/python-modules/gremlinpython/default.nix
+++ b/pkgs/development/python-modules/gremlinpython/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     hash = "sha256-SQ+LcHeHDB1Hd5wXGDJBZmBG4KEZ3NsV4+4X9WgPb9E=";
   };
 
-  sourceRoot = "source/gremlin-python/src/main/python";
+  sourceRoot = "${src.name}/gremlin-python/src/main/python";
 
   postPatch = ''
     sed -i '/pytest-runner/d' setup.py

--- a/pkgs/development/python-modules/hexdump/default.nix
+++ b/pkgs/development/python-modules/hexdump/default.nix
@@ -11,7 +11,6 @@ buildPythonPackage rec {
   };
 
   # the source zip has no prefix, so everything gets unpacked to /build otherwise
-  sourceRoot = "source";
   unpackPhase = ''
     runHook preUnpack
     mkdir source
@@ -20,6 +19,8 @@ buildPythonPackage rec {
     popd
     runHook postUnpack
   '';
+
+  sourceRoot = "source";
 
   pythonImportsCheck = [ "hexdump" ];
 

--- a/pkgs/development/python-modules/libcst/default.nix
+++ b/pkgs/development/python-modules/libcst/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    sourceRoot = "source/${cargoRoot}";
+    sourceRoot = "${src.name}/${cargoRoot}";
     name = "${pname}-${version}";
     hash = "sha256-rPB3bAMdvjgsT3jkEDoWatW8LPwgIaFSbFPqiqANtBY=";
   };

--- a/pkgs/development/python-modules/openrazer/pylib.nix
+++ b/pkgs/development/python-modules/openrazer/pylib.nix
@@ -12,7 +12,7 @@ in
 buildPythonPackage (common // {
   pname = "openrazer";
 
-  sourceRoot = "source/pylib";
+  sourceRoot = "${common.src.name}/pylib";
 
   propagatedBuildInputs = [
     dbus-python

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage {
     then "${toString (lib.toInt versionMajor + 1)}.${versionMinor}.${versionPatch}"
     else protobuf.version;
 
-  sourceRoot = "source/python";
+  sourceRoot = "${protobuf.src.name}/python";
 
   patches = lib.optionals (pythonAtLeast "3.11") [
     (fetchpatch {

--- a/pkgs/development/python-modules/pykdl/default.nix
+++ b/pkgs/development/python-modules/pykdl/default.nix
@@ -4,7 +4,7 @@ toPythonModule (stdenv.mkDerivation {
   pname = "pykdl";
   inherit (orocos-kdl) version src;
 
-  sourceRoot = "source/python_orocos_kdl";
+  sourceRoot = "${orocos-kdl.src.name}/python_orocos_kdl";
 
   # Fix hardcoded installation path
   postPatch = ''

--- a/pkgs/development/python-modules/python-csxcad/default.nix
+++ b/pkgs/development/python-modules/python-csxcad/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     sha256 = "072s765jyzpdq8qqysdy0dld17m6sr9zfcs0ip2zk8c4imxaysnb";
   };
 
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   nativeBuildInputs = [
     cython

--- a/pkgs/development/python-modules/python-olm/default.nix
+++ b/pkgs/development/python-modules/python-olm/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage {
 
   disabled = !isPy3k;
 
-  sourceRoot = "source/python";
+  sourceRoot = "${olm.src.name}/python";
   buildInputs = [ olm ];
 
   preBuild = ''

--- a/pkgs/development/python-modules/python-openems/default.nix
+++ b/pkgs/development/python-modules/python-openems/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     sha256 = "1dca6b6ccy771irxzsj075zvpa3dlzv4mjb8xyg9d889dqlgyl45";
   };
 
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   nativeBuildInputs = [
     cython

--- a/pkgs/development/python-modules/safetensors/default.nix
+++ b/pkgs/development/python-modules/safetensors/default.nix
@@ -30,11 +30,11 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    sourceRoot = "source/bindings/python";
+    sourceRoot = "${src.name}/bindings/python";
     hash = "sha256-tC0XawmKWNGCaByHQfJEfmHM3m/qgTuIpcRaEFJC6dM";
   };
 
-  sourceRoot = "source/bindings/python";
+  sourceRoot = "${src.name}/bindings/python";
 
   nativeBuildInputs = [
     setuptools-rust

--- a/pkgs/development/python-modules/sentencepiece/default.nix
+++ b/pkgs/development/python-modules/sentencepiece/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ sentencepiece.dev ];
 
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   # sentencepiece installs 'bin' output.
   meta = builtins.removeAttrs sentencepiece.meta [ "outputsToInstall" ];

--- a/pkgs/development/python-modules/simpleitk/default.nix
+++ b/pkgs/development/python-modules/simpleitk/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   format = "pyproject";
   disabled = pythonOlder "3.8";
 
-  sourceRoot = "source/Wrapping/Python";
+  sourceRoot = "${src.name}/Wrapping/Python";
   preBuild = ''
     make
   '';

--- a/pkgs/development/python-modules/tokenizers/default.nix
+++ b/pkgs/development/python-modules/tokenizers/default.nix
@@ -79,7 +79,7 @@ buildPythonPackage rec {
     lockFile = ./Cargo.lock;
   };
 
-  sourceRoot = "source/bindings/python";
+  sourceRoot = "${src.name}/bindings/python";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/python-modules/typecode/libmagic.nix
+++ b/pkgs/development/python-modules/typecode/libmagic.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "xnUGDMS34iMVMGo/nZwRarGzzbj3X4Rt+YHvvKpmy6A=";
   };
 
-  sourceRoot = "source/builtins/typecode_libmagic-linux";
+  sourceRoot = "${src.name}/builtins/typecode_libmagic-linux";
 
   propagatedBuildInputs = [
     plugincode

--- a/pkgs/development/python-modules/unicorn/default.nix
+++ b/pkgs/development/python-modules/unicorn/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = unicorn-emu.src;
 
-  sourceRoot = "source/bindings/python";
+  sourceRoot = "${src.name}/bindings/python";
 
   prePatch = ''
     ln -s ${unicorn-emu}/lib/libunicorn.* prebuilt/

--- a/pkgs/development/python-modules/zxing_cpp/default.nix
+++ b/pkgs/development/python-modules/zxing_cpp/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   pname = "zxing_cpp";
   inherit (zxing-cpp) src version;
 
-  sourceRoot = "source/wrappers/python";
+  sourceRoot = "${src.name}/wrappers/python";
   patches = [
     ./use-nixpkgs-pybind11.patch
   ];

--- a/pkgs/development/tools/analysis/spin/default.nix
+++ b/pkgs/development/tools/analysis/spin/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ bison ];
 
-  sourceRoot = "source/Src";
+  sourceRoot = "${src.name}/Src";
 
   preBuild = ''
     mkdir -p $out/bin

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -36,7 +36,7 @@ buildPythonApplication rec {
     hash = "sha256-tevQ/Ocusz2PythGnedP6r4xARgetVosAc8uTD49H3M=";
   };
 
-  sourceRoot = "source/server";
+  sourceRoot = "${src.name}/server";
 
   postPatch = ''
     substituteInPlace tox.ini \

--- a/pkgs/development/tools/elkhound/default.nix
+++ b/pkgs/development/tools/elkhound/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     patchShebangs scripts
   '';
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   nativeBuildInputs = [ bison cmake flex perl ];
 

--- a/pkgs/development/tools/kustomize/3.nix
+++ b/pkgs/development/tools/kustomize/3.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
   doCheck = true;
 
   # avoid finding test and development commands
-  sourceRoot = "source/kustomize";
+  sourceRoot = "${src.name}/kustomize";
 
   vendorSha256 = "sha256-xLeetcmzvpILLLMhMx7oahWLxguFjG3qbYpeeWpFUlw=";
 

--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     sha256 = "1160i2ghgzqvnb44kgwd6s3p4jnk9668rmc15jlcwl7pdf3xqm95";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   patches = [
     # Remove FAQ

--- a/pkgs/development/tools/loganalyzer/default.nix
+++ b/pkgs/development/tools/loganalyzer/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     wrapQtAppsHook
   ];
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -15,7 +15,7 @@ mkDerivation rec {
   nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase qtwebengine qtwebkit ];
 
-  sourceRoot = "source/MiniZincIDE";
+  sourceRoot = "${src.name}/MiniZincIDE";
 
   dontWrapQtApps = true;
 

--- a/pkgs/development/tools/misc/grpc-tools/default.nix
+++ b/pkgs/development/tools/misc/grpc-tools/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  sourceRoot = "source/packages/grpc-tools";
+  sourceRoot = "${src.name}/packages/grpc-tools";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/tools/misc/licenseclassifier/default.nix
+++ b/pkgs/development/tools/misc/licenseclassifier/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
   };
 
   # The new and improved "License Classifier v2" is hidden in a subdirectory.
-  sourceRoot = "source/v2";
+  sourceRoot = "${src.name}/v2";
 
   vendorHash = "sha256-u0VR8DCmbZS0MF26Y4HfqtLaGyX2n2INdAidVNbnXPE=";
 

--- a/pkgs/development/tools/misc/micronucleus/default.nix
+++ b/pkgs/development/tools/misc/micronucleus/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   pname = "micronucleus";
   version = "2.04";
 
-  sourceRoot = "source/commandline";
+  sourceRoot = "${src.name}/commandline";
 
   src = fetchFromGitHub {
     owner = "micronucleus";

--- a/pkgs/development/tools/misc/unixbench/default.nix
+++ b/pkgs/development/tools/misc/unixbench/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   patchFlags = [ "-p2" ];
 
-  sourceRoot = "source/UnixBench";
+  sourceRoot = "${src.name}/UnixBench";
 
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/development/tools/misc/xxdiff/default.nix
+++ b/pkgs/development/tools/misc/xxdiff/default.nix
@@ -22,7 +22,7 @@ mkDerivation rec {
   # c++11 and above is needed for building with Qt 5.9+
   env.NIX_CFLAGS_COMPILE = toString [ "-std=c++14" ];
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   postPatch = ''
     substituteInPlace xxdiff.pro --replace ../bin ./bin

--- a/pkgs/development/tools/oh-my-posh/default.nix
+++ b/pkgs/development/tools/oh-my-posh/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-cATGMi/nL8dvlsR+cuvKH6Y9eR3UqcVjvZAj35Ydn2c=";
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/development/tools/parsing/antlr/4.nix
+++ b/pkgs/development/tools/parsing/antlr/4.nix
@@ -81,7 +81,7 @@ let
         pname = "antlr-runtime-cpp";
         inherit version;
         src = source;
-        sourceRoot = "source/runtime/Cpp";
+        sourceRoot = "${source.name}/runtime/Cpp";
 
         outputs = [ "out" "dev" "doc" ];
 

--- a/pkgs/development/tools/protoc-gen-dart/default.nix
+++ b/pkgs/development/tools/protoc-gen-dart/default.nix
@@ -13,7 +13,7 @@ buildDartApplication rec {
     rev = "protobuf-v${version}";
     sha256 = "sha256-uBQ8s1NBSWm88mpLfZwobTe/BDDT6UymSra88oUuPIA=";
   };
-  sourceRoot = "source/protoc_plugin";
+  sourceRoot = "${src.name}/protoc_plugin";
 
   pubspecLockFile = ./pubspec.lock;
   vendorHash = "sha256-jyhHZ1OUFo6ce3C5jEQPqmtRL4hr2nTfgVMR0k6AXtM=";

--- a/pkgs/development/tools/protoc-gen-grpc-web/default.nix
+++ b/pkgs/development/tools/protoc-gen-grpc-web/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-OetDAZ6zC8r7e82FILpQQnM+JHG9eludwhEuPaklrnw=";
   };
 
-  sourceRoot = "source/javascript/net/grpc/web/generator";
+  sourceRoot = "${finalAttrs.src.name}/javascript/net/grpc/web/generator";
 
   enableParallelBuilding = true;
   strictDeps = true;

--- a/pkgs/development/tools/rust/cargo-insta/default.nix
+++ b/pkgs/development/tools/rust/cargo-insta/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-hQaVUBw8X60DW1Ox4GzO+OCWMHmVYuCkjH5x/sMULiE=";
   };
 
-  sourceRoot = "source/cargo-insta";
+  sourceRoot = "${src.name}/cargo-insta";
 
   cargoHash = "sha256-q6Ups4SDGjT5Zc9ujhRpRdh3uWq99lizgA7gpPVSl+A=";
 

--- a/pkgs/development/tools/rust/cargo-raze/default.nix
+++ b/pkgs/development/tools/rust/cargo-raze/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-ip0WuBn1b7uN/pAhOl5tfmToK73ZSHK7rucdtufsbCQ=";
   };
-  sourceRoot = "source/impl";
+  sourceRoot = "${src.name}/impl";
 
   cargoHash = "sha256-hNZgQwhm4UPqmANplZGxG0DYHa31tu06nmqYaCA7Vdg=";
 

--- a/pkgs/development/tools/rust/cargo-tauri/default.nix
+++ b/pkgs/development/tools/rust/cargo-tauri/default.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
 
   # Manually specify the sourceRoot since this crate depends on other crates in the workspace. Relevant info at
   # https://discourse.nixos.org/t/difficulty-using-buildrustpackage-with-a-src-containing-multiple-cargo-workspaces/10202
-  sourceRoot = "source/tooling/cli";
+  sourceRoot = "${src.name}/tooling/cli";
 
   cargoHash = "sha256-ErUzhmPA2M1H4B4SrEt4FRWHcWLA1UzQqVA1gkrmdJQ=";
 

--- a/pkgs/development/tools/rust/crate2nix/default.nix
+++ b/pkgs/development/tools/rust/crate2nix/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-JaF9/H3m4Wrc5MtXcONkOAgKVkswLVw0yZe0dBr2e4Y=";
   };
 
-  sourceRoot = "source/crate2nix";
+  sourceRoot = "${src.name}/crate2nix";
 
   cargoSha256 = "sha256-PD7R1vcb3FKd4hfpViKyvfCExJ5H1Xo2HPYden5zpxQ=";
 

--- a/pkgs/development/tools/rust/tauri-mobile/default.nix
+++ b/pkgs/development/tools/rust/tauri-mobile/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage {
 
   # Manually specify the sourceRoot since this crate depends on other crates in the workspace. Relevant info at
   # https://discourse.nixos.org/t/difficulty-using-buildrustpackage-with-a-src-containing-multiple-cargo-workspaces/10202
-  # sourceRoot = "source/tooling/cli";
+  # sourceRoot = "${src.name}/tooling/cli";
 
   cargoHash = "sha256-MtLfcDJcLVhsIGD6pjpomuu9GYGqa7L8xnaQ++f+0H4=";
 

--- a/pkgs/development/web/ihp-new/default.nix
+++ b/pkgs/development/web/ihp-new/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   dontConfigure = true;
-  sourceRoot = "source/ProjectGenerator";
+  sourceRoot = "${src.name}/ProjectGenerator";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/games/doom-ports/prboom-plus/default.nix
+++ b/pkgs/games/doom-ports/prboom-plus/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-moU/bZ2mS1QfKPP6HaAwWP1nRNZ4Ue5DFl9zBBrJiHw=";
   };
 
-  sourceRoot = "source/prboom2";
+  sourceRoot = "${src.name}/prboom2";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/games/endgame-singularity/default.nix
+++ b/pkgs/games/endgame-singularity/default.nix
@@ -6,24 +6,28 @@
 , enableDefaultMusicPack ? true
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
   pname = "endgame-singularity";
   version = "1.00";
 
-  srcs = [
-    (fetchFromGitHub {
-      owner = "singularity";
-      repo = "singularity";
-      rev = "v${version}";
-      sha256 = "0ndrnxwii8lag6vrjpwpf5n36hhv223bb46d431l9gsigbizv0hl";
-    })
-  ] ++ lib.optional enableDefaultMusicPack (
-    fetchurl {
-      url = "http://www.emhsoft.com/singularity/endgame-singularity-music-007.zip";
-      sha256 = "0vf2qaf66jh56728pq1zbnw50yckjz6pf6c6qw6dl7vk60kkqnpb";
-    }
-  );
-  sourceRoot = "source";
+  main_src = fetchFromGitHub {
+    owner = "singularity";
+    repo = "singularity";
+    rev = "v${version}";
+    sha256 = "0ndrnxwii8lag6vrjpwpf5n36hhv223bb46d431l9gsigbizv0hl";
+  };
+
+  music_src = fetchurl {
+    url = "http://www.emhsoft.com/singularity/endgame-singularity-music-007.zip";
+    sha256 = "0vf2qaf66jh56728pq1zbnw50yckjz6pf6c6qw6dl7vk60kkqnpb";
+  };
+in
+
+python3.pkgs.buildPythonApplication rec {
+  inherit pname version;
+
+  srcs = [ main_src ] ++ lib.optional enableDefaultMusicPack music_src;
+  sourceRoot = main_src.name;
 
   nativeBuildInputs = [ unzip ]; # The music is zipped
   propagatedBuildInputs = with python3.pkgs; [ pygame numpy polib ];

--- a/pkgs/games/iortcw/default.nix
+++ b/pkgs/games/iortcw/default.nix
@@ -2,8 +2,8 @@
 
 let
   sp = callPackage ./sp.nix {};
-  mp = sp.overrideAttrs (oldAttrs: rec {
-    sourceRoot = "source/MP";
+  mp = sp.overrideAttrs (oldAttrs: {
+    sourceRoot = "${oldAttrs.src.name}/MP";
   });
 in buildEnv {
   name = "iortcw";

--- a/pkgs/games/iortcw/sp.nix
+++ b/pkgs/games/iortcw/sp.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  sourceRoot = "source/SP";
+  sourceRoot = "${src.name}/SP";
 
   makeFlags = [
     "USE_INTERNAL_LIBS=0"

--- a/pkgs/games/keeperrl/default.nix
+++ b/pkgs/games/keeperrl/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     sha256 = "0115pxdzdyma2vicxgr0j21pp82gxdyrlj090s8ihp0b50f0nlll";
   } else null;
 
-  sourceRoot = "source";
+  sourceRoot = free-src.name;
 
   srcs = [ free-src ] ++ lib.optional unfree_assets assets;
 

--- a/pkgs/games/koboredux/default.nix
+++ b/pkgs/games/koboredux/default.nix
@@ -11,36 +11,43 @@
 }:
 
 with lib;
-stdenv.mkDerivation rec {
+
+let
   pname = "koboredux";
   version = "0.7.5.1";
 
-  src =
-    [(fetchFromGitHub {
-      owner = "olofson";
-      repo = "koboredux";
-      rev = "v${version}";
-      sha256 = "09h9r65z8bar2z89s09j6px0gdq355kjf38rmd85xb2aqwnm6xig";
-    })]
-    ++
-    (optional useProprietaryAssets (requireFile {
-      name = "koboredux-${version}-Linux.tar.bz2";
-      sha256 = "11bmicx9i11m4c3dp19jsql0zy4rjf5a28x4hd2wl8h3bf8cdgav";
-      message = ''
-        Please purchase the game on https://olofson.itch.io/kobo-redux
-        and download the Linux build.
+  main_src = fetchFromGitHub {
+    owner = "olofson";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09h9r65z8bar2z89s09j6px0gdq355kjf38rmd85xb2aqwnm6xig";
+  };
 
-        Once you have downloaded the file, please use the following command
-        and re-run the installation:
+  assets_src = requireFile {
+    name = "koboredux-${version}-Linux.tar.bz2";
+    sha256 = "11bmicx9i11m4c3dp19jsql0zy4rjf5a28x4hd2wl8h3bf8cdgav";
+    message = ''
+      Please purchase the game on https://olofson.itch.io/kobo-redux
+      and download the Linux build.
 
-        nix-prefetch-url file://\$PWD/koboredux-${version}-Linux.tar.bz2
+      Once you have downloaded the file, please use the following command
+      and re-run the installation:
 
-        Alternatively, install the "koboredux-free" package, which replaces the
-        proprietary assets with a placeholder theme.
-      '';
-    }));
+      nix-prefetch-url file://\$PWD/koboredux-${version}-Linux.tar.bz2
 
-  sourceRoot = "source"; # needed when we have the assets source
+      Alternatively, install the "koboredux-free" package, which replaces the
+      proprietary assets with a placeholder theme.
+    '';
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  inherit pname version;
+
+  src = [ main_src ] ++ optional useProprietaryAssets assets_src;
+
+  sourceRoot = main_src.name;
 
   # Fix clang build
   patches = [(fetchpatch {

--- a/pkgs/games/quakespasm/vulkan.nix
+++ b/pkgs/games/quakespasm/vulkan.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-+8DU1QT3Lgqf1AIReVnXQ2Lq6R6eBb8VjdkJfAn/Rtc=";
   };
 
-  sourceRoot = "source/Quake";
+  sourceRoot = "${src.name}/Quake";
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/games/sauerbraten/default.nix
+++ b/pkgs/games/sauerbraten/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   enableParallelBuilding = true;
 

--- a/pkgs/games/sil-q/default.nix
+++ b/pkgs/games/sil-q/default.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [ ncurses libX11 ];
 
   # Makefile(s) and config are not top-level
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   postPatch = ''
     # allow usage of ANGBAND_PATH

--- a/pkgs/games/sil/default.nix
+++ b/pkgs/games/sil/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ ncurses libX11 libXaw libXt libXext libXmu ];
 
-  sourceRoot = "source/Sil/src";
+  sourceRoot = "${src.name}/Sil/src";
 
   makefile = "Makefile.std";
 

--- a/pkgs/games/vvvvvv/default.nix
+++ b/pkgs/games/vvvvvv/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-sLNO4vkmlirsqJmCV9YWpyNnIiigU1KMls7rOgWgSmQ=";
   };
-  sourceRoot = "source/desktop_version";
+  sourceRoot = "${src.name}/desktop_version";
   dataZip = fetchurl {
     url = "https://thelettervsixtim.es/makeandplay/data.zip";
     name = "data.zip";

--- a/pkgs/os-specific/bsd/freebsd/evdev-proto/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/evdev-proto/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
 
   src = freebsd.ports;
 
-  sourceRoot = "source/devel/evdev-proto";
+  sourceRoot = "${freebsd.ports.name}/devel/evdev-proto";
 
   useTempPrefix = true;
 

--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, pkgsBuildBuild, cmake, python3, ncurses }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "libtapi";
   version = "1100.0.11"; # determined by looking at VERSION.txt
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "1y1yl46msabfy14z0rln333a06087bk14f5h7q1cdawn8nmvbdbr";
   };
 
-  sourceRoot = "source/src/llvm";
+  sourceRoot = "${src.name}/src/llvm";
 
   # Backported from newer llvm, fixes configure error when cross compiling.
   # Also means we don't have to manually fix the result with install_name_tool.

--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, pkgsBuildBuild, cmake, python3, ncurses }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtapi";
   version = "1100.0.11"; # determined by looking at VERSION.txt
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1y1yl46msabfy14z0rln333a06087bk14f5h7q1cdawn8nmvbdbr";
   };
 
-  sourceRoot = "${src.name}/src/llvm";
+  sourceRoot = "${finalAttrs.src.name}/src/llvm";
 
   # Backported from newer llvm, fixes configure error when cross compiling.
   # Also means we don't have to manually fix the result with install_name_tool.
@@ -74,4 +74,4 @@ stdenv.mkDerivation rec {
     license = licenses.ncsa;
     maintainers = with maintainers; [ matthewbauer ];
   };
-}
+})

--- a/pkgs/os-specific/linux/akvcam/default.nix
+++ b/pkgs/os-specific/linux/akvcam/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1f0vjia2d7zj3y5c63lx1r537bdjx6821yxy29ilbrvsbjq2szj8";
   };
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
   makeFlags = kernel.makeFlags ++ [

--- a/pkgs/os-specific/linux/aseq2json/default.nix
+++ b/pkgs/os-specific/linux/aseq2json/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, pkg-config, alsa-lib, glib, json-glib }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "aseq2json";
   version = "unstable-2018-04-28";
   src = fetchFromGitHub {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     rev = "8572e6313a0d7ec95492dcab04a46c5dd30ef33a";
     sha256 = "LQ9LLVumi3GN6c9tuMSOd1Bs2pgrwrLLQbs5XF+NZeA=";
   };
-  sourceRoot = "${src.name}/aseq2json";
+  sourceRoot = "${finalAttrs.src.name}/aseq2json";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ alsa-lib glib json-glib ];
@@ -25,4 +25,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.queezle ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/os-specific/linux/aseq2json/default.nix
+++ b/pkgs/os-specific/linux/aseq2json/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, pkg-config, alsa-lib, glib, json-glib }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "aseq2json";
   version = "unstable-2018-04-28";
   src = fetchFromGitHub {
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     rev = "8572e6313a0d7ec95492dcab04a46c5dd30ef33a";
     sha256 = "LQ9LLVumi3GN6c9tuMSOd1Bs2pgrwrLLQbs5XF+NZeA=";
   };
-  sourceRoot = "source/aseq2json";
+  sourceRoot = "${src.name}/aseq2json";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ alsa-lib glib json-glib ];

--- a/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
+++ b/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
@@ -11,7 +11,7 @@
 , ipuVersion ? "ipu6"
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "${ipuVersion}-camera-bin";
   version = "unstable-2023-02-08";
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     hash = "sha256-QnedM2UBbGyd2wIF762Mi+VkDZYtC6MifK4XGGxlUzw=";
   };
 
-  sourceRoot = "source/${ipuVersion}";
+  sourceRoot = "${src.name}/${ipuVersion}";
 
   nativeBuildInputs = [
     autoPatchelfHook

--- a/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
+++ b/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
@@ -11,7 +11,7 @@
 , ipuVersion ? "ipu6"
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "${ipuVersion}-camera-bin";
   version = "unstable-2023-02-08";
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-QnedM2UBbGyd2wIF762Mi+VkDZYtC6MifK4XGGxlUzw=";
   };
 
-  sourceRoot = "${src.name}/${ipuVersion}";
+  sourceRoot = "${finalAttrs.src.name}/${ipuVersion}";
 
   nativeBuildInputs = [
     autoPatchelfHook
@@ -76,4 +76,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/os-specific/linux/fwts/module.nix
+++ b/pkgs/os-specific/linux/fwts/module.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   inherit (fwts) src;
 
-  sourceRoot = "source/efi_runtime";
+  sourceRoot = "${src.name}/efi_runtime";
 
   postPatch = ''
     substituteInPlace Makefile --replace \

--- a/pkgs/os-specific/linux/gasket/default.nix
+++ b/pkgs/os-specific/linux/gasket/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
   installTargets = [ "modules_install" ];
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
   hardeningDisable = [ "pic" "format" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/gt/default.nix
+++ b/pkgs/os-specific/linux/gt/default.nix
@@ -2,7 +2,7 @@
 , asciidoc
 , libusbgx
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gt";
   version = "unstable-2022-05-08";
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-km4U+t4Id2AZx6GpH24p2WNmvV5RVjJ14sy8tWLCQsk=";
   };
 
-  sourceRoot = "${src.name}/source";
+  sourceRoot = "${finalAttrs.src.name}/source";
 
   preConfigure = ''
     cmakeFlagsArray+=("-DBASH_COMPLETION_COMPLETIONSDIR=$out/share/bash-completions/completions")
@@ -29,4 +29,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ lheckemann ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/os-specific/linux/gt/default.nix
+++ b/pkgs/os-specific/linux/gt/default.nix
@@ -2,7 +2,7 @@
 , asciidoc
 , libusbgx
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "gt";
   version = "unstable-2022-05-08";
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
     sha256 = "sha256-km4U+t4Id2AZx6GpH24p2WNmvV5RVjJ14sy8tWLCQsk=";
   };
 
-  sourceRoot = "source/source";
+  sourceRoot = "${src.name}/source";
 
   preConfigure = ''
     cmakeFlagsArray+=("-DBASH_COMPLETION_COMPLETIONSDIR=$out/share/bash-completions/completions")

--- a/pkgs/os-specific/linux/kvmfr/default.nix
+++ b/pkgs/os-specific/linux/kvmfr/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = looking-glass-client.version;
 
   src = looking-glass-client.src;
-  sourceRoot = "source/module";
+  sourceRoot = "${looking-glass-client.src.name}/module";
   patches = lib.optional (kernel.kernelAtLeast "6.4") [
     ./linux-6-4-compat.patch
   ];

--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "sha256-s4JFFmawokdC4qoqNvZDhuJSinhQ3YKSIfAYi79VTTA=";
   };
 
-  sourceRoot = "source/python/legion_linux";
+  sourceRoot = "${src.name}/python/legion_linux";
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 

--- a/pkgs/os-specific/linux/lenovo-legion/default.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   pname = "lenovo-legion-module";
   inherit (lenovo-legion) version src;
 
-  sourceRoot = "source/kernel_module";
+  sourceRoot = "${lenovo-legion.src.name}/kernel_module";
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/ultrablue-server/default.nix
+++ b/pkgs/os-specific/linux/ultrablue-server/default.nix
@@ -3,7 +3,7 @@
 , buildGoModule
 }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "ultrablue-server";
   version = "unstable-fosdem2023";
 
@@ -16,7 +16,7 @@ buildGoModule {
     # rev = "6de04af6e353e38c030539c5678e5918f64be37e";
   };
 
-  sourceRoot = "source/server";
+  sourceRoot = "${src.name}/server";
 
   vendorSha256 = "sha256-249LWguTHIF0HNIo8CsE/HWpAtBw4P46VPvlTARLTpw=";
   doCheck = false;

--- a/pkgs/os-specific/linux/unstick/default.nix
+++ b/pkgs/os-specific/linux/unstick/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "08la3jmmzlf4pm48bf9zx4cqj9gbqalpqy0s57bh5vfsdk74nnhv";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   nativeBuildInputs = [ meson ninja pkg-config ];
   buildInputs = [ libseccomp ];

--- a/pkgs/os-specific/linux/wiringpi/default.nix
+++ b/pkgs/os-specific/linux/wiringpi/default.nix
@@ -18,7 +18,7 @@ let
   }: stdenv.mkDerivation rec {
     pname = "wiringpi-${subprj}";
     inherit version src;
-    sourceRoot = "source/${subprj}";
+    sourceRoot = "${src.name}/${subprj}";
     inherit buildInputs;
     # Remove (meant for other OSs) lines from Makefiles
     preInstall = ''

--- a/pkgs/servers/authelia/web.nix
+++ b/pkgs/servers/authelia/web.nix
@@ -7,7 +7,7 @@ buildNpmPackage {
   pname = "${pname}-web";
   inherit src version npmDepsHash;
 
-  sourceRoot = "source/web";
+  sourceRoot = "${src.name}/web";
 
   patches = [
     ./change-web-out-dir.patch

--- a/pkgs/servers/baserow/default.nix
+++ b/pkgs/servers/baserow/default.nix
@@ -25,7 +25,7 @@ let
           hash = "sha256-zT2afl3QNE2dO3JXjsZXqSmm1lv3EorG3mYZLQQMQ2Q=";
         };
 
-        sourceRoot = "source/premium/backend";
+        sourceRoot = "${src.name}/premium/backend";
 
         doCheck = false;
       };
@@ -45,7 +45,7 @@ with python.pkgs; buildPythonApplication rec {
     hash = "sha256-zT2afl3QNE2dO3JXjsZXqSmm1lv3EorG3mYZLQQMQ2Q=";
   };
 
-  sourceRoot = "source/backend";
+  sourceRoot = "${src.name}/backend";
 
   postPatch = ''
     # remove dependency constraints

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-bGJSeWq2TN7ukStu+oiYboGnm/RHbO6N0NdZC81IQ8k=";
   };
 
-  sourceRoot = "source/klippy";
+  sourceRoot = "${src.name}/klippy";
 
   # NB: This is needed for the postBuild step
   nativeBuildInputs = [

--- a/pkgs/servers/ldap/389/default.nix
+++ b/pkgs/servers/ldap/389/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    sourceRoot = "source/src";
+    sourceRoot = "${src.name}/src";
     name = "${pname}-${version}";
     hash = "sha256-972tJ8aKNxC3O8VxbAau7OSej873IBXsP3isMXAXKcU=";
   };

--- a/pkgs/servers/misc/navidrome/default.nix
+++ b/pkgs/servers/misc/navidrome/default.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
 
   npmDeps = fetchNpmDeps {
     inherit src;
-    sourceRoot = "source/ui";
+    sourceRoot = "${src.name}/ui";
     hash = "sha256-qxwTiXLmZnTnmTSBmWPjeFCP7qzvTFN0xXp5lFkWFog=";
   };
 

--- a/pkgs/servers/misc/oven-media-engine/default.nix
+++ b/pkgs/servers/misc/oven-media-engine/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-pLLnk0FXJ6gb0WSdWGEzJSEbKdOpjdWECIRzrHvi8HQ=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
   makeFlags = [ "release" "CONFIG_LIBRARY_PATHS=" "CONFIG_PKG_PATHS=" "GLOBAL_CC=$(CC)" "GLOBAL_CXX=$(CXX)" "GLOBAL_LD=$(CXX)" "SHELL=${stdenv.shell}" ];
   enableParallelBuilding = true;
 

--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -4,7 +4,7 @@ let
   libflux_version = "0.170.1";
 
   # This is copied from influxdb2 with flux version matching the needed by thi
-  flux = rustPlatform.buildRustPackage {
+  flux = rustPlatform.buildRustPackage rec {
     pname = "libflux";
     version = "v${libflux_version}";
     src = fetchFromGitHub {
@@ -23,7 +23,7 @@ let
         sha256 = "sha256-Fb4CuH9ZvrPha249dmLLI8MqSNQRKqKPxPbw2pjqwfY=";
       })
     ];
-    sourceRoot = "source/libflux";
+    sourceRoot = "${src.name}/libflux";
     cargoSha256 = "sha256-kYiZ5ZRiFHRf1RQeeUGjIhnEkTvhNSZ0t4tidpRIDyk=";
     nativeBuildInputs = [ rustPlatform.bindgenHook ];
     buildInputs = lib.optional stdenv.isDarwin libiconv;

--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -39,7 +39,7 @@ let
       rev = "v${libflux_version}";
       sha256 = "sha256-Xmh7V/o1Gje62kcnTeB9h/fySljhfu+tjbyvryvIGRc=";
     };
-    sourceRoot = "source/libflux";
+    sourceRoot = "${src.name}/libflux";
     cargoSha256 = "sha256-9rPW0lgi3lXJARa1KXgSY8LVJsoFjppok5ODGlqYeYw=";
     nativeBuildInputs = [ rustPlatform.bindgenHook ];
     buildInputs = lib.optional stdenv.isDarwin libiconv;

--- a/pkgs/servers/photofield/default.nix
+++ b/pkgs/servers/photofield/default.nix
@@ -22,7 +22,7 @@ let
     inherit src version;
     pname = "photofield-ui";
 
-    sourceRoot = "source/ui";
+    sourceRoot = "${src.name}/ui";
 
     npmDepsHash = "sha256-YVyaZsFh5bolDzMd5rXWrbbXQZBeEIV6Fh/kwN+rvPk=";
 

--- a/pkgs/servers/search/quickwit/default.nix
+++ b/pkgs/servers/search/quickwit/default.nix
@@ -11,7 +11,7 @@ let
   pname = "quickwit";
   version = "0.6.2";
 in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   inherit pname version;
 
   src = fetchFromGitHub {
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage {
       --replace '&[]' '&["."]'
   '';
 
-  sourceRoot = "source/quickwit";
+  sourceRoot = "${src.name}/quickwit";
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 

--- a/pkgs/servers/search/zincsearch/default.nix
+++ b/pkgs/servers/search/zincsearch/default.nix
@@ -17,7 +17,7 @@ let
     inherit src version;
     pname = "zinc-ui";
 
-    sourceRoot = "source/web";
+    sourceRoot = "${src.name}/web";
 
     npmDepsHash = "sha256-2AjUaEOn2Tj+X4f42SvNq1kX07WxkB1sl5KtGdCjbdw=";
 

--- a/pkgs/servers/unpfs/default.nix
+++ b/pkgs/servers/unpfs/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-zyDkUb+bFsVnxAE4UODbnRtDim7gqUNuY22vuxMsLZM=";
   };
 
-  sourceRoot = "source/example/unpfs";
+  sourceRoot = "${src.name}/example/unpfs";
 
   cargoSha256 = "sha256-v8hbxKuxux0oYglEIK5dM9q0oBQzjyYDP1JB1cYR/T0=";
 

--- a/pkgs/servers/web-apps/kavita/default.nix
+++ b/pkgs/servers/web-apps/kavita/default.nix
@@ -43,7 +43,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     pname = "kavita-frontend";
     inherit (finalAttrs) version src;
 
-    sourceRoot = "source/UI/Web";
+    sourceRoot = "${finalAttrs.src.name}/UI/Web";
 
     npmBuildScript = "prod";
     npmFlags = [ "--legacy-peer-deps" ];

--- a/pkgs/servers/windmill/default.nix
+++ b/pkgs/servers/windmill/default.nix
@@ -40,7 +40,7 @@ let
     pname = "windmill-ui";
     src = fullSrc;
 
-    sourceRoot = "source/frontend";
+    sourceRoot = "${fullSrc.name}/frontend";
 
     npmDepsHash = "sha256-nRx/UQ7GU1iwhddTotCTG08RoOmdbP66zGKYsEp9XOE=";
 

--- a/pkgs/tools/admin/gam/default.nix
+++ b/pkgs/tools/admin/gam/default.nix
@@ -15,7 +15,7 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "sha256-/VmBFMjCkd1xhudlcjYGGv+6tgEsyY/xqQoGdupJvOg=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   patches = [
     # Also disables update check

--- a/pkgs/tools/archivers/ctrtool/default.nix
+++ b/pkgs/tools/archivers/ctrtool/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "07aayck82w5xcp3si35d7ghybmrbqw91fqqvmbpjrjcixc6m42z7";
   };
 
-  sourceRoot = "source/ctrtool";
+  sourceRoot = "${src.name}/ctrtool";
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "CXX=${stdenv.cc.targetPrefix}c++"];
   enableParallelBuilding = true;

--- a/pkgs/tools/audio/picotts/default.nix
+++ b/pkgs/tools/audio/picotts/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, popt }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "picotts";
   version = "unstable-2018-10-19";
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   };
   nativeBuildInputs = [ autoconf automake ];
   buildInputs = [ libtool popt ];
-  sourceRoot = "source/pico";
+  sourceRoot = "${src.name}/pico";
   preConfigure = "./autogen.sh";
   meta = {
     description = "Text to speech voice sinthesizer from SVox";
@@ -22,5 +22,3 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
   };
 }
-
-

--- a/pkgs/tools/audio/picotts/default.nix
+++ b/pkgs/tools/audio/picotts/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, popt }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "picotts";
   version = "unstable-2018-10-19";
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
   nativeBuildInputs = [ autoconf automake ];
   buildInputs = [ libtool popt ];
-  sourceRoot = "${src.name}/pico";
+  sourceRoot = "${finalAttrs.src.name}/pico";
   preConfigure = "./autogen.sh";
   meta = {
     description = "Text to speech voice sinthesizer from SVox";
@@ -21,4 +21,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.canndrew ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/tools/audio/piper/default.nix
+++ b/pkgs/tools/audio/piper/default.nix
@@ -16,21 +16,18 @@
 , piper-train
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "piper";
   version = "1.2.0";
-in
-stdenv.mkDerivation rec {
-  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "piper";
-    rev = "refs/tags/v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-6WNWqJt0PO86vnf+3iHaRRg2KwBOEj4aicmB+P2phlk=";
   };
 
-  sourceRoot = "${src.name}/src/cpp";
+  sourceRoot = "${finalAttrs.src.name}/src/cpp";
 
   nativeBuildInputs = [
     cmake
@@ -63,10 +60,10 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    changelog = "https://github.com/rhasspy/piper/releases/tag/v${version}";
+    changelog = "https://github.com/rhasspy/piper/releases/tag/v${finalAttrs.version}";
     description = "A fast, local neural text to speech system";
     homepage = "https://github.com/rhasspy/piper";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];
   };
-}
+})

--- a/pkgs/tools/audio/piper/default.nix
+++ b/pkgs/tools/audio/piper/default.nix
@@ -20,7 +20,7 @@ let
   pname = "piper";
   version = "1.2.0";
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   inherit pname version;
 
   src = fetchFromGitHub {
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     hash = "sha256-6WNWqJt0PO86vnf+3iHaRRg2KwBOEj4aicmB+P2phlk=";
   };
 
-  sourceRoot = "source/src/cpp";
+  sourceRoot = "${src.name}/src/cpp";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/tools/audio/piper/train.nix
+++ b/pkgs/tools/audio/piper/train.nix
@@ -15,7 +15,7 @@ python.pkgs.buildPythonPackage {
   pname = "piper-train";
   format = "setuptools";
 
-  sourceRoot = "source/src/python";
+  sourceRoot = "${piper-tts.src.name}/src/python";
 
   nativeBuildInputs = with python.pkgs; [
     cython

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage {
   version = yabridge.version;
 
   src = yabridge.src;
-  sourceRoot = "source/tools/yabridgectl";
+  sourceRoot = "${yabridge.src.name}/tools/yabridgectl";
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {

--- a/pkgs/tools/backup/hpe-ltfs/default.nix
+++ b/pkgs/tools/backup/hpe-ltfs/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "193593hsc8nf5dn1fkxhzs1z4fpjh64hdkc8q6n9fgplrpxdlr4s";
   };
 
-  sourceRoot = "source/ltfs";
+  sourceRoot = "${src.name}/ltfs";
 
   # include sys/sysctl.h is deprecated in glibc. The sysctl calls are only used
   # for Apple to determine the kernel version. Because this build only targets

--- a/pkgs/tools/filesystems/blobfuse/default.nix
+++ b/pkgs/tools/filesystems/blobfuse/default.nix
@@ -12,7 +12,7 @@ let
     pname = "cpplite";
     inherit version src;
 
-    sourceRoot = "source/cpplite";
+    sourceRoot = "${src.name}/cpplite";
     patches = [ ./install-adls.patch ];
 
     cmakeFlags = [ "-DBUILD_ADLS=ON" "-DUSE_OPENSSL=OFF" ];

--- a/pkgs/tools/filesystems/cpcfs/default.nix
+++ b/pkgs/tools/filesystems/cpcfs/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0rfbry0qy8mv746mzk9zdfffkdgq4w7invgb5cszjma2cp83q3i2";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   nativeBuildInputs = [ makeWrapper ncurses readline ronn ];
 

--- a/pkgs/tools/filesystems/tar2ext4/default.nix
+++ b/pkgs/tools/filesystems/tar2ext4/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-+GhYeQ27uwg9JOv1qbf1+UbMd+vPXJ05nsXZD9OakzI=";
   };
 
-  sourceRoot = "source/cmd/tar2ext4";
+  sourceRoot = "${src.name}/cmd/tar2ext4";
   vendorHash = null;
 
   meta = with lib; {

--- a/pkgs/tools/graphics/pdftoipe/default.nix
+++ b/pkgs/tools/graphics/pdftoipe/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  sourceRoot = "source/pdftoipe";
+  sourceRoot = "${src.name}/pdftoipe";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ poppler ];

--- a/pkgs/tools/graphics/realesrgan-ncnn-vulkan/default.nix
+++ b/pkgs/tools/graphics/realesrgan-ncnn-vulkan/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-eLAIlOl1sUxijeVPFG+NscZGxDdtrQqVkMuxhegESHk=";
   };
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   models = fetchzip {
     # Choose the newst release from https://github.com/xinntao/Real-ESRGAN/releases to update

--- a/pkgs/tools/misc/opentelemetry-collector/contrib.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/contrib.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
   vendorHash = "sha256-ABaRedZXPr2q2AmslVNIJUvONZa4tv7OkxBLR9GuBRE=";
 
   # there is a nested go.mod
-  sourceRoot = "source/cmd/otelcontribcol";
+  sourceRoot = "${src.name}/cmd/otelcontribcol";
 
   # upstream strongly recommends disabling CGO
   # additionally dependencies have had issues when GCO was enabled that weren't caught upstream

--- a/pkgs/tools/misc/opentelemetry-collector/default.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     hash = "sha256-yywmnJUTigDYeiAuK0f2511vh6sS4oD4hJLPozAlWz4=";
   };
   # there is a nested go.mod
-  sourceRoot = "source/cmd/otelcorecol";
+  sourceRoot = "${src.name}/cmd/otelcorecol";
   vendorHash = "sha256-BNIQ0pTHGgwWw1cy7au6hUeECC8oGsSkxaX5BUCRG9Y=";
 
   # upstream strongly recommends disabling CGO

--- a/pkgs/tools/misc/trdl-client/default.nix
+++ b/pkgs/tools/misc/trdl-client/default.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
     hash = "sha256-jJwRIfxmjlhfS/0+IN2IdQPlO9FkTb64PWUiLwkarfM=";
   };
 
-  sourceRoot = "source/client";
+  sourceRoot = "${src.name}/client";
 
   vendorHash = "sha256-f7FPeR+us3WvwqzcSQLbkKv905CCIAAm+HNV2FFF8OY=";
 

--- a/pkgs/tools/misc/usbimager/default.nix
+++ b/pkgs/tools/misc/usbimager/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-CEGUXJXqXmD8uT93T9dg49Lf5vTpAzQjdnhYmbR5zTI=";
   };
 
-  sourceRoot = "source/src/";
+  sourceRoot = "${src.name}/src/";
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook ];
   buildInputs = lib.optionals withUdisks [ udisks glib ]

--- a/pkgs/tools/misc/wimboot/default.nix
+++ b/pkgs/tools/misc/wimboot/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-rbJONP3ge+2+WzCIpTUZeieQz9Q/MZfEUmQVbZ+9Dro=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   buildInputs = [ libbfd zlib libiberty ];
   makeFlags = [ "wimboot.x86_64.efi" ];

--- a/pkgs/tools/networking/bitmask-vpn/default.nix
+++ b/pkgs/tools/networking/bitmask-vpn/default.nix
@@ -39,7 +39,7 @@ let
   # and may one day be replaced by pkg/helper
   bitmask-root = mkDerivation {
     inherit src version;
-    sourceRoot = "source/helpers";
+    sourceRoot = "${src.name}/helpers";
     pname = "bitmask-root";
     nativeBuildInputs = [ python3Packages.wrapPython ];
     postPatch = ''

--- a/pkgs/tools/networking/dd-agent/integrations-core.nix
+++ b/pkgs/tools/networking/dd-agent/integrations-core.nix
@@ -51,7 +51,7 @@ let
     inherit src version;
     name = "datadog-integration-${pname}-${version}";
 
-    sourceRoot = "source/${args.sourceRoot or pname}";
+    sourceRoot = "${src.name}/${args.sourceRoot or pname}";
     doCheck = false;
   });
 

--- a/pkgs/tools/networking/gnirehtet/default.nix
+++ b/pkgs/tools/networking/gnirehtet/default.nix
@@ -21,7 +21,7 @@ apk = stdenv.mkDerivation {
   '';
 };
 in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "gnirehtet";
   inherit version;
 
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage {
     inherit apk;
   };
 
-  sourceRoot = "source/relay-rust";
+  sourceRoot = "${src.name}/relay-rust";
 
   cargoHash = "sha256-3oVWFMFzYsuCec1wxZiHXW6O45qbdL1npqYrg/m4SPc=";
 

--- a/pkgs/tools/networking/mqttmultimeter/default.nix
+++ b/pkgs/tools/networking/mqttmultimeter/default.nix
@@ -41,7 +41,7 @@ buildDotnetModule rec {
     hash = "sha256-/XQ5HD0dBfFn3ERlLwHknS9Fyd3YMpKHBXuvMwRXcQ8=";
   };
 
-  sourceRoot = "source/Source";
+  sourceRoot = "${src.name}/Source";
 
   projectFile = [ "mqttMultimeter.sln" ];
   nugetDeps = ./deps.nix;

--- a/pkgs/tools/networking/pykms/default.nix
+++ b/pkgs/tools/networking/pykms/default.nix
@@ -43,7 +43,7 @@ pypkgs.buildPythonApplication rec {
     hash = "sha256-9KiMbS0uKTbWSZVIv5ziIeR9c8+EKfKd20yPmjCX7GQ=";
   };
 
-  sourceRoot = "source/py-kms";
+  sourceRoot = "${src.name}/py-kms";
 
   propagatedBuildInputs = with pypkgs; [ systemd pytz tzlocal dnspython ];
 

--- a/pkgs/tools/networking/ratman/default.nix
+++ b/pkgs/tools/networking/ratman/default.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
   dashboard = stdenv.mkDerivation rec {
     pname = "ratman-dashboard";
     inherit version src;
-    sourceRoot = "source/ratman/dashboard";
+    sourceRoot = "${src.name}/ratman/dashboard";
 
     yarnDeps = fetchYarnDeps {
       yarnLock = src + "/ratman/dashboard/yarn.lock";

--- a/pkgs/tools/networking/reaver-wps-t6x/default.nix
+++ b/pkgs/tools/networking/reaver-wps-t6x/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ libpcap pixiewps ];
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   meta = with lib; {
     description = "Online and offline brute force attack against WPS";

--- a/pkgs/tools/networking/sleep-on-lan/default.nix
+++ b/pkgs/tools/networking/sleep-on-lan/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     sha256 = "sha256-WooFGIdXIIoJPMqmPpnT+bc+P+IARMSxa3CvXY9++mw=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
   vendorSha256 = "sha256-JqDDG53khtDdMLVOscwqi0oGviF+3DMkv5tkHvp1gJc=";
 
   ldflags = [

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" ];
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/security/b2sum/default.nix
+++ b/pkgs/tools/security/b2sum/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "FILES=b2sum.c ../sse/" "#FILES=b2sum.c ../sse/"
   '';
 
-  sourceRoot = "source/b2sum";
+  sourceRoot = "${finalAttrs.src.name}/b2sum";
 
   buildInputs = [ openmp ];
 

--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -41,7 +41,7 @@ let
   desktop-native = rustPlatform.buildRustPackage {
     pname = "bitwarden-desktop-native";
     inherit src version;
-    sourceRoot = "source-patched/apps/desktop/desktop_native";
+    sourceRoot = "${src.name}/apps/desktop/desktop_native";
     cargoSha256 = "sha256-8U4E5q2OSZGXy2ZRn0y4Skm5Y+FiOJVU1mtzObO9UqY=";
 
     nativeBuildInputs = [

--- a/pkgs/tools/security/donkey/default.nix
+++ b/pkgs/tools/security/donkey/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     rev = "tags/release/${version}";
     hash = "sha256-2xgb9l0Eko39HJVROAWEIP3qLg5t/5h/rm2MoXoKnJI=";
   };
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   buildInputs = [ libmd ];
 

--- a/pkgs/tools/security/hashcat-utils/default.nix
+++ b/pkgs/tools/security/hashcat-utils/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0wgc6wv7i6cs95rgzzx3zqm14xxbjyajvcqylz8w97d8kk4x4wjr";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/security/jwx/default.nix
+++ b/pkgs/tools/security/jwx/default.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-RyAQh1uXw3bEZ6vuh8+mEf8T4l3ZIFAaFJ6dGMoANys=";
 
-  sourceRoot = "source/cmd/jwx";
+  sourceRoot = "${src.name}/cmd/jwx";
 
   meta = with lib; {
     description = " Implementation of various JWx (Javascript Object Signing and Encryption/JOSE) technologies";

--- a/pkgs/tools/security/lesspass-cli/default.nix
+++ b/pkgs/tools/security/lesspass-cli/default.nix
@@ -14,7 +14,7 @@ buildPythonApplication rec {
     rev = version;
     sha256 = "126zk248s9r72qk9b8j27yvb8gglw49kazwz0sd69b5kkxvhz2dh";
   };
-  sourceRoot = "source/cli";
+  sourceRoot = "${src.name}/cli";
 
   # some tests are designed to run against code in the source directory - adapt to run against
   # *installed* code

--- a/pkgs/tools/typesetting/xmlroff/default.nix
+++ b/pkgs/tools/typesetting/xmlroff/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     popt
   ];
 
-  sourceRoot = "source/xmlroff/";
+  sourceRoot = "${src.name}/xmlroff/";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes

This replaces all the uses of `sourceRoot = "source";`, `sourceRoot = "source/subdir";`, and similar in package derivations that use the default `unpackPhase` with `sourceRoot = src.name`, `sourceRoot = "${src.name}/subdir";` and similar.

It also fixes `sourceRoot` and `setSourceRoot` description in the docs to match the implementation, and deprecates the old usage in release notes.

The primary motivation for this change is to make #49862 (or its reverse) trivial to implement.

###### Things done

It's a mostly noop change except for the changes to documentation (which cause `nixos-install-tools` to be rebuilt).