### PR TITLE
farge: init at 1.0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8259,6 +8259,12 @@
     name = "John Soo";
     githubId = 10039785;
   };
+  jtbx = {
+    email = "jtbx@duck.com";
+    name = "Jeremy Baxter";
+    github = "jtbx";
+    githubId = 92071952;
+  };
   jtcoolen = {
     email = "jtcoolen@pm.me";
     name = "Julien Coolen";

--- a/pkgs/tools/misc/farge/default.nix
+++ b/pkgs/tools/misc/farge/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, bash
+, bc
+, feh
+, grim
+, imagemagick
+, slurp
+, wl-clipboard
+, xcolor
+, waylandSupport ? true
+, x11Support ? true
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "farge";
+  version = "1.0.9";
+
+  src = fetchFromGitHub {
+    owner = "sdushantha";
+    repo = "farge";
+    rev = "2ff6669e2350644d4f0b1bd84526efe5eae3c302";
+    hash = "sha256-vCMuFMGcI4D4EzbSsXeNGKNS6nBFkfTcAmSzb9UMArc=";
+  };
+
+  buildInputs = [ bash bc feh imagemagick ]
+    ++ lib.optionals waylandSupport [ grim slurp wl-clipboard ]
+    ++ lib.optionals x11Support [ xcolor ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -m755 farge $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A tool that shows the color value of a given pixel on your screen";
+    homepage = "https://github.com/sdushantha/farge";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jtbx ];
+    mainProgram = "farge";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7875,6 +7875,8 @@ with pkgs;
 
   faraday-cli = callPackage ../tools/security/faraday-cli { };
 
+  farge = callPackage ../tools/misc/farge { };
+
   fastlane = callPackage ../tools/admin/fastlane { };
 
   fatresize = callPackage ../tools/filesystems/fatresize { };


### PR DESCRIPTION
Added [farge](https://github.com/sdushantha/farge), a color picking script for X11 and Wayland.

Has been tested on NixOS x86_64.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
