### PR TITLE
nyxt: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -296,12 +296,12 @@ let
 
   nclasses = build-asdf-system {
     pname = "nclasses";
-    version = "0.5.0";
+    version = "0.6.0";
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nclasses";
-      rev = "0.5.0";
-      sha256 = "sha256-UcavZ0fCA2hkVU/CqUZfyCqJ8gXKPpXTCP0WLUIF1Ss=";
+      rev = "0.6.0";
+      sha256 = "sha256-JupP+TIxavUoyOPnp57FqpEjWfgKspdFoSRnV2rk5U4=";
     };
     lispLibs = [ self.nasdf super.moptilities ];
   };
@@ -330,10 +330,12 @@ let
 
   nhooks = build-asdf-system {
     pname = "nhooks";
-    version = "20230214-git";
-    src = pkgs.fetchzip {
-      url = "http://beta.quicklisp.org/archive/nhooks/2023-02-14/nhooks-20230214-git.tgz";
-      sha256 = "0rapn9v942yd2snlskvlr1g22hmyhlsrclahxjsgn4pbvqc5gwyw";
+    version = "1.2.1";
+    src = pkgs.fetchFromGitHub {
+      owner = "atlas-engineer";
+      repo = "nhooks";
+      rev = "1.2.1";
+      hash = "sha256-D61QHxHTceIu5mCGKf3hy53niQMfs0idEYQK1ZYn1YM=";
     };
     lispLibs = with self; [ bordeaux-threads closer-mop serapeum ];
   };
@@ -368,7 +370,7 @@ let
 
   nyxt-gtk = build-asdf-system {
     pname = "nyxt";
-    version = "3.4.0";
+    version = "3.5.0";
 
     lispLibs = (with super; [
       alexandria
@@ -437,8 +439,8 @@ let
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nyxt";
-      rev = "3.4.0";
-      sha256 = "sha256-o+GAMHKi+9q+EGY6SEZrxKCEO4IxdOiB4oPpJPGYO0w=";
+      rev = "3.5.0";
+      sha256 = "sha256-/x3S4qAvvHxUxDcs6MAuZvAtqLTQdwlH7r4zFlKIjY4=";
     };
 
     nativeBuildInputs = [ pkgs.makeWrapper ];
@@ -451,15 +453,17 @@ let
       pkgs.gnome.adwaita-icon-theme
     ];
 
-    # This is needed since asdf:make tries to write in the directory of the .asd file of the system it's compiling
-    postConfigure = ''
-      export CL_SOURCE_REGISTRY=$CL_SOURCE_REGISTRY:$(pwd)//
-    '';
+    # This patch removes the :build-operation component from the nyxt/gi-gtk-application system.
+    # This is done because if asdf:operate is used and the operation matches the system's :build-operation
+    # then output translations are ignored, causing the result of the operation to be placed where
+    # the .asd is located, which in this case is the nix store.
+    # see: https://gitlab.common-lisp.net/asdf/asdf/-/blob/master/doc/asdf.texinfo#L2582
+    patches = [ ./patches/nyxt-remove-build-operation.patch ];
 
     buildScript = pkgs.writeText "build-nyxt.lisp" ''
       (load "${super.alexandria.asdfFasl}/asdf.${super.alexandria.faslExt}")
-      ;; There's a weird error while copy/pasting in Nyxt that manifests with sb-ext:save-lisp-and-die, so we use asdf:make instead
-      (asdf:make :nyxt/gi-gtk-application)
+      ;; There's a weird error while copy/pasting in Nyxt that manifests with sb-ext:save-lisp-and-die, so we use asdf:operare :program-op instead
+      (asdf:operate :program-op :nyxt/gi-gtk-application)
     '';
 
     # TODO(kasper): use wrapGAppsHook

--- a/pkgs/development/lisp-modules/patches/nyxt-remove-build-operation.patch
+++ b/pkgs/development/lisp-modules/patches/nyxt-remove-build-operation.patch
@@ -1,0 +1,12 @@
+diff --git a/nyxt.asd b/nyxt.asd
+index ea2630ce..fdf837e4 100644
+--- a/nyxt.asd
++++ b/nyxt.asd
+@@ -480,7 +480,6 @@ The renderer is configured from NYXT_RENDERER or `*nyxt-renderer*'."))
+   :defsystem-depends-on ("nasdf")
+   :class :nasdf-system
+   :depends-on (nyxt/gi-gtk)
+-  :build-operation "program-op"
+   :build-pathname "nyxt"
+   :entry-point "nyxt:entry-point")
+ 


### PR DESCRIPTION
###### Description of changes

Also updated nclasses and nhooks (Nyxt dependecies).

I modified the build to remove the `postConfigure` hack, due to it causing issues due to Nyxt not finding it's own source code, see: https://github.com/atlas-engineer/nyxt/issues/3075#issuecomment-1649680175.

I had to add a patch to remove the `:build-operation` component from the `nyxt/gi-gtk-appliaction` system (the one we are building), because if a system is built using `asdf:make` or `asdf:operate` and the operation used matches the system's `:build-operation` then output translations are ignored and the result of the operation is placed where the .asd file resides, which in our case would be the nix store, which is not desirable. See: https://gitlab.common-lisp.net/asdf/asdf/-/blob/master/doc/asdf.texinfo#L2582

The fix for this is simply removing `:build-operation` and calling `asdf:operate :progam-op` explicitly instead of using `asdf:make` (`asdf:make` builds the system with the operation defined by `:build-operation`, so we can't use it anymore if we unset `:build-operation`).

Release notes: https://nyxt.atlas.engineer/article/release-3.5.0.org

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
