### PR TITLE
libsForQt5.qmltermwidget: Adopt, cleanups, make Lomiri-compatible

### DIFF
--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , qmake
 , qtbase
 , qtquick1
@@ -30,6 +31,15 @@ stdenv.mkDerivation {
   ] ++ lib.optional stdenv.isDarwin utmp;
 
   patches = [
+    # Changes required to make it compatible with lomiri-terminal-app
+    # QML-exposed colorscheme, scrollbar & clipboard functionality
+    # Remove when https://github.com/Swordfish90/qmltermwidget/pull/39 merged
+    (fetchpatch {
+      name = "0001-qmltermwidget-lomiri-submissions.patch";
+      url = "https://github.com/Swordfish90/qmltermwidget/compare/63228027e1f97c24abb907550b22ee91836929c5..ffc6b2b2a20ca785f93300eca93c25c4b74ece17.patch";
+      hash = "sha256-1GjC2mdfP3NpePDWZaT8zvIq3vwWIZs+iQ9o01iQtD4=";
+    })
+
     # Some files are copied twice to the output which makes the build fails
     ./do-not-copy-artifacts-twice.patch
   ];

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -1,9 +1,9 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, qmake
 , qtbase
 , qtquick1
-, qmake
 , qtmultimedia
 , utmp
 }:
@@ -13,13 +13,15 @@ stdenv.mkDerivation {
   version = "unstable-2022-01-09";
 
   src = fetchFromGitHub {
-    repo = "qmltermwidget";
     owner = "Swordfish90";
+    repo = "qmltermwidget";
     rev = "63228027e1f97c24abb907550b22ee91836929c5";
     hash = "sha256-aVaiRpkYvuyomdkQYAgjIfi6a3wG2a6hNH1CfkA2WKQ=";
   };
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    qmake
+  ];
 
   buildInputs = [
     qtbase
@@ -34,17 +36,15 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace qmltermwidget.pro \
-      --replace '$$[QT_INSTALL_QML]' "/$qtQmlPrefix/"
+      --replace '$$[QT_INSTALL_QML]' '$$PREFIX/${qtbase.qtQmlPrefix}/'
   '';
-
-  installFlags = [ "INSTALL_ROOT=${placeholder "out"}" ];
 
   dontWrapQtApps = true;
 
   meta = {
     description = "A QML port of qtermwidget";
     homepage = "https://github.com/Swordfish90/qmltermwidget";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = with lib.maintainers; [ OPNA2608 ];
   };

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/Swordfish90/qmltermwidget";
     license = lib.licenses.gpl2;
     platforms = with lib.platforms; linux ++ darwin;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ OPNA2608 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Working towards #99090.

`lomiri-terminal-app` needs a `qmltermwidget` that exposes certain interfaces, and `qmltermwidget` was recently orphaned. This PR assigns the package to me, does some small cleanups, and pulls in the patches required to make it Lomiri-compatible.

- Adopt
- Clarify license from GPL-2 to specifically GPL-2+
- Don't set `INSTALL_ROOT` as a substitute for using the `PREFIX`, not what that variable is for (it works like `DESTDIR`)
- Pull in patches that allow `lomiri-terminal-app` to use this version of `qmltermwidget`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
