### PR TITLE
texstudio: 4.5.2 -> 4.6.2

### DIFF
--- a/pkgs/applications/editors/texstudio/default.nix
+++ b/pkgs/applications/editors/texstudio/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation rec {
   pname = "texstudio";
-  version = "4.5.2";
+  version = "4.6.2";
 
   src = fetchFromGitHub {
     owner = "${pname}-org";
     repo = pname;
     rev = version;
-    hash = "sha256-L+q4+k4XWywnxIvhfXPCBeCqnGj4E9BhAmgcAZhm7S8=";
+    hash = "sha256-2bvKB/8HcZoTk2J6FQXXJREqGp6EZ95C2Aqcx9o/eho=";
   };
 
   nativeBuildInputs = [ cmake wrapQtAppsHook pkg-config ];

--- a/pkgs/applications/editors/texstudio/default.nix
+++ b/pkgs/applications/editors/texstudio/default.nix
@@ -1,19 +1,33 @@
-{ lib, mkDerivation, fetchFromGitHub, cmake, qtbase, qtscript, qtsvg,
-  wrapQtAppsHook, poppler, zlib, pkg-config }:
+{ stdenv, lib, fetchFromGitHub, cmake, qtbase, qttools, qtsvg, qt5compat, quazip
+, hunspell
+, wrapQtAppsHook, poppler, zlib, pkg-config }:
 
-mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "texstudio";
   version = "4.6.2";
 
   src = fetchFromGitHub {
-    owner = "${pname}-org";
-    repo = pname;
-    rev = version;
+    owner = "texstudio-org";
+    repo = "texstudio";
+    rev = finalAttrs.version;
     hash = "sha256-2bvKB/8HcZoTk2J6FQXXJREqGp6EZ95C2Aqcx9o/eho=";
   };
 
-  nativeBuildInputs = [ cmake wrapQtAppsHook pkg-config ];
-  buildInputs = [ qtbase qtscript qtsvg poppler zlib ];
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+    pkg-config
+  ];
+  buildInputs = [
+    hunspell
+    poppler
+    qt5compat
+    qtbase
+    qtsvg
+    qttools
+    quazip
+    zlib
+  ];
 
   meta = with lib; {
     description = "TeX and LaTeX editor";
@@ -28,4 +42,4 @@ mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ ajs124 cfouche ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13465,7 +13465,7 @@ with pkgs;
 
   texmaker = libsForQt5.callPackage ../applications/editors/texmaker { };
 
-  texstudio = libsForQt5.callPackage ../applications/editors/texstudio { };
+  texstudio = qt6Packages.callPackage ../applications/editors/texstudio { };
 
   textadept = callPackage ../applications/editors/textadept { };
 


### PR DESCRIPTION
## Description of changes
https://texstudio-org.github.io/CHANGELOG.html#texstudio-4-6-2

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).