### PR TITLE
openmw: 0.47.0 -> 0.48.0

### DIFF
--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -1,78 +1,68 @@
 { lib
 , stdenv
-, mkDerivation
-, fetchFromGitHub
+, fetchFromGitLab
 , fetchpatch
 , cmake
 , pkg-config
 , wrapQtAppsHook
-, openscenegraph
-, mygui
+, SDL2
+, CoreMedia
+, VideoToolbox
+, VideoDecodeAcceleration
+, boost
 , bullet
 , ffmpeg
-, boost
-, SDL2
-, unshield
-, openal
 , libXt
+, luajit
 , lz4
+, mygui
+, openal
+, openscenegraph
 , recastnavigation
-, VideoDecodeAcceleration
+, unshield
+, yaml-cpp
 }:
 
 let
-  openscenegraph_openmw = (openscenegraph.override { colladaSupport = true; })
-    .overrideDerivation (self: {
-      src = fetchFromGitHub {
-        owner = "OpenMW";
-        repo = "osg";
-        rev = "bbe61c3bc510a4f5bb4aea21cce506519c2d24e6";
-        sha256 = "sha256-t3smLqstp7wWfi9HXJoBCek+3acqt/ySBYF8RJOG6Mo=";
-      };
-      patches = [
-        (fetchpatch {
-          # For Darwin, OSG doesn't build some plugins as they're redundant with QuickTime.
-          # OpenMW doesn't like this, and expects them to be there. Apply their patch for it.
-          name = "darwin-osg-plugins-fix.patch";
-          url = "https://gitlab.com/OpenMW/openmw-dep/-/raw/0abe3c9c3858211028d881d7706813d606335f72/macos/osg.patch";
-          sha256 = "sha256-/CLRZofZHot8juH78VG1/qhTHPhy5DoPMN+oH8hC58U=";
-        })
-      ];
-    });
+  GL = "GLVND"; # or "LEGACY";
 
-  bullet_openmw = bullet.overrideDerivation (old: rec {
-    version = "3.17";
-    src = fetchFromGitHub {
-      owner = "bulletphysics";
-      repo = "bullet3";
-      rev = version;
-      sha256 = "sha256-uQ4X8F8nmagbcFh0KexrmnhHIXFSB3A1CCnjPVeHL3Q=";
-    };
-    patches = [];
-    cmakeFlags = (old.cmakeFlags or []) ++ [
+  osg' = (openscenegraph.override { colladaSupport = true; }).overrideDerivation (old: {
+    patches = [
+      (fetchpatch {
+        # Darwin: Without this patch, OSG won't build osgdb_png.so, which is required by OpenMW.
+        name = "darwin-osg-plugins-fix.patch";
+        url = "https://gitlab.com/OpenMW/openmw-dep/-/raw/0abe3c9c3858211028d881d7706813d606335f72/macos/osg.patch";
+        sha256 = "sha256-/CLRZofZHot8juH78VG1/qhTHPhy5DoPMN+oH8hC58U=";
+      })
+    ];
+    cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+      "-Wno-dev"
+      "-DOpenGL_GL_PREFERENCE=${GL}"
+      "-DBUILD_OSG_PLUGINS_BY_DEFAULT=0"
+      "-DBUILD_OSG_DEPRECATED_SERIALIZERS=0"
+    ] ++ (map (e: "-DBUILD_OSG_PLUGIN_${e}=1") [ "BMP" "DAE" "DDS" "FREETYPE" "JPEG" "OSG" "PNG" "TGA" ]);
+  });
+
+  bullet' = bullet.overrideDerivation (old: {
+    cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+      "-Wno-dev"
+      "-DOpenGL_GL_PREFERENCE=${GL}"
       "-DUSE_DOUBLE_PRECISION=ON"
       "-DBULLET2_MULTITHREADING=ON"
     ];
   });
 
 in
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "openmw";
-  version = "0.47.0";
+  version = "0.48.0";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
     owner = "OpenMW";
     repo = "openmw";
     rev = "${pname}-${version}";
-    sha256 = "sha256-Xq9hDUTCQr79Zzjk0CsiXclVTHK6nrSowukIQqVdrKY=";
+    hash = "sha256-zkjVt3GfQZsFXl2Ht3lCuQtDMYQWxhdFO4aGSb3rsyo=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://gitlab.com/OpenMW/openmw/-/merge_requests/1239.diff";
-      sha256 = "sha256-RhbIGeE6GyqnipisiMTwWjcFnIiR055hUPL8IkjPgZw=";
-    })
-  ];
 
   postPatch = ''
     sed '1i#include <memory>' -i components/myguiplatform/myguidatamanager.cpp # gcc12
@@ -84,27 +74,30 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
 
   # If not set, OSG plugin .so files become shell scripts on Darwin.
-  dontWrapQtApps = true;
+  dontWrapQtApps = stdenv.isDarwin;
 
   buildInputs = [
     SDL2
     boost
-    bullet_openmw
+    bullet'
     ffmpeg
     libXt
+    luajit
+    lz4
     mygui
     openal
-    openscenegraph_openmw
-    unshield
-    lz4
+    osg'
     recastnavigation
+    unshield
+    yaml-cpp
   ] ++ lib.optionals stdenv.isDarwin [
+    CoreMedia
     VideoDecodeAcceleration
+    VideoToolbox
   ];
 
   cmakeFlags = [
-    # as of 0.46, openmw is broken with GLVND
-    "-DOpenGL_GL_PREFERENCE=LEGACY"
+    "-DOpenGL_GL_PREFERENCE=${GL}"
     "-DOPENMW_USE_SYSTEM_RECASTNAVIGATION=1"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DOPENMW_OSX_DEPLOYMENT=ON"

--- a/pkgs/games/openmw/tes3mp.nix
+++ b/pkgs/games/openmw/tes3mp.nix
@@ -3,6 +3,7 @@
 , cmake
 , openmw
 , fetchFromGitHub
+, fetchpatch
 , luajit
 , makeWrapper
 , symlinkJoin
@@ -86,8 +87,15 @@ let
         --replace "\"./\"" "\"$out/bin/\""
     '';
 
-    # https://github.com/TES3MP/openmw-tes3mp/issues/552
-    patches = oldAttrs.patches ++ [ ./tes3mp.patch ];
+    patches = [
+      (fetchpatch {
+        url = "https://gitlab.com/OpenMW/openmw/-/commit/98a7d90ee258ceef9c70b0b2955d0458ec46f048.patch";
+        sha256 = "sha256-RhbIGeE6GyqnipisiMTwWjcFnIiR055hUPL8IkjPgZw=";
+      })
+
+      # https://github.com/TES3MP/openmw-tes3mp/issues/552
+      ./tes3mp.patch
+    ];
 
     env.NIX_CFLAGS_COMPILE = "-fpermissive";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38335,7 +38335,7 @@ with pkgs;
   openloco = pkgsi686Linux.callPackage ../games/openloco { };
 
   openmw = libsForQt5.callPackage ../games/openmw {
-    inherit (darwin.apple_sdk.frameworks) VideoDecodeAcceleration;
+    inherit (darwin.apple_sdk.frameworks) CoreMedia VideoDecodeAcceleration VideoToolbox;
   };
 
   openmw-tes3mp = libsForQt5.callPackage ../games/openmw/tes3mp.nix { };


### PR DESCRIPTION
###### Description of changes

Thank you to everyone who contributed code and ideas to this PR. It was a group effort.

Some notable changes that were made:

- Replaced openscenegraph fork with upstream version
  - See the diff between the fork and upstream v3.6 [here](https://github.com/OpenMW/osg/compare/3.6...openscenegraph:OpenSceneGraph:OpenSceneGraph-3.6)
- Un-hardcoded version of bullet dependency
  - The up-to-date version is >= 3.17 so I presume it's fine
- Removed a post-0.47.0 openmw patch that is already part of 0.48.0
- Switched the code source from GitHub to GitLab, since that seems to be the primary development platform
- Added some new dependencies that are now required
- Made some tweaks for Darwin that I cannot test

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Additional Notes

- Briefly tested the following binaries and confimed that they launch (on linux):
  - `openmw`
  - `openmw-cs`
  - `openmw-launcher`
- Started a new game and left the ship.

Closes #245429.
