### PR TITLE
libnghttp2_asio: init at unstable 2022-08-11

### DIFF
--- a/pkgs/by-name/li/libnghttp2_asio/package.nix
+++ b/pkgs/by-name/li/libnghttp2_asio/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, nghttp2
+, openssl
+, boost
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libnghttp2_asio";
+  version = "unstable-2022-08-11";
+
+  outputs = [ "out" "dev" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "nghttp2";
+    repo = "nghttp2-asio";
+    rev = "e877868abe06a83ed0a6ac6e245c07f6f20866b5";
+    sha256 = "sha256-XQXRHLz0kvaIQq1nbqkJnETHR51FXMB1P9F/hQeZh6A=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    boost
+    nghttp2
+    openssl
+  ];
+
+  meta = with lib; {
+    description = "High level HTTP/2 C++ library";
+    longDescription = ''
+      libnghttp2_asio is C++ library built on top of libnghttp2
+      and provides high level abstraction API to build HTTP/2
+      applications. It depends on the Boost::ASIO library and
+      OpenSSL. libnghttp2_asio provides both client and server APIs.
+    '';
+    homepage = "https://github.com/nghttp2/nghttp2-asio";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ izorkin ];
+  };
+}


### PR DESCRIPTION
###### Description of changes
Add libnghttp2_asio.
Issue - https://github.com/NixOS/nixpkgs/pull/234676#issuecomment-1632215952

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
