### PR TITLE
swift: use stdenv libc++ on Darwin

### DIFF
--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -2,11 +2,14 @@
 , pkgs
 , newScope
 , darwin
+, llvmPackages
 , llvmPackages_15
 , overrideCC
 }:
 
 let
+  swiftLlvmPackages = llvmPackages_15;
+
   self = rec {
 
     callPackage = newScope self;
@@ -24,12 +27,25 @@ let
     # used in Swift, and applies the same libc overrides as `apple_sdk.stdenv`.
     clang = if pkgs.stdenv.isDarwin
       then
-        llvmPackages_15.clang.override rec {
+        swiftLlvmPackages.clang.override rec {
           libc = apple_sdk.Libsystem;
           bintools = pkgs.bintools.override { inherit libc; };
+          # Ensure that Swift’s internal clang uses the same libc++ and libc++abi as the
+          # default Darwin stdenv. Using the default libc++ avoids issues (such as crashes)
+          # that can happen when a Swift application dynamically links different versions
+          # of libc++ and libc++abi than libraries it links are using.
+          inherit (llvmPackages) libcxx;
+          extraPackages = [
+            llvmPackages.libcxxabi
+            # Use the compiler-rt associated with clang, but use the libc++abi from the stdenv
+            # to avoid linking against two different versions (for the same reasons as above).
+            (swiftLlvmPackages.compiler-rt.override {
+              inherit (llvmPackages) libcxxabi;
+            })
+          ];
         }
       else
-        llvmPackages_15.clang;
+        swiftLlvmPackages.clang;
 
     # Overrides that create a useful environment for swift packages, allowing
     # packaging with `swiftPackages.callPackage`. These are similar to


### PR DESCRIPTION
###### Description of changes

Swift uses libc++ 15, but it should really be using the same libc++ from the stdenv. While not strictly needed currently, Swift 5.9 will support C++ interop. If Swift is not using the stdenv C++, any C++ library used with interop would need to be rebuilt against the Swift libc++.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
