### PR TITLE
{wlcs,mir}: Bump to newer versions

### DIFF
--- a/pkgs/development/tools/wlcs/default.nix
+++ b/pkgs/development/tools/wlcs/default.nix
@@ -2,7 +2,6 @@
 , lib
 , gitUpdater
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , pkg-config
 , boost
@@ -12,24 +11,14 @@
 
 stdenv.mkDerivation rec {
   pname = "wlcs";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "MirServer";
     repo = "wlcs";
     rev = "v${version}";
-    hash = "sha256-QxmWxu+w77/WE5pGXMWXm+NP95QmYo2O8ltZYrgCIWw=";
+    hash = "sha256-+YM5dT45p9wk0gJeATmhWDFJJMaUdcTfw8GLS/vMkw4=";
   };
-
-  patches = [
-    # Improves pkg-config paths even more
-    # Remove when https://github.com/MirServer/wlcs/pull/260 merged & in a release
-    (fetchpatch {
-      name = "0001-wlcs-pkgsconfig-Use-better-path-concatenations.patch";
-      url = "https://github.com/MirServer/wlcs/pull/260/commits/20f28d82fa4dfa6a6e27212dbd6b0f2e8a833c69.patch";
-      hash = "sha256-m8zPD27JbX/vN2YQgNhcRsh/O+qLfvoeky5E5ZEeD1I=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -40,11 +29,6 @@ stdenv.mkDerivation rec {
     boost
     gtest
     wayland
-  ];
-
-  env.NIX_CFLAGS_COMPILE = toString [
-    # Needed with GCC 12
-    "-Wno-error=maybe-uninitialized"
   ];
 
   passthru.updateScript = gitUpdater {

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , gitUpdater
 , testers
 , cmake
@@ -41,24 +40,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mir";
-  version = "2.13.0";
+  version = "2.14.1";
 
   src = fetchFromGitHub {
     owner = "MirServer";
     repo = "mir";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Ip8p4mjcgmZQJTU4MNvWkTTtSJc+cCL3x1mMDFlZrVY=";
+    hash = "sha256-IEGeZVNxwzHn5GASCyjNuQsnCzzfQBHdC33MWVMeZws=";
   };
-
-  patches = [
-    # Fixes Mir being able to drop first input device on launch
-    # Drop when https://github.com/MirServer/mir/issues/2837 fixed in a release
-    (fetchpatch {
-      name = "0001-mir-Simplify_probing_of_evdev_input_platform.patch";
-      url = "https://github.com/MirServer/mir/commit/7787cfa721934bb43d3255218e7c92e700923fcb.patch";
-      hash = "sha256-9C9qcmngd+K8EAcyOYUJFTdFDu1Nt1MM7Y9TRNOXFB4=";
-    })
-  ];
 
   postPatch = ''
     # Fix scripts that get run in tests


### PR DESCRIPTION
###### Description of changes

- wlcs: 1.5.0 -> 1.6.0
- mir: 2.13.0 -> 2.14.1

Updating these together because updating  either of them individually makes the Mir tests segfault.

~~Would run Miriway VM test as a check, but it's broken on master. :slightly_frowning_face: 
Fix for that: #245880~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
