### PR TITLE
zfs: stable supports up to Linux 6.4

### DIFF
--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -225,7 +225,7 @@ stdenv'.mkDerivation {
       with lib.systems.inspect.patterns;
       map (p: p // isLinux) [ isx86_32 isx86_64 isPower isAarch64 isSparc ];
 
-    maintainers = with lib.maintainers; [ jcumming jonringer globin raitobezarius ];
+    maintainers = with lib.maintainers; [ raitobezarius ];
     mainProgram = "zfs";
     # If your Linux kernel version is not yet supported by zfs, try zfsUnstable.
     # On NixOS set the option boot.zfs.enableUnstable.

--- a/pkgs/os-specific/linux/zfs/stable.nix
+++ b/pkgs/os-specific/linux/zfs/stable.nix
@@ -13,10 +13,10 @@ callPackage ./generic.nix args {
   # check the release notes for compatible kernels
   kernelCompatible =
     if stdenv'.isx86_64 || removeLinuxDRM
-    then kernel.kernelOlder "6.4"
+    then kernel.kernelOlder "6.5"
     else kernel.kernelOlder "6.2";
   latestCompatibleLinuxPackages = if stdenv'.isx86_64 || removeLinuxDRM then
-    linuxKernel.packages.linux_6_3
+    linuxKernel.packages.linux_6_4
   else
     linuxKernel.packages.linux_6_1;
 


### PR DESCRIPTION
###### Description of changes

ZFS stable supports up to 6.4 in fact, this is not clearly communicated in the META file
but it does not matter, I have been running 6.4 for a while with ZFS (and even bcachefs).

~~Unblocks #244883.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
