### PR TITLE
Various VSCode / VSCodium extension additions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3410,6 +3410,22 @@ let
         };
       };
 
+      unifiedjs.vscode-mdx = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-mdx";
+          publisher = "unifiedjs";
+          version = "1.4.0";
+          sha256 = "sha256-qqqq0QKTR0ZCLdPltsnQh5eTqGOh9fV1OSOZMjj4xXg=";
+        };
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/unifiedjs.vscode-mdx/changelog";
+          description = "VSCode language support for MDX";
+          downloadPage = "https://github.com/mdx-js/mdx-analyzer";
+          homepage = "https://github.com/mdx-js/mdx-analyzer#readme";
+          license = lib.licenses.mit;
+        };
+      };
+
       usernamehw.errorlens = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "errorlens";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1107,6 +1107,22 @@ let
         };
       };
 
+      dotenv.dotenv-vscode = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "dotenv-vscode";
+          publisher = "dotenv";
+          version = "0.28.0";
+          sha256 = "sha256-KiQgFvbfLsA/ADROoG6y6c/i0XHuTNH2AN+6mWEm0P8=";
+        };
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/dotenv.dotenv-vscode/changelog";
+          description = "Official Dotenv extension for VSCode. Offers syntax highlighting, auto-cloaking, auto-completion, in-code secret peeking, and optionally dotenv-vault";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=dotenv.dotenv-vscode";
+          homepage = "https://github.com/dotenv-org/dotenv-vscode";
+          license = lib.licenses.mit;
+        };
+      };
+
       dotjoshjohnson.xml = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "xml";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1266,6 +1266,22 @@ let
         };
       };
 
+      enkia.tokyo-night = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "tokyo-night";
+          publisher = "enkia";
+          version = "1.0.0";
+          sha256 = "sha256-/fM+aUDUzVJ6P38i+GrxhLv2eLJNa8OFkKsM4yPBy4c=";
+        };
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/enkia.tokyo-night/changelog";
+          description = "A clean Visual Studio Code theme that celebrates the lights of Downtown Tokyo at night";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=enkia.tokyo-night";
+          homepage = "https://github.com/enkia/tokyo-night-vscode-theme";
+          license = lib.licenses.mit;
+        };
+      };
+
       equinusocio.vsc-material-theme = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vsc-material-theme";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1234,6 +1234,22 @@ let
         };
       };
 
+      emroussel.atomize-atom-one-dark-theme = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "atomize-atom-one-dark-theme";
+          publisher = "emroussel";
+          version = "2.0.2";
+          sha256 = "sha256-GwuFtBVj0Z2rHryst/7cegskvZIMPsrAH12+K942+JA=";
+        };
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/emroussel.atomize-atom-one-dark-theme/changelog";
+          description = "A detailed and accurate Atom One Dark theme for VSCode";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=emroussel.atomize-atom-one-dark-theme";
+          homepage = "https://github.com/emroussel/atomize/blob/main/README.md";
+          license = lib.licenses.mit;
+        };
+      };
+
       equinusocio.vsc-material-theme = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vsc-material-theme";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -507,6 +507,22 @@ let
         };
       };
 
+       bierner.docs-view = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "docs-view";
+          publisher = "bierner";
+          version = "0.0.11";
+          sha256 = "sha256-3njIL2SWGFp87cvQEemABJk2nXzwI1Il/WG3E0ZYZxw=";
+        };
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/bierner.docs-view/changelog";
+          description = "A VSCode extension that displays documentation in the sidebar or panel";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=bierner.docs-view";
+          homepage = "https://github.com/mattbierner/vscode-docs-view#readme";
+          license = lib.licenses.mit;
+        };
+      };
+
       bierner.emojisense = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "emojisense";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3649,6 +3649,21 @@ let
         };
       };
 
+      wmaurer.change-case = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "change-case";
+          publisher = "wmaurer";
+          version = "1.0.0";
+          sha256 = "sha256-tN/jlG2PzuiCeERpgQvdqDoa3UgrUaM7fKHv6KFqujc=";
+        };
+        meta = {
+          description = "A VSCode extension for quickly changing the case (camelCase, CONSTANT_CASE, snake_case, etc) of the current selection or current word";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=wmaurer.change-case";
+          homepage = "https://github.com/wmaurer/vscode-change-case";
+          license = lib.licenses.mit;
+        };
+      };
+
       xadillax.viml = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "viml";


### PR DESCRIPTION
## Description of changes

- vscode-extensions.emroussel.atomize-atom-one-dark-theme: init at 2.0.2
- vscode-extensions.wmaurer.change-case: init at 1.0.0
- vscode-extensions.bierner.docs-view: init at 0.0.11
- vscode-extensions.unifiedjs.vscode-mdx: init at 1.4.0
- vscode-extensions.enkia.tokyo-night: init at 1.0.0
- vscode-extensions.dotenv.dotenv-vscode: init at 0.28.0

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
