### PR TITLE
shufflecake: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -189,6 +189,12 @@
     githubId = 43320117;
     name = "Sebastian Marquardt";
   };
+  _8aed = {
+    email = "8aed@riseup.net";
+    github = "8aed";
+    githubId = 140662578;
+    name = "Huit Aed";
+  };
   _9999years = {
     email = "rbt@fastmail.com";
     github = "9999years";

--- a/pkgs/os-specific/linux/shufflecake/default.nix
+++ b/pkgs/os-specific/linux/shufflecake/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchFromGitHub, kernel, kmod, lvm2, libgcrypt }:
+
+stdenv.mkDerivation rec {
+  pname = "shufflecake";
+  version = "0.4.0";
+  src = builtins.fetchGit {
+    url = "https://codeberg.org/shufflecake/shufflecake-c.git";
+    ref = "refs/tags/v${version}";
+  };
+
+  hardeningDisable = [ "pic" "format" ];
+  makeFlags = [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  installPhase = ''
+    make -C dm-sflc install \
+      KERNELRELEASE=${kernel.modDirVersion} \
+      KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \
+      INSTALL_MOD_PATH=$out
+    mkdir $out/bin
+    cp ./shufflecake $out/bin
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  buildInputs = [ lvm2 libgcrypt ];
+
+  meta = with lib; {
+    description = "Shufflecake is a plausible deniability (hidden storage) layer for Linux.";
+    homepage = "https://codeberg.org/shufflecake/shufflecake-c.git";
+    license = licenses.gpl2;
+    maintainers = [ maintainers."8aed" ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
