### PR TITLE
gettext: do not output date when --no-translator is set

### DIFF
--- a/pkgs/development/libraries/gettext/0001-msginit-Do-not-use-POT-Creation-Date.patch
+++ b/pkgs/development/libraries/gettext/0001-msginit-Do-not-use-POT-Creation-Date.patch
@@ -1,0 +1,32 @@
+From 1e000ca711886055176a2f90197a383d09de0e67 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Miguel=20=C3=81ngel=20Arruga=20Vivas?=
+ <rosen644835@gmail.com>
+Date: Fri, 18 Dec 2020 14:19:36 +0100
+Subject: [PATCH] msginit: Do not use POT-Creation-Date.
+
+* gettext-tools/src/msginit.c (po_revision_date): Do not use
+POT-Creation-Date when the file is automatically generated.
+---
+ gettext-tools/src/msginit.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gettext-tools/src/msginit.c b/gettext-tools/src/msginit.c
+index 8ca9a3b77..06e0e7195 100644
+--- a/gettext-tools/src/msginit.c
++++ b/gettext-tools/src/msginit.c
+@@ -1075,9 +1075,9 @@ static const char *
+ po_revision_date (const char *header)
+ {
+   if (no_translator)
+-    /* Because the PO file is automatically generated, we use the
+-       POT-Creation-Date, not the current time.  */
+-    return get_field (header, "POT-Creation-Date");
++    /* Because the PO file is automatically generated, we don't
++       generate PO-Revision-Date field.  */
++    return NULL;
+   else
+     {
+       /* Assume the translator will modify the PO file now.  */
+-- 
+2.29.2
+

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -17,6 +17,9 @@ stdenv.mkDerivation rec {
   };
   patches = [
     ./absolute-paths.diff
+    # fix reproducibile output, in particular in the grub2 build
+    # https://savannah.gnu.org/bugs/index.php?59658
+    ./0001-msginit-Do-not-use-POT-Creation-Date.patch
   ] ++ lib.optional stdenv.hostPlatform.isWindows (fetchpatch {
     url = "https://aur.archlinux.org/cgit/aur.git/plain/gettext_formatstring-ruby.patch?h=mingw-w64-gettext&id=e8b577ee3d399518d005e33613f23363a7df07ee";
     name = "gettext_formatstring-ruby.patch";


### PR DESCRIPTION
###### Description of changes

See upstream https://savannah.gnu.org/bugs/index.php?59658
Fixes #245356

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
