### PR TITLE
qoi: init at unstable-2023-08-10

### DIFF
--- a/pkgs/development/libraries/qoi/default.nix
+++ b/pkgs/development/libraries/qoi/default.nix
@@ -1,0 +1,51 @@
+{ fetchFromGitHub
+, lib
+, stb
+, stdenv
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qoi";
+  version = "unstable-2023-08-10";  # no upstream version yet.
+
+  src = fetchFromGitHub {
+    owner = "phoboslab";
+    repo = "qoi";
+    rev = "19b3b4087b66963a3699ee45f05ec9ef205d7c0e";
+    hash = "sha256-E1hMtjMuDS2zma2s5hlHby/sroRGhtyZm9gLQ+VztsM=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ stb ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    make CFLAGS_CONV="-I${stb}/include/stb -O3" qoiconv
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Conversion utility for images->qoi. Not usually needed for development.
+    mkdir -p ${placeholder "out"}/bin
+    install qoiconv ${placeholder "out"}/bin
+
+    # The actual single-header implementation. Nothing to compile, just install.
+    mkdir -p ${placeholder "dev"}/include/
+    install qoi.h ${placeholder "dev"}/include
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "'Quite OK Image Format' for fast, lossless image compression";
+    homepage = "https://qoiformat.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hzeller ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24402,6 +24402,8 @@ with pkgs;
 
   qimageblitz = callPackage ../development/libraries/qimageblitz { };
 
+  qoi = callPackage ../development/libraries/qoi { };
+
   qolibri = libsForQt5.callPackage ../applications/misc/qolibri { };
 
   quarto = callPackage ../development/libraries/quarto { };


### PR DESCRIPTION
## Description of changes

Initial import of the [QOI image format](https://qoiformat.org/) single header implementation.

The repository also has a simple `qoiconv` image  conversion tool, so separated the outputs and provide a qoi.dev.

**For reviewer**: I am new to the separation of development outputs and 'regular' outputs, so please double-check that I did it correctly. qoi is a Header-only 'library', so the dev part just copies the header.

Context: I am using qoi in the [timg tool](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/graphics/timg/default.nix) which currently uses a vendored copy of qoi. With this, I'll be able to update the derivation to use qoi provided by nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
