### PR TITLE
zfs-autobackup: 3.1 -> 3.1.3

### DIFF
--- a/pkgs/tools/backup/zfs-autobackup/default.nix
+++ b/pkgs/tools/backup/zfs-autobackup/default.nix
@@ -1,32 +1,30 @@
 { lib, python3Packages, fetchPypi }:
 
-let
-  pythonPackages = python3Packages;
-
-in
-pythonPackages.buildPythonApplication rec {
-  pname = "zfs_autobackup";
-  version = "3.1";
+python3Packages.buildPythonApplication rec {
+  pname = "zfs-autobackup";
+  version = "3.1.3";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "42c22001717b3d7cfdae6297fedc11b2dd1eb2a4bd25b6bb1c9232dd3b70ad67";
+    inherit version;
+    pname = "zfs_autobackup";
+    sha256 = "sha256-ckikq8Am81O0wkL4ozRBFTCa15PrmkD54A2qEY6kA5c=";
   };
 
-  # argparse is part of the standardlib
-  prePatch = ''
-    substituteInPlace setup.py --replace "argparse" ""
-  '';
+  nativeBuildInputs = with python3Packages; [ pythonRelaxDepsHook ];
 
-  propagatedBuildInputs = with pythonPackages; [ colorama ];
+  propagatedBuildInputs = with python3Packages; [ colorama ];
+
+  pythonRemoveDeps = [ "argparse" ];
 
   # tests need zfs filesystem
   doCheck = false;
-  pythonImportsCheck = [ "colorama" "argparse" ];
+
+  pythonImportsCheck = [ "zfs_autobackup" ];
 
   meta = with lib; {
-    homepage = "https://github.com/psy0rz/zfs_autobackup";
     description = "ZFS backup, replicationand snapshot tool";
+    homepage = "https://github.com/psy0rz/zfs_autobackup";
+    changelog = "https://github.com/psy0rz/zfs_autobackup/releases/tag/v${version}";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ ];
   };


### PR DESCRIPTION
Changelog: https://github.com/psy0rz/zfs_autobackup/releases/tag/v3.1.3

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
