### PR TITLE
cudaPackages.autoAddOpenGLRunpathHook: fix to skip unsupported

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/auto-add-opengl-runpath-hook.sh
+++ b/pkgs/development/compilers/cudatoolkit/auto-add-opengl-runpath-hook.sh
@@ -1,14 +1,24 @@
-# Run autoOpenGLRunpath on all files
+# shellcheck shell=bash
+# Run addOpenGLRunpath on all dynamically linked, ELF files
 echo "Sourcing auto-add-opengl-runpath-hook"
 
-autoAddOpenGLRunpathPhase  () {
-    # TODO: support multiple outputs
-    for file in $(find ${out,lib,bin} -type f); do
-        addOpenGLRunpath $file
-    done
-}
+autoAddOpenGLRunpathPhase() (
+  local outputPaths
+  mapfile -t outputPaths < <(for o in $(getAllOutputNames); do echo "${!o}"; done)
+  find "${outputPaths[@]}" -type f -executable -print0  | while IFS= read -rd "" f; do
+    if isELF "$f"; then
+      # patchelf returns an error on statically linked ELF files
+      if patchelf --print-interpreter "$f" >/dev/null 2>&1; then
+        echo "autoAddOpenGLRunpathHook: patching $f"
+        addOpenGLRunpath "$f"
+      elif [ -n "${DEBUG-}" ]; then
+        echo "autoAddOpenGLRunpathHook: skipping ELF file $f"
+      fi
+    fi
+  done
+)
 
 if [ -z "${dontUseAutoAddOpenGLRunpath-}" ]; then
-    echo "Using autoAddOpenGLRunpathPhase"
-    postFixupHooks+=(autoAddOpenGLRunpathPhase)
+  echo "Using autoAddOpenGLRunpathPhase"
+  postFixupHooks+=(autoAddOpenGLRunpathPhase)
 fi

--- a/pkgs/os-specific/linux/dcgm/default.nix
+++ b/pkgs/os-specific/linux/dcgm/default.nix
@@ -104,6 +104,8 @@ in gcc11Stdenv.mkDerivation rec {
 
   hardeningDisable = [ "all" ];
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     # autoAddOpenGLRunpathHook does not actually depend on or incur any dependency
     # of cudaPackages. It merely adds an impure, non-Nix PATH to the RPATHs of
@@ -113,18 +115,16 @@ in gcc11Stdenv.mkDerivation rec {
     cmake
     git
     python3
-
-    jsoncpp-static
-    jsoncpp-static.dev
-    libevent-nossl-static
-    libevent-nossl-static.dev
-    plog.dev # header-only
-    tclap_1_4 # header-only
   ];
 
   buildInputs = [
+    plog.dev # header-only
+    tclap_1_4 # header-only
+
     catch2
     fmt_9
+    jsoncpp-static
+    libevent-nossl-static
     yaml-cpp
   ];
 

--- a/pkgs/os-specific/linux/dcgm/default.nix
+++ b/pkgs/os-specific/linux/dcgm/default.nix
@@ -105,7 +105,11 @@ in gcc11Stdenv.mkDerivation rec {
   hardeningDisable = [ "all" ];
 
   nativeBuildInputs = [
-    addOpenGLRunpath
+    # autoAddOpenGLRunpathHook does not actually depend on or incur any dependency
+    # of cudaPackages. It merely adds an impure, non-Nix PATH to the RPATHs of
+    # executables that need to use cuda at runtime.
+    cudaPackages_12.autoAddOpenGLRunpathHook
+
     cmake
     git
     python3
@@ -123,16 +127,6 @@ in gcc11Stdenv.mkDerivation rec {
     fmt_9
     yaml-cpp
   ];
-
-  # libcuda.so must be found at runtime because it is supplied by the NVIDIA
-  # driver. autoAddOpenGLRunpathHook breaks on the statically linked exes.
-  postFixup = ''
-    find "$out/bin" "$out/lib" -type f -executable -print0 | while IFS= read -r -d "" f; do
-      if isELF "$f" && [[ $(patchelf --print-needed "$f" || true) == *libcuda.so* ]]; then
-        addOpenGLRunpath "$f"
-      fi
-    done
-  '';
 
   disallowedReferences = lib.concatMap (x: x.pkgSet) cudaPackageSetByVersion;
 


### PR DESCRIPTION
###### Description of changes

`cudaPackages.autoAddOpenGLRunpathHook` is far too liberal about what it attempts to patch. For this reason, it currently fails when run on a package that has statically linked executables.

This rewrite does 3 things:
  1. Fixes a TODO about supporting multiple outputs
  2. Fixes use cases where the package contains statically linked executables in one of those outputs
  3. ~~Limits which executables get patched based on their `DT_NEEDED`s~~

~~Points 1 and 2 are non-controversial. However, point 3 has potential fallout or unintended consequences that must be reviewed/considered. For example, while the current `autoAddOpenGLRunpathHook` patches 690 files in the `cudaPackages` set, this version patches only 9 files. (This was determined by instrumenting the hook, manually building before/after versions, and inspecting the logs.[^1])~~

~~If the idea of limiting the patching behavior is acceptable, we may need to tune it to patch the right things.~~

**EDIT: Feature 3 was removed.**

[^1]: I used `nix-build -E 'with import ./. {}; lib.mapAttrs (n: v: if builtins.any (x: x == "x86_64-linux") v.meta.platforms or [] then v else null) cudaPackages' --keep-going |& tee after.txt` and then `grep 'autoAddOpenGLRunpathHook: Patching' after.txt | wc -l`.

cc @NixOS/cuda-maintainers @samuela 

This is follow-up from https://github.com/NixOS/nixpkgs/pull/235024#discussion_r1268701481.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
