### PR TITLE
Update Heroic Games Launcher and dependencies

### DIFF
--- a/pkgs/games/gogdl/default.nix
+++ b/pkgs/games/gogdl/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonApplication rec {
   pname = "gogdl";
-  version = "0.7.2";
+  version = "0.7.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "heroic-gogdl";
-    rev = "d7f29dfef5818e8b323d04761e18a9abb750f93e";
-    hash = "sha256-9dAenawt9h/sz5paVYoqk+nmzPrInlqyh1EgshI25CE=";
+    rev = "d2fa34bfba7beb2ecc0e3fc70a657f2c612c8a10";
+    hash = "sha256-YCqtfY49lDg6sLrF/INOZVD9cMCwvejhySzUWrxHKAw=";
   };
 
   disabled = pythonOlder "3.8";

--- a/pkgs/games/gogdl/default.nix
+++ b/pkgs/games/gogdl/default.nix
@@ -1,4 +1,5 @@
 { lib
+, fetchpatch
 , writeScript
 , buildPythonApplication
 , fetchFromGitHub
@@ -25,6 +26,13 @@ buildPythonApplication rec {
   propagatedBuildInputs = [
     setuptools
     requests
+  ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/Heroic-Games-Launcher/heroic-gogdl/pull/37.patch";
+      hash = "sha256-oZLetPoWzsEDrL0Bh89HB4hTn70FTh8aXj9mKGr4Dqw=";
+    })
   ];
 
   pythonImportsCheck = [ "gogdl" ];

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -42,6 +42,8 @@ in stdenv.mkDerivation rec {
     # Reverts part of upstream PR 2761 so that we don't have to use a non-free Electron fork.
     # https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/2761
     ./remove-drm-support.patch
+    # Make Heroic create Steam shortcuts (to non-steam games) with the correct path to heroic.
+    ./fix-non-steam-shortcuts.patch
   ];
 
   configurePhase = ''

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -38,6 +38,12 @@ in stdenv.mkDerivation rec {
     makeWrapper
   ];
 
+  patches = [
+    # Reverts part of upstream PR 2761 so that we don't have to use a non-free Electron fork.
+    # https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/2761
+    ./remove-drm-support.patch
+  ];
+
   configurePhase = ''
     runHook preConfigure
 

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -10,23 +10,24 @@
 , electron
 , gogdl
 , legendary-gl
+, nile
 }:
 
 let appName = "heroic";
 in stdenv.mkDerivation rec {
   pname = "heroic-unwrapped";
-  version = "2.8.0";
+  version = "2.9.1";
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "HeroicGamesLauncher";
     rev = "v${version}";
-    hash = "sha256-AZwJRBkWuzBPT+ADVHabiK2KRXe6clZFa0IO99BO2Wk=";
+    hash = "sha256-1FtAcp6cG2qRfWrAgCOQ87DzMvszqqhObfSzepezBGc=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-xiLK0D9+oL2UMD7b/9htOQJEpYCNayKW+KJ/vNVCgsw=";
+    hash = "sha256-KEzTjtoBcHNJxC/7W/Bft75JZuZUSHieOOAwhbr5d3s=";
   };
 
   nativeBuildInputs = [
@@ -74,7 +75,11 @@ in stdenv.mkDerivation rec {
     chmod -R u+w "$out/share/${appName}/public/bin" "$out/share/${appName}/build/bin"
     rm -rf "$out/share/${appName}/public/bin" "$out/share/${appName}/build/bin"
     mkdir -p "$out/share/${appName}/build/bin/${binPlatform}"
-    ln -s "${gogdl}/bin/gogdl" "${legendary-gl}/bin/legendary" "$out/share/${appName}/build/bin/${binPlatform}"
+    ln -s \
+      "${gogdl}/bin/gogdl" \
+      "${legendary-gl}/bin/legendary" \
+      "${nile}"/bin/nile \
+      "$out/share/${appName}/build/bin/${binPlatform}"
 
     makeWrapper "${electron}/bin/electron" "$out/bin/heroic" \
       --inherit-argv0 \
@@ -92,7 +97,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A Native GOG and Epic Games Launcher for Linux, Windows and Mac";
+    description = "A Native GOG, Epic, and Amazon Games Launcher for Linux, Windows and Mac";
     homepage = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher";
     changelog = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases";
     license = licenses.gpl3Only;

--- a/pkgs/games/heroic/fix-non-steam-shortcuts.patch
+++ b/pkgs/games/heroic/fix-non-steam-shortcuts.patch
@@ -1,0 +1,13 @@
+diff --git a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+index ebef6aa4..c8bd853d 100644
+--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
++++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+@@ -252,7 +252,7 @@ async function addNonSteamGame(props: {
+     // add new Entry
+     const newEntry = {} as ShortcutEntry
+     newEntry.AppName = props.gameInfo.title
+-    newEntry.Exe = `"${app.getPath('exe')}"`
++    newEntry.Exe = `"heroic"`
+     newEntry.StartDir = `"${process.cwd()}"`
+ 
+     if (isFlatpak) {

--- a/pkgs/games/heroic/remove-drm-support.patch
+++ b/pkgs/games/heroic/remove-drm-support.patch
@@ -1,0 +1,24 @@
+diff --git a/src/backend/main.ts b/src/backend/main.ts
+index 2cd1a28f..a60e04d0 100644
+--- a/src/backend/main.ts
++++ b/src/backend/main.ts
+@@ -19,8 +19,7 @@ import {
+   powerSaveBlocker,
+   protocol,
+   screen,
+-  clipboard,
+-  components
++  clipboard
+ } from 'electron'
+ import 'backend/updater'
+ import { autoUpdater } from 'electron-updater'
+@@ -286,8 +285,7 @@ if (!gotTheLock) {
+     initImagesCache()
+ 
+     if (!process.env.CI) {
+-      await components.whenReady()
+-      logInfo(['DRM module staus', components.status()])
++      logInfo('DRM modules disabled for nixpkgs')
+     }
+ 
+     // try to fix notification app name on windows

--- a/pkgs/games/legendary-gl/default.nix
+++ b/pkgs/games/legendary-gl/default.nix
@@ -4,20 +4,24 @@
 , buildPythonApplication
 , pythonOlder
 , requests
+, filelock
 }:
 
 buildPythonApplication rec {
   pname = "legendary-gl"; # Name in pypi
-  version = "0.20.32";
+  version = "0.20.33";
 
   src = fetchFromGitHub {
     owner = "derrod";
     repo = "legendary";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-MsvhVS3lqhgBJ+S/cjXFP70I3rM5WBYT7TyVlRWhNWw=";
+    sha256 = "sha256-fEQUChkxrKV2IkFGORUolZE2qTzA10Xxogjl5Va4TcE=";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [
+    requests
+    filelock
+  ];
 
   disabled = pythonOlder "3.8";
 

--- a/pkgs/games/nile/default.nix
+++ b/pkgs/games/nile/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, writeScript
+, buildPythonApplication
+, fetchFromGitHub
+, pythonOlder
+, setuptools
+, requests
+, protobuf
+, pycryptodome
+, zstandard
+, json5
+, platformdirs
+, cacert
+}:
+
+buildPythonApplication rec {
+  pname = "nile";
+  version = "1.0.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "imLinguin";
+    repo = "nile";
+    rev = "f5f3b96f6483c59cfc646afbda6e97cb0bd94778";
+    hash = "sha256-HibY3U9/MibEDwHY+YiErW/pz6qwtps8wwjhznTISgA=";
+  };
+
+  disabled = pythonOlder "3.8";
+
+  propagatedBuildInputs = [
+    setuptools
+    requests
+    protobuf
+    pycryptodome
+    zstandard
+    json5
+    platformdirs
+  ];
+
+  pyprojectAppendix = ''
+    [tool.setuptools.packages.find]
+    include = ["nile*"]
+  '';
+
+  postPatch = ''
+    echo "$pyprojectAppendix" >> pyproject.toml
+  '';
+
+  pythonImportsCheck = [ "nile" ];
+
+  meta = with lib; {
+    description = "Unofficial Amazon Games client";
+    homepage = "https://github.com/imLinguin/nile";
+    license = with licenses; [ gpl3 ];
+    maintainers = with maintainers; [ aidalgol ];
+  };
+
+  # Upstream does not create git tags when bumping the version, so we have to
+  # extract it from the source code on the main branch.
+  passthru.updateScript = writeScript "gogdl-update-script" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl gnused jq common-updater-scripts
+    set -eou pipefail;
+
+    owner=imLinguin
+    repo=nile
+    path='nile/__init__.py'
+
+    version=$(
+      curl --cacert "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+      https://raw.githubusercontent.com/$owner/$repo/main/$path |
+      sed -n 's/^\s*version\s*=\s*"\([0-9]\.[0-9]\.[0-9]\)"\s*$/\1/p')
+
+    commit=$(curl --cacert "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+      https://api.github.com/repos/$owner/$repo/commits?path=$path |
+      jq -r '.[0].sha')
+
+    update-source-version \
+      ${pname} \
+      "$version" \
+      --file=./pkgs/games/nile/default.nix \
+      --rev=$commit
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37600,6 +37600,8 @@ with pkgs;
 
   nexuiz = callPackage ../games/nexuiz { };
 
+  nile = python3Packages.callPackage ../games/nile { };
+
   ninvaders = callPackage ../games/ninvaders { };
 
   njam = callPackage ../games/njam { };


### PR DESCRIPTION
## Description of changes
Update Heroic to 2.9.1, and its dependencies gogdl and legendary (@equirosa) to their latest stable versions.  Also added Nile for Heroic's Amazon Games support.

This version upstream moved to a non-free Electron fork for DRM support to go along with the new support for web applications.  This has been patched out to allow us to continue using mainline Electron from nixpkgs.

If anyone wants to take on packaging the [ECS fork](https://github.com/castlabs/electron-releases), then we can add an option to build the heroic package with and without DRM support (e.g. `heroic` and `heroic-unfree`).

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
