### PR TITLE
bazel_6.updater: add more comments

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -36,6 +36,7 @@ let
   # 1. export BAZEL_SELF=$(nix-build -A bazel_6)
   # 2. update version and hash for sources above
   # 3. `eval $(nix-build -A bazel_6.updater)`
+  #    If it complains about incompatible version, try export USE_BAZEL_VERSION=<version of BAZEL_SELF>
   # 4. add new dependencies from the dict in ./src-deps.json if required by failing build
   srcDeps = lib.attrsets.attrValues srcDepsSet;
   srcDepsSet =


### PR DESCRIPTION
To fix potential failures like following when bumping the version
```
Traceback (most recent call last):
  File "/nix/store/6k91h3s5gci716k82a6jl8lm5h169zdb-update-srcDeps.py", line 36, in <module>
    exec(sys.stdin.read())
  File "<string>", line 1
    ERROR: The project you're trying to build requires Bazel 6.2.1 (specified in /nix/store/7vkxp7qbd0h2q5pxi53l49ryhdmfzdai-updater-sources/.bazelversion), but it wasn't found in /nix/store/0mhk7af6g6y6phmp6dc4f73rlbv81lq6-bazel-6.1.2/bin.
```
Related to https://github.com/bazelbuild/bazel/issues/18189 bazel dist archive specifies recommended version to build bazel with if we bootstrap from previous bazel rather than without bazel. 

Nixpkgs builds bazel without bazel, but the updater helper script needs bazel to simplify srcDeps.json updates. This helper script uses `bazel query` and it may complain about .bazelversion, but quite likely to simply query deps any reasonably recent version will do, so let's mention a way to override the complaint.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
