### PR TITLE
opencomposite: init at unstable-2023-07-02

### DIFF
--- a/pkgs/development/libraries/opencomposite/cmake-use-find_package-where-needed.patch
+++ b/pkgs/development/libraries/opencomposite/cmake-use-find_package-where-needed.patch
@@ -1,0 +1,112 @@
+From 5430196765402655715f759e3de0166ad3fbe1fe Mon Sep 17 00:00:00 2001
+From: Sefa Eyeoglu <contact@scrumplex.net>
+Date: Fri, 28 Jul 2023 12:26:58 +0200
+Subject: [PATCH] cmake: use find_package where needed
+
+Signed-off-by: Sefa Eyeoglu <contact@scrumplex.net>
+---
+ CMakeLists.txt | 62 ++++----------------------------------------------
+ 1 file changed, 4 insertions(+), 58 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bb3c49a..e9d6d56 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -98,66 +98,13 @@ endif ()
+ # === OpenXR ===
+ # Building CMake subprojects is a real pain (IMO), so just build this here
+ 
+-set(XrDir libs/openxr-sdk)
+-set(XrDirLoader libs/openxr-sdk/src/loader)
+-set(XrDirCommon libs/openxr-sdk/src/common)
+-if (ANDROID)
+-	# Whatever consumes this library must then link to an OpenXR loader, such as the Oculus one
+-	add_library(OpenXR STATIC scripts/empty.c) # Doesn't do anything
+-else ()
+-add_library(OpenXR STATIC
+-	${XrDirLoader}/api_layer_interface.cpp
+-	${XrDirLoader}/api_layer_interface.hpp
+-	${XrDirLoader}/loader_core.cpp
+-	${XrDirLoader}/loader_instance.cpp
+-	${XrDirLoader}/loader_instance.hpp
+-	${XrDirLoader}/loader_logger.cpp
+-	${XrDirLoader}/loader_logger.hpp
+-	${XrDirLoader}/loader_logger_recorders.cpp
+-	${XrDirLoader}/loader_logger_recorders.hpp
+-	${XrDirLoader}/manifest_file.cpp
+-	${XrDirLoader}/manifest_file.hpp
+-	${XrDirLoader}/runtime_interface.cpp
+-	${XrDirLoader}/runtime_interface.hpp
+-
+-	${XrDirLoader}/xr_generated_loader.hpp
+-	${XrDirLoader}/xr_generated_loader.cpp
+-	${XrDir}/src/xr_generated_dispatch_table.h
+-	${XrDir}/src/xr_generated_dispatch_table.c
+-
+-	${XrDirCommon}/filesystem_utils.cpp
+-	${XrDirCommon}/object_info.cpp
+-
+-	${XrDir}/src/external/jsoncpp/src/lib_json/json_reader.cpp
+-	${XrDir}/src/external/jsoncpp/src/lib_json/json_value.cpp
+-	${XrDir}/src/external/jsoncpp/src/lib_json/json_writer.cpp
+-)
+-endif()
+-target_include_directories(OpenXR PRIVATE ${XrDirCommon} ${XrDir}/src ${XrDir}/src/external/jsoncpp/include)
+-target_include_directories(OpenXR PUBLIC ${XrDir}/include)
+-# Platform-dependent flags
+-if (WIN32)
+-	target_compile_definitions(OpenXR PRIVATE -DXR_OS_WINDOWS -DXR_USE_PLATFORM_WIN32
+-	-DXR_USE_GRAPHICS_API_D3D11 -DXR_USE_GRAPHICS_API_D3D12 -DXR_USE_GRAPHICS_API_OPENGL)
+-	target_link_libraries(OpenXR PUBLIC advapi32 pathcch OpenGL32)
+-else()
+-	# TODO Turtle1331 should we include -DXR_USE_PLATFORM_(XLIB|XCB|WAYLAND) here?
+-	target_compile_definitions(OpenXR PRIVATE -DXR_OS_LINUX
+-	-DXR_USE_GRAPHICS_API_OPENGL -DXR_USE_GRAPHICS_API_VULKAN)
+-	target_link_libraries(OpenXR PUBLIC -ldl)
+-endif()
+-target_link_libraries(OpenXR PUBLIC Vulkan)
+-
+-if (ANDROID)
+-	target_compile_definitions(OpenXR PUBLIC -DXR_USE_PLATFORM_ANDROID -DXR_USE_GRAPHICS_API_OPENGL_ES)
+-endif()
++find_package(OpenXR REQUIRED)
+ 
+ # === glm ===
+ # Since we used to use LibOVR's maths library, we need a replacement
+ # glm is an obvious choice
+ 
+-add_library(glm INTERFACE)
+-target_include_directories(glm INTERFACE libs/glm) # No separate include directory :(
++find_package(glm REQUIRED)
+ 
+ # === DrvOpenXR ===
+ add_library(DrvOpenXR STATIC
+@@ -189,7 +136,7 @@ add_library(DrvOpenXR STATIC
+ )
+ target_include_directories(DrvOpenXR PUBLIC DrvOpenXR/pub ${CMAKE_BINARY_DIR})
+ target_include_directories(DrvOpenXR PRIVATE DrvOpenXR OpenOVR)
+-target_link_libraries(DrvOpenXR PUBLIC OpenVR OpenXR glm)
++target_link_libraries(DrvOpenXR PUBLIC OpenVR OpenXR::openxr_loader glm::glm)
+ target_compile_definitions(DrvOpenXR PRIVATE ${GRAPHICS_API_SUPPORT_FLAGS} -D_CRT_SECURE_NO_WARNINGS)
+ source_group(Public REGULAR_EXPRESSION DrvOpenXR/pub/*)
+ 
+@@ -357,7 +304,7 @@ target_include_directories(OCCore PUBLIC OpenOVR ${CMAKE_BINARY_DIR})  # TODO ma
+ target_include_directories(OCCore PRIVATE BundledLibs OpenVRHeaders)
+ target_compile_definitions(OCCore PRIVATE ${GRAPHICS_API_SUPPORT_FLAGS})
+ 
+-target_link_libraries(OCCore OpenVR OpenXR Vulkan glm)
++target_link_libraries(OCCore OpenVR OpenXR::openxr_loader Vulkan glm::glm)
+ 
+ if (NOT WIN32 AND NOT ANDROID)
+ 	find_package(OpenGL REQUIRED) # for glGetError()
+@@ -411,7 +358,6 @@ endif ()
+ if (WIN32)
+ else ()
+ 	target_compile_options(DrvOpenXR PRIVATE -fPIC)
+-	target_compile_options(OpenXR PRIVATE -fPIC)
+ 	target_compile_options(OCCore PRIVATE -fPIC)
+ endif ()
+ 
+-- 
+2.41.0
+

--- a/pkgs/development/libraries/opencomposite/default.nix
+++ b/pkgs/development/libraries/opencomposite/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+
+, cmake
+
+, glm
+, libGL
+, openxr-loader
+, python3
+, vulkan-headers
+, vulkan-loader
+, xorg
+}:
+
+stdenv.mkDerivation {
+  pname = "opencomposite";
+  version = "unstable-2023-07-02";
+
+  src = fetchFromGitLab {
+    owner = "znixian";
+    repo = "OpenOVR";
+    rev = "a59b16204a1ee61a59413667a516375071a113f0";
+    hash = "sha256-JSVd/+A/WldP+A2vOOG4lbwb4QCE/PymEm4VbjUxWrw=";
+  };
+
+  patches = [
+    # Force OpenComposite to use our OpenXR and glm, instead of its Git submodules
+    ./cmake-use-find_package-where-needed.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    glm
+    libGL
+    openxr-loader
+    python3
+    vulkan-headers
+    vulkan-loader
+    xorg.libX11
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/opencomposite
+    cp -r bin/ $out/lib/opencomposite
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Reimplementation of OpenVR, translating calls to OpenXR";
+    homepage = "https://gitlab.com/znixian/OpenOVR";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ Scrumplex ];
+  };
+}

--- a/pkgs/development/libraries/opencomposite/helper.nix
+++ b/pkgs/development/libraries/opencomposite/helper.nix
@@ -1,0 +1,18 @@
+{ writeShellApplication
+
+, monado
+, opencomposite
+}:
+writeShellApplication {
+  name = "opencomposite-helper";
+  text = ''
+    # Tell Proton to use OpenComposite instead of OpenVR
+    export VR_OVERRIDE=${opencomposite}/lib/opencomposite
+    # Help OpenComposite find the OpenXR runtime
+    export XR_RUNTIME_JSON=${monado}/share/openxr/1/openxr_monado.json
+    # Tell Steam Pressure Vessel to allow access to Monado
+    export PRESSURE_VESSEL_FILESYSTEMS_RW=$XDG_RUNTIME_DIR/monado_comp_ipc
+    exec "$@"
+  '';
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5968,6 +5968,10 @@ with pkgs;
 
   ondir = callPackage ../tools/misc/ondir { };
 
+  opencomposite = callPackage ../development/libraries/opencomposite { };
+
+  opencomposite-helper = callPackage ../development/libraries/opencomposite/helper.nix { };
+
   osdlyrics = callPackage ../applications/audio/osdlyrics { };
 
   ossutil = callPackage ../tools/admin/ossutil { };


### PR DESCRIPTION
###### Description of changes

[OpenComposite](https://gitlab.com/znixian/OpenOVR) is a free and open source implementation of Valve's OpenVR on top of OpenXR.

Despite its name, OpenVR's "reference" implementation (SteamVR) is proprietary.

I also included a helper package (`opencomposite-helper`), that sets the appropriate environment variables to make it work with Proton games on Steam. I am not sure if we want to keep this in nixpkgs though.

I personally tested this with the game Hot Dogs, Horseshoes & Hand Grenades (H3VR) on a Valve Index using my NixOS module proposed in #245005.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
