### PR TITLE
python3Packages.jenkinsapi: fix failing build

### DIFF
--- a/pkgs/development/python-modules/jenkinsapi/default.nix
+++ b/pkgs/development/python-modules/jenkinsapi/default.nix
@@ -1,43 +1,52 @@
-{ lib, stdenv
+{ lib
 , buildPythonPackage
-, pythonAtLeast
 , fetchPypi
+, flit-core
 , mock
-, pytest
+, pbr
 , pytest-mock
+, pytestCheckHook
 , pytz
 , requests
-, requests-kerberos
-, toml
+, six
 }:
 
 buildPythonPackage rec {
   pname = "jenkinsapi";
   version = "0.3.13";
-  format = "setuptools";
-
-  disabled = pythonAtLeast "3.6";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-JGqYpj5h9UoV0WEFyxVIjFZwc030HobHrw1dnAryQLk=";
   };
 
-  propagatedBuildInputs = [ pytz requests ];
-  nativeCheckInputs = [ mock pytest pytest-mock requests-kerberos toml ];
-  # TODO requests-kerberos is broken on darwin, weeding out the broken tests without
-  # access to macOS is not an adventure I am ready to embark on - @rski
-  doCheck = !stdenv.isDarwin;
-  # don't run tests that try to spin up jenkins, and a few more that are mysteriously broken
-  checkPhase = ''
-    py.test jenkinsapi_tests \
-      -k "not systests and not test_plugins and not test_view"
-  '';
+  nativeBuildInputs = [
+    flit-core
+    pbr
+  ];
+
+  propagatedBuildInputs = [
+    pytz
+    requests
+    six
+  ];
+
+  nativeCheckInputs = [
+    mock
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  # don't run tests that try to spin up jenkins
+  disabledTests = [ "systests" ];
+
+  pythonImportsCheck = [ "jenkinsapi" ];
 
   meta = with lib; {
     description = "A Python API for accessing resources on a Jenkins continuous-integration server";
     homepage = "https://github.com/salimfadhley/jenkinsapi";
-    maintainers = with maintainers; [ drets ];
+    maintainers = with maintainers; [ drets ] ++ teams.deshaw.members;
     license = licenses.mit;
   };
 


### PR DESCRIPTION
## Description of changes

Build was failing when using `setuptools` build system, but with `pyproject` it works. I also refactored how tests are managed.

cc @drets

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
