### PR TITLE
vulnz: init at 5.1.2

### DIFF
--- a/pkgs/by-name/vu/vulnz/package.nix
+++ b/pkgs/by-name/vu/vulnz/package.nix
@@ -1,0 +1,126 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gradle
+, perl
+, jre
+}:
+
+let
+  pname = "vulnz";
+  version = "5.1.2";
+
+  src = fetchFromGitHub {
+    owner = "jeremylong";
+    repo = "Open-Vulnerability-Project";
+    rev = "v${version}";
+    hash = "sha256-TvyQTbWKZeiA2QTirQK34z7r9WC8wytbTiVZQeBJn/o=";
+  };
+  deps = stdenv.mkDerivation {
+    name = "${pname}-deps";
+    inherit src;
+    nativeBuildInputs = [ gradle perl ];
+    buildPhase = ''
+      runHook preBuild
+
+      export GRADLE_USER_HOME=$(mktemp -d)
+      gradle --no-daemon jar
+
+      runHook postBuild
+    '';
+    # Mavenize dependency paths
+    # e.g. org.codehaus.groovy/groovy/2.4.0/{hash}/groovy-2.4.0.jar -> org/codehaus/groovy/groovy/2.4.0/groovy-2.4.0.jar
+    installPhase = ''
+      runHook preInstall
+
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+
+      runHook postInstall
+    '';
+
+    # Compensate for the `move-docs.sh` setup hook - is there a way to
+    # prevent it from running entirely?
+    postFixup = ''
+      mv $out/share/info $out/info
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = "sha256-cjs1STVgGDkStnwfRJN8ddTXDGRyZhuvwD/EThD10L4=";
+  };
+in stdenv.mkDerivation (finalAttrs: {
+  inherit pname version src;
+
+  nativeBuildInputs = [ gradle ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    depsDir=$(mktemp -d)
+    cp -R ${deps}/* $depsDir
+    chmod -R u+w $depsDir
+
+    gradleInit=$(mktemp)
+    cat >$gradleInit <<EOF
+      gradle.projectsLoaded {
+        rootProject.allprojects {
+          buildscript {
+            repositories {
+              clear()
+              maven { url '$depsDir' }
+            }
+          }
+          repositories {
+            clear()
+            maven { url '$depsDir' }
+          }
+        }
+      }
+
+      settingsEvaluated { settings ->
+        settings.pluginManagement {
+          repositories {
+            maven { url '$depsDir' }
+          }
+        }
+      }
+    EOF
+
+    export GRADLE_USER_HOME=$(mktemp -d)
+    gradle --offline --no-daemon --info --init-script $gradleInit vulnz:bootJar
+
+    runHook preBuild
+   '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out $out/share
+    ls vulnz
+    cp vulnz/build/libs/vulnz-${version}.jar $out/share
+
+    mkdir $out/bin
+    echo "${jre}/bin/java -jar $out/share/${pname}-${version}.jar \$*" > $out/bin/vulnz
+    chmod a+x $out/bin/vulnz
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CLI to work with various vulnerability data-sources";
+    longDescription = ''
+      The Open Vulnerability Project is a collection of Java libraries and a
+      CLI to work with various vulnerability data-sources (NVD, GitHub Security
+      Advisories, CISA Known Exploited Vulnerablity Catalog, FIRST Exploit
+      Prediction Scoring System (EPSS), etc.).
+    '';
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode  # deps
+    ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ raboof ];
+  };
+})


### PR DESCRIPTION
###### Description of changes

The Open Vulnerability Project is a collection of Java libraries and a CLI to work with various vulnerability data-sources (NVD, GitHub Security Advisories, CISA Known Exploited Vulnerablity Catalog, FIRST Exploit Prediction Scoring System (EPSS), etc.).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Related to #81418