### PR TITLE
briar-desktop: use tor binary shipped by upstream

### DIFF
--- a/pkgs/applications/networking/instant-messengers/briar-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/briar-desktop/default.nix
@@ -1,20 +1,13 @@
 { lib
 , stdenv
+, zstd
 , fetchurl
 , openjdk
 , libnotify
 , makeWrapper
-, tor
-, p7zip
 , bash
-, writeScript
 }:
 let
-
-  briar-tor = writeScript "briar-tor" ''
-    #! ${bash}/bin/bash
-    exec ${tor}/bin/tor "$@"
-  '';
 
 in
 stdenv.mkDerivation rec {
@@ -30,7 +23,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     makeWrapper
-    p7zip
   ];
 
   installPhase = ''
@@ -41,16 +33,6 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
         libnotify
       ]}"
-  '';
-
-  fixupPhase = ''
-    # Replace the embedded Tor binary (which is in a Tar archive)
-    # with one from Nixpkgs.
-    cp ${briar-tor} ./tor
-    for arch in {aarch64,armhf,x86_64}; do
-      7z a tor_linux-$arch.zip tor
-      7z a $out/lib/briar-desktop.jar tor_linux-$arch.zip
-    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

The current version of this package replaced the `tor` binary shipped with briar-desktop with the system `tor` binary because the upstream binary does not work. `ldd` reports a broken dependency on `libzstd`. Instead of using this kind of workaround, I'm suggesting to just add `zstd` as a dependency to this package.

###### Things done

I'm a beginner with NixOS so I haven't been able to verify my changes actually work. Would appreciate if this could be tested by a more experienced person.

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
