### PR TITLE
firefox_decrypt: unstable-2023-07-06 -> 1.1.0

### DIFF
--- a/pkgs/tools/security/firefox_decrypt/default.nix
+++ b/pkgs/tools/security/firefox_decrypt/default.nix
@@ -8,15 +8,15 @@
 
 buildPythonApplication rec {
   pname = "firefox_decrypt";
-  version = "unstable-2023-07-06";
+  version = "1.1.0";
 
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "unode";
     repo = pname;
-    rev = "2c61b27e6754cdf6a518ea617d05433f5ccf9f39";
-    sha256 = "sha256-/Q6ET6NJ23eYo0ywYMY5TPYpzPHGDzH5+wEpFdsibh8=";
+    rev = "0931c0484d7429f7d4de3a2f5b62b01b7924b49f";
+    sha256 = "sha256-9HbH8DvHzmlem0XnDbcrIsMQRBuf82cHObqpLzQxNZM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

see <https://github.com/NixOS/nixpkgs/pull/245755#pullrequestreview-1551696648>

> There is [virtually no difference](https://github.com/unode/firefox_decrypt/compare/1.1.0...a3b981efa86ce53503ddbbbd9181ea430965d148) between version [1.1.0](https://github.com/unode/firefox_decrypt/releases/tag/1.1.0) and <https://github.com/unode/firefox_decrypt/commit/a3b981efa86ce53503ddbbbd9181ea430965d148> so we can just use 1.1.0 this time.
> 
> If we use the commit hash in `fetchFromGitHub { rev = ...` instead of `version` then _nix-update_ can still update the package correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
