### PR TITLE
ravenna-alsa-lkm-bondagit: init at unstable-2023-07-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18091,6 +18091,12 @@
     githubId = 15896005;
     name = "Vladyslav Burzakovskyy";
   };
+  mrobbetts = {
+    email = "mrobbetts@gmail.com";
+    github = "mrobbetts";
+    githubId = 1067896;
+    name = "Matthew Robbetts";
+  };
   MrSom3body = {
     email = "nix@sndh.dev";
     matrix = "@mrsom3body:matrix.org";

--- a/pkgs/os-specific/linux/ravenna-alsa-lkm-bondagit/default.nix
+++ b/pkgs/os-specific/linux/ravenna-alsa-lkm-bondagit/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "ravenna-alsa-lkm_${version}_${kernel.version}";
+
+  version = "1.14";
+
+  src = fetchFromGitHub {
+    owner = "bondagit";
+    repo = "ravenna-alsa-lkm";
+    rev = "7e3b67f35f7733fc7abc0bba53450ef9ca66785e";
+    sha256 = "sha256-iYZLnBsNLMwNlPk9lC0UUHoGyaPwqfN8z6nAGTMfpYA=";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  enableParallelBuilding = true;
+
+  configurePhase = ''
+    cd driver
+    substituteInPlace ./Makefile --replace "/lib/modules" "${kernel.dev}/lib/modules"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install --verbose --mode=644 -D --target-directory="$out/lib/modules/${kernel.modDirVersion}/kernel/sound/drivers/ravenna" MergingRavennaALSA.ko
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Merging Technologies' ALSA driver implementation of Ravenna and AES67, with additional work by bondagit";
+    homepage = "https://github.com/bondagit/ravenna-alsa-lkm";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.mrobbetts ];
+  };
+}

--- a/pkgs/os-specific/linux/ravenna-alsa-lkm-bondagit/default.nix
+++ b/pkgs/os-specific/linux/ravenna-alsa-lkm-bondagit/default.nix
@@ -3,13 +3,19 @@
 stdenv.mkDerivation rec {
   name = "ravenna-alsa-lkm_${version}_${kernel.version}";
 
-  version = "1.14";
+  version = "1.14+";
 
   src = fetchFromGitHub {
     owner = "bondagit";
     repo = "ravenna-alsa-lkm";
-    rev = "7e3b67f35f7733fc7abc0bba53450ef9ca66785e";
-    sha256 = "sha256-iYZLnBsNLMwNlPk9lC0UUHoGyaPwqfN8z6nAGTMfpYA=";
+/*
+    # 1.14. Works nicely with linux-6.14
+    #rev = "7e3b67f35f7733fc7abc0bba53450ef9ca66785e";
+    #sha256 = "sha256-iYZLnBsNLMwNlPk9lC0UUHoGyaPwqfN8z6nAGTMfpYA=";
+*/
+    # Include fixes for linux-6.15
+    rev = "e1ecd6a3f998396ee3066c3ff8fa4f246a560144";
+    hash = "sha256-VF19IviTPAIL+7sHKSkPRvxpE/aPPc0XJ4XcpMz5Efw=";
   };
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -513,6 +513,8 @@ in
 
         r8168 = callPackage ../os-specific/linux/r8168 { };
 
+        ravenna-alsa-lkm-bondagit = callPackage ../os-specific/linux/ravenna-alsa-lkm-bondagit { };
+
         rtl8188eus-aircrack = callPackage ../os-specific/linux/rtl8188eus-aircrack { };
 
         rtl8192eu = callPackage ../os-specific/linux/rtl8192eu { };


### PR DESCRIPTION
## Description of changes

Init the (customized) Merging Technologies Ravenna ALSA kernel module from https://github.com/bondagit/ravenna-alsa-lkm/

This module provides AES67 capability, (alongside a user-space control process, such as the [aes67-daemon](https://github.com/bondagit/aes67-linux-daemon) project, for which a NixOS PR will follow).

I have this running on my x86-64 linux system, enabled via:

```nix
boot.extraModulePackages = [ config.boot.kernelPackages.ravenna-alsa-lkm-bondagit ];
```

and auto-loaded with:

```nix
boot.kernelModules = [ ... "MergingRavennaALSA" ];
```

One question I have is, the upstream documentation notes that this module requires a kernel with:
```
NETFILTER
HIGH_RES_TIMERS
NETLINK
```

options enabled, but I couldn't figure out a way to define such a requirement from inside the driver's module package. One thought is, this driver is only really going to be pulled in as a dependency of the aes67-daemon package, for which I have a NixOS module, and these requirements can be encoded there. Is this the standard approach?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
