### PR TITLE
init: zetta at unstable-2023-06-16

### DIFF
--- a/pkgs/tools/misc/zetta/default.nix
+++ b/pkgs/tools/misc/zetta/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, gitSupport ? true
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, cmake
+, pandoc
+, pkg-config
+, zlib
+, Security
+, libiconv
+, installShellFiles
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "zetta";
+  version = "unstable-2023-06-16";
+
+  src = fetchFromGitHub {
+    owner = "syphar";
+    repo = "zetta";
+    rev = "0f39fffa164b62d97d599cd718bee81ca080ed56";
+    hash = "sha256-2pNp1AHPZCvLt5de8+OJfazi8WmApLbPMgCF/kIXV90=";
+  };
+
+  cargoHash = "sha256-qgZhp6EkgSma/hdakaE65VkH4UbwLkxav7a9xnWJDhs=";
+
+  nativeBuildInputs = [ cmake pkg-config installShellFiles pandoc ];
+  buildInputs = [ zlib ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = lib.optional gitSupport "git";
+
+  outputs = [ "out" "man" ];
+
+  # BLOCKED: upstream has to update man/exa.1.md to man/zetta.1.md etc.
+  # BLOCKED: upstream has to update completions
+  postInstall = ''
+    pandoc --standalone -f markdown -t man man/exa.1.md > man/zetta.1
+    pandoc --standalone -f markdown -t man man/exa_colors.5.md > man/zetta_colors.5
+    installManPage man/zetta.1 man/zetta_colors.5
+    # installShellCompletion \
+    #   --bash completions/bash/exa \
+    #   --fish completions/fish/exa.fish \
+    #   --zsh completions/zsh/_exa
+  '';
+
+  meta = with lib; {
+    description = "Replacement for 'ls' written in Rust";
+    longDescription = ''
+      zetta builds on the awesome foundation of exa so we can add more features.
+      When exa becomes maintained again, features could be merged back.
+    '';
+    changelog = "https://github.com/syphar/zetta/releases";
+    homepage = "https://github.com/syphar/zetta";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cafkafk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7757,6 +7757,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  zetta = callPackage ../tools/misc/zetta {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   exactaudiocopy = callPackage ../applications/audio/exact-audio-copy { };
 
   exempi = callPackage ../development/libraries/exempi { };


### PR DESCRIPTION
###### Description of changes
Due to exa being unmaintained, a interim fork has emerged https://github.com/ogham/exa/issues/1139#issuecomment-1655211406.

This PR adds a basic package definition for the fork (https://github.com/syphar/zetta)

###### Limitations
- No autocompletion support yet (waiting on upstream).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
