### PR TITLE
python310Packages.scikit-build-core: 0.2.0 -> 0.4.8

### DIFF
--- a/pkgs/development/python-modules/scikit-build-core/default.nix
+++ b/pkgs/development/python-modules/scikit-build-core/default.nix
@@ -77,6 +77,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A next generation Python CMake adaptor and Python API for plugins";
     homepage = "https://github.com/scikit-build/scikit-build-core";
+    changelog = "https://github.com/scikit-build/scikit-build-core/releases/tag/v${version}";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ veprbl ];
   };

--- a/pkgs/development/python-modules/scikit-build-core/default.nix
+++ b/pkgs/development/python-modules/scikit-build-core/default.nix
@@ -8,6 +8,7 @@
 , hatchling
 , cattrs
 , cmake
+, ninja
 , packaging
 , pathspec
 , pyproject-metadata
@@ -18,13 +19,13 @@
 
 buildPythonPackage rec {
   pname = "scikit-build-core";
-  version = "0.2.0";
+  version = "0.4.8";
   format = "pyproject";
 
   src = fetchPypi {
     pname = "scikit_build_core";
     inherit version;
-    hash = "sha256-0qdtlEekEgONxeJd0lmwPCUnhmGgx8Padmu5ccGprNI=";
+    hash = "sha256-n6wcrBo4uhFoGQt72Y9irs8GzUbbcYXsjCeyfg2krUs=";
   };
 
   postPatch = ''
@@ -58,14 +59,17 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     cattrs
     cmake
+    ninja
     pytest-subprocess
     pytestCheckHook
   ] ++ passthru.optional-dependencies.pyproject;
 
   disabledTestPaths = [
     # runs pip, requires network access
+    "tests/test_custom_modules.py"
     "tests/test_pyproject_pep517.py"
     "tests/test_pyproject_pep518.py"
+    "tests/test_pyproject_pep660.py"
     "tests/test_setuptools_pep517.py"
     "tests/test_setuptools_pep518.py"
   ];


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/scikit-build/scikit-build-core/releases/tag/v0.4.8

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
