### PR TITLE
gog-downloader: init at 1.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14181,6 +14181,12 @@
     githubId = 1810487;
     name = "Rika";
   };
+  rikudou = {
+    email = "me@rikudousage.com";
+    github = "RikudouSage";
+    githubId = 13106547;
+    name = "RikudouSage";
+  };
   rileyinman = {
     email = "rileyminman@gmail.com";
     github = "rileyinman";

--- a/pkgs/tools/games/gog-downloader/default.nix
+++ b/pkgs/tools/games/gog-downloader/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, makeWrapper, lib, php }:
+
+let
+  pname = "gog-downloader";
+  version = "1.2.3";
+  hash = "0kv09vmrz6dcjvaf2sw89cpb14wdr01r1kkzg84szfxwzr5bcc9p";
+in
+stdenv.mkDerivation {
+  inherit pname version hash;
+
+  src = fetchurl {
+    url = "https://github.com/RikudouSage/GogDownloader/releases/download/v${version}/gog-downloader";
+    sha256 = hash;
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src $out/share/gog-downloader
+    makeWrapper ${php}/bin/php $out/bin/gog-downloader --add-flags "$out/share/gog-downloader"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    changelog = "https://github.com/RikudouSage/GogDownloader/releases/tag/v${version}";
+    description = "GOG games downloader";
+    longDescription = ''
+      GOG downloader is a tool for downloading game installers of games
+      you own on GOG. Supports various filters and options to fine-tune
+      your downloads.
+    '';
+    license = licenses.mit;
+    homepage = "https://github.com/RikudouSage/GogDownloader";
+    maintainers = [maintainers.rikudou];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41527,4 +41527,6 @@ with pkgs;
 
   wttrbar = callPackage ../applications/misc/wttrbar { };
 
+  gog-downloader = callPackage ../tools/games/gog-downloader { };
+
 }


### PR DESCRIPTION
## Description of changes

Adding a new package `gog-downloader` - a CLI tool to download game installers of games you own on GOG.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
