### PR TITLE
lomiri.lomiri-app-launch: init at 0.1.8

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -21,6 +21,7 @@ let
     #### Services
     biometryd = callPackage ./services/biometryd { };
     hfd-service = callPackage ./services/hfd-service { };
+    lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
   };
 in
   lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
@@ -1,0 +1,129 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, testers
+, cmake
+, cmake-extras
+, curl
+, dbus
+, dbus-test-runner
+, dpkg
+, gobject-introspection
+, gtest
+, json-glib
+, libxkbcommon
+, lomiri-api
+, lttng-ust
+, pkg-config
+, properties-cpp
+, python3
+, systemd
+, ubports-click
+, zeitgeist
+, withDocumentation ? true
+, doxygen
+, python3Packages
+, sphinx
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-app-launch";
+  version = "0.1.8";
+
+  outputs = [
+    "out"
+    "dev"
+  ] ++ lib.optionals withDocumentation [
+    "doc"
+  ];
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-app-launch";
+    rev = finalAttrs.version;
+    hash = "sha256-NIBZk5H0bPwAwkI0Qiq2S9dZvchAFPBCHKi2inUVZmI=";
+  };
+
+  postPatch = ''
+    patchShebangs tests/{desktop-hook-test.sh.in,repeat-until-pass.sh}
+
+    # used pkg_get_variable, cannot replace prefix
+    substituteInPlace data/CMakeLists.txt \
+      --replace 'DESTINATION "''${SYSTEMD_USER_UNIT_DIR}"' 'DESTINATION "${placeholder "out"}/lib/systemd/user"'
+
+    substituteInPlace tests/jobs-systemd.cpp \
+      --replace '^(/usr)?' '^(/nix/store/\\w+-bash-.+)?'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    dpkg # for setting LOMIRI_APP_LAUNCH_ARCH
+    gobject-introspection
+    pkg-config
+  ] ++ lib.optionals withDocumentation [
+    doxygen
+    python3Packages.breathe
+    sphinx
+  ];
+
+  buildInputs = [
+    cmake-extras
+    curl
+    dbus
+    json-glib
+    libxkbcommon
+    lomiri-api
+    lttng-ust
+    properties-cpp
+    systemd
+    ubports-click
+    zeitgeist
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+  ];
+
+  checkInputs = [
+    dbus-test-runner
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_MIRCLIENT=OFF"
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+  ];
+
+  postBuild = lib.optionalString withDocumentation ''
+    make -C ../docs html
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  postInstall = lib.optionalString withDocumentation ''
+    mkdir -p $doc/share/doc/lomiri-app-launch
+    mv ../docs/_build/html $doc/share/doc/lomiri-app-launch/
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "System and associated utilities to launch applications in a standard and confined way";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-app-launch";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "lomiri-app-launch-0"
+    ];
+  };
+})


### PR DESCRIPTION
###### Description of changes

Working towards #99090.

[Lomiri App Launch](https://gitlab.com/ubports/development/core/lomiri-app-launch), an abstraction layer to start & stop applications. Required by some inter-process (Content Hub, Lomiri URL Dispatcher) and top-level systems (Lomiri itself, QtMir), mostly to uhh… launch apps :stuck_out_tongue:.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
