### PR TITLE
[WIP] rpcs3: enable building on darwin

### DIFF
--- a/pkgs/by-name/rp/rpcs3/package.nix
+++ b/pkgs/by-name/rp/rpcs3/package.nix
@@ -21,8 +21,9 @@
   python3,
   pugixml,
   flatbuffers,
-  llvm_16,
+  llvm_18,
   cubeb,
+  opencv,
   enableDiscordRpc ? false,
   faudioSupport ? true,
   faudio,
@@ -34,10 +35,10 @@
 
 let
   # Keep these separate so the update script can regex them
-  rpcs3GitVersion = "17265-418a99a62";
-  rpcs3Version = "0.0.34-17265-418a99a62";
-  rpcs3Revision = "418a99a62b814b7f831072610c9e7d7b5e90610c";
-  rpcs3Hash = "sha256-NN7gEtt/18JCAHFZNQ8OqpATWx50qXda2Kk7NVq5T9Y=";
+  rpcs3GitVersion = "17543-1dc3ebf89";
+  rpcs3Version = "0.0.35-17543-1dc3ebf89";
+  rpcs3Revision = "1dc3ebf891d29a7cd31c940e4ba8aaf987421bce";
+  rpcs3Hash = "sha256-2pMR1q0QkEG+fxsE7+CST5IBJEDZDR+FoQ8RZUsvcco=";
 
   inherit (qt6Packages)
     qtbase
@@ -80,6 +81,7 @@ stdenv.mkDerivation {
     (lib.cmakeBool "USE_SYSTEM_PUGIXML" true)
     (lib.cmakeBool "USE_SYSTEM_FLATBUFFERS" true)
     (lib.cmakeBool "USE_SYSTEM_SDL" true)
+    (lib.cmakeBool "USE_SYSTEM_OPENCV" true)
     (lib.cmakeBool "USE_SDL" true)
     (lib.cmakeBool "WITH_LLVM" true)
     (lib.cmakeBool "BUILD_LLVM" false)
@@ -117,8 +119,9 @@ stdenv.mkDerivation {
       pugixml
       SDL2
       flatbuffers
-      llvm_16
+      llvm_18
       libSM
+      opencv
     ]
     ++ cubeb.passthru.backendLibs
     ++ lib.optional faudioSupport faudio


### PR DESCRIPTION
## Description of changes

Attempting to get rpcs3 compiling on Darwin.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

