### PR TITLE
qmenumodel: init at 0.9.2

### DIFF
--- a/pkgs/development/libraries/qmenumodel/default.nix
+++ b/pkgs/development/libraries/qmenumodel/default.nix
@@ -1,0 +1,99 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gitUpdater
+, testers
+, cmake
+, cmake-extras
+, dbus
+, dbus-test-runner
+, glib
+, pkg-config
+, python3
+, qtbase
+, qtdeclarative
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qmenumodel";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "qmenumodel";
+    rev = finalAttrs.version;
+    hash = "sha256-cKolDRMamLWV8ASFLp1k0xslNAqVRCuM3/xvvBG98RI=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  postPatch = ''
+    substituteInPlace libqmenumodel/src/qmenumodel.pc.in \
+      --replace "\''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@" "\''${prefix}/lib" \
+      --replace "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" "\''${prefix}/include"
+
+    substituteInPlace libqmenumodel/QMenuModel/CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+  '' + lib.optionalString finalAttrs.doCheck ''
+    patchShebangs tests/{client,script}/*.py
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    glib
+    qtbase
+    qtdeclarative
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    dbus-test-runner
+    (python3.withPackages (ps: with ps; [
+      dbus-python
+      pygobject3
+    ]))
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Tests have been flaky sometimes, hoping that not running in parallel helps
+  enableParallelChecking = false;
+
+  preCheck = ''
+    # Tests all need some Qt stuff
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Qt5 renderer for Ayatana Indicators";
+    longDescription = ''
+      QMenuModel - a Qt/QML binding for GMenuModel
+      (see http://developer.gnome.org/gio/unstable/GMenuModel.html)
+    '';
+    homepage = "https://github.com/AyatanaIndicators/qmenumodel";
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "qmenumodel"
+    ];
+  };
+})

--- a/pkgs/development/libraries/qmenumodel/default.nix
+++ b/pkgs/development/libraries/qmenumodel/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qmenumodel";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "qmenumodel";
     rev = finalAttrs.version;
-    hash = "sha256-cKolDRMamLWV8ASFLp1k0xslNAqVRCuM3/xvvBG98RI=";
+    hash = "sha256-zbKAfq9R5fD2IqVYOAhy903QX1TDom9m6Ib2qpkFMak=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24801,6 +24801,10 @@ with pkgs;
 
   qdjango = libsForQt5.callPackage ../development/libraries/qdjango { };
 
+  qmenumodel = libsForQt5.callPackage ../development/libraries/qmenumodel {
+    inherit (lomiri) cmake-extras;
+  };
+
   qoi = callPackage ../development/libraries/qoi { };
 
   qolibri = libsForQt5.callPackage ../applications/misc/qolibri { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[QMenuModel](https://github.com/AyatanaIndicators/qmenumodel), a Qt5 renderer for Ayatana Indicators. Used by Lomiri itself, presumably to render the active indicators in the top bar?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
