### PR TITLE
xsimd: 9.0.1 -> 11.1.0

### DIFF
--- a/pkgs/development/libraries/xsimd/default.nix
+++ b/pkgs/development/libraries/xsimd/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, cmake, doctest }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, doctest
+}:
+
 stdenv.mkDerivation rec {
   pname = "xsimd";
   version = "11.1.0";
@@ -9,14 +15,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-l6IRzndjb95hIcFCCm8zmlNHWtKduqy2t/oml/9Xp+w=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTS=${if (doCheck && stdenv.hostPlatform == stdenv.buildPlatform) then "ON" else "OFF"}"
   ];
 
   doCheck = true;
-  nativeCheckInputs = [ doctest ];
+  nativeCheckInputs = [
+    doctest
+  ];
   checkTarget = "xtest";
 
   meta = with lib; {

--- a/pkgs/development/libraries/xsimd/default.nix
+++ b/pkgs/development/libraries/xsimd/default.nix
@@ -14,6 +14,18 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-l6IRzndjb95hIcFCCm8zmlNHWtKduqy2t/oml/9Xp+w=";
   };
+  patches = [
+    # Ideally, Accelerate/Accelerate.h should be used for this implementation,
+    # but it doesn't work... Needs a Darwin user to debug this. We apply this
+    # patch unconditionally, because the #if macros make sure it doesn't
+    # interfer with the Linux implementations.
+    ./fix-darwin-exp10-implementation.patch
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Upstream reports:
+    # https://github.com/xtensor-stack/xsimd/issues/807
+    # https://github.com/xtensor-stack/xsimd/issues/917
+    ./disable-darwin-failing-tests.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/xsimd/default.nix
+++ b/pkgs/development/libraries/xsimd/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, cmake, gtest }:
+{ lib, stdenv, fetchFromGitHub, cmake, doctest }:
 stdenv.mkDerivation rec {
   pname = "xsimd";
-  version = "9.0.1";
+  version = "11.1.0";
   src = fetchFromGitHub {
     owner = "xtensor-stack";
     repo = "xsimd";
     rev = version;
-    sha256 = "sha256-onALN6agtrHWigtFlCeefD9CiRZI4Y690XTzy2UDnrk=";
+    sha256 = "sha256-l6IRzndjb95hIcFCCm8zmlNHWtKduqy2t/oml/9Xp+w=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -16,22 +16,8 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
-  nativeCheckInputs = [ gtest ];
+  nativeCheckInputs = [ doctest ];
   checkTarget = "xtest";
-  GTEST_FILTER =
-    let
-      # Upstream Issue: https://github.com/xtensor-stack/xsimd/issues/456
-      filteredTests = lib.optionals stdenv.hostPlatform.isDarwin [
-        "error_gamma_test/*"
-      ];
-    in
-    "-${builtins.concatStringsSep ":" filteredTests}";
-
-  # https://github.com/xtensor-stack/xsimd/issues/748
-  postPatch = ''
-    substituteInPlace xsimd.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
-  '';
 
   meta = with lib; {
     description = "C++ wrappers for SIMD intrinsics";

--- a/pkgs/development/libraries/xsimd/disable-darwin-failing-tests.patch
+++ b/pkgs/development/libraries/xsimd/disable-darwin-failing-tests.patch
@@ -1,0 +1,58 @@
+diff --git i/test/test_error_gamma.cpp w/test/test_error_gamma.cpp
+index 214cbb5..299e5b8 100644
+--- i/test/test_error_gamma.cpp
++++ w/test/test_error_gamma.cpp
+@@ -131,25 +131,6 @@ struct error_gamma_test
+             INFO("lgamma");
+             CHECK_EQ(diff, 0);
+         }
+-#if !(XSIMD_WITH_AVX && !XSIMD_WITH_AVX2)
+-
+-        // tgamma (negative input)
+-        {
+-            std::transform(gamma_neg_input.cbegin(), gamma_neg_input.cend(), expected.begin(),
+-                           [](const value_type& v)
+-                           { return std::lgamma(v); });
+-            batch_type in, out;
+-            for (size_t i = 0; i < nb_input; i += size)
+-            {
+-                detail::load_batch(in, gamma_neg_input, i);
+-                out = lgamma(in);
+-                detail::store_batch(out, res, i);
+-            }
+-            size_t diff = detail::get_nb_diff(res, expected);
+-            INFO("lgamma (negative input)");
+-            CHECK_EQ(diff, 0);
+-        }
+-#endif
+     }
+ };
+ 
+diff --git i/test/test_xsimd_api.cpp w/test/test_xsimd_api.cpp
+index 84b4b0b..1b29742 100644
+--- i/test/test_xsimd_api.cpp
++++ w/test/test_xsimd_api.cpp
+@@ -515,11 +515,6 @@ struct xsimd_api_float_types_functions
+         value_type val(2);
+         CHECK_EQ(extract(xsimd::exp(T(val))), std::exp(val));
+     }
+-    void test_exp10()
+-    {
+-        value_type val(2);
+-        CHECK_EQ(extract(xsimd::exp10(T(val))), std::pow(value_type(10), val));
+-    }
+     void test_exp2()
+     {
+         value_type val(2);
+@@ -804,11 +799,6 @@ TEST_CASE_TEMPLATE("[xsimd api | float types functions]", B, FLOAT_TYPES)
+         Test.test_exp();
+     }
+ 
+-    SUBCASE("exp10")
+-    {
+-        Test.test_exp10();
+-    }
+-
+     SUBCASE("exp2")
+     {
+         Test.test_exp2();

--- a/pkgs/development/libraries/xsimd/fix-darwin-exp10-implementation.patch
+++ b/pkgs/development/libraries/xsimd/fix-darwin-exp10-implementation.patch
@@ -1,0 +1,22 @@
+diff --git i/include/xsimd/arch/xsimd_scalar.hpp w/include/xsimd/arch/xsimd_scalar.hpp
+index 9066da6..7aa3b6b 100644
+--- i/include/xsimd/arch/xsimd_scalar.hpp
++++ w/include/xsimd/arch/xsimd_scalar.hpp
+@@ -502,16 +502,7 @@ namespace xsimd
+         return !(x0 == x1);
+     }
+ 
+-#if defined(__APPLE__)
+-    inline float exp10(const float& x) noexcept
+-    {
+-        return __exp10f(x);
+-    }
+-    inline double exp10(const double& x) noexcept
+-    {
+-        return __exp10(x);
+-    }
+-#elif defined(__GLIBC__)
++#if defined(__GLIBC__)
+     inline float exp10(const float& x) noexcept
+     {
+         return ::exp10f(x);


### PR DESCRIPTION
Diff: https://github.com/xtensor-stack/xsimd/compare/9.0.1...11.1.0

## Description of changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).