### PR TITLE
python310Packages.zope-i18nmessageid: 5.1.1 -> 6.0.1; rename

### DIFF
--- a/pkgs/development/python-modules/zope-component/default.nix
+++ b/pkgs/development/python-modules/zope-component/default.nix
@@ -6,7 +6,7 @@
 , zope_deprecation
 , zope_event
 , zope-hookable
-, zope_i18nmessageid
+, zope-i18nmessageid
 , zope_interface
 }:
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     zope_deprecation
     zope_event
     zope-hookable
-    zope_i18nmessageid
+    zope-i18nmessageid
     zope_interface
   ];
 

--- a/pkgs/development/python-modules/zope-i18nmessageid/default.nix
+++ b/pkgs/development/python-modules/zope-i18nmessageid/default.nix
@@ -2,13 +2,14 @@
 , buildPythonPackage
 , fetchPypi
 , six
-, coverage
 , zope_testrunner
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "zope-i18nmessageid";
   version = "5.1.1";
+  format = "setuptools";
 
   src = fetchPypi {
     pname = "zope.i18nmessageid";
@@ -18,13 +19,24 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six ];
 
-  nativeCheckInputs = [ coverage zope_testrunner ];
+  nativeCheckInputs = [
+    unittestCheckHook
+    zope_testrunner
+  ];
+
+  unittestFlagsArray = [
+    "src/zope/i18nmessageid"
+  ];
+
+  pythonImportsCheck = [
+    "zope.i18nmessageid"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/zopefoundation/zope.i18nmessageid";
     description = "Message Identifiers for internationalization";
+    changelog = "https://github.com/zopefoundation/zope.i18nmessageid/blob/${version}/CHANGES.rst";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];
   };
-
 }

--- a/pkgs/development/python-modules/zope-i18nmessageid/default.nix
+++ b/pkgs/development/python-modules/zope-i18nmessageid/default.nix
@@ -7,11 +7,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "zope.i18nmessageid";
+  pname = "zope-i18nmessageid";
   version = "5.1.1";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "zope.i18nmessageid";
+    inherit version;
     hash = "sha256-R7djR7gOCytmxIbuZvP4bFdJOiB1uFqfuAJpD6cwvZI=";
   };
 

--- a/pkgs/development/python-modules/zope-i18nmessageid/default.nix
+++ b/pkgs/development/python-modules/zope-i18nmessageid/default.nix
@@ -1,23 +1,20 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, six
 , zope_testrunner
 , unittestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "zope-i18nmessageid";
-  version = "5.1.1";
+  version = "6.0.1";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "zope.i18nmessageid";
     inherit version;
-    hash = "sha256-R7djR7gOCytmxIbuZvP4bFdJOiB1uFqfuAJpD6cwvZI=";
+    hash = "sha256-LVvOb7MfHOoO+iZEZJvIZ9KXIwPx272f/vzlsuueAXY=";
   };
-
-  propagatedBuildInputs = [ six ];
 
   nativeCheckInputs = [
     unittestCheckHook

--- a/pkgs/development/python-modules/zope_configuration/default.nix
+++ b/pkgs/development/python-modules/zope_configuration/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, zope_i18nmessageid
+, zope-i18nmessageid
 , zope_schema
 , zope_testrunner
 , manuel
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ zope_testrunner manuel ];
 
-  propagatedBuildInputs = [ zope_i18nmessageid zope_schema ];
+  propagatedBuildInputs = [ zope-i18nmessageid zope_schema ];
 
   # Need to investigate how to run the tests with zope-testrunner
   doCheck = false;

--- a/pkgs/development/python-modules/zope_size/default.nix
+++ b/pkgs/development/python-modules/zope_size/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, zope_i18nmessageid
+, zope-i18nmessageid
 , zope_interface
 }:
 
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     hash = "sha256-bhv3QJdZtNpyAuL6/aZXWD1Acx8661VweWaItJPpkHk=";
   };
 
-  propagatedBuildInputs = [ zope_i18nmessageid zope_interface ];
+  propagatedBuildInputs = [ zope-i18nmessageid zope_interface ];
 
   meta = with lib; {
     homepage = "https://github.com/zopefoundation/zope.size";

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -383,4 +383,5 @@ mapAliases ({
   zc_buildout_nix = throw "zc_buildout_nix was pinned to a version no longer compatible with other modules";
   zope_broken = throw "zope_broken has been removed because it is obsolete and not needed in zodb>=3.10"; # added 2023-07-26
   zope_component = zope-component; # added 2023-07-28
+  zope_i18nmessageid = zope-i18nmessageid; # added 2023-07-29
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13923,7 +13923,7 @@ self: super: with self; {
 
   zope-hookable = callPackage ../development/python-modules/zope-hookable { };
 
-  zope_i18nmessageid = callPackage ../development/python-modules/zope_i18nmessageid { };
+  zope-i18nmessageid = callPackage ../development/python-modules/zope-i18nmessageid { };
 
   zope_interface = callPackage ../development/python-modules/zope_interface { };
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/zopefoundation/zope.i18nmessageid/blob/6.0.1/CHANGES.rst

- rename from `zope_i18nmessageid`
- refactor

relates to #245383

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
