### PR TITLE
python3Packages.blinkstick: blinkstick: 1.2.0 -> unstable-2023-05-04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12992,6 +12992,12 @@
     githubId = 152312;
     name = "Periklis Tsirakidis";
   };
+  perstark = {
+    email = "perstark.se@gmail.com";
+    github = "perstarkse";
+    githubId = 63069986;
+    name = "Per Stark";
+  };
   petercommand = {
     email = "petercommand@gmail.com";
     github = "petercommand";

--- a/pkgs/development/python-modules/blinkstick/default.nix
+++ b/pkgs/development/python-modules/blinkstick/default.nix
@@ -1,24 +1,16 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, pyusb
-}:
+{ lib, buildPythonPackage, fetchFromGitHub, pyusb }:
 
 buildPythonPackage rec {
   pname = "blinkstick";
-  version = "1.2.0";
+  version = "unstable-2023-05-04";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0rdk3i81s6byw23za0bxvkh7sj5l16qxxgc2c53qjg3klc24wcm9";
+  src = fetchFromGitHub {
+    owner = "arvydas";
+    repo = "blinkstick-python";
+    rev = "8140b9fa18a9ff4f0e9df8e70c073f41cb8f1d35";
+    hash = "sha256-9bc7TD/Ilc952ywLauFd0+3Lh64lQlYuDC1KG9eWDgs=";
   };
-
-  # Upstream fix https://github.com/arvydas/blinkstick-python/pull/54
-  # https://github.com/arvydas/blinkstick-python/pull/54/commits/b9bee2cd72f799f1210e5d9e13207f93bbc2d244.patch
-  # has line ending issues after 1.2.0
-  postPatch = ''
-    substituteInPlace setup.py --replace "pyusb==1.0.0" "pyusb>=1.0.0"
-  '';
 
   propagatedBuildInputs = [ pyusb ];
 
@@ -26,10 +18,10 @@ buildPythonPackage rec {
   doCheck = false;
   pythonImportsCheck = [ "blinkstick" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python package to control BlinkStick USB devices";
     homepage = "https://github.com/arvydas/blinkstick-python";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ np ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ np perstark ];
   };
 }


### PR DESCRIPTION
## Description of changes

Update to build from github source instead of pip package. This due to new community patches being merged into main repository. postPatch is no longer needed, and various other updates are merged. No new release version. See [merged pull](https://github.com/arvydas/blinkstick-python/commits/master) requests for more information 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

