### PR TITLE
cljfmt: init at 0.11.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16171,6 +16171,13 @@
     githubId = 75371;
     name = "Stig Palmquist";
   };
+  sg-qwt = {
+    email = "hello@edgerunners.eu.org";
+    matrix = "@dhl:edgerunners.eu.org";
+    github = "sg-qwt";
+    name = "sg-qwt";
+    githubId = 115715554;
+  };
   sgraf = {
     email = "sgraf1337@gmail.com";
     github = "sgraf812";

--- a/pkgs/by-name/cl/cljfmt/package.nix
+++ b/pkgs/by-name/cl/cljfmt/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildGraalvmNativeImage
+, fetchurl
+, nix-update-script
+, testers
+, cljfmt
+}:
+
+buildGraalvmNativeImage rec {
+  pname = "cljfmt";
+  version = "0.11.2";
+
+  src = fetchurl {
+    url = "https://github.com/weavejester/${pname}/releases/download/${version}/${pname}-${version}-standalone.jar";
+    sha256 = "sha256-vEldQ7qV375mHMn3OUdn0FaPd+f/v9g+C+PuzbSTWtk=";
+  };
+
+  extraNativeImageBuildArgs = [
+    "-H:+ReportExceptionStackTraces"
+    "-H:Log=registerResource:"
+    "--initialize-at-build-time"
+    "--diagnostics-mode"
+    "--report-unsupported-elements-at-runtime"
+    "--no-fallback"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  passthru.tests.version = testers.testVersion {
+    inherit version;
+    package = cljfmt;
+    command = "cljfmt --version";
+  };
+
+  meta = with lib; {
+    mainProgram = "cljfmt";
+    description = "A tool for formatting Clojure code";
+    homepage = "https://github.com/weavejester/cljfmt";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    license = licenses.epl10;
+    changelog = "https://github.com/weavejester/cljfmt/blob/${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ sg-qwt ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

A tool for formatting Clojure code. This closes [#242986](https://github.com/NixOS/nixpkgs/issues/242986).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
