### PR TITLE
Revert "lib.customisation: uncurry makeScopeWithSplicing"

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -279,15 +279,7 @@ rec {
 
   /* Like the above, but aims to support cross compilation. It's still ugly, but
      hopefully it helps a little bit. */
-  makeScopeWithSplicing =
-    { splicePackages
-    , newScope
-    }:
-    { otherSplices
-    , keep ? (_self: {})
-    , extra ? (_spliced0: {})
-    , f
-    }:
+  makeScopeWithSplicing = splicePackages: newScope: otherSplices: keep: extra: f:
     let
       spliced0 = splicePackages {
         pkgsBuildBuild = otherSplices.selfBuildBuild;
@@ -303,11 +295,13 @@ rec {
         callPackage = newScope spliced; # == self.newScope {};
         # N.B. the other stages of the package set spliced in are *not*
         # overridden.
-        overrideScope = g: (makeScopeWithSplicing
-          { inherit splicePackages newScope; }
-          { inherit otherSplices keep extra;
-            f = lib.fixedPoints.extends g f;
-          });
+        overrideScope = g: makeScopeWithSplicing
+          splicePackages
+          newScope
+          otherSplices
+          keep
+          extra
+          (lib.fixedPoints.extends g f);
         packages = f;
       };
     in self;

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -5,9 +5,16 @@
 , makeScopeWithSplicing
 }:
 
-makeScopeWithSplicing {
-  otherSplices = generateSplicesForMkScope "xfce";
-  f = (self:
+let
+  keep = _self: { };
+  extra = _spliced0: { };
+
+in
+makeScopeWithSplicing
+  (generateSplicesForMkScope "xfce")
+  keep
+  extra
+  (self:
     let
       inherit (self) callPackage;
     in
@@ -170,5 +177,4 @@ makeScopeWithSplicing {
       thunar-bare = self.thunar.override { thunarPlugins = [ ]; }; # added 2019-11-04
 
       xfce4-hardware-monitor-plugin = throw "xfce.xfce4-hardware-monitor-plugin has been removed: abandoned by upstream and does not build"; # added 2023-01-15
-    });
-}
+    })

--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -39,15 +39,18 @@ let
             selfHostHost = luaOnHostForHost.pkgs;
             selfTargetTarget = luaOnTargetForTarget.pkgs or {};
           };
+          keep = self: { };
+          extra = spliced0: {};
           extensions = lib.composeManyExtensions [
             generatedPackages
             overriddenPackages
             overrides
           ];
-        in makeScopeWithSplicing {
-          inherit otherSplices;
-          f = lib.extends extensions luaPackagesFun;
-        })
+        in makeScopeWithSplicing
+          otherSplices
+          keep
+          extra
+          (lib.extends extensions luaPackagesFun))
         {
           overrides = packageOverrides;
           lua = self;

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -34,10 +34,13 @@ let
             selfHostHost = perlOnHostForHost.pkgs;
             selfTargetTarget = perlOnTargetForTarget.pkgs or {};
           };
-        in makeScopeWithSplicing {
-          inherit otherSplices;
-          f = perlPackagesFun;
-        })
+          keep = self: { };
+          extra = spliced0: {};
+        in makeScopeWithSplicing
+          otherSplices
+          keep
+          extra
+          perlPackagesFun)
         {
           perl = self;
         };

--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -48,6 +48,7 @@
       };
       hooks = import ./hooks/default.nix;
       keep = lib.extends hooks pythonPackagesFun;
+      extra = _: {};
       optionalExtensions = cond: as: lib.optionals cond as;
       pythonExtension = import ../../../top-level/python-packages.nix;
       python2Extension = import ../../../top-level/python2-packages.nix;
@@ -59,10 +60,12 @@
         overrides
       ]);
       aliases = self: super: lib.optionalAttrs config.allowAliases (import ../../../top-level/python-aliases.nix lib self super);
-    in makeScopeWithSplicing {
-      inherit otherSplices keep;
-      f = lib.extends (lib.composeExtensions aliases extensions) keep;
-    }) {
+    in makeScopeWithSplicing
+      otherSplices
+      keep
+      extra
+      (lib.extends (lib.composeExtensions aliases extensions) keep))
+    {
       overrides = packageOverrides;
       python = self;
     });

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -334,7 +334,4 @@ let
       overrideScope' = lib.warn "qt5 now uses makeScopeWithSplicing which does not have \"overrideScope'\", use \"overrideScope\"." self.overrideScope;
     };
 
-in makeScopeWithSplicing {
-  otherSplices = generateSplicesForMkScope "qt5";
-  f = addPackages;
-}
+in makeScopeWithSplicing (generateSplicesForMkScope "qt5") (_: {}) (_: {}) addPackages

--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -32,7 +32,6 @@ let
 
     steamcmd = callPackage ./steamcmd.nix { };
   };
-in makeScopeWithSplicing {
-  otherSplices = generateSplicesForMkScope "steamPackages";
-  f = steamPackagesFun;
-}
+  keep = self: { };
+  extra = spliced0: { };
+in makeScopeWithSplicing (generateSplicesForMkScope "steamPackages") keep extra steamPackagesFun

--- a/pkgs/os-specific/bsd/freebsd/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/default.nix
@@ -66,9 +66,11 @@ let
     done
   '';
 
-in makeScopeWithSplicing {
-  otherSplices = generateSplicesForMkScope "freebsd";
-  f = (self: let
+in makeScopeWithSplicing
+  (generateSplicesForMkScope "freebsd")
+  (_: {})
+  (_: {})
+  (self: let
     inherit (self) mkDerivation;
   in {
   inherit freebsdSrc;
@@ -896,5 +898,4 @@ in makeScopeWithSplicing {
     '';
   });
 
-});
-}
+})

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -26,9 +26,11 @@ let
       else "no"}"
   ];
 
-in makeScopeWithSplicing {
-  otherSplices = generateSplicesForMkScope "netbsd";
-  f = (self: let
+in makeScopeWithSplicing
+  (generateSplicesForMkScope "netbsd")
+  (_: {})
+  (_: {})
+  (self: let
     inherit (self) mkDerivation;
   in {
 
@@ -1009,5 +1011,4 @@ in makeScopeWithSplicing {
   # END MISCELLANEOUS
   #
 
-});
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27121,6 +27121,9 @@ with pkgs;
   };
 
   xorg = let
+    keep = _self: { };
+    extra = _spliced0: { };
+
     # Use `lib.callPackageWith __splicedPackages` rather than plain `callPackage`
     # so as not to have the newly bound xorg items already in scope,  which would
     # have created a cycle.
@@ -27135,10 +27138,11 @@ with pkgs;
 
     generatedPackages = lib.callPackageWith __splicedPackages ../servers/x11/xorg/default.nix { };
 
-    xorgPackages = makeScopeWithSplicing {
-      otherSplices = generateSplicesForMkScope "xorg";
-      f = lib.extends overrides generatedPackages;
-    };
+    xorgPackages = makeScopeWithSplicing
+      (generateSplicesForMkScope "xorg")
+      keep
+      extra
+      (lib.extends overrides generatedPackages);
 
   in recurseIntoAttrs xorgPackages;
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -15,10 +15,7 @@ let
                                         (stdenv.targetPlatform.config + "-");
 in
 
-makeScopeWithSplicing {
-  otherSplices = generateSplicesForMkScope "darwin";
-  extra = spliced: spliced.apple_sdk.frameworks;
-  f = (self: let
+makeScopeWithSplicing (generateSplicesForMkScope "darwin") (_: {}) (spliced: spliced.apple_sdk.frameworks) (self: let
   inherit (self) mkDerivation callPackage;
 
   # Must use pkgs.callPackage to avoid infinite recursion.
@@ -254,5 +251,4 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
 } // lib.optionalAttrs config.allowAliases {
   builder = throw "'darwin.builder' has been changed and renamed to 'darwin.linux-builder'. The default ssh port is now 31022. Please update your configuration or override the port back to 22. See https://nixos.org/manual/nixpkgs/unstable/#sec-darwin-builder"; # added 2023-07-06
-});
-}
+})

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -144,7 +144,7 @@ in
   newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // extra);
 
   # prefill 2 fields of the function for convenience
-  makeScopeWithSplicing = lib.makeScopeWithSplicing { inherit splicePackages; inherit (pkgs) newScope; };
+  makeScopeWithSplicing = lib.makeScopeWithSplicing splicePackages pkgs.newScope;
 
   # generate 'otherSplices' for 'makeScopeWithSplicing'
   generateSplicesForMkScope = attr:


### PR DESCRIPTION
Reverts NixOS/nixpkgs#245824, because it's a breaking change to `lib` without appropriate deprecation.