### PR TITLE
josm: add update script

### DIFF
--- a/pkgs/applications/misc/josm/default.nix
+++ b/pkgs/applications/misc/josm/default.nix
@@ -3,19 +3,20 @@
 }:
 let
   pname = "josm";
-  version = "18789";
+  versions = builtins.fromJSON (lib.readFile (./versions.json));
+  version = versions.version;
   srcs = {
     jar = fetchurl {
-      url = "https://josm.openstreetmap.de/download/josm-snapshot-${version}.jar";
-      hash = "sha256-0NuCdGqDNY+UCXv9AhX4oT0WJbxMc5ghkL0YvqVWXOs=";
+      url = "https://josm.openstreetmap.de/download/josm-snapshot-${versions.version}.jar";
+      hash = versions.linux.hash;
     };
     macosx = fetchurl {
-      url = "https://josm.openstreetmap.de/download/macosx/josm-macos-${version}-java17.zip";
-      hash = "sha256-f8VoPMF7cR6idzadkXC6/oUfzq4dnKb3UPa2JjsRNsw=";
+      url = "https://josm.openstreetmap.de/download/macosx/josm-macos-${versions.version}-java17.zip";
+      hash = versions.macosx.hash;
     };
     pkg = fetchsvn {
       url = "https://josm.openstreetmap.de/svn/trunk/native/linux/tested";
-      rev = version;
+      rev = versions.version;
       sha256 = "sha256-/zdOaiyuvSwdVZcnw0ghDj2I+YKpFLc12fjZUMtRtVg=";
     };
   };

--- a/pkgs/applications/misc/josm/update_script.py
+++ b/pkgs/applications/misc/josm/update_script.py
@@ -1,0 +1,82 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3 python3.pkgs.requests python3.pkgs.beautifulsoup4
+import json
+import logging
+import pathlib
+import re
+import subprocess
+import sys
+
+from bs4 import BeautifulSoup
+import requests
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+# See https://httpd.apache.org/docs/2.4/mod/mod_autoindex.html#page-header
+apache_sort_params='?C=M;O=D'
+target_selector=re.compile('(^josm-macos-(\d+)-java(\d{2})\.zip)')
+
+current_path = pathlib.Path(__file__).parent
+versions_file_path = current_path.joinpath("versions.json").resolve()
+
+with open(versions_file_path, "r") as versions_file:
+    versions = json.load(versions_file)
+
+def nix_prefetch_url(url, algo='sha256'):
+    """Prefetches the content of the given URL."""
+    print(f'nix-prefetch-url {url}')
+    out = subprocess.check_output(['nix-prefetch-url', '--type', algo, url])
+    return out.decode('utf-8').rstrip()
+
+def get_current_version():
+    """Get the current revision."""
+    logging.info('Opening default.nix')
+    return versions["version"]
+
+def hash_to_sri(algorithm: str, value: str):
+    out = subprocess.check_output(['nix', "--show-trace", "--extra-experimental-features", "nix-command", "hash", "to-sri", "--type", algorithm, value])
+    return out.decode('utf-8').rstrip()
+
+
+# Check for changes in the macOS release, because this is not as frequently
+# updated as the linux release. Hence, we have fewer versions to check.
+linux_update_url = 'https://josm.openstreetmap.de/download/'
+mac_update_url = linux_update_url + 'macosx/'
+logging.info("Checking for updates from %s", linux_update_url)
+updates_response = requests.get(mac_update_url + apache_sort_params)
+
+soup = BeautifulSoup(updates_response.text, 'html.parser')
+
+# Find the first Link that matches our selector. This is the
+# most recent version, because we already request the listing
+# as sorted list.
+target_element=soup.find('a', {'href': target_selector})
+parsed_info=target_selector.match(target_element['href'])
+
+old_version = get_current_version()
+new_version = parsed_info.group(2)
+if old_version == new_version:
+    logging.info('No new update available.')
+    sys.exit(0)
+
+logging.info(f"Update found: josm: {old_version} -> {new_version}")
+
+versions["version"] = new_version
+versions["linux"]["hash"] = hash_to_sri('sha256',  nix_prefetch_url(linux_update_url + f"josm-snapshot-{new_version}.jar"))
+versions["macosx"]["hash"] = hash_to_sri('sha256', nix_prefetch_url(mac_update_url + target_element['href']))
+
+logging.info(f'Hash (Linux): {versions["linux"]["hash"]}')
+logging.info(f'Hash (MacOS): {versions["macosx"]["hash"]}')
+
+logging.info('Updating versions.json...')
+with open(versions_file_path, "w") as versions_file:
+    json.dump(versions, versions_file, indent=2)
+    versions_file.write("\n")
+
+# Commit the result:
+logging.info("Committing changes...")
+commit_message = f"josm: {old_version} -> {new_version}"
+subprocess.run(['git', 'add', versions_file_path], check=True)
+subprocess.run(['git', 'commit', '--file=-'], input=commit_message.encode(), check=True)
+
+logging.info("Done.")

--- a/pkgs/applications/misc/josm/versions.json
+++ b/pkgs/applications/misc/josm/versions.json
@@ -1,0 +1,9 @@
+{
+  "version": "18789",
+  "linux": {
+    "hash": "sha256-0NuCdGqDNY+UCXv9AhX4oT0WJbxMc5ghkL0YvqVWXOs="
+  },
+  "macosx": {
+    "hash": "sha256-f8VoPMF7cR6idzadkXC6/oUfzq4dnKb3UPa2JjsRNsw="
+  }
+}


### PR DESCRIPTION
## Description of changes

This does two things:
1. extract the hashes and version into a separate json file. This was done to avoid awkward regexes to update the version in the `default.nix` file (this way is much cleaner).
2. add an `update_script.py`. This file is directly executable and checks for a new JOSM Version in the macosx folder (the linux version may be updated more frequently, but we ignore that for now).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
