### PR TITLE
nixos: make extendModules retain pkgs on nixos configs

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -109,8 +109,10 @@ let
 
   nixosWithUserModules = noUserModules.extendModules { modules = allUserModules; };
 
+  withExtraArgs = nixosSystem: nixosSystem // {
+    inherit extraArgs;
+    inherit (nixosSystem._module.args) pkgs;
+    extendModules = args: withExtraArgs (nixosSystem.extendModules args);
+  };
 in
-withWarnings nixosWithUserModules // {
-  inherit extraArgs;
-  inherit (nixosWithUserModules._module.args) pkgs;
-}
+withWarnings (withExtraArgs nixosWithUserModules)


### PR DESCRIPTION
## Description of changes

Before change, without `extendModules`:
```
nix-repl> :p (lib.nixosSystem { modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; boot.loader.grub.enable = false; boot.initrd.enable = false; } ]; }).pkgs.nixos-rebuild  
«derivation /nix/store/30hqx7sxjia00mm1imdwz848gjy142s8-nixos-rebuild.drv»
```

Before change, with `extendModules`:
```
nix-repl> :p ((lib.nixosSystem { modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; boot.loader.grub.enable = false; boot.initrd.enable = false; } ]; }).extendModules { modules = []; }).pkgs.nixos-rebuild                                
error: attribute 'pkgs' missing

       at «string»:1:1:

            1| ((lib.nixosSystem { modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; boot.loader.grub.enable = false; boot.initrd.enable = false; } ]; }).extendModules { modules = []; }).pkgs.nixos-rebuild
```

After change, with `extendModules`:
```
nix-repl> :p ((lib.nixosSystem { modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; boot.loader.grub.enable = false; boot.initrd.enable = false; } ]; }).extendModules { modules = []; }).pkgs.nixos-rebuild
«derivation /nix/store/30hqx7sxjia00mm1imdwz848gjy142s8-nixos-rebuild.drv»
```

Ping @Lassulus