### PR TITLE
nixos/hostapd: fix regression after refactoring to RFC42.

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -921,9 +921,7 @@ in {
                 };
 
                 config = let
-                  bss = bssSubmod.name;
                   bssCfg = bssSubmod.config;
-
                   pairwiseCiphers =
                     concatStringsSep " " (unique (bssCfg.authentication.pairwiseCiphers
                       ++ optionals bssCfg.authentication.enableRecommendedPairwiseCiphers ["CCMP" "CCMP-256" "GCMP" "GCMP-256"]));
@@ -964,9 +962,9 @@ in {
                   } // optionalAttrs (bssCfg.bssid != null) {
                     bssid = bssCfg.bssid;
                   } // optionalAttrs (bssCfg.macAllow != [] || bssCfg.macAllowFile != null || bssCfg.authentication.saeAddToMacAllow) {
-                    accept_mac_file = "/run/hostapd/${bss}.mac.allow";
+                    accept_mac_file = "/run/hostapd/${bssCfg._module.args.name}.mac.allow";
                   } // optionalAttrs (bssCfg.macDeny != [] || bssCfg.macDenyFile != null) {
-                    deny_mac_file = "/run/hostapd/${bss}.mac.deny";
+                    deny_mac_file = "/run/hostapd/${bssCfg._module.args.name}.mac.deny";
                   } // optionalAttrs (bssCfg.authentication.mode == "none") {
                     wpa = mkDefault 0;
                   } // optionalAttrs (bssCfg.authentication.mode == "wpa3-sae") {
@@ -1051,7 +1049,6 @@ in {
           };
 
           config.settings = let
-            radio = radioSubmod.name;
             radioCfg = radioSubmod.config;
           in {
             driver = radioCfg.driver;

--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -34,6 +34,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
               ssid = "nixos-test-mixed";
               authentication = {
                 mode = "wpa3-sae-transition";
+                saeAddToMacAllow = true;
                 saePasswordsFile = pkgs.writeText "password" "reproducibility";
                 wpaPasswordFile = pkgs.writeText "password" "reproducibility";
               };


### PR DESCRIPTION
###### Description of changes

Switching `attrsOf` submodule notation from `({name, ...}: {})` to `(submod: {})` that was introduced to avoid shadowing
seems to require a different accessing scheme which wasn't tested before. This fixes the notation and modifies the test to evaluate that part of the configuration to prevent future regressions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
