### PR TITLE
btrfs-assistant: init at 1.8

### DIFF
--- a/pkgs/tools/misc/btrfs-assistant/default.nix
+++ b/pkgs/tools/misc/btrfs-assistant/default.nix
@@ -1,0 +1,86 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, bash
+, btrfs-progs
+, cmake
+, coreutils
+, git
+, pkg-config
+, qtbase
+, qtsvg
+, qttools
+, snapper
+, util-linux
+, wrapQtAppsHook
+}:
+
+let
+  runtimeDeps = lib.makeBinPath [
+    coreutils
+    snapper
+    util-linux
+  ];
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "btrfs-assistant";
+  version = "1.8";
+
+  src = fetchFromGitLab {
+    owner = "btrfs-assistant";
+    repo = "btrfs-assistant";
+    rev = finalAttrs.version;
+    hash = "sha256-Ay2wxDVue+tG09RgAo4Zg2ktlq6dk7GdIwAlbuVULB4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    git
+    pkg-config
+  ];
+
+  buildInputs = [
+    btrfs-progs
+    qtbase
+    qtsvg
+    qttools
+  ];
+
+  propagatedBuildInputs = [ wrapQtAppsHook ];
+
+  prePatch = ''
+    substituteInPlace src/util/System.cpp \
+      --replace '/bin/bash' "${bash}/bin/bash"
+
+     substituteInPlace src/main.cpp \
+      --replace '/usr/bin/snapper' "${snapper}/bin/snapper"
+  '';
+
+  postPatch = ''
+    substituteInPlace src/org.btrfs-assistant.pkexec.policy \
+      --replace '/usr/bin' "$out/bin"
+
+    substituteInPlace src/btrfs-assistant \
+      --replace 'btrfs-assistant-bin' "$out/bin/btrfs-assistant-bin"
+
+    substituteInPlace src/btrfs-assistant-launcher \
+      --replace 'btrfs-assistant' "$out/bin/btrfs-assistant"
+
+    substituteInPlace src/btrfs-assistant.conf \
+      --replace '/usr/bin/snapper' "${snapper}/bin/snapper"
+  '';
+
+  qtWrapperArgs = [
+    "--prefix PATH : ${runtimeDeps}"
+  ];
+
+  meta = {
+    description = "A GUI management tool to make managing a Btrfs filesystem easier";
+    homepage = "https://gitlab.com/btrfs-assistant/btrfs-assistant";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "btrfs-assistant-bin";
+    maintainers = with lib.maintainers; [ khaneliman ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3460,6 +3460,8 @@ with pkgs;
 
   boulder = callPackage ../tools/admin/boulder { };
 
+  btrfs-assistant = libsForQt5.callPackage ../tools/misc/btrfs-assistant { };
+
   btrfs-heatmap = callPackage ../tools/filesystems/btrfs-heatmap { };
 
   bucklespring = bucklespring-x11;


### PR DESCRIPTION
## Description of changes
Adding new package btrfs-assistant to help managing btrfs filesystems.

- btrfsmaintenance doesn't exist on nixpkgs so that functionality is missing from the application. Will need to package that application to support. 
- Snapper can be disabled through override. Defaults to enabled. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
