### PR TITLE
ocamlPackages.{trace,trace-tef}: init at 0.2

### DIFF
--- a/pkgs/development/ocaml-modules/trace/default.nix
+++ b/pkgs/development/ocaml-modules/trace/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchurl, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "trace";
+  version = "0.2";
+
+  minimalOCamlVersion = "4.05";
+
+  src = fetchurl {
+    url = "https://github.com/c-cube/trace/releases/download/v${version}/trace-${version}.tbz";
+    hash = "sha256-iScnZxjgzDqZFxbDDXB0K4TkdDJDcrMC03sK/ltbqJQ=";
+  };
+
+  meta = {
+    description = "Common interface for tracing/instrumentation libraries in OCaml";
+    license = lib.licenses.mit;
+    homepage = "https://c-cube.github.io/trace/";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/trace/tef.nix
+++ b/pkgs/development/ocaml-modules/trace/tef.nix
@@ -1,0 +1,15 @@
+{ buildDunePackage, trace, mtime }:
+
+buildDunePackage {
+  pname = "trace-tef";
+  inherit (trace) src version;
+
+  propagatedBuildInputs = [ mtime trace ];
+
+  doCheck = true;
+
+  meta = trace.meta // {
+    description = "A simple backend for trace, emitting Catapult JSON into a file";
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1640,6 +1640,10 @@ let
       inherit (pkgs.python3Packages) torch;
     };
 
+    trace = callPackage ../development/ocaml-modules/trace { };
+
+    trace-tef = callPackage ../development/ocaml-modules/trace/tef.nix { };
+
     trie = callPackage ../development/ocaml-modules/trie { };
 
     tsdl = callPackage ../development/ocaml-modules/tsdl {


### PR DESCRIPTION
###### Description of changes

> Common interface for tracing/instrumentation libraries in OCaml

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

