### PR TITLE
sqlite-utils: repair, add test

### DIFF
--- a/pkgs/development/python-modules/sqlite-utils/default.nix
+++ b/pkgs/development/python-modules/sqlite-utils/default.nix
@@ -8,8 +8,11 @@
 , python-dateutil
 , sqlite-fts4
 , tabulate
+, pluggy
 , pytestCheckHook
 , hypothesis
+, testers
+, sqlite-utils
 }:
 
 buildPythonPackage rec {
@@ -35,6 +38,7 @@ buildPythonPackage rec {
     python-dateutil
     sqlite-fts4
     tabulate
+    pluggy
   ];
 
   nativeCheckInputs = [
@@ -45,6 +49,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "sqlite_utils"
   ];
+
+  passthru.tests.version = testers.testVersion {
+    package = sqlite-utils;
+  };
 
   meta = with lib; {
     description = "Python CLI utility and library for manipulating SQLite databases";


### PR DESCRIPTION
###### Description of changes

sqlite-utils broke with #244977 . The changelog mentions a new plugin system. Repair it and let's add a test to detect this early.

The error message was:
```
$ sqlite-utils
Traceback (most recent call last):
  File "/nix/store/7kz60hskb7zvl740a1w9yr83ii79pbr3-python3.10-sqlite-utils-3.34/bin/.sqlite-utils-wrapped", line 6, in <module>
    from sqlite_utils.cli import cli
  File "/nix/store/7kz60hskb7zvl740a1w9yr83ii79pbr3-python3.10-sqlite-utils-3.34/lib/python3.10/site-packages/sqlite_utils/__init__.py", line 2, in <module>
    from .hookspecs import hookimpl
  File "/nix/store/7kz60hskb7zvl740a1w9yr83ii79pbr3-python3.10-sqlite-utils-3.34/lib/python3.10/site-packages/sqlite_utils/hookspecs.py", line 1, in <module>
    from pluggy import HookimplMarker
ModuleNotFoundError: No module named 'pluggy'
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).