### PR TITLE
jack2: refactor

### DIFF
--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch2, pkg-config, python3Packages, makeWrapper
-, libsamplerate, libsndfile, readline, eigen, celt
+, libsamplerate, eigen, celt
 , wafHook
 , gitUpdater
 # Darwin Dependencies
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkg-config python makeWrapper wafHook ];
-  buildInputs = [ libsamplerate libsndfile readline eigen celt
+  buildInputs = [ libsamplerate eigen celt
     optDbus optPythonDBus optLibffado optAlsaLib optLibopus
   ] ++ lib.optionals stdenv.isDarwin [
     aften AudioUnit CoreAudio Accelerate libobjc
@@ -56,9 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  postPatch = ''
-    patchShebangs --build svnversion_regenerate.sh
-  '';
+  dontAddWafCrossFlags = true;
 
   wafConfigureFlags = [
     "--classic"

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch2, pkg-config, python3Packages, makeWrapper
 , libsamplerate, libsndfile, readline, eigen, celt
 , wafHook
+, gitUpdater
 # Darwin Dependencies
 , aften, AudioUnit, CoreAudio, libobjc, Accelerate
 
@@ -78,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "$out/include" "$dev/include"
   '';
 
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
   meta = with lib; {

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -14,7 +14,7 @@
 # Optional build-time dependencies
 , doxygen ? null
 
-# Extra options
+# Use prefix = "lib" to build a minimal libraries-only package
 , prefix ? ""
 }:
 

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -2,32 +2,26 @@
 , libsamplerate, eigen, celt
 , wafHook
 , gitUpdater
+, testers
+
 # Darwin Dependencies
 , aften, AudioUnit, CoreAudio, libobjc, Accelerate
 
 # Optional Dependencies
 , dbus ? null, libffado ? null, alsa-lib ? null
-, libopus ? null
+, libopus ? null, systemd ? null, db ? null
 
 # Extra options
 , prefix ? ""
-
-, testers
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: let
   inherit (python3Packages) python dbus-python;
-  shouldUsePkg = pkg: if pkg != null && lib.meta.availableOn stdenv.hostPlatform pkg then pkg else null;
-
+  shouldUsePkg = pkg: pkg != null && lib.meta.availableOn stdenv.hostPlatform pkg;
+  enabled = pkg: pkg != null && lib.elem pkg finalAttrs.buildInputs;
   libOnly = prefix == "lib";
-
-  optDbus = if stdenv.isDarwin then null else shouldUsePkg dbus;
-  optPythonDBus = if libOnly then null else shouldUsePkg dbus-python;
-  optLibffado = if libOnly then null else shouldUsePkg libffado;
-  optAlsaLib = if libOnly then null else shouldUsePkg alsa-lib;
-  optLibopus = shouldUsePkg libopus;
-in
-stdenv.mkDerivation (finalAttrs: {
+  withJackDbus = !libOnly && enabled dbus;
+in {
   pname = "${prefix}jack2";
   version = "1.9.22";
 
@@ -41,11 +35,17 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkg-config python makeWrapper wafHook ];
-  buildInputs = [ libsamplerate eigen celt
-    optDbus optPythonDBus optLibffado optAlsaLib optLibopus
-  ] ++ lib.optionals stdenv.isDarwin [
-    aften AudioUnit CoreAudio Accelerate libobjc
-  ];
+  buildInputs = lib.filter shouldUsePkg (lib.concatLists [
+    [ libsamplerate eigen celt libopus db ]
+    (lib.optionals (!libOnly) [
+      dbus-python libffado alsa-lib systemd
+    ])
+    (if stdenv.isDarwin then [
+      aften AudioUnit CoreAudio Accelerate libobjc
+    ] else [
+      dbus
+    ])
+  ]);
 
   patches = [
     (fetchpatch2 {
@@ -59,16 +59,27 @@ stdenv.mkDerivation (finalAttrs: {
   dontAddWafCrossFlags = true;
 
   wafConfigureFlags = [
+    "--pkgconfigdir=${placeholder "dev"}/lib/pkgconfig"
     "--classic"
-    "--autostart=${if (optDbus != null) then "dbus" else "classic"}"
-  ] ++ lib.optional (optDbus != null) "--dbus"
-    ++ lib.optional (optLibffado != null) "--firewire"
-    ++ lib.optional (optAlsaLib != null) "--alsa";
+    "--autostart=${if withJackDbus then "dbus" else "classic"}"
+  ] ++ lib.optionals withJackDbus [
+    "--dbus"
+  ];
 
-  postInstall = (if libOnly then ''
-    rm -rf $out/{bin,share}
-    rm -rf $out/lib/{jack,libjacknet*,libjackserver*}
-  '' else lib.optionalString (optDbus != null) ''
+  postInstall = ''
+    _multioutJack2Bin() {
+      local bin="$1"
+      moveToOutput bin "$bin"
+      moveToOutput lib/jack "$bin"
+      moveToOutput "lib/libjacknet*" "$bin"
+      moveToOutput "lib/libjackserver*" "$bin"
+      moveToOutput share/dbus-1 "$bin"
+      moveToOutput share/man "$bin"
+    }
+  '' + (if libOnly then ''
+    _multioutJack2Bin REMOVE
+    sed -i -e '/^server_libs/d' "$dev/lib/pkgconfig/jack.pc"
+  '' else lib.optionalString (withJackDbus != null) ''
     wrapProgram $out/bin/jack_control --set PYTHONPATH $PYTHONPATH
   '');
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38770,7 +38770,6 @@ with pkgs;
 
   itamae = callPackage ../tools/admin/itamae { };
 
-  # using the new configuration style proposal which is unstable
   jack1 = callPackage ../misc/jackaudio/jack1.nix { };
 
   jack2 = callPackage ../misc/jackaudio {


### PR DESCRIPTION
###### Description of changes

Updates to the latest JACK2 release [1.9.22](https://github.com/jackaudio/jack2/releases/tag/v1.9.22).

Notice that some `buildInputs` have been removed here. They are no longer required because of jack-example-tools (PR #243378).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
