### PR TITLE
qt6Packages.qt6gtk2: init at 0.2

### DIFF
--- a/nixos/modules/config/qt.nix
+++ b/nixos/modules/config/qt.nix
@@ -19,7 +19,7 @@ let
       pkgs.qgnomeplatform-qt6
       pkgs.adwaita-qt6
     ]
-    else if isQtStyle then [ pkgs.libsForQt5.qtstyleplugins ]
+    else if isQtStyle then [ pkgs.libsForQt5.qtstyleplugins pkgs.qt6Packages.qt6gtk2 ]
     else if isQt5ct then [ pkgs.libsForQt5.qt5ct pkgs.qt6Packages.qt6ct ]
     else if isLxqt then [ pkgs.lxqt.lxqt-qtplugin pkgs.lxqt.lxqt-config ]
     else if isKde then [ pkgs.libsForQt5.plasma-integration pkgs.libsForQt5.systemsettings ]
@@ -86,6 +86,7 @@ in
           "adwaita-qt"
           "adwaita-qt6"
           ["libsForQt5" "qtstyleplugins"]
+          ["qt6Packages" "qt6gtk2"]
         ];
         description = lib.mdDoc ''
           Selects the style to use for Qt applications.

--- a/pkgs/tools/misc/qt6gtk2/default.nix
+++ b/pkgs/tools/misc/qt6gtk2/default.nix
@@ -1,0 +1,36 @@
+{ fetchFromGitHub, lib, stdenv, gtk2, pkg-config, qmake, qtbase }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qt6gtk2";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "trialuser02";
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
+    hash = "sha256-g5ZCwTnNEJJ57zEwNqMxrl0EWYJMt3PquZ2IsmxQYqk=";
+  };
+
+  buildInputs = [ gtk2 qtbase ];
+  nativeBuildInputs = [ pkg-config qmake ];
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/qt-6/plugins/{platformthemes,styles}
+    cp -pr src/qt6gtk2-qtplugin/libqt6gtk2.so $out/lib/qt-6/plugins/platformthemes
+    cp -pr src/qt6gtk2-style/libqt6gtk2-style.so $out/lib/qt-6/plugins/styles
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "GTK+2.0 integration plugins for Qt6";
+    license = lib.licenses.gpl2Plus;
+    homepage = "https://github.com/trialuser02/qt6gtk2";
+    maintainers = [ lib.maintainers.misterio77 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -33,6 +33,8 @@ in
 
   qt6ct = callPackage ../tools/misc/qt6ct { };
 
+  qt6gtk2 = callPackage ../tools/misc/qt6gtk2 { };
+
   qtkeychain = callPackage ../development/libraries/qtkeychain {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation Security;
   };


### PR DESCRIPTION
###### Description of changes

Add [qt6gtk2](https://github.com/trialuser02/qt6gtk2), plugins that help make qt6 apps use gtk2 theming.

I've also set qt's NixOS module to have qt6gtk2 available when using `platformTheme` gtk2.

Fixes https://github.com/NixOS/nixpkgs/issues/244895

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
