### PR TITLE
lftp: use openssl instead of gnutls

### DIFF
--- a/pkgs/tools/networking/lftp/default.nix
+++ b/pkgs/tools/networking/lftp/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, gnutls, pkg-config, readline, zlib, libidn2, gmp, libiconv, libunistring, gettext }:
+{ lib, stdenv, fetchurl, openssl, pkg-config, readline, zlib, libidn2, gmp, libiconv, libunistring, gettext }:
 
 stdenv.mkDerivation rec {
   pname = "lftp";
@@ -14,11 +14,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ gnutls readline zlib libidn2 gmp libiconv libunistring gettext ];
+  buildInputs = [ openssl readline zlib libidn2 gmp libiconv libunistring gettext ];
 
   hardeningDisable = lib.optional stdenv.isDarwin "format";
 
   configureFlags = [
+    "--with-openssl"
     "--with-readline=${readline.dev}"
     "--with-zlib=${zlib.dev}"
     "--without-expat"


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fixes lftp failing to verify sites secured with letsencrypt.

- more specifically, lftp doesn't validate the cross-signed ISRG Root X1 correctly<sup id="cite_ref-1"><a href="#cite_note-1">[1]</a></sup><sup id="cite_ref-2"><a href="#cite_note-2">[2]</a></sup>.
- this issue is not present when built against openssl.
- a fix for the gnutls codepath has been merged<sup id="cite_ref-3"><a href="#cite_note-3">[3]</a></sup>, but the project has not seen a release since 2020.
- given this, and the questionable quality of gnutls, it seems reasonable to build with openssl instead.

reproducing this bug yields the following:

```
Fatal error: Certificate verification: Not trusted (93:3C:6D:DE:E9:5C:9C:41:A4:0F:9F:50:49:3D:82:BE:03:AD:87:BF)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## References

<ol>
<li id="cite_note-1"><b><a href="#cite_ref-1">^</a></b> u_Ltd.. <a href="https://askubuntu.com/questions/1366456/lftp-certificate-suddenly-not-trusted#comment2395548_1366818">"lftp certificate suddenly not trusted"</a>. <i>Ask Ubuntu</i>.
<li id="cite_note-2"><b><a href="#cite_ref-2">^</a></b> Stefan Bühler. <a href="https://github.com/lavv17/lftp/issues/641">"gnutls integration code manually tries to verify chain, can't handle cross-signed CA"</a>. <i>GitHub</i>.
<li id="cite_note-3"><b><a href="#cite_ref-3">^</a></b> Miao Wang. <a href="https://github.com/lavv17/lftp/pull/642">"Use gnutls_certificate_verify_peers2 to verify server certificates"</a>. <i>GitHub</i>.
</ol>