### PR TITLE
texlive: fix build with clang 16

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -102,6 +102,12 @@ core = stdenv.mkDerivation rec {
     perl
   ];
 
+  patches = [
+    # Fix implicit `int` on `main`, which results in an error when building with clang 16.
+    # This is fixed upstream and can be dropped with the 2023 release.
+    ./fix-implicit-int.patch
+  ];
+
   hardeningDisable = [ "format" ];
 
   preConfigure = ''
@@ -224,6 +230,9 @@ core-big = stdenv.mkDerivation { #TODO: upmendex
       stripLen = 1;
       extraPrefix = "libs/luajit/LuaJIT-src/";
     })
+    # Fix implicit `int` on `main`, which results in an error when building with clang 16.
+    # This is fixed upstream and can be dropped with the 2023 release.
+    ./fix-implicit-int.patch
   ];
 
   hardeningDisable = [ "format" ];

--- a/pkgs/tools/typesetting/tex/texlive/fix-implicit-int.patch
+++ b/pkgs/tools/typesetting/tex/texlive/fix-implicit-int.patch
@@ -1,0 +1,22 @@
+diff -ur a/utils/m-tx/mtx-src/prepmx.c b/utils/m-tx/mtx-src/prepmx.c
+--- a/utils/m-tx/mtx-src/prepmx.c	2018-04-28 17:56:18.000000000 -0600
++++ b/utils/m-tx/mtx-src/prepmx.c	2023-07-11 15:21:26.351024424 -0600
+@@ -769,6 +769,7 @@
+ }
+ 
+ 
++int
+ main(int argc, Char *argv[])
+ {  /* ---- Main program ------------------------ */
+   PASCAL_MAIN(argc, argv);
+diff -ur a/utils/pmx/pmx-src/libf2c/main.c b/utils/pmx/pmx-src/libf2c/main.c
+--- a/utils/pmx/pmx-src/libf2c/main.c	2016-02-09 22:31:26.000000000 -0700
++++ b/utils/pmx/pmx-src/libf2c/main.c	2023-07-11 15:49:35.043438384 -0600
+@@ -106,6 +106,7 @@
+ #ifdef KR_headers
+ main(argc, argv) int argc; char **argv;
+ #else
++int
+ main(int argc, char **argv)
+ #endif
+ {


### PR DESCRIPTION
###### Description of changes

There are two instances of `main` with an implicit `int` return type. This is fixed upstream, so this patch is to allow texlive-2022 to build until texlive-2023 is merged into nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
