### PR TITLE
Revert "pkgs.formats.toml: fix TOML semantics by upgrading tomlkit"

### DIFF
--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -11,6 +11,7 @@
 , pytest-mock
 , pytestCheckHook
 , setuptools
+, tomlkit
 , virtualenv
 }:
 
@@ -53,6 +54,7 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
     setuptools
+    tomlkit
     virtualenv
   ];
 

--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -6,20 +6,16 @@
 , functools32, typing ? null
 , pytestCheckHook
 , pyaml
-, poetry-core
 }:
 
 buildPythonPackage rec {
   pname = "tomlkit";
-  version = "0.11.8";
-  format = "pyproject";
+  version = "0.11.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-kzD8f6odtntUGyjmIBjBfSC+czF30pChOyTGLRYU4MM=";
+    hash = "sha256-cblS5XIWiJN/sCz501TbzweFBmFJ0oVeRFMevdK2XXM=";
   };
-
-  nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs =
     lib.optionals isPy27 [ enum34 functools32 ]

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -219,35 +219,6 @@ in runBuildTests {
     '';
   };
 
-  # see https://github.com/NixOS/nixpkgs/issues/237521 for this particular test
-  testTomlSemantics = {
-    drv = evalFormat formats.toml {} {
-      processors = {
-        override = [
-          { tags = { cluster = "staging"; }; }
-        ];
-        rename = [
-          {
-            replace = [
-              { dest = "ceph_telegraf_check"; measurement = "exec"; }
-            ];
-          }
-        ];
-      };
-    };
-    expected = ''
-      [processors]
-      [[processors.override]]
-      [processors.override.tags]
-      cluster = "staging"
-
-      [[processors.rename]]
-      [[processors.rename.replace]]
-      dest = "ceph_telegraf_check"
-      measurement = "exec"
-    '';
-  };
-
   # This test is responsible for
   #   1. testing type coercions
   #   2. providing a more readable example test


### PR DESCRIPTION
Reverts NixOS/nixpkgs#245440

Caused too many rebuilds, broke pylint and by extension all nixos tests, and as such created a channel blocker.