### PR TITLE
python310Packages.myst-nb: fix compatibility with myst-parser 1.0

### DIFF
--- a/pkgs/development/python-modules/myst-nb/default.nix
+++ b/pkgs/development/python-modules/myst-nb/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
+, fetchpatch
 , flit-core
 , importlib-metadata
 , ipython
@@ -30,6 +31,27 @@ buildPythonPackage rec {
     hash = "sha256-D2E4ZRX6sHxzZGrcqX//L2n0HpDTE6JgIXxbvkGdhYs=";
   };
 
+  patches = [
+    # Fix compatiblity with myst-parser 1.0. Remove with the next release.
+    (fetchpatch {
+      url = "https://github.com/executablebooks/MyST-NB/commit/48c45c6a8c4501005766c2d821b5e9ddfbedd5fa.patch";
+      hash = "sha256-jGL2MjZArvPtbiaR/rRGCIi0QwYO0iTIK26GLuTrBM8=";
+      excludes = [
+        "myst_nb/__init__.py"
+        "docs/authoring/custom-formats.Rmd"
+        "docs/authoring/jupyter-notebooks.md"
+        "docs/index.md"
+        "pyproject.toml"
+        "tests/nb_fixtures/reporter_warnings.txt"
+      ];
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "myst-parser~=0.18.0" "myst-parser"
+  '';
+
   nativeBuildInputs = [
     flit-core
     pythonRelaxDepsHook
@@ -53,7 +75,10 @@ buildPythonPackage rec {
     "myst-parser"
   ];
 
-  pythonImportsCheck = [ "myst_nb" ];
+  pythonImportsCheck = [
+    "myst_nb"
+    "myst_nb.sphinx_ext"
+  ];
 
   meta = with lib; {
     description = "A Jupyter Notebook Sphinx reader built on top of the MyST markdown parser";


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/241503

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
