### PR TITLE
ocamlPackages.mirage-clock: 3.1.0 → 4.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-clock/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-clock/default.nix
@@ -2,15 +2,13 @@
 
 buildDunePackage rec {
   pname = "mirage-clock";
-  version = "3.1.0";
+  version = "4.2.0";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.06";
+  minimalOCamlVersion = "4.06";
 
   src = fetchurl {
-    url = "https://github.com/mirage/mirage-clock/releases/download/v${version}/mirage-clock-v${version}.tbz";
-    sha256 = "0cqa07aqkamw0dvis1fl46brvk81zvb92iy5076ik62gv9n5a0mn";
+    url = "https://github.com/mirage/mirage-clock/releases/download/v${version}/mirage-clock-${version}.tbz";
+    hash = "sha256-+hfRXVviPHm6dB9ffLiO1xEt4WpEEM6oHHG5gIaImEc=";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/mirage-clock/solo5.nix
+++ b/pkgs/development/ocaml-modules/mirage-clock/solo5.nix
@@ -4,13 +4,11 @@
 }:
 
 buildDunePackage {
-  pname = "mirage-clock-freestanding";
+  pname = "mirage-clock-solo5";
 
   inherit (mirage-clock)
     version
     src
-    useDune2
-    minimumOCamlVersion
     ;
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/mirage-clock/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-clock/unix.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "mirage-clock-unix";
 
-  inherit (mirage-clock) version useDune2 src;
+  inherit (mirage-clock) version src;
 
   buildInputs = [ dune-configurator ];
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1000,7 +1000,7 @@ let
 
     mirage-clock = callPackage ../development/ocaml-modules/mirage-clock { };
 
-    mirage-clock-freestanding = callPackage ../development/ocaml-modules/mirage-clock/freestanding.nix { };
+    mirage-clock-solo5 = callPackage ../development/ocaml-modules/mirage-clock/solo5.nix { };
 
     mirage-clock-unix = callPackage ../development/ocaml-modules/mirage-clock/unix.nix { };
 


### PR DESCRIPTION
## Description of changes

https://github.com/mirage/mirage-clock/blob/v4.2.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
