### PR TITLE
commit-mono: init at 1.132

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18358,6 +18358,12 @@
     github = "ymeister";
     githubId = 47071325;
   };
+  yoavlavi = {
+    email = "yoav@yoavlavi.com";
+    github = "yoav-lavi";
+    githubId = 14347895;
+    name = "Yoav Lavi";
+  };
   yochai = {
     email = "yochai@titat.info";
     github = "yochai";

--- a/pkgs/data/fonts/commit-mono/default.nix
+++ b/pkgs/data/fonts/commit-mono/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenvNoCC
+, fetchzip
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "commit-mono";
+  version = "1.132";
+
+  src = fetchzip {
+    url = "https://github.com/eigilnikolajsen/commit-mono/releases/download/${version}/CommitMono-${version}.zip";
+    sha256 = "sha256-a9zxzjfOFmqemSIb4Tav0l7YtKvbyizDy+1dwPuZ4d4=";
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontPatch = true;
+  dontBuild = true;
+  dontFixup = true;
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 -t $out/share/fonts/opentype/ *.otf
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An anonymous and neutral programming typeface focused on creating a better reading experience";
+    homepage = "https://commitmono.com/";
+    license = licenses.ofl;
+    maintainers = [ maintainers.yoavlavi ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28875,6 +28875,8 @@ with pkgs;
 
   combinatorial_designs = callPackage ../data/misc/combinatorial_designs { };
 
+  commit-mono = callPackage ../data/fonts/commit-mono { };
+
   conway_polynomials = callPackage ../data/misc/conway_polynomials { };
 
   cooper-hewitt = callPackage ../data/fonts/cooper-hewitt { };


### PR DESCRIPTION
## Description of changes

commit-mono: init at 1.132

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

