### PR TITLE
libreoffice-qt: fix build

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -226,9 +226,10 @@ in
   # in the binary causing the closure size to blow up because of many unnecessary
   # dependencies to dev outputs. This behavior was patched away in nixpkgs
   # (see above), make sure these don't leak again by accident.
-  disallowedRequisites = lib.concatMap
-    (x: lib.optional (x?dev) x.dev)
-    buildInputs;
+  disallowedRequisites = lib.optionals (!kdeIntegration)
+    (lib.concatMap
+      (x: lib.optional (x?dev) x.dev)
+      buildInputs);
 
   ### QT/KDE
   #


### PR DESCRIPTION

###### Description of changes
Broke in 408ece7d3d5b68f5c0d870abb936ee8950a1b9f9 because the `disallowedRequisites` fails here since the QT variant apparently needs to reference a few dev outputs[1].

I won't look into the details of that now, so the easiest way to unbreak is to skip the check for the QT variant. It should be kept for non-QT though to make sure that a change similar to the BUILDCONFIG thing isn't missed again by us.

[1] https://github.com/NixOS/nixpkgs/pull/245361#issuecomment-1651389735

    error: output '/nix/store/2y0czyy26gcsqhmcvd2mlqa35f0gcl4l-libreoffice-7.5.4.1' is not allowed to refer to the following paths:
             /nix/store/0hmvklj0mbhrn8flwbcwivvkv45limhg-freetype-2.13.0-dev
             /nix/store/0rnx7rc87hwkbrhsys7mgwq4jw6pz7ma-zlib-1.2.13-dev
             [...]

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
