### PR TITLE
proxmox-image: add additionalDiskSpace parameter as input to make-disk-image.nix

### DIFF
--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -95,8 +95,8 @@ with lib;
         '';
       };
 
-      additionalDiskSize = mkOption {
-        type = types.str;
+      additionalDiskSize = lib.mkOption {
+        type = lib.types.str;
         default = "512M";
         description = lib.mdDoc ''
           Additional disk space to be added to the image.

--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -94,6 +94,15 @@ with lib;
           Expect guest to have qemu agent running
         '';
       };
+
+      additionalDiskSize = mkOption {
+        type = types.str;
+        default = "512M";
+        description = lib.mdDoc ''
+          Additional disk space to be added to the image.
+          Defaults to 512M (Megabytes), Suffix can also be specified with `G` (gigabyte) or `K` (kilobyte).
+        '';
+      };
     };
     qemuExtraConf = mkOption {
       type = with types; attrsOf (oneOf [ str int ]);
@@ -116,6 +125,14 @@ with lib;
       default = if config.proxmox.qemuConf.bios == "seabios" then "legacy" else "efi";
       defaultText = lib.literalExpression ''if config.proxmox.qemuConf.bios == "seabios" then "legacy" else "efi"'';
       example = "hybrid";
+    };
+    additionalDiskSpace = mkOption {
+      type = types.str;
+      default = "512M";
+      description = lib.mdDoc ''
+        Additional disk space to be added to the image.
+        Defaults to 512M (Megabytes), Suffix can also be specified with `G` (gigabyte) or `K` (kilobyte).
+        '';
     };
     filenameSuffix = mkOption {
       type = types.str;
@@ -168,6 +185,7 @@ with lib;
     system.build.VMA = import ../../lib/make-disk-image.nix {
       name = "proxmox-${cfg.filenameSuffix}";
       inherit partitionTableType;
+      additionalSpace = config.proxmox.additionalDiskSpace;
       postVM = let
         # Build qemu with PVE's patch that adds support for the VMA format
         vma = (pkgs.qemu_kvm.override {

--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -94,15 +94,6 @@ with lib;
           Expect guest to have qemu agent running
         '';
       };
-
-      additionalDiskSize = lib.mkOption {
-        type = lib.types.str;
-        default = "512M";
-        description = lib.mdDoc ''
-          Additional disk space to be added to the image.
-          Defaults to 512M (Megabytes), Suffix can also be specified with `G` (gigabyte) or `K` (kilobyte).
-        '';
-      };
     };
     qemuExtraConf = mkOption {
       type = with types; attrsOf (oneOf [ str int ]);
@@ -126,7 +117,7 @@ with lib;
       defaultText = lib.literalExpression ''if config.proxmox.qemuConf.bios == "seabios" then "legacy" else "efi"'';
       example = "hybrid";
     };
-    additionalDiskSpace = mkOption {
+    additionalSpace = mkOption {
       type = types.str;
       default = "512M";
       description = lib.mdDoc ''
@@ -184,8 +175,7 @@ with lib;
     ];
     system.build.VMA = import ../../lib/make-disk-image.nix {
       name = "proxmox-${cfg.filenameSuffix}";
-      inherit partitionTableType;
-      additionalSpace = config.proxmox.additionalDiskSpace;
+      inherit (cfg) partitionTableType additionalSpace;
       postVM = let
         # Build qemu with PVE's patch that adds support for the VMA format
         vma = (pkgs.qemu_kvm.override {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Add additionalDiskSpace option for proxmox images to be passed to make-disk-image.nix.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
