### PR TITLE
tilt: 0.33.1 -> 0.33.3

### DIFF
--- a/pkgs/applications/networking/cluster/tilt/default.nix
+++ b/pkgs/applications/networking/cluster/tilt/default.nix
@@ -1,28 +1,32 @@
-{ stdenv, lib, buildGoModule, fetchFromGitHub }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
 
 buildGoModule rec {
   pname = "tilt";
   /* Do not use "dev" as a version. If you do, Tilt will consider itself
     running in development environment and try to serve assets from the
     source tree, which is not there once build completes.  */
-  version = "0.33.1";
+  version = "0.33.3";
 
   src = fetchFromGitHub {
-    owner  = "tilt-dev";
-    repo   = pname;
-    rev    = "v${version}";
-    sha256 = "sha256-3CRE+gpifV3MHyKdiiHmGwGre0ne3IjheYH0r6NMKY8=";
+    owner = "tilt-dev";
+    repo = "tilt";
+    rev = "v${version}";
+    hash = "sha256-TNZE335tH50E96yJzD26U+JbVxjU746Wa/8YDGHFeto=";
   };
+
   vendorHash = null;
 
   subPackages = [ "cmd/tilt" ];
 
   ldflags = [ "-X main.version=${version}" ];
 
-  meta = with lib; {
+  meta = {
     description = "Local development tool to manage your developer instance when your team deploys to Kubernetes in production";
     homepage = "https://tilt.dev/";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ anton-dessiatov ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ anton-dessiatov ];
   };
 }


### PR DESCRIPTION
## Description of changes
* Workaround for backwards-compatibility breaking changes in Go 1.20.6
* Fixes Docker `ImageBuild` timeouts

Release notes: https://github.com/tilt-dev/tilt/releases/tag/v0.33.3
Compare changes: https://github.com/tilt-dev/tilt/compare/v0.33.1...v0.33.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


