### PR TITLE
eza: init at 0.10.4

### DIFF
--- a/pkgs/tools/misc/eza/default.nix
+++ b/pkgs/tools/misc/eza/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, gitSupport ? true
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, cmake
+, pandoc
+, pkg-config
+, zlib
+, Security
+, libiconv
+, installShellFiles
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "eza";
+  version = "0.10.4";
+
+  src = fetchFromGitHub {
+    owner = "cafkafk";
+    repo = "eza";
+    rev = "v${version}";
+    hash = "sha256-9Pw7DQ/QTRHNsCPen+Nn5HdvjX1ju08q+KyitPF9+xQ=";
+  };
+
+  cargoHash = "sha256-KveRmlgyree77ZDOB4hQA35F/u/ARKiAHRgHpjCXOow=";
+
+  nativeBuildInputs = [ cmake pkg-config installShellFiles pandoc ];
+  buildInputs = [ zlib ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = lib.optional gitSupport "git";
+
+  outputs = [ "out" "man" ];
+
+  postInstall = ''
+    pandoc --standalone -f markdown -t man man/eza.1.md > man/eza.1
+    pandoc --standalone -f markdown -t man man/eza_colors.5.md > man/eza_colors.5
+    installManPage man/eza.1 man/eza_colors.5
+    installShellCompletion \
+      --bash completions/bash/eza \
+      --fish completions/fish/eza.fish \
+      --zsh completions/zsh/_eza
+  '';
+
+  meta = with lib; {
+    description = "A modern, maintained replacement for ls";
+    longDescription = ''
+      eza is a modern replacement for ls. It uses colours for information by
+      default, helping you distinguish between many types of files, such as
+      whether you are the owner, or in the owning group. It also has extra
+      features not present in the original ls, such as viewing the Git status
+      for a directory, or recursing into directories with a tree view. eza is
+      written in Rust, so it’s small, fast, and portable.
+    '';
+    homepage = "https://github.com/cafkafk/eza";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cafkafk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7789,6 +7789,10 @@ with pkgs;
 
   expliot = callPackage ../tools/security/expliot { };
 
+  eza = callPackage ../tools/misc/eza {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   f2fs-tools = callPackage ../tools/filesystems/f2fs-tools { };
 
   Fabric = with python3Packages; toPythonApplication fabric;


### PR DESCRIPTION
## Description of changes
Due to exa being [without any active maintainers](https://github.com/ogham/exa/issues/1139#issuecomment-1656702098), I and another contributor have created a [fork](https://github.com/cafkafk/eza).

Several major pull requests, as well as security fixes have already been made:

Changelog (general):
- Merged pr-1177: add hyperlink support
- Merged pr-855: add selinux context outputs
- Merged pr-797: git repo status, current branch
- Merged pr-1219: fish inode completions
- Merged pr-1164: -o shortcut for --octal-permissions
- Merged pr-1099: typo
- Merged pr-69: fix cargo.toml, completions, man pages
- Merged pr-981: use stdout for timezone errors

Changelog (security):
- Bumped openssl-src: SM2 Decryption Buffer Overflow (Critical)
- Bumped openssl-src: openssl-src contains Double free after calling `PEM_read_bio_ex` (High)
- Bumped openssl-src: AES OCB fails to encrypt some bytes (High)
- Bumped openssl-src: openssl-src's infinite loop in `BN_mod_sqrt()` reachable when parsing certificates (High)
- Bumped openssl-src: Read buffer overruns processing ASN.1 strings (High)
- Bumped openssl-src: openssl-src vulnerable to Use-after-free following `BIO_new_NDEF` (High)
- Bumped openssl-src: Vulnerable OpenSSL included in cryptography wheels (High)
- Bumped openssl-src: openssl-src subject to Timing Oracle in RSA Decryption (Moderate)
- Bumped git2-rs: git2-rs fails to verify SSH keys by default (Moderate)
- Bumped git2-rs: git2-rs fails to verify SSH keys by default (Moderate)

I think the security issue alone speak for the creation of this package (the features added equally so).

Everything is working, including autocompletions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
