### PR TITLE
iina: 1.3.2 -> 1.3.3

### DIFF
--- a/pkgs/applications/video/iina/default.nix
+++ b/pkgs/applications/video/iina/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "iina";
-  version = "1.3.2";
+  version = "1.3.3";
 
   src = fetchurl {
     url = "https://github.com/iina/iina/releases/download/v${version}/IINA.v${version}.dmg";
-    hash = "sha256-rF5yv2QHWVUUsyf/u78jWRn4C629GBJgB/i8YnaKHBk=";
+    hash = "sha256-Sz9sS+07t32+KcEr9tXQlZKEr7Ace1mjX9caOicIiZE=";
   };
 
   nativeBuildInputs = [ undmg ];

--- a/pkgs/applications/video/iina/default.nix
+++ b/pkgs/applications/video/iina/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     description = "The modern media player for macOS";
     platforms = platforms.darwin;
     license = licenses.gpl3;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ arkivm stepbrobd ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/iina/iina/releases/tag/v1.3.3
Also add `meta.sourceProvenance` because this package is not built from source.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).