### PR TITLE
Update maintainer-related info for WilliButz

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -231,11 +231,6 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 # VsCode Extensions
 /pkgs/applications/editors/vscode/extensions   @jonringer
 
-# Prometheus exporter modules and tests
-/nixos/modules/services/monitoring/prometheus/exporters.nix  @WilliButz
-/nixos/modules/services/monitoring/prometheus/exporters.xml  @WilliButz
-/nixos/tests/prometheus-exporters.nix                        @WilliButz
-
 # PHP interpreter, packages, extensions, tests and documentation
 /doc/languages-frameworks/php.section.md          @aanderse @drupol @etu @globin @ma27 @talyz
 /nixos/tests/php                                  @aanderse @drupol @etu @globin @ma27 @talyz

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -40,7 +40,7 @@ let
         description = "C++ library for developing web applications";
         platforms = platforms.linux;
         license = licenses.gpl2;
-        maintainers = with maintainers; [ juliendehos willibutz ];
+        maintainers = with maintainers; [ juliendehos ];
       };
     };
 in {

--- a/pkgs/servers/monitoring/prometheus/varnish-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/varnish-exporter.nix
@@ -26,6 +26,6 @@ buildGoModule rec {
     homepage = "https://github.com/jonnenauha/prometheus_varnish_exporter";
     description = "Varnish exporter for Prometheus";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ MostAwesomeDude willibutz ];
+    maintainers = with lib.maintainers; [ MostAwesomeDude ];
   };
 }

--- a/pkgs/tools/admin/oxidized/default.nix
+++ b/pkgs/tools/admin/oxidized/default.nix
@@ -14,7 +14,7 @@ bundlerApp {
     description = "A network device configuration backup tool. It's a RANCID replacement!";
     homepage    = "https://github.com/ytti/oxidized";
     license     = licenses.asl20;
-    maintainers = with maintainers; [ willibutz nicknovitski netali ];
+    maintainers = with maintainers; [ nicknovitski netali ];
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

After a period spanning approximately two years of essentially being inactive here for a few personal reasons, I'd like to _gradually_ return to actively maintaining nixpkgs again. :)

This PR removes me as code owner for the prometheus exporter infrastructure to reflect the status quo. It also removes me as maintainer from some packages which I no longer use and where I'm not the only maintainer.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).