### PR TITLE
smtprelay: init at 1.10.0

### DIFF
--- a/pkgs/servers/mail/smtprelay/default.nix
+++ b/pkgs/servers/mail/smtprelay/default.nix
@@ -1,4 +1,8 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
 buildGoModule rec {
   pname = "smtprelay";
   version = "1.10.0";
@@ -6,7 +10,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "decke";
     repo = "smtprelay";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-zZ3rgbo8nvrpFMtUmhyXnTgoVd0FIh1kWzuM2hCh5gY=";
   };
 
@@ -15,11 +19,16 @@ buildGoModule rec {
   CGO_ENABLED = 0;
 
   # We do not supply the build time as the build wouldn't be reproducible otherwise.
-  ldflags = [ "-s" "-w" "-X main.appVersion=v${version}" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.appVersion=v${version}"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/decke/smtprelay";
     description = "Simple Golang SMTP relay/proxy server";
+    changelog = "https://github.com/decke/smtprelay/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ juliusrickert ];
   };

--- a/pkgs/servers/mail/smtprelay/default.nix
+++ b/pkgs/servers/mail/smtprelay/default.nix
@@ -16,6 +16,10 @@ buildGoModule rec {
 
   vendorHash = "sha256-assGzM8/APNVVm2vZapPK6sh3tWNTnw6PSFwvEqNDPk=";
 
+  subPackages = [
+    "."
+  ];
+
   CGO_ENABLED = 0;
 
   # We do not supply the build time as the build wouldn't be reproducible otherwise.

--- a/pkgs/servers/mail/smtprelay/default.nix
+++ b/pkgs/servers/mail/smtprelay/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+buildGoModule rec {
+  pname = "smtprelay";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "decke";
+    repo = "smtprelay";
+    rev = "v${version}";
+    hash = "sha256-zZ3rgbo8nvrpFMtUmhyXnTgoVd0FIh1kWzuM2hCh5gY=";
+  };
+
+  vendorHash = "sha256-assGzM8/APNVVm2vZapPK6sh3tWNTnw6PSFwvEqNDPk=";
+
+  CGO_ENABLED = 0;
+
+  # We do not supply the build time as the build wouldn't be reproducible otherwise.
+  ldflags = [ "-s" "-w" "-X main.appVersion=v${version}" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/decke/smtprelay";
+    description = "Simple Golang SMTP relay/proxy server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ juliusrickert ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26579,6 +26579,8 @@ with pkgs;
 
   quark = callPackage ../servers/http/quark { };
 
+  smtprelay = callPackage ../servers/mail/smtprelay { };
+
   soft-serve = callPackage ../servers/soft-serve { };
 
   sympa = callPackage ../servers/mail/sympa { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

_smtprelay_ is a simple SMTP relay server written in Go.

https://github.com/decke/smtprelay

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
