### PR TITLE
nixos/invoiceplane allow caddy to run on specified port

### DIFF
--- a/nixos/modules/services/web-apps/invoiceplane.nix
+++ b/nixos/modules/services/web-apps/invoiceplane.nix
@@ -80,7 +80,7 @@ let
           '';
         };
         port = mkOption {
-          type = types.int;
+          type = types.port;
           default = 80;
           example = 8080;
           description = lib.mdDoc "Port for Caddy to listen on";

--- a/nixos/modules/services/web-apps/invoiceplane.nix
+++ b/nixos/modules/services/web-apps/invoiceplane.nix
@@ -79,6 +79,12 @@ let
             adjusted as required.
           '';
         };
+        port = mkOption {
+          type = types.int;
+          default = 80;
+          example = 8080;
+          description = lib.mdDoc "Port for Caddy to listen on";
+        };
 
         database = {
           host = mkOption {
@@ -343,7 +349,7 @@ in
     services.caddy = {
       enable = true;
       virtualHosts = mapAttrs' (hostName: cfg: (
-        nameValuePair "http://${hostName}" {
+        nameValuePair "http://${hostName}:${cfg.port}" {
           extraConfig = ''
             root * ${pkg hostName cfg}
             file_server

--- a/nixos/modules/services/web-apps/invoiceplane.nix
+++ b/nixos/modules/services/web-apps/invoiceplane.nix
@@ -9,7 +9,7 @@ let
   webserver = config.services.${cfg.webserver};
 
   invoiceplane-config = hostName: cfg: pkgs.writeText "ipconfig.php" ''
-    IP_URL=http://${hostName}
+    IP_URL=http://${hostName}${if cfg.port != 80 then ":" + (toString cfg.port) else ""}
     ENABLE_DEBUG=false
     DISABLE_SETUP=false
     REMOVE_INDEXPHP=false
@@ -349,7 +349,7 @@ in
     services.caddy = {
       enable = true;
       virtualHosts = mapAttrs' (hostName: cfg: (
-        nameValuePair "http://${hostName}:${cfg.port}" {
+        nameValuePair "http://${hostName}:${toString cfg.port}" {
           extraConfig = ''
             root * ${pkg hostName cfg}
             file_server


### PR DESCRIPTION
## Description of changes

Added the option to specify a port. The value is then used to write the IP_URL in the ipconfig.php file and to specify the virtualhost in the caddy settings.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
