### PR TITLE
retroarch: include dosbox-pure core

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -360,6 +360,17 @@ in
     };
   };
 
+  dosbox-pure = mkLibretroCore {
+    core = "dosbox-pure";
+    CXXFLAGS = "-std=gnu++11";
+    hardeningDisable = [ "format" ];
+    makefile = "Makefile";
+    meta = {
+      description = "Port of DOSBox to libretro aiming for simplicity and ease of use.";
+      license = lib.licenses.gpl2Only;
+    };
+  };
+
   eightyone = mkLibretroCore {
     core = "81";
     src = getCoreSrc "eightyone";

--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -1,9 +1,9 @@
 {
     "2048": {
-      "owner": "libretro",
-      "repo": "libretro-2048",
-      "rev": "331c1de588ed8f8c370dcbc488e5434a3c09f0f2",
-      "hash": "sha256-gPrAmoBnfuTnW6t699pqS43vE6t0ca3jZcqTNRaJipA="
+        "owner": "libretro",
+        "repo": "libretro-2048",
+        "rev": "331c1de588ed8f8c370dcbc488e5434a3c09f0f2",
+        "hash": "sha256-gPrAmoBnfuTnW6t699pqS43vE6t0ca3jZcqTNRaJipA="
     },
     "atari800": {
         "owner": "libretro",
@@ -143,6 +143,12 @@
         "repo": "dosbox-libretro",
         "rev": "b7b24262c282c0caef2368c87323ff8c381b3102",
         "hash": "sha256-PG2eElenlEpu0U/NIh53p0uLqewnEdaq6Aoak5E1P3I="
+    },
+    "dosbox-pure": {
+        "owner": "schellingb",
+        "repo": "dosbox-pure",
+        "rev": "035e01e43623f83a9e71f362364fd74091379455",
+        "hash": "sha256-j7Or4yTK5l+ZVC5UFeym9sLx+88PRlofoBT1tMuf31A="
     },
     "eightyone": {
         "owner": "libretro",

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -36,6 +36,7 @@ CORES = {
     "desmume2015": {"repo": "desmume2015"},
     "dolphin": {"repo": "dolphin"},
     "dosbox": {"repo": "dosbox-libretro"},
+    "dosbox-pure": {"repo": "dosbox-pure", "owner": "schellingb"},
     "eightyone": {"repo": "81-libretro"},
     "fbalpha2012": {"repo": "fbalpha2012"},
     "fbneo": {"repo": "fbneo"},


### PR DESCRIPTION
###### Description of changes

I've included the `dosbox-pure` core to the retroarch infrastructure. This core has some useful features such a robust controller support, loading games from archives and saving changes to directory structures to archives.

Upstream is [here](https://github.com/schellingb/dosbox-pure).

I loaded up DOOM 1993's shareware as a test and it worked just fine.

Some outstanding questions:
1. Even though the libretro github organization has a fork of dosbox-pure (as [libretro/dosbox-pure](https://github.com/libretro/dosbox-pure)) I decided to define the source as the upstream author, since this mirrors how the PPSSPP core is handled (it fetches from hrygard/ppsspp instead of libretro/ppsspp). Is this okay?
2. I wasn't sure exactly how often or when the core hashes are updated, so I decided to pin the current version on the last commit **before** the last hash refresh happened (which seemed to be around mid-march?). Future updates to the hashes can then pull in the latest changes of this core. Hopefully that makes sense?

Thanks!

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
