### PR TITLE
Add U-Boot firmware environment tool package and tool configuration module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -334,6 +334,7 @@
   ./programs/trippy.nix
   ./programs/tsm-client.nix
   ./programs/turbovnc.nix
+  ./programs/uboot-fwenv.nix
   ./programs/udevil.nix
   ./programs/usbtop.nix
   ./programs/vim.nix

--- a/nixos/modules/programs/uboot-fwenv.nix
+++ b/nixos/modules/programs/uboot-fwenv.nix
@@ -1,0 +1,68 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    mkIf
+    optionalString
+    maintainers
+    ;
+
+  cfg = config.programs.uboot-fwenv;
+in
+{
+  options.programs.uboot-fwenv = {
+    enable = mkEnableOption ''
+      U-Boot environment access configuration.
+
+      Use this to setup access to the U-Boot's environment variables with
+      generic ubootEnvTools package.
+    '';
+    package = mkPackageOption pkgs "ubootEnvTools" { };
+    device = mkOption {
+      type = types.str;
+      description = "Device with U-Boot environment";
+    };
+    offset = mkOption {
+      type = types.strMatching "0x[a-fA-F0-9]+";
+      default = "0x0";
+      description = "Offset in the device to the environment";
+    };
+    size = mkOption {
+      type = types.strMatching "0x[a-fA-F0-9]+";
+      description = "Environment size";
+    };
+    secsize = mkOption {
+      type = with types; nullOr (strMatching "0x[a-fA-F0-9]+");
+      default = null;
+      description = "Flash sector size.";
+    };
+    numsec = mkOption {
+      type = with types; nullOr (strMatching "0x[a-fA-F0-9]+");
+      default = null;
+      description = "Number of sectors";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."fw_env.config".text =
+      "${cfg.device} ${cfg.offset} ${cfg.size}"
+      + optionalString (cfg.secsize != null) (
+        " ${cfg.secsize}" + (optionalString (cfg.numsec != null) " ${cfg.numsec}")
+      );
+
+    environment.systemPackages = [ cfg.package ];
+  };
+
+  meta.maintainers = with maintainers; [
+    cynerd
+    Luflosi
+  ];
+}

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -214,6 +214,23 @@ in
     };
   };
 
+  ubootEnvTools = buildUBoot {
+    pname = "uboot-envtools-only_defconfig";
+    defconfig = "tools-only_defconfig";
+    installDir = "$out/bin";
+    hardeningDisable = [ ];
+    dontStrip = false;
+    extraMeta.platforms = lib.platforms.linux;
+    extraMakeFlags = [ "envtools" ];
+    filesToInstall = [ "tools/env/fw_printenv" ];
+    postInstall = ''
+      # from u-boot's tools/env/README:
+      # "You should then create a symlink from fw_setenv to fw_printenv. They
+      # use the same program and its function depends on its basename."
+      ln -sf fw_printenv $out/bin/fw_setenv
+    '';
+  };
+
   ubootPythonTools = lib.recurseIntoAttrs (callPackages ./python.nix { });
 
   ubootA20OlinuxinoLime = buildUBoot {

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -46,7 +46,7 @@ let
     ncurses # tools/kwboot
     libuuid # tools/mkeficapsule
     gnutls # tools/mkeficapsule
-    openssl # tools/mkimage and tools/env/fw_printenv
+    openssl # tools/mkimage
   ];
 
   buildUBoot = lib.makeOverridable (
@@ -180,7 +180,6 @@ in
       "HOST_TOOLS_ALL=y"
       "NO_SDL=1"
       "cross_tools"
-      "envtools"
     ];
 
     outputs = [
@@ -190,13 +189,7 @@ in
 
     postInstall = ''
       installManPage doc/*.1
-
-      # from u-boot's tools/env/README:
-      # "You should then create a symlink from fw_setenv to fw_printenv. They
-      # use the same program and its function depends on its basename."
-      ln -s $out/bin/fw_printenv $out/bin/fw_setenv
     '';
-
     filesToInstall = [
       "tools/dumpimage"
       "tools/fdt_add_pubkey"
@@ -205,7 +198,6 @@ in
       "tools/mkeficapsule"
       "tools/mkenvimage"
       "tools/mkimage"
-      "tools/env/fw_printenv"
       "tools/mkeficapsule"
     ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10261,6 +10261,7 @@ with pkgs;
   inherit (callPackage ../misc/uboot { })
     buildUBoot
     ubootTools
+    ubootEnvTools
     ubootPythonTools
     ubootA20OlinuxinoLime
     ubootA20OlinuxinoLime2EMMC


### PR DESCRIPTION
###### Description of changes

This introduces new package `ubootEnvTools` with `fw_printenv` and `fw_setenv`. Those tools can be used to access U-Boot's firmware environment from the running system. These tools are either build with settings compiled-in for a specific target or they read `/etc/fw_env.config` file. To provide a generic environment tools the second option is chosen here and NixOS module to create that configuration file is submitted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
