### PR TITLE
sn-cli: init at 0.2.4

### DIFF
--- a/pkgs/applications/misc/sn-cli/default.nix
+++ b/pkgs/applications/misc/sn-cli/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, buildGoModule, installShellFiles, stdenv, testers, gh }:
+
+buildGoModule rec {
+  pname = "sn-cli";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "jonhadfield";
+    repo = "sn-cli";
+    rev = "${version}";
+    hash = "sha256-KU1EW/yJ+Ff8Cwv1GnFlRv7AyRLZ4/3tqNUQDJL/peo=";
+  };
+
+  vendorHash = "sha256-mTgh11XjsAedFXJVAP7iaDt1XaGaNYPaozlsN4DNtek=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # requires a server instance to work against
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A command line interface for standard notes";
+    homepage = "https://github.com/jonhadfield/sn-cli";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ s1341 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6151,6 +6151,8 @@ with pkgs;
 
   smokeqt = callPackage ../development/libraries/smokeqt { };
 
+  sn-cli = callPackage ../applications/misc/sn-cli { };
+
   snazy = callPackage ../development/tools/snazy { };
 
   snippetpixie = callPackage ../tools/text/snippetpixie { };


### PR DESCRIPTION
Init's the `sn-cli` tool, which allows command line access to Standard Notes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
