### PR TITLE
scdoc: refactor

### DIFF
--- a/pkgs/tools/typesetting/scdoc/default.nix
+++ b/pkgs/tools/typesetting/scdoc/default.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ primeos AndersonTorres ];
     platforms = lib.platforms.unix;
+    mainProgram = "scdoc";
   };
 })

--- a/pkgs/tools/typesetting/scdoc/default.nix
+++ b/pkgs/tools/typesetting/scdoc/default.nix
@@ -1,38 +1,41 @@
-{ lib, stdenv, fetchFromSourcehut, buildPackages }:
+{ lib
+, stdenv
+, fetchFromSourcehut
+, buildPackages
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "scdoc";
   version = "1.11.2";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
-    repo = pname;
-    rev = version;
-    sha256 = "07c2vmdgqifbynm19zjnrk7h102pzrriv73izmx8pmd7b3xl5mfq";
+    repo = "scdoc";
+    rev = finalAttrs.version;
+    hash = "sha256-2NVC+1in1Yt6/XGcHXP+V4AAz8xW/hSq9ctF/Frdgh0=";
   };
+
+  outputs = [ "out" "man" "dev" ];
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace "-static" "" \
-      --replace "/usr/local" "$out"
+      --replace "-static" ""
   '';
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    "HOST_SCDOC=${buildPackages.scdoc}/bin/scdoc"
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "HOST_SCDOC=${lib.getExe buildPackages.scdoc}"
   ];
 
   doCheck = true;
 
-  meta = with lib; {
-    description = "A simple man page generator";
-    longDescription = ''
-      scdoc is a simple man page generator written for POSIX systems written in
-      C99.
-    '';
+  meta = {
+    description = "A simple man page generator written in C99 for POSIX systems";
     homepage = "https://git.sr.ht/~sircmpwn/scdoc";
-    changelog = "https://git.sr.ht/~sircmpwn/scdoc/refs/${version}";
-    license = licenses.mit;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ primeos ];
+    changelog = "https://git.sr.ht/~sircmpwn/scdoc/refs/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ primeos AndersonTorres ];
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
- one parameter per line
- use rec-less, overlay-style overridable recursive attributes (in effect since https://github.com/NixOS/nixpkgs/pull/119942)
- remove references to pname
- SRI hash
- multiple outputs
- remove with nesting (following https://nix.dev/anti-patterns/language#with-attrset-expression)
- simplify meta
- add myself as maintainer

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
