### PR TITLE
libgudev: fix cross failing to build checks

### DIFF
--- a/pkgs/development/libraries/libgudev/default.nix
+++ b/pkgs/development/libraries/libgudev/default.nix
@@ -9,7 +9,6 @@
 , gnome
 , vala
 , gobject-introspection
-, fetchpatch
 , glibcLocales
 , umockdev
 }:
@@ -44,6 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
   checkInputs = [
     glibcLocales
     umockdev
+  ];
+
+  mesonFlags = [
+    (lib.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = true;


### PR DESCRIPTION
###### Description of changes

Since `doCheck` is still forced off for cross<sup>[1]</sup>, `checkInputs` do not get added to `buildInputs`. Prior to this change libgudev still tries to build the tests and fails because it can't find `umockdev`

Forcing tests off when `doCheck` is forcibly turned off fixes the `libgudev` build after #241939

[1]: https://github.com/NixOS/nixpkgs/blob/bdddb46f4b058465ad53134d4a118671f9956662/pkgs/stdenv/generic/make-derivation.nix#L171

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-linux -> aarch64-linux (cross)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).