### PR TITLE
icloudpd: init at 1.15.1

### DIFF
--- a/pkgs/applications/networking/icloudpd/default.nix
+++ b/pkgs/applications/networking/icloudpd/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3Packages
+, nix-update-script
+, icloudpd
+, testers
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "icloudpd";
+  version = "1.15.1";
+  format = "pyproject";
+
+  src =  fetchFromGitHub {
+    owner = "icloud-photos-downloader";
+    repo = "icloud_photos_downloader";
+    rev = "v${version}";
+    sha256 = "sha256-nKtV9VGcEiIVfg1XeHzIw9kr2pp4aHugfjVK03iPDR8=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    wheel
+    setuptools
+    requests
+    schema
+    click
+    python-dateutil
+    tqdm
+    piexif
+    urllib3
+    six
+    tzlocal
+    pytz
+    certifi
+    future
+    keyring
+    keyrings-alt
+    pytest
+    mock
+    freezegun
+    vcrpy
+    pytest-cov
+    pylint
+    coveralls
+    autopep8
+    pytest-timeout
+    pytest-xdist
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = testers.testVersion { package = icloudpd; };
+  };
+
+  preBuild = ''
+    substituteInPlace pyproject.toml \
+      --replace "certifi>=2022.12.7,<2023" "certifi" \
+      --replace "urllib3>=1.26.14,<2" "urllib3" \
+      --replace "pytz>=2022.7.1,<2023" "pytz"
+  '';
+  doCheck = false;
+  meta = with lib; {
+    homepage = "https://github.com/icloud-photos-downloader/icloud_photos_downloader";
+    description = "iCloud Photos Downloader";
+    license = licenses.mit;
+    maintainers = with maintainers; [ anpin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41793,4 +41793,6 @@ with pkgs;
   gitrs = callPackage ../tools/misc/gitrs { };
 
   wttrbar = callPackage ../applications/misc/wttrbar { };
+
+  icloudpd = callPackage ../applications/networking/icloudpd { };
 }


### PR DESCRIPTION
## Description of changes

A command-line tool to download photos from iCloud 
https://github.com/icloud-photos-downloader/icloud_photos_downloader

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).