### PR TITLE
nbqa: init at 1.7.0

### DIFF
--- a/pkgs/tools/misc/blacken-docs/default.nix
+++ b/pkgs/tools/misc/blacken-docs/default.nix
@@ -1,0 +1,38 @@
+{ black
+, fetchFromGitHub
+, lib
+, python3
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "blacken-docs";
+  version = "1.15.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "adamchainz";
+    repo = "blacken-docs";
+    rev = version;
+    hash = "sha256-3FGuFOAHCcybPwujWlh58NWtuF5CebaKTgBWgCGpSL8=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+  ];
+
+  propagatedBuildInputs = [
+    black
+  ];
+
+  nativeCheckInputs = [
+    black
+    python3.pkgs.pytestCheckHook
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/adamchainz/blacken-docs";
+    changelog = "https://github.com/adamchainz/blacken-docs/blob/${src.rev}/CHANGELOG.rst";
+    description = "Run Black on Python code blocks in documentation files";
+    license = licenses.mit;
+    maintainers = with maintainers; [ l0b0 ];
+  };
+}

--- a/pkgs/tools/misc/nbqa/default.nix
+++ b/pkgs/tools/misc/nbqa/default.nix
@@ -1,0 +1,93 @@
+{ black
+, blacken-docs
+, fetchFromGitHub
+, lib
+, python3
+, ruff
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "nbqa";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "nbQA-dev";
+    repo = "nbQA";
+    rev = version;
+    hash = "sha256-CTF5HisBS44Ta18cVT04UrMIF30WmEBwZBGW7fkKXwk=";
+  };
+
+  passthru.optional-dependencies = {
+    black = [ black ];
+    blacken-docs = [ blacken-docs ];
+    flake8 = [ python3.pkgs.flake8 ];
+    isort = [ python3.pkgs.isort ];
+    jupytext = [ python3.pkgs.jupytext ];
+    mypy = [ python3.pkgs.mypy ];
+    pylint = [ python3.pkgs.pylint ];
+    pyupgrade = [ python3.pkgs.pyupgrade ];
+    ruff = [ ruff ];
+  };
+
+  propagatedBuildInputs = with python3.pkgs;
+    [
+      autopep8
+      ipython
+      tokenize-rt
+      tomli
+    ]
+    ++ builtins.attrValues passthru.optional-dependencies;
+
+  postPatch = ''
+    # Force using the Ruff executable rather than the Python package
+    substituteInPlace nbqa/__main__.py --replace 'if shell:' 'if shell or main_command == "ruff":'
+  '';
+
+  preCheck = ''
+    # Allow the tests to run `nbqa` itself from the path
+    export PATH="$out/bin":"$PATH"
+  '';
+
+  nativeCheckInputs =
+    [
+      black
+      ruff
+    ]
+    ++ (with python3.pkgs; [
+      autoflake
+      flake8
+      isort
+      jupytext
+      mdformat
+      pre-commit-hooks
+      pydocstyle
+      pylint
+      pytestCheckHook
+      pyupgrade
+      yapf
+    ]);
+
+  disabledTests = [
+    # Test data not found
+    "test_black_multiple_files"
+    "test_black_return_code"
+    "test_grep"
+    "test_jupytext_on_folder"
+    "test_mypy_works"
+    "test_running_in_different_dir_works"
+    "test_unable_to_reconstruct_message_pythonpath"
+    "test_with_subcommand"
+  ];
+
+  disabledTestPaths = [
+    # Test data not found
+    "tests/test_include_exclude.py"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nbQA-dev/nbQA";
+    changelog = "https://nbqa.readthedocs.io/en/latest/history.html";
+    description = "Run ruff, isort, pyupgrade, mypy, pylint, flake8, black, blacken-docs, and more on Jupyter Notebooks";
+    license = licenses.mit;
+    maintainers = with maintainers; [ l0b0 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6916,6 +6916,8 @@ with pkgs;
 
   bbin = callPackage ../development/tools/bbin { };
 
+  blacken-docs = callPackage ../tools/misc/blacken-docs { };
+
   bore = callPackage ../tools/networking/bore {
     inherit (darwin) Libsystem;
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10991,6 +10991,8 @@ with pkgs;
 
   nb = callPackage ../tools/misc/nb { };
 
+  nbqa = callPackage ../tools/misc/nbqa { };
+
   kb = callPackage ../tools/misc/kb { };
 
   notable = callPackage ../applications/misc/notable { };


### PR DESCRIPTION
###### Description of changes

Jupyter Notebook linter/formatter runner. From the [project](https://github.com/nbQA-dev/nbQA):

>  Run ruff, isort, pyupgrade, mypy, pylint, flake8, and more on Jupyter Notebooks

Closes #210444.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).