### PR TITLE
chicken: enable cross-compilation

### DIFF
--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, darwin, bootstrap-chicken ? null }:
+{ lib, stdenv, fetchurl, makeWrapper, darwin, bootstrap-chicken ? null, testers }:
 
 let
   platform = with stdenv;
@@ -8,30 +8,41 @@ let
     else if isSunOS then "solaris"
     else "linux"; # Should be a sane default
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "chicken";
   version = "5.3.0";
 
   binaryVersion = 11;
 
   src = fetchurl {
-    url = "https://code.call-cc.org/releases/${version}/chicken-${version}.tar.gz";
+    url = "https://code.call-cc.org/releases/${finalAttrs.version}/chicken-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-w62Z2PnhftgQkS75gaw7DC4vRvsOzAM7XDttyhvbDXY=";
   };
 
+  # Disable two broken tests: "static link" and "linking tests"
+  postPatch = ''
+    sed -i tests/runtests.sh -e "/static link/,+4 { s/^/# / }"
+    sed -i tests/runtests.sh -e "/linking tests/,+11 { s/^/# / }"
+  '';
+
   setupHook = lib.optional (bootstrap-chicken != null) ./setup-hook.sh;
 
-  # -fno-strict-overflow is not a supported argument in clang on darwin
-  hardeningDisable = lib.optionals stdenv.isDarwin ["strictoverflow"];
+  # -fno-strict-overflow is not a supported argument in clang
+  hardeningDisable = lib.optionals stdenv.cc.isClang [ "strictoverflow" ];
 
   makeFlags = [
-    "PLATFORM=${platform}" "PREFIX=$(out)"
-  ] ++ (lib.optionals stdenv.isDarwin [
-    "XCODE_TOOL_PATH=${darwin.binutils.bintools}/bin"
+    "PLATFORM=${platform}"
+    "PREFIX=$(out)"
     "C_COMPILER=$(CC)"
     "CXX_COMPILER=$(CXX)"
+    "TARGET_C_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
+    "TARGET_CXX_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++"
+  ] ++ (lib.optionals stdenv.isDarwin [
+    "XCODE_TOOL_PATH=${darwin.binutils.bintools}/bin"
     "LINKER_OPTIONS=-headerpad_max_install_names"
     "POSTINSTALL_PROGRAM=install_name_tool"
+  ]) ++ (lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "HOSTSYSTEM=${stdenv.hostPlatform.config}"
   ]);
 
   nativeBuildInputs = [
@@ -44,24 +55,16 @@ stdenv.mkDerivation rec {
     bootstrap-chicken
   ];
 
-  postInstall = ''
-    for f in $out/bin/*
-    do
-      wrapProgram $f \
-        --prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}
-    done
-  '';
-
   doCheck = !stdenv.isDarwin;
   postCheck = ''
     ./csi -R chicken.pathname -R chicken.platform \
-       -p "(assert (equal? \"${toString binaryVersion}\" (pathname-file (car (repository-path)))))"
+       -p "(assert (equal? \"${toString finalAttrs.binaryVersion}\" (pathname-file (car (repository-path)))))"
   '';
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/chicken -version
-  '';
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "csi -version";
+  };
 
   meta = {
     homepage = "https://call-cc.org/";
@@ -77,4 +80,4 @@ stdenv.mkDerivation rec {
       Windows, and many Unix flavours.
     '';
   };
-}
+})

--- a/pkgs/development/compilers/chicken/5/eggDerivation.nix
+++ b/pkgs/development/compilers/chicken/5/eggDerivation.nix
@@ -17,14 +17,16 @@ in
 (stdenv.mkDerivation ({
   name = "chicken-${name}";
   propagatedBuildInputs = buildInputs;
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ chicken makeWrapper ];
   buildInputs = [ chicken ];
+
+  strictDeps = true;
 
   CSC_OPTIONS = lib.concatStringsSep " " cscOptions;
 
   buildPhase = ''
     runHook preBuild
-    chicken-install -cached -no-install ${lib.escapeShellArgs chickenInstallFlags}
+    chicken-install -cached -no-install -host ${lib.escapeShellArgs chickenInstallFlags}
     runHook postBuild
   '';
 
@@ -33,7 +35,7 @@ in
 
     export CHICKEN_INSTALL_PREFIX=$out
     export CHICKEN_INSTALL_REPOSITORY=$out/lib/chicken/${toString chicken.binaryVersion}
-    chicken-install -cached ${lib.escapeShellArgs chickenInstallFlags}
+    chicken-install -cached -host ${lib.escapeShellArgs chickenInstallFlags}
 
     for f in $out/bin/*
     do


### PR DESCRIPTION
###### Description of changes

This allows the cross compilation of chicken in, at least, the following ways:

```sh
nix-build -A pkgsCross.aarch64-multiplatform.chicken
```

and

```sh
nix-build -A pkgsCross.raspberryPi.chicken
```

Building with clang on x86_64-linux has also been repaired.

Additionally, instead of reimplementing a version tester in the
`installCheckPhase`, this test has been pulled out into its own tester
attribute.

While two broken tests needed to be disabled, the functionality of static
building is not broken. Only the tests themselves seem not to be able to handle
the specification of absolute compiler paths.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).