### PR TITLE
pgcat: init at 1.1.0

### DIFF
--- a/pkgs/servers/sql/pgcat/default.nix
+++ b/pkgs/servers/sql/pgcat/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pgcat";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "postgresml";
+    repo = "pgcat";
+    rev = "v${version}";
+    hash = "sha256-ESHBOh9JSzu6Zxh0z/+nebumi/zyFVdTK0DIwR/46Xo=";
+  };
+
+  cargoHash = "sha256-2wZADXEi8bfNgSQuL7yAmDYd/a0LOssdPFa/kvSSLFU=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  checkFlags = [
+    # requires network access
+    "--skip=dns_cache::CachedResolver::lookup_ip"
+    "--skip=dns_cache::CachedResolver::new"
+    "--skip=dns_cache::CachedResolver"
+    "--skip=dns_cache::tests::has_changed"
+    "--skip=dns_cache::tests::incorrect_address"
+    "--skip=dns_cache::tests::lookup_ip"
+    "--skip=dns_cache::tests::new"
+    "--skip=dns_cache::tests::thread"
+    "--skip=dns_cache::tests::unknown_host"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/pgcat --version | grep "pgcat ${version}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/postgresml/pgcat";
+    description = "PostgreSQL pooler with sharding, load balancing and failover support.";
+    license = with licenses; [mit];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [cathalmullan];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26802,6 +26802,8 @@ with pkgs;
 
   pgbouncer = callPackage ../servers/sql/pgbouncer { };
 
+  pgcat = callPackage ../servers/sql/pgcat {};
+
   pgpool = callPackage ../servers/sql/pgpool { };
 
   tang = callPackage ../servers/tang {


### PR DESCRIPTION
###### Description of changes

PostgreSQL pooler with sharding, load balancing and failover support.

Homepage: https://github.com/postgresml/pgcat

Resolves https://github.com/NixOS/nixpkgs/issues/245733

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
