### PR TITLE
Simplify hibernate test

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -597,6 +597,11 @@ in
       # drop-in in /etc, it does apply.
       overrideStrategy = "asDropin";
     };
+    systemd.services."systemd-mkswap@" = {
+      restartIfChanged = false;
+      path = [ pkgs.util-linux ];
+      overrideStrategy = "asDropin";
+    };
     systemd.services.systemd-random-seed.restartIfChanged = false;
     systemd.services.systemd-remount-fs.restartIfChanged = false;
     systemd.services.systemd-update-utmp.restartIfChanged = false;

--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -8,128 +8,48 @@
 
 with import ../lib/testing-python.nix { inherit system pkgs; };
 
-let
-  # System configuration of the installed system, which is used for the actual
-  # hibernate testing.
-  installedConfig = with pkgs.lib; {
-    imports = [
-      ../modules/testing/test-instrumentation.nix
-      ../modules/profiles/qemu-guest.nix
-      ../modules/profiles/minimal.nix
-    ];
-
-    hardware.enableAllFirmware = mkForce false;
-    documentation.nixos.enable = false;
-    boot.loader.grub.device = "/dev/vda";
-
-    systemd.services.backdoor.conflicts = [ "sleep.target" ];
-
-    powerManagement.resumeCommands = "systemctl --no-block restart backdoor.service";
-
-    fileSystems."/" = {
-      device = "/dev/vda2";
-      fsType = "ext3";
-    };
-    swapDevices = mkOverride 0 [ { device = "/dev/vda1"; } ];
-    boot.resumeDevice = mkIf systemdStage1 "/dev/vda1";
-    boot.initrd.systemd = mkIf systemdStage1 {
-      enable = true;
-      emergencyAccess = true;
-    };
-  };
-  installedSystem = (import ../lib/eval-config.nix {
-    inherit system;
-    modules = [ installedConfig ];
-  }).config.system.build.toplevel;
-in makeTest {
+makeTest {
   name = "hibernate";
 
   nodes = {
-    # System configuration used for installing the installedConfig from above.
     machine = { config, lib, pkgs, ... }: {
       imports = [
-        ../modules/profiles/installation-device.nix
-        ../modules/profiles/base.nix
         ./common/auto-format-root-device.nix
       ];
 
-      nix.settings = {
-        substituters = lib.mkForce [];
-        hashed-mirrors = null;
-        connect-timeout = 1;
-      };
+      systemd.services.backdoor.conflicts = [ "sleep.target" ];
+      powerManagement.resumeCommands = "systemctl --no-block restart backdoor.service";
 
-      virtualisation.diskSize = 8 * 1024;
-      virtualisation.emptyDiskImages = [
-        # Small root disk for installer
-        512
-      ];
-      virtualisation.rootDevice = "/dev/vdb";
+      virtualisation.emptyDiskImages = [ (2 * config.virtualisation.memorySize) ];
+      virtualisation.useNixStoreImage = true;
+
+      swapDevices = lib.mkOverride 0 [ { device = "/dev/vdc"; options = [ "x-systemd.makefs" ]; } ];
+      boot.resumeDevice = "/dev/vdc";
+      boot.initrd.systemd.enable = systemdStage1;
     };
   };
 
-  # 9P doesn't support reconnection to virtio transport after a hibernation.
-  # Therefore, machine just hangs on any Nix store access.
-  # To avoid this, we install NixOS onto a temporary disk with everything we need
-  # included into the store.
+  testScript = ''
+    # Drop in file that checks if we un-hibernated properly (and not booted fresh)
+    machine.wait_for_unit("default.target")
+    machine.succeed(
+        "mkdir /run/test",
+        "mount -t ramfs -o size=1m ramfs /run/test",
+        "echo not persisted to disk > /run/test/suspended",
+    )
 
-  testScript =
-    ''
-      def create_named_machine(name):
-          machine = create_machine(
-              {
-                  "qemuFlags": "-cpu max ${
-                    if system == "x86_64-linux" then "-m 1024"
-                    else "-m 768 -enable-kvm -machine virt,gic-version=host"}",
-                  "hdaInterface": "virtio",
-                  "hda": "vm-state-machine/machine.qcow2",
-                  "name": name,
-              }
-          )
-          driver.machines.append(machine)
-          return machine
+    # Hibernate machine
+    machine.execute("systemctl hibernate >&2 &", check_return=False)
+    machine.wait_for_shutdown()
 
+    # Restore machine from hibernation, validate our ramfs file is there.
+    machine.start()
+    machine.succeed("grep 'not persisted to disk' /run/test/suspended")
 
-      # Install NixOS
-      machine.start()
-      machine.succeed(
-          # Partition /dev/vda
-          "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
-          + " mkpart primary linux-swap 1M 1024M"
-          + " mkpart primary ext2 1024M -1s",
-          "udevadm settle",
-          "mkfs.ext3 -L nixos /dev/vda2",
-          "mount LABEL=nixos /mnt",
-          "mkswap /dev/vda1 -L swap",
-          # Install onto /mnt
-          "nix-store --load-db < ${pkgs.closureInfo {rootPaths = [installedSystem];}}/registration",
-          "nixos-install --root /mnt --system ${installedSystem} --no-root-passwd --no-channel-copy >&2",
-      )
-      machine.shutdown()
-
-      # Start up
-      hibernate = create_named_machine("hibernate")
-
-      # Drop in file that checks if we un-hibernated properly (and not booted fresh)
-      hibernate.succeed(
-          "mkdir /run/test",
-          "mount -t ramfs -o size=1m ramfs /run/test",
-          "echo not persisted to disk > /run/test/suspended",
-      )
-
-      # Hibernate machine
-      hibernate.execute("systemctl hibernate >&2 &", check_return=False)
-      hibernate.wait_for_shutdown()
-
-      # Restore machine from hibernation, validate our ramfs file is there.
-      resume = create_named_machine("resume")
-      resume.start()
-      resume.succeed("grep 'not persisted to disk' /run/test/suspended")
-
-      # Ensure we don't restore from hibernation when booting again
-      resume.crash()
-      resume.wait_for_unit("default.target")
-      resume.fail("grep 'not persisted to disk' /run/test/suspended")
-    '';
+    # Ensure we don't restore from hibernation when booting again
+    machine.crash()
+    machine.wait_for_unit("default.target")
+    machine.fail("grep 'not persisted to disk' /run/test/suspended")
+  '';
 
 }


### PR DESCRIPTION
## Description of changes

This isn't *exactly* a prerequisite for #243242, but it's closely related. With systemd 254, hibernation will now require us to set `boot.resumeDevice` when we're not EFI booting. I took the opportunity to greatly simplify the test now that we can use `useNixStoreImage` to avoid 9p altogether.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
