### PR TITLE
lomiri.lomiri-schemas: init at 0.1.3

### DIFF
--- a/pkgs/desktops/lomiri/data/lomiri-schemas/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-schemas/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gitUpdater
+, testers
+, cmake
+, cmake-extras
+, glib
+, intltool
+, pkg-config
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-schemas";
+  version = "0.1.3";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-schemas";
+    rev = finalAttrs.version;
+    hash = "sha256-FrDUFqdD0KW2VG2pTA6LMb6/9PdNtQUlYTEo1vnW6QQ=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    glib # glib-compile-schemas
+    pkg-config
+    intltool
+  ];
+
+  buildInputs = [
+    cmake-extras
+    glib
+  ];
+
+  cmakeFlags = [
+    "-DGSETTINGS_LOCALINSTALL=ON"
+    "-DGSETTINGS_COMPILE=ON"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "GSettings / AccountsService schema files for Lomiri";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-schemas";
+    license = licenses.lgpl21Plus;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "lomiri-schemas"
+    ];
+  };
+})

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -7,6 +7,9 @@ let
   packages = self: let
     inherit (self) callPackage;
   in {
+    #### Data
+    lomiri-schemas = callPackage ./data/lomiri-schemas { };
+
     #### Development tools / libraries
     cmake-extras = callPackage ./development/cmake-extras { };
     deviceinfo = callPackage ./development/deviceinfo { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri Schemas](https://gitlab.com/ubports/development/core/lomiri-schemas) are… well, gsettings & accountsservice schemas used in Lomiri (and sometimes Ayatana Indicators). Nothing super interesting about them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
