### PR TITLE
jfsw: init at 20211225

### DIFF
--- a/pkgs/games/jfsw/default.nix
+++ b/pkgs/games/jfsw/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, which
+, SDL2
+, perl
+, pkg-config
+, wrapGAppsHook
+, gtk3
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jfsw";
+  version = "20211225";
+
+  src = fetchFromGitHub {
+    owner = "jonof";
+    repo = "jfsw";
+    rev = "refs/tags/${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-oRJHVsVo+KQfJyd8TcPxTMPPi993qxQb0wnD9nR4vJY=";
+  };
+
+  nativeBuildInputs = [
+    which
+    SDL2
+    perl
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    SDL2
+    gtk3
+  ];
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 sw -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Modern port the original Shadow Warrior";
+    homepage = "http://www.jonof.id.au/jfsw/";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "sw";
+    maintainers = with lib.maintainers; [ moody ];
+    broken = stdenv.isDarwin;
+    inherit (SDL2.meta) platforms;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37494,6 +37494,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };
 
+  jfsw = callPackage ../games/jfsw { };
+
   katago = callPackage ../games/katago { };
 
   katagoWithCuda = katago.override {


### PR DESCRIPTION
###### Description of changes

Adds jfsw, a modern port of the classic shadow warrior DOS game.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
