### PR TITLE
python3Packages.sphinx-basic-ng: 1.0.0.beta1 -> 1.0.0.beta2

### DIFF
--- a/pkgs/development/python-modules/sphinx-basic-ng/default.nix
+++ b/pkgs/development/python-modules/sphinx-basic-ng/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "sphinx-basic-ng";
-  version = "1.0.0.beta1";
+  version = "1.0.0.beta2";
   disable = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pradyunsg";
     repo = "sphinx-basic-ng";
     rev = version;
-    hash = "sha256-Zh9KvKs4js+AVSfIk0pAj6Kzq/O2m/MGTF+HCwYJTXk=";
+    hash = "sha256-MHBGIKOKhGklrx3O075LRud8NhY2hzlTWh+jalrFpko=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes
https://github.com/pradyunsg/sphinx-basic-ng/releases/tag/1.0.0.beta2
The four build failures (python311Packages.langchain, python311Packages.langchain.dist, python311Packages.libretranslate and python311Packages.libretranslate.dist) also happen on master because tensorflow does not compile.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).