### PR TITLE
python3.pkgs.pydevd: fix tests against numpy 1.25

### DIFF
--- a/pkgs/development/python-modules/pydevd/default.nix
+++ b/pkgs/development/python-modules/pydevd/default.nix
@@ -2,6 +2,7 @@
 , lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , numpy
 , psutil
 , pytestCheckHook
@@ -23,6 +24,17 @@ buildPythonPackage rec {
     rev = "pydev_debugger_${lib.replaceStrings ["."] ["_"] version}";
     hash = "sha256-TDU/V7kY7zVxiP4OVjGqpsRVYplpkgCly2qAOqhZONo=";
   };
+
+  patches = [
+    # https://github.com/fabioz/PyDev.Debugger/pull/258
+    (fetchpatch {
+      name = "numpy-1.25-test-compatibility.patch";
+      url = "https://github.com/fabioz/PyDev.Debugger/commit/6f637d951cda62dc2202a2c7b6af526c4d1e8a00.patch";
+      hash = "sha256-DLzZZwQHtqGZGA8nsBLNQqamuI4xUfQ89Gd21sJa9/s=";
+    })
+  ];
+
+  __darwinAllowLocalNetworking = true;
 
   nativeCheckInputs = [
     numpy


### PR DESCRIPTION
## Description of changes

Pull in https://github.com/fabioz/PyDev.Debugger/pull/258 to fix `pydevd` tests when run against numpy 1.25 (at the time of this writing, that update is in staging-next).

Relevant to https://github.com/NixOS/nixpkgs/pull/245935.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
