### PR TITLE
pkgs.formats.toml: fix TOML semantics by upgrading tomlkit

### DIFF
--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -11,7 +11,6 @@
 , pytest-mock
 , pytestCheckHook
 , setuptools
-, tomlkit
 , virtualenv
 }:
 
@@ -54,7 +53,6 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
     setuptools
-    tomlkit
     virtualenv
   ];
 

--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -6,16 +6,20 @@
 , functools32, typing ? null
 , pytestCheckHook
 , pyaml
+, poetry-core
 }:
 
 buildPythonPackage rec {
   pname = "tomlkit";
   version = "0.11.6";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-cblS5XIWiJN/sCz501TbzweFBmFJ0oVeRFMevdK2XXM=";
   };
+
+  nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs =
     lib.optionals isPy27 [ enum34 functools32 ]

--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -11,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "tomlkit";
-  version = "0.11.6";
+  version = "0.11.8";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-cblS5XIWiJN/sCz501TbzweFBmFJ0oVeRFMevdK2XXM=";
+    hash = "sha256-kzD8f6odtntUGyjmIBjBfSC+czF30pChOyTGLRYU4MM=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -219,6 +219,35 @@ in runBuildTests {
     '';
   };
 
+  # see https://github.com/NixOS/nixpkgs/issues/237521 for this particular test
+  testTomlSemantics = {
+    drv = evalFormat formats.toml {} {
+      processors = {
+        override = [
+          { tags = { cluster = "staging"; }; }
+        ];
+        rename = [
+          {
+            replace = [
+              { dest = "ceph_telegraf_check"; measurement = "exec"; }
+            ];
+          }
+        ];
+      };
+    };
+    expected = ''
+      [processors]
+      [[processors.override]]
+      [processors.override.tags]
+      cluster = "staging"
+
+      [[processors.rename]]
+      [[processors.rename.replace]]
+      dest = "ceph_telegraf_check"
+      measurement = "exec"
+    '';
+  };
+
   # This test is responsible for
   #   1. testing type coercions
   #   2. providing a more readable example test


### PR DESCRIPTION
###### Description of changes

This fixes #237521 by upgrading tomlkit to 0.11.8.

It also introduces tests to make sure this behavior is kept, as some of our configurations (such as telegraf) depend on it.

Tested these changes by running `nix build .\#tests.pkgs-lib.formats`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
