### PR TITLE
writers: use `callPackages` to import sub-groups of writers

### DIFF
--- a/pkgs/build-support/writers/data.nix
+++ b/pkgs/build-support/writers/data.nix
@@ -1,4 +1,4 @@
-{ lib, runCommandNoCC, dasel }:
+{ lib, runCommand, dasel }:
 let
   daselBin = lib.getExe dasel;
 
@@ -28,7 +28,7 @@ rec {
     let
       name = last (builtins.split "/" nameOrPath);
     in
-    runCommandNoCC name
+    runCommand name
       {
         input = input data;
         passAsFile = [ "input" ];

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -1,17 +1,13 @@
-{ pkgs, config, lib }:
+{ config, lib, callPackages }:
 
 let
   aliases = if config.allowAliases then (import ./aliases.nix lib) else prev: {};
 
   # Writers for JSON-like data structures
-  dataWriters = import ./data.nix {
-    inherit lib; inherit (pkgs) runCommandNoCC dasel;
-  };
+  dataWriters = callPackages ./data.nix { };
 
   # Writers for scripts
-  scriptWriters = import ./scripts.nix {
-    inherit lib pkgs;
-  };
+  scriptWriters = callPackages ./scripts.nix { };
 
   writers = scriptWriters // dataWriters;
 in

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib }:
+{ pkgs, buildPackages, lib, stdenv, libiconv, mkNugetDeps, mkNugetSource, gixy }:
 let
   inherit (lib)
     concatMapStringsSep
@@ -9,15 +9,6 @@ let
     stringLength
     strings
     types
-    ;
-
-  inherit (pkgs)
-    buildPackages
-    gixy
-    libiconv
-    mkNugetDeps
-    mkNugetSource
-    stdenv
     ;
 in
 rec {


### PR DESCRIPTION
###### Description of changes

Use `callPackages` instead of plain `import` to get proper splicing. Without this, `writeNginxConfig` fails when cross-compiling:

```
/nix/store/rgb5qi33s9gkp764067c5czsshvd70sn-gixy-0.1.20-armv6l-unknown-linux-gnueabihf/bin/.gixy-wrapped: /nix/store/rgb5qi33s9gkp764067c5czsshvd70sn-gixy-0.1.20-armv6l-unknown-linux-gnueabihf/bin/gixy: line 3: syntax error near unexpected token `lambda'
/nix/store/rgb5qi33s9gkp764067c5czsshvd70sn-gixy-0.1.20-armv6l-unknown-linux-gnueabihf/bin/.gixy-wrapped: /nix/store/rgb5qi33s9gkp764067c5czsshvd70sn-gixy-0.1.20-armv6l-unknown-linux-gnueabihf/bin/gixy: line 3: `import sys;import site;import functools;sys.argv[0] = '/nix/store/rgb5qi33s9gkp764067c5czsshvd70sn-gixy-0.1.20-armv6l-unknown-linux-gnueabihf/bin/gixy';functools.reduce(lambda k, p: site.addsitedir(p, k), ['/nix/store/rgb5qi33s9gkp764067c5czsshvd70sn-gixy-0.1.20-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/9wj8r2wkg9k498kbrmq5idd1ank76qlj-python3.10-cached-property-1.5.2-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/7zwq6d471517idl7pbx5dyk7jkj8gvhv-python3.10-configargparse-1.5.5-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/yh5vr25fbp2dyxl4nmlch6ls2n9ipgqp-python3.10-pyparsing-2.4.7-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/yd7jyxbb7hgfrvllzlwmg6l3sg008dsj-python3.10-Jinja2-3.1.2-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/hhfxy9c941696sfaamg8njbiqdz4i4y0-python3.10-babel-2.12.1-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/2sgrxhwc97gjs25gqs38mxkqjpr36mz6-python3.10-markupsafe-2.1.3-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/rr9gh0yhm2v9sdq929jlcr2k9dxqiaqa-python3.10-nose-1.3.7-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/az94m56lzk4p4va6y40yhfqf4mh1rb3j-python3.10-coverage-7.2.1-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/k49gqafjic5wbx7djlr15smjr0z4bysf-python3.10-setuptools-67.4.0-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages','/nix/store/20w5xp1miy5hlrl7f5pj8350561jpyw0-python3.10-six-1.16.0-armv6l-unknown-linux-gnueabihf/lib/python3.10/site-packages'], site._init_pathinfo());'
```

This fixes #244835, which split the writers into multiple files.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv6l-linux (cross)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @zimbatm @Lassulus 
