### PR TITLE
numcpp: init at 2.11.0

### DIFF
--- a/pkgs/development/libraries/numcpp/default.nix
+++ b/pkgs/development/libraries/numcpp/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  boost,
+  python3,
+  gtest,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "numcpp";
+  version = "2.11.0";
+
+  src = fetchFromGitHub {
+    owner = "dpilger26";
+    repo = "NumCpp";
+    rev = "Version_${finalAttrs.version}";
+    hash = "sha256-IAku1bcaMkawZxpQbvxcS6VX07ogw4UGo1DX2Wa8xwU=";
+  };
+
+  nativeCheckInputs = [gtest python3];
+
+  nativeBuildInputs = [cmake];
+
+  buildInputs = [boost];
+
+  cmakeFlags = lib.optionals finalAttrs.finalPackage.doCheck [
+    "-DBUILD_TESTS=ON"
+    "-DBUILD_MULTIPLE_TEST=ON"
+  ];
+
+  doCheck = !stdenv.isDarwin && !stdenv.hostPlatform.isStatic;
+
+  postInstall = ''
+    substituteInPlace $out/share/NumCpp/cmake/NumCppConfig.cmake \
+      --replace "\''${PACKAGE_PREFIX_DIR}/" ""
+  '';
+
+  NIX_CFLAGS_COMPILE="-Wno-error";
+
+  meta = with lib; {
+    description = "A Templatized Header Only C++ Implementation of the Python NumPy Library";
+    homepage = "https://github.com/dpilger26/NumCpp";
+    license = licenses.mit;
+    maintainers = with maintainers; [spalf];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23840,6 +23840,8 @@ with pkgs;
 
   ntrack = callPackage ../development/libraries/ntrack { };
 
+  numcpp = callPackage ../development/libraries/numcpp { };
+
   nuraft = callPackage ../development/libraries/nuraft { };
 
   nuspell = callPackage ../development/libraries/nuspell { };


### PR DESCRIPTION
## Description of changes

https://github.com/dpilger26/NumCpp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).