### PR TITLE
xfce.xfce4-power-manager: use fixed path for helpers

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
@@ -26,6 +26,14 @@ mkXfceDerivation {
     xfce4-panel
   ];
 
+  # using /run/current-system/sw/bin instead of nix store path prevents polkit permission errors on
+  # rebuild.  See https://github.com/NixOS/nixpkgs/issues/77485
+  postPatch = ''
+    substituteInPlace src/org.xfce.power.policy.in2 --replace "@sbindir@" "/run/current-system/sw/bin"
+    substituteInPlace common/xfpm-brightness.c --replace "SBINDIR" "\"/run/current-system/sw/bin\""
+    substituteInPlace src/xfpm-suspend.c --replace "SBINDIR" "\"/run/current-system/sw/bin\""
+  '';
+
   meta = with lib; {
     description = "A power manager for the Xfce Desktop Environment";
     maintainers = with maintainers; [ ] ++ teams.xfce.members;


### PR DESCRIPTION
Using a nix store path for `xfpm-power-backlight-helper` and `xfce4-pm-helper` causes permission errors after a rebuild when adjusting brightness or putting the system to sleep, because the permitted executables are different from the ones `xfce4-power-manager` wants to execute.  Using a fixed path (/run/current-system/sw/bin) means the paths do not change after a rebuild, so there's no permission error.

A similar approach is taken with gnome's `gsd-backlight-helper`.

###### Description of changes

Before building, the `sbindir` variable references in the polkit configuration and in the `xfce4-power-manager` source are replaced with the hard coded path `/run/current-system/sw/bin`. The polkit and executable paths will always match, even if the system is rebuilt while `xfce4-power-manager` is running. This approach was stolen from gnome's handling of `gst-backlight-helper`.

One alternative I had considered, but didn't fully explore, is somehow restarting `xfce4-power-manager` after a rebuild (using an `activationScript`?). If it would work, it would be a fix only for the NixOS module, which may or may not be better.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@bobby285271 @romildo @muscaln