### PR TITLE
onthespot: init at 0.5

### DIFF
--- a/pkgs/applications/misc/onthespot/default.nix
+++ b/pkgs/applications/misc/onthespot/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, python3
+, fetchFromGitHub
+, copyDesktopItems
+, wrapQtAppsHook
+, makeDesktopItem
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "onthespot";
+  version = "0.5";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "casualsnek";
+    repo = "onthespot";
+    rev = "v${version}";
+    hash = "sha256-VaJBNsT7uNOGY43GnzhUqDQNiPoFZcc2UaIfOKgkufg=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    copyDesktopItems
+    pythonRelaxDepsHook
+    wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    charset-normalizer
+    defusedxml
+    librespot
+    music-tag
+    packaging
+    pillow
+    protobuf
+    pyogg
+    pyqt5
+    pyqt5_sip
+    pyxdg
+    requests
+    setuptools
+    show-in-file-manager
+    urllib3
+    zeroconf
+  ];
+
+  pythonRemoveDeps = [
+    "PyQt5-Qt5"
+    "PyQt5-stubs"
+  ];
+
+  pythonRelaxDeps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  meta = {
+    description = " QT based Spotify music downloader written in Python";
+    homepage = "https://github.com/casualsnek/onthespot";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ onny ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/librespot/default.nix
+++ b/pkgs/development/python-modules/librespot/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, defusedxml
+, protobuf
+, pythonRelaxDepsHook
+, websocket-client
+, pyogg
+, zeroconf
+, requests
+, pycryptodomex
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "librespot";
+  version = "0.0.9";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "kokarare1212";
+    repo = "librespot-python";
+    rev = "v${version}";
+    hash = "sha256-k9qVsxjRlUZ7vCBx00quiAR7S+YkfyoZiAKVnOOG4xM=";
+  };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    defusedxml
+    protobuf
+    pycryptodomex
+    pyogg
+    requests
+    websocket-client
+    zeroconf
+  ];
+
+  pythonRelaxDeps = [
+    "protobuf"
+    "pyogg"
+    "requests"
+    "zeroconf"
+  ];
+
+  # Doesn't include any tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "librespot"
+  ];
+
+  meta = with lib; {
+    description = "Open Source Spotify Client";
+    homepage = "https://github.com/kokarare1212/librespot-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/python-modules/music-tag/default.nix
+++ b/pkgs/development/python-modules/music-tag/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, mutagen
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "music-tag";
+  version = "0.4.3";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Cqtubu2o3w9TFuwtIZC9dFYbfgNWKrCRzo1Wh828//Y=";
+  };
+
+  propagatedBuildInputs = [
+    mutagen
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "test" ];
+
+  # Tests fail: ModuleNotFoundError: No module named '_test_common'
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "music_tag"
+  ];
+
+  meta = with lib; {
+    description = "Simple interface to edit audio file metadata";
+    homepage = "https://github.com/KristoforMaynard/music-tag";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11042,6 +11042,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  onthespot = libsForQt5.callPackage ../applications/misc/onthespot { };
+
   opencorsairlink = callPackage ../tools/misc/opencorsairlink { };
 
   openfpgaloader = callPackage ../development/embedded/fpga/openfpgaloader { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5860,6 +5860,8 @@ self: super: with self; {
     (p: p.py)
   ];
 
+  librespot = callPackage ../development/python-modules/librespot { };
+
   libretranslate = callPackage ../development/python-modules/libretranslate { };
 
   librosa = callPackage ../development/python-modules/librosa { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6710,6 +6710,8 @@ self: super: with self; {
 
   musicbrainzngs = callPackage ../development/python-modules/musicbrainzngs { };
 
+  music-tag = callPackage ../development/python-modules/music-tag { };
+
   mutag = callPackage ../development/python-modules/mutag { };
 
   mutagen = callPackage ../development/python-modules/mutagen { };


### PR DESCRIPTION
###### Description of changes

Spotify downloader with QT5 frontend written in Python https://github.com/casualsnek/onthespot

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
