### PR TITLE
blender: Build with Draco support

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -35,7 +35,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-SzdWyzdGhsaesv1VX5ZUfUnLHvRvW8buJTlOVxz6yOk=";
   };
 
-  patches = lib.optional stdenv.isDarwin ./darwin.patch;
+  patches = [
+    ./draco.patch
+  ] ++ lib.optional stdenv.isDarwin ./darwin.patch;
 
   nativeBuildInputs =
     [ cmake makeWrapper python310Packages.wrapPython llvmPackages.llvm.dev
@@ -165,6 +167,7 @@ stdenv.mkDerivation rec {
     mkdir $out/Applications
     mv $out/Blender.app $out/Applications
   '' + ''
+    mv $out/share/blender/${lib.versions.majorMinor version}/python{,-ext}
     buildPythonPath "$pythonPath"
     wrapProgram $blenderExecutable \
       --prefix PATH : $program_PATH \

--- a/pkgs/applications/misc/blender/draco.patch
+++ b/pkgs/applications/misc/blender/draco.patch
@@ -1,0 +1,26 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -898,11 +898,6 @@ set_and_warn_dependency(WITH_PYTHON WITH_CYCLES        OFF)
+ set_and_warn_dependency(WITH_PYTHON WITH_DRACO         OFF)
+ set_and_warn_dependency(WITH_PYTHON WITH_MOD_FLUID     OFF)
+ 
+-if(WITH_DRACO AND NOT WITH_PYTHON_INSTALL)
+-  message(STATUS "WITH_DRACO requires WITH_PYTHON_INSTALL to be ON, disabling WITH_DRACO for now")
+-  set(WITH_DRACO OFF)
+-endif()
+-
+ # enable boost for cycles, audaspace or i18n
+ # otherwise if the user disabled
+ 
+--- a/scripts/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
++++ b/scripts/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
+@@ -17,7 +17,7 @@ def dll_path() -> Path:
+     """
+     lib_name = 'extern_draco'
+-    blender_root = Path(bpy.app.binary_path).parent
++    blender_root = Path(bpy.app.binary_path).parent.parent
+-    python_lib = Path('{v[0]}.{v[1]}/python/lib'.format(v=bpy.app.version))
++    python_lib = Path('share/blender/{v[0]}.{v[1]}/python-ext/lib'.format(v=bpy.app.version))
+     python_version = 'python{v[0]}.{v[1]}'.format(v=sys.version_info)
+ 
+     path = os.environ.get('BLENDER_EXTERN_DRACO_LIBRARY_PATH')


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/217921

Blender sets WITH_DRACO=OFF if WITH_PYTHON_INSTALL=OFF, however that’s not totally necessary. Removing that forced-set then builds with WITH_DRACO=ON, however Blender fails to launch because this creates e.g. `share/blender/3.6/python`, and Blender then sets this as Python’s home dir, so Python fails to init since it expects Python core to be there (and it’s not). I couldn’t figure out how Blender sets Python’s home dir, and explicitly setting PYTHONHOME in the env didn’t have any effect. So instead just rename that dir to python-ext to avoid this behavior. All that is left then is to adjust where Blender is looking for the Draco lib.

This functionality may be verified by:

1. Visiting File → Export → glTF 2.0
2. In the right side panel (press the gear icon in top-right if not visible), expanding “Data”
3. Enabling “Compression”
4. Press “Export glTF 2.0”
5. Verifying no error or warning message and exported file exists

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Have verified functionality as described in the commit message.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
