### PR TITLE
python310Packages.pecan: 1.4.2 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/pecan/default.nix
+++ b/pkgs/development/python-modules/pecan/default.nix
@@ -3,34 +3,35 @@
 , buildPythonPackage
 , logutils
 , mako
+, webob
 , webtest
 , pythonOlder
 , pytestCheckHook
 , genshi
 , gunicorn
 , jinja2
-, six
 , sqlalchemy
 , virtualenv
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "pecan";
-  version = "1.4.2";
+  version = "1.5.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-SbJV5wHD8UYWBfWw6PVPDCGSLXhF1BTCTdZAn+aV1VA=";
+    hash = "sha256-YGMnLV+GB3P7tLSyrhsJ2oyVQGLvhxFQwGz9sjkdk1U=";
   };
 
   propagatedBuildInputs = [
     logutils
     mako
-    webtest
-    six
+    webob
+    setuptools
   ];
 
   nativeCheckInputs = [
@@ -40,20 +41,11 @@ buildPythonPackage rec {
     jinja2
     sqlalchemy
     virtualenv
+    webtest
   ];
 
   pytestFlagsArray = [
     "--pyargs pecan"
-    # tests fail with sqlalchemy 2.0
-  ] ++ lib.optionals (lib.versionAtLeast sqlalchemy.version "2.0") [
-    # The 'sqlalchemy.orm.mapper()' function is removed as of SQLAlchemy
-    # 2.0.  Use the 'sqlalchemy.orm.registry.map_imperatively()` method
-    # of the ``sqlalchemy.orm.registry`` class to perform classical
-    # mapping.
-    # https://github.com/pecan/pecan/issues/143
-    "--deselect=pecan/tests/test_jsonify.py::TestJsonifySQLAlchemyGenericEncoder::test_result_proxy"
-    "--deselect=pecan/tests/test_jsonify.py::TestJsonifySQLAlchemyGenericEncoder::test_row_proxy"
-    "--deselect=pecan/tests/test_jsonify.py::TestJsonifySQLAlchemyGenericEncoder::test_sa_object"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Description of changes
update pecan to 1.5.1
Change log: https://pecan.readthedocs.io/en/latest/changes.html
As of 1.5 pecan only supports sqlalchemy 2.0.
Closed issue pecan/pecan#142 -> Re-enable tests.

Add missing `setuptools` runtime dependency causing pecan binary failed to import `pkg_resources`.
Closes #245766
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
