### PR TITLE
lomiri.lomiri-download-manager: init at 0.1.2

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -29,6 +29,7 @@ let
     biometryd = callPackage ./services/biometryd { };
     hfd-service = callPackage ./services/hfd-service { };
     lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
+    lomiri-download-manager = callPackage ./services/lomiri-download-manager { };
     mediascanner2 = callPackage ./services/mediascanner2 { };
   };
 in

--- a/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
@@ -1,0 +1,163 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, testers
+, boost
+, cmake
+, cmake-extras
+, dbus
+, dbus-test-runner
+, withDocumentation ? true
+, doxygen
+, glog
+, graphviz
+, gtest
+, lomiri-api
+, pkg-config
+, python3
+, qtbase
+, qtdeclarative
+, wrapQtAppsHook
+, xvfb-run
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-download-manager";
+  version = "0.1.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-download-manager";
+    rev = finalAttrs.version;
+    hash = "sha256-a9C+hactBMHMr31E+ImKDPgpzxajy1klkjDcSEkPHqI=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ] ++ lib.optionals withDocumentation [
+    "doc"
+  ];
+
+  patches = [
+    # Make documentation building optional
+    # Remove when version > 0.1.2
+    (fetchpatch {
+      name = "0001-lomiri-download-manager-Make-documentation-build-optional.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-download-manager/-/commit/32d7369714c01bd425af9c6de5bdc04399a12e0a.patch";
+      hash = "sha256-UztcBAAFXDX2j0X5D3kMp9q0vFm3/PblUAKPJ5nZyiY=";
+    })
+
+    # Make documentation building optional
+    # Remove when version > 0.1.2
+    (fetchpatch {
+      name = "0002-lomiri-download-manager-Upgrade-C++-standard-to-C++17.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-download-manager/-/commit/a6bc7ae80f2ff4c4743978c6c694149707d9d2e2.patch";
+      hash = "sha256-iA1sZhHI8Osgo1ofL5RTqgVzUG32zx0dU/28qcEqmQc=";
+    })
+
+    # Fix version identification, make -Werror & tests optional
+    # Remove when version > 0.1.2
+    (fetchpatch {
+      name = "0003-lomiri-download-manager-Bump-version-make-Werror-and-tests-optional.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-download-manager/-/commit/73ec04c429e5285f05dd72d5bb9720ba6ff31be2.patch";
+      hash = "sha256-0BrJSKCvUhITwfln05OrHgHEpldbgBoh4rivAvw+qrc=";
+    })
+
+    # Use GNUInstallDirs variables for
+    # Remove when version > 0.1.2
+    (fetchpatch {
+      name = "0004-lomiri-download-manager-Use-GNUInstallDirs-variables-for-more-install-destinations.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-download-manager/-/commit/5d40daf053de62150aa5ee618285e415d7d3f1c8.patch";
+      hash = "sha256-r5fpiJkZkDsYX9fcX5JuPsE/qli9z5/DatmGJ9/QauU=";
+    })
+  ];
+
+  postPatch = ''
+    # Patch cannot apply renames, only changes contents
+    # Remove when version > 0.1.2
+    for service in src/{uploads,downloads}/daemon/{lomiri-*-manager,lomiri-*-manager-systemd,com.lomiri.*}.service; do
+      mv "$service" "$service".in
+    done
+
+    # pkg_get_variable doesn't let us substitute prefix pkg-config variable from systemd
+    substituteInPlace CMakeLists.txt \
+      --replace 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'set(SYSTEMD_USER_DIR "${placeholder "out"}/lib/systemd/user")' \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+  ] ++ lib.optionals withDocumentation [
+    doxygen
+    graphviz
+  ];
+
+  buildInputs = [
+    boost
+    cmake-extras
+    glog
+    lomiri-api
+    qtbase
+    qtdeclarative
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    dbus-test-runner
+    python3
+    xvfb-run
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_DOC=${lib.boolToString withDocumentation}"
+    # Deprecation warnings on Qt 5.15
+    # https://gitlab.com/ubports/development/core/lomiri-download-manager/-/issues/1
+    "-DENABLE_WERROR=OFF"
+  ];
+
+  makeTargets = [
+    "all"
+  ] ++ lib.optionals withDocumentation [
+    "doc"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # xvfb tests are flaky on xvfb shutdown when parallelised
+  enableParallelChecking = false;
+
+  preCheck = ''
+    export HOME=$TMPDIR # temp files in home
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix} # xcb platform & sqlite driver
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Performs uploads and downloads from a centralized location";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-download-manager";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "ldm-common"
+      "lomiri-download-manager-client"
+      "lomiri-download-manager-common"
+      "lomiri-upload-manager-common"
+    ];
+  };
+})

--- a/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # Make documentation building optional
     # Remove when version > 0.1.2
     (fetchpatch {
       name = "0001-lomiri-download-manager-Make-documentation-build-optional.patch";
@@ -50,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-UztcBAAFXDX2j0X5D3kMp9q0vFm3/PblUAKPJ5nZyiY=";
     })
 
-    # Make documentation building optional
     # Remove when version > 0.1.2
     (fetchpatch {
       name = "0002-lomiri-download-manager-Upgrade-C++-standard-to-C++17.patch";
@@ -58,7 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-iA1sZhHI8Osgo1ofL5RTqgVzUG32zx0dU/28qcEqmQc=";
     })
 
-    # Fix version identification, make -Werror & tests optional
     # Remove when version > 0.1.2
     (fetchpatch {
       name = "0003-lomiri-download-manager-Bump-version-make-Werror-and-tests-optional.patch";
@@ -66,7 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-0BrJSKCvUhITwfln05OrHgHEpldbgBoh4rivAvw+qrc=";
     })
 
-    # Use GNUInstallDirs variables for
     # Remove when version > 0.1.2
     (fetchpatch {
       name = "0004-lomiri-download-manager-Use-GNUInstallDirs-variables-for-more-install-destinations.patch";
@@ -76,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    # Patch cannot apply renames, only changes contents
+    # fetchpatch strips renames
     # Remove when version > 0.1.2
     for service in src/{uploads,downloads}/daemon/{lomiri-*-manager,lomiri-*-manager-systemd,com.lomiri.*}.service; do
       mv "$service" "$service".in


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri Download Manager](https://gitlab.com/ubports/development/core/lomiri-download-manager), a daemon for performing long-running downloads in the background. Required by Content Hub and Lomiri itself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
