### PR TITLE
fcitx5: pass FCITX_ADDON_DIRS to fcitx5-qt via configtool

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -48,8 +48,6 @@ mkDerivation rec {
     libXdmcp
   ];
 
-  qtWrapperArgs = [ "--prefix" "FCITX_ADDON_DIRS" ":" "${placeholder "out"}/lib/fcitx5" ];
-
   meta = with lib; {
     description = "Fcitx5 Qt Library";
     homepage = "https://github.com/fcitx/fcitx5-qt";

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -2,6 +2,7 @@
 , symlinkJoin
 , makeBinaryWrapper
 , fcitx5
+, withConfigtool ? true
 , fcitx5-configtool
 , fcitx5-qt
 , fcitx5-gtk
@@ -11,7 +12,13 @@
 symlinkJoin {
   name = "fcitx5-with-addons-${fcitx5.version}";
 
-  paths = [ fcitx5 fcitx5-configtool fcitx5-qt fcitx5-gtk ] ++ addons;
+  paths = [
+    fcitx5
+    fcitx5-qt
+    fcitx5-gtk
+  ] ++ lib.optionals withConfigtool [
+    fcitx5-configtool
+  ] ++ addons;
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
@@ -22,7 +29,7 @@ symlinkJoin {
       --suffix PATH : "$out/bin" \
       --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath (lib.flatten (map (x: x.extraLdLibraries or []) addons))}"
 
-    ${lib.optionalString (fcitx5-configtool != null)''
+    ${lib.optionals withConfigtool ''
       # Configtool call libexec/fcitx5-qt5-gui-wrapper for gui addons in FCITX_ADDON_DIRS
       wrapProgram $out/bin/fcitx5-config-qt --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5"
     ''}

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -1,6 +1,6 @@
 { lib
 , symlinkJoin
-, makeWrapper
+, makeBinaryWrapper
 , fcitx5
 , fcitx5-configtool
 , fcitx5-qt
@@ -13,14 +13,14 @@ symlinkJoin {
 
   paths = [ fcitx5 fcitx5-configtool fcitx5-qt fcitx5-gtk ] ++ addons;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
 
   postBuild = ''
     wrapProgram $out/bin/fcitx5 \
       --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5" \
       --suffix XDG_DATA_DIRS : "$out/share" \
       --suffix PATH : "$out/bin" \
-      --suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath (lib.flatten (map (x: x.extraLdLibraries or []) addons))}
+      --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath (lib.flatten (map (x: x.extraLdLibraries or []) addons))}"
 
     ${lib.optionalString (fcitx5-configtool != null)''
       # Configtool call libexec/fcitx5-qt5-gui-wrapper for gui addons in FCITX_ADDON_DIRS

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -1,4 +1,12 @@
-{ lib, symlinkJoin, makeWrapper, fcitx5, fcitx5-configtool, fcitx5-qt, fcitx5-gtk, addons ? [ ] }:
+{ lib
+, symlinkJoin
+, makeWrapper
+, fcitx5
+, fcitx5-configtool
+, fcitx5-qt
+, fcitx5-gtk
+, addons ? [ ]
+}:
 
 symlinkJoin {
   name = "fcitx5-with-addons-${fcitx5.version}";
@@ -13,6 +21,11 @@ symlinkJoin {
       --suffix XDG_DATA_DIRS : "$out/share" \
       --suffix PATH : "$out/bin" \
       --suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath (lib.flatten (map (x: x.extraLdLibraries or []) addons))}
+
+    ${lib.optionalString (fcitx5-configtool != null)''
+      # Configtool call libexec/fcitx5-qt5-gui-wrapper for gui addons in FCITX_ADDON_DIRS
+      wrapProgram $out/bin/fcitx5-config-qt --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5"
+    ''}
 
     desktop=share/applications/org.fcitx.Fcitx5.desktop
     autostart=etc/xdg/autostart/org.fcitx.Fcitx5.desktop


### PR DESCRIPTION
## Description of changes

fcitx5 configtool load gui addons via `fcitx5-qt5-gui-wrapper` from `fcitx5-qt`. However, `fcitx5-qt5-gui-wrapper` finds gui addons in `FCITX_ADDON_DIRS` which needs to be set to the path in `fcitx5-with-addons` so that gui addons from addons can be found. So the `FCITX_ADDON_DIRS` needs to be added to the wrapper in `with-addons.nix`. However (another however), [`fcitx5-configtool` find `fcitx5-qt` in its `buildInputs`](https://github.com/fcitx/fcitx5-configtool/blob/fd53565aab2dd908269f2cccbd0d2bfeb7f13b1c/CMakeLists.txt#L65) so that it doesn't use the wrapper of `fcitx5-qt5-gui-wrapper` in `fcitx5-with-addons`. So `fcitx5-configtool` is wrapped instead and the `FCITX_ADDON_DIRS` is inherited.

This is a proper fix for https://github.com/NixOS/nixpkgs/pull/245920.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@NickCao 