### PR TITLE
matrix-appservice-irc: 0.38.0 -> 1.0.1

### DIFF
--- a/nixos/modules/services/matrix/appservice-irc.nix
+++ b/nixos/modules/services/matrix/appservice-irc.nix
@@ -12,16 +12,14 @@ let
 
   configFile = pkgs.runCommand "matrix-appservice-irc.yml" {
     # Because this program will be run at build time, we need `nativeBuildInputs`
-    nativeBuildInputs = [ (pkgs.python3.withPackages (ps: [ ps.pyyaml ps.jsonschema ])) ];
+    nativeBuildInputs = [ (pkgs.python3.withPackages (ps: [ ps.jsonschema ])) pkgs.remarshal ];
     preferLocalBuild = true;
 
     config = builtins.toJSON cfg.settings;
     passAsFile = [ "config" ];
   } ''
     # The schema is given as yaml, we need to convert it to json
-    python -c 'import json; import yaml; import sys; json.dump(yaml.safe_load(sys.stdin), sys.stdout)' \
-      < ${pkg}/lib/node_modules/matrix-appservice-irc/config.schema.yml \
-      > config.schema.json
+    remarshal --if yaml --of json -i ${pkg}/config.schema.yml -o config.schema.json
     python -m jsonschema config.schema.json -i $configPath
     cp "$configPath" "$out"
   '';

--- a/pkgs/servers/matrix-synapse/matrix-appservice-irc/default.nix
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-irc/default.nix
@@ -1,32 +1,79 @@
 { lib
-, buildNpmPackage
+, stdenv
 , fetchFromGitHub
-, python3
+, fetchYarnDeps
+, prefetch-yarn-deps
+, nodejs
+, nodejs-slim
 , matrix-sdk-crypto-nodejs
 , nixosTests
 , nix-update-script
 }:
 
-buildNpmPackage rec {
+let
   pname = "matrix-appservice-irc";
-  version = "0.38.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
-    repo = "matrix-appservice-irc";
+    repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-rV4B9OQl1Ht26X4e7sqCe1PR5RpzIcjj4OvWG6udJWo=";
+    hash = "sha256-wUbWvCa9xvot73nXZjF3/RawM98ffBCW5YR2+ZKzmEo=";
   };
 
-  npmDepsHash = "sha256-iZuPr3a1BPtRfkEoxOs4oRL/nCfy3PLx5T9dX49/B0s=";
+  yarnOfflineCache = fetchYarnDeps {
+    name = "${pname}-${version}-offline-cache";
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-P9u5sK9rIHWRE8kFMj05fVjv26jwsawvHBZgSn7j5BE=";
+  };
+
+in
+stdenv.mkDerivation {
+  inherit pname version src yarnOfflineCache;
 
   nativeBuildInputs = [
-    python3
+    prefetch-yarn-deps
+    nodejs-slim
+    nodejs.pkgs.yarn
+    nodejs.pkgs.node-gyp-build
   ];
 
-  postInstall = ''
-    rm -rv $out/lib/node_modules/matrix-appservice-irc/node_modules/@matrix-org/matrix-sdk-crypto-nodejs
-    ln -sv ${matrix-sdk-crypto-nodejs}/lib/node_modules/@matrix-org/matrix-sdk-crypto-nodejs $out/lib/node_modules/matrix-appservice-irc/node_modules/@matrix-org/
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    yarn config --offline set yarn-offline-mirror "$yarnOfflineCache"
+    fixup-yarn-lock yarn.lock
+    yarn install --frozen-lockfile --offline --no-progress --non-interactive --ignore-scripts
+    patchShebangs node_modules/ bin/
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --offline build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp app.js config.schema.yml $out
+    cp -r bin lib public $out
+
+    # prune dependencies to production only
+    yarn install --frozen-lockfile --offline --no-progress --non-interactive --ignore-scripts --production
+    cp -r node_modules $out
+
+    # replace matrix-sdk-crypto-nodejs with nixos package
+    rm -rv $out/node_modules/@matrix-org/matrix-sdk-crypto-nodejs
+    ln -sv ${matrix-sdk-crypto-nodejs}/lib/node_modules/@matrix-org/matrix-sdk-crypto-nodejs $out/node_modules/@matrix-org/
+
+    runHook postInstall
   '';
 
   passthru.tests.matrix-appservice-irc = nixosTests.matrix-appservice-irc;


### PR DESCRIPTION
https://github.com/matrix-org/matrix-appservice-irc/releases/tag/1.0.0
    
* This release drops support for Node 16. The minimum required version is now 18+.
* Moved from NPM to Yarn

https://github.com/matrix-org/matrix-appservice-irc/releases/tag/1.0.1

* Fixes for GHSA-vc7j-h8xg-fv5x.
* Fixes for GHSA-3pmj-jqqp-2mj3.
* Fixes for GHSA-c7hh-3v6c-fj4q
* Update matrix-appservice-bridge to 9.0.1

while there was an effort to make this package with `mkYarnPackage`, in the end it
was suggested to just use `stdenv.mkDerivation` instead

nixos/matrix-appservice-irc:
* fix path to config.schema.yml directory stucture of the package changed
* use remarshal instead of python and pyyaml
  to convert the config schema from yaml to json


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

