### PR TITLE
emacs: disable native compilation when cross-compiling

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -77,7 +77,7 @@
 , withNativeCompilation ?
   if nativeComp != null
   then lib.warn "nativeComp option is deprecated and will be removed; use withNativeCompilation instead" nativeComp
-  else true
+  else stdenv.buildPlatform.canExecute stdenv.hostPlatform
 , noGui ? false
 , srcRepo ? true
 , withAcl ? false
@@ -393,6 +393,6 @@ mkDerivation (finalAttrs: (lib.optionalAttrs withNativeCompilation {
   };
 
   meta = meta // {
-    broken = !(stdenv.buildPlatform.canExecute stdenv.hostPlatform);
+    broken = withNativeCompilation && !(stdenv.buildPlatform.canExecute stdenv.hostPlatform);
   };
 }))


### PR DESCRIPTION
###### Description of changes

Also unmarks Emacs as broken in this build configuration.

Emacs cross compilation is specifically broken with native compilation since it tries to run binaries compiled for the host platform.

Tested these, on build system x86_64-linux, on top of commit 1cfa64e7bd6f4f6d5dc3b28ec3e88139c45b36f8 (current master fails at least armv7l builds because p11-kit fails to compile):

|             | armv7l-linux | aarch64-linux |
|-------------|--------------|---------------|
| emacs       | works        | works         |
| emacs-nox   | works        | works         |
| emacs29     | OOM          | works         |
| emacs29-nox | OOM          | works         |

Note that cross-compiling emacs29(-nox) to armv7l fails due to an out of memory error while processing a Lisp file:

> Memory exhausted--use C-x s then exit and restart Emacs
> Error (auto-save): Auto-saving ja-dic.el: Memory exhausted--use C-x s then exit and restart Emacs
> make[3]: *** [Makefile:140: ../lisp/leim/ja-dic/ja-dic.el] Error 255
> make[3]: Leaving directory '/build/source/leim'
> make[2]: *** [Makefile:170: generate-ja-dic] Error 2

Not sure if cross-compilation is broken specifically here or this is due to running out of address space on a 32-bit arch due to that file being too large in Emacs 29. My guess is the latter, but I don't have a powerful enough armv7l box to test native compilation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
