### PR TITLE
dnscrypt-wrapper fixes

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -214,7 +214,7 @@ in {
   disable-installer-tools = handleTest ./disable-installer-tools.nix {};
   discourse = handleTest ./discourse.nix {};
   dnscrypt-proxy2 = handleTestOn ["x86_64-linux"] ./dnscrypt-proxy2.nix {};
-  dnscrypt-wrapper = handleTestOn ["x86_64-linux"] ./dnscrypt-wrapper {};
+  dnscrypt-wrapper = runTestOn ["x86_64-linux"] ./dnscrypt-wrapper;
   dnsdist = handleTest ./dnsdist.nix {};
   doas = handleTest ./doas.nix {};
   docker = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker.nix {};

--- a/pkgs/tools/networking/dnscrypt-wrapper/default.nix
+++ b/pkgs/tools/networking/dnscrypt-wrapper/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libsodium, libevent }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libsodium, libevent, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "dnscrypt-wrapper";
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ libsodium libevent ];
+
+  passthru.tests = {
+    inherit (nixosTests) dnscrypt-wrapper;
+  };
 
   meta = with lib; {
     description = "A tool for adding dnscrypt support to any name resolver";

--- a/pkgs/tools/networking/dnscrypt-wrapper/default.nix
+++ b/pkgs/tools/networking/dnscrypt-wrapper/default.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # causes `dnscrypt-wrapper --gen-provider-keypair` to crash
+  hardeningDisable = [ "fortify3" ];
+
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ libsodium libevent ];
 


### PR DESCRIPTION
###### Description of changes

Fix dnscrypt-wrapper functionality and flaky NixOS test

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested `nixosTests.dnscrypt-wrapper`
- [x] Tested compilation of all packages that depend on this change (only `dnscrypt-wrapper`)
- [x] Tested basic functionality of all binary files
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
