### PR TITLE
Build fixes for haskell-updates branch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -120,7 +120,7 @@ in {
 
   # Apply workaround for Cabal 3.8 bug https://github.com/haskell/cabal/issues/8455
   # by making `pkg-config --static` happy. Note: Cabal 3.9 is also affected, so
-  # the GHC 9.6 configuration may need similar overrides eventually.
+  # the GHC 9.6 configuration shall need similar overrides.
   X11-xft = __CabalEagerPkgConfigWorkaround super.X11-xft;
   # Jailbreaks for https://github.com/gtk2hs/gtk2hs/issues/323#issuecomment-1416723309
   glib = __CabalEagerPkgConfigWorkaround (doJailbreak super.glib);
@@ -149,7 +149,12 @@ in {
   gi-soup = __CabalEagerPkgConfigWorkaround super.gi-soup;
   gio = __CabalEagerPkgConfigWorkaround super.gio;
   gtk = __CabalEagerPkgConfigWorkaround super.gtk;
-
-  # Cabal 3.8 bug workaround for applications using haskell-gi family of libraries
   termonad = __CabalEagerPkgConfigWorkaround super.termonad;
+  gi-cairo-render = __CabalEagerPkgConfigWorkaround super.gi-cairo-render;
+  gi-dbusmenu = __CabalEagerPkgConfigWorkaround super.gi-dbusmenu;
+  gi-dbusmenugtk3 = __CabalEagerPkgConfigWorkaround super.gi-dbusmenugtk3;
+  gi-gdkx11 = __CabalEagerPkgConfigWorkaround super.gi-gdkx11;
+  gi-xlib = __CabalEagerPkgConfigWorkaround super.gi-xlib;
+  gtk-sni-tray = __CabalEagerPkgConfigWorkaround super.gtk-sni-tray;
+  taffybar = __CabalEagerPkgConfigWorkaround super.taffybar;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -144,6 +144,15 @@ self: super: {
     })
     (doJailbreak super.monad-par);
 
+  # Patch 0.17.1 for support of mtl-2.3
+  xmonad-contrib = appendPatch
+    (pkgs.fetchpatch {
+      name = "xmonad-contrib-mtl-2.3.patch";
+      url = "https://github.com/xmonad/xmonad-contrib/commit/8cb789af39e93edb07f1eee39c87908e0d7c5ee5.patch";
+      sha256 = "sha256-ehCvVy0N2Udii/0K79dsRSBP7/i84yMoeyupvO8WQz4=";
+    })
+    (doJailbreak super.xmonad-contrib);
+
   # 2023-04-03: plugins disabled for hls 1.10.0.0 based on
   #
   haskell-language-server =
@@ -212,7 +221,6 @@ self: super: {
     implicit-hie-cradle
     focus
     hie-compat
-    xmonad-contrib              # mtl >=1 && <2.3
     dbus       # template-haskell >=2.18 && <2.20, transformers <0.6, unix <2.8
     gi-cairo-connector          # mtl <2.3
     haskintex                   # text <2

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -135,14 +135,14 @@ self: super: {
   }) (doJailbreak super.language-haskell-extract);
 
   # Patch for support of mtl-2.3
-  monad-par = appendPatches [
+  monad-par = appendPatch
     (pkgs.fetchpatch {
       name = "monad-par-mtl-2.3.patch";
       url = "https://github.com/simonmar/monad-par/pull/75/commits/ce53f6c1f8246224bfe0223f4aa3d077b7b6cc6c.patch";
       sha256 = "1jxkl3b3lkjhk83f5q220nmjxbkmni0jswivdw4wfbzp571djrlx";
       stripLen = 1;
     })
-  ] (doJailbreak super.monad-par);
+    (doJailbreak super.monad-par);
 
   # 2023-04-03: plugins disabled for hls 1.10.0.0 based on
   #

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -153,6 +153,15 @@ self: super: {
     })
     (doJailbreak super.xmonad-contrib);
 
+  # Patch 0.12.0.1 for support of unix-2.8.0.0
+  arbtt = appendPatch
+    (pkgs.fetchpatch {
+      name = "arbtt-unix-2.8.0.0.patch";
+      url = "https://github.com/nomeata/arbtt/pull/168/commits/ddaac94395ac50e3d3cd34c133dda4a8e5a3fd6c.patch";
+      sha256 = "sha256-5Gmz23f4M+NfgduA5O+9RaPmnneAB/lAlge8MrFpJYs=";
+    })
+    super.arbtt;
+
   # 2023-04-03: plugins disabled for hls 1.10.0.0 based on
   #
   haskell-language-server =


### PR DESCRIPTION
These are Haskell package overrides to make various things build under ghc945 and ghc962.

This branch is based on `haskell-updates` (#240387), cc: @maralorn @cdepillabout.

I am testing the build on `x86_64-linux` with this expression:

```nix
{ pkgs ? import ./default.nix {}, lib ? pkgs.lib }: let
  withPackagesVer = ghcVer: pkgs.haskell.packages.${ghcVer}.ghcWithHoogle;
  selectPackages = hp: with hp; [
    taffybar
    arbtt
    lentil
    xmonad-contrib
  ];
in
  lib.mapAttrs withPackagesVer {
    ghc96 = selectPackages;
    ghc94 = selectPackages;
  }
```
