### PR TITLE
nixos/frigate: fix recording and serving of clips/recordings

### DIFF
--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -322,6 +322,16 @@ in
       '';
     };
 
+    systemd.services.nginx.serviceConfig.SupplementaryGroups = [
+      "frigate"
+    ];
+
+    users.users.frigate = {
+      isSystemUser = true;
+      group = "frigate";
+    };
+    users.groups.frigate = {};
+
     systemd.services.frigate = {
       after = [
         "go2rtc.service"
@@ -349,15 +359,18 @@ in
       serviceConfig = {
         ExecStart = "${cfg.package.python.interpreter} -m frigate";
 
-        DynamicUser = true;
         User = "frigate";
+        Group = "frigate";
+
+        UMask = "0027";
 
         StateDirectory = "frigate";
-        UMask = "0077";
+        StateDirectoryMode = "0750";
 
         # Caches
         PrivateTmp = true;
         CacheDirectory = "frigate";
+        CacheDirectoryMode = "0750";
 
         BindPaths = [
           "/migrations:${cfg.package}/share/frigate/migrations:ro"


### PR DESCRIPTION
Frigate does string prefix matching for paths, which isn't exactly compatible with dynamically provisioned directories of systemd, where /var/cache/frigate is actually a symlink to /var/cache/private/frigate.

Because we are unlikely to get this fixed upstream, this is one of the reason we should stop using DynamicUser= here.

The other being, that nginx needs to be able to serve clips and recordings from both the CacheDirectory and the StateDirectory, and nginx being a member on a group that may only exist after it was started up doesn't work reliably.

This is also why we relax the umask to allow g+r/g+rx for newly created files. Existing installs may need the following permissions fix to get things going.

```
find /var/lib/frigate/recordings -type d -exec chmod g+rx {} \;
find /var/lib/frigate/recordings -type f -exec chmod g+r {} \;
find /var/cache/frigate -type f -exec chmod g+r {} \;
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
