### PR TITLE
libkcapi: init at 1.4.0

### DIFF
--- a/pkgs/development/libraries/libkcapi/default.nix
+++ b/pkgs/development/libraries/libkcapi/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, buildPackages
+  # libkcapi offers multiple tools. They can be disabled for minimization.
+, kcapi-test ? true
+, kcapi-speed ? true
+, kcapi-hasher ? true
+, kcapi-rngapp ? true
+, kcapi-encapp ? true
+, kcapi-dgstapp ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libkcapi";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "smuellerDD";
+    repo = "libkcapi";
+    rev = "v${version}";
+    hash = "sha256-G/4G8179Gc8RfQfQImOCsBC8WXKK7jQJfUSXm0hYLJ0=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  # libkcapi looks also for a host c compiler when cross-compiling
+  # otherwise you obtain following error message:
+  # "error: no acceptable C compiler found in $PATH"
+  depsBuildBuild = [
+    buildPackages.stdenv.cc
+  ];
+
+  enableParallelBuilding = true;
+
+  configureFlags =
+    lib.optional kcapi-test "--enable-kcapi-test" ++
+    lib.optional kcapi-speed "--enable-kcapi-speed" ++
+    lib.optional kcapi-hasher "--enable-kcapi-hasher" ++
+    lib.optional kcapi-rngapp "--enable-kcapi-rngapp" ++
+    lib.optional kcapi-encapp "--enable-kcapi-encapp" ++
+    lib.optional kcapi-dgstapp "--enable-kcapi-dgstapp"
+  ;
+
+  meta = {
+    homepage = "http://www.chronox.de/libkcapi.html";
+    description = "Linux Kernel Crypto API User Space Interface Library";
+    license = with lib.licenses; [ bsd3 gpl2Only ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ orichter thillux ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22464,6 +22464,8 @@ with pkgs;
 
   libinklevel = callPackage ../development/libraries/libinklevel { };
 
+  libkcapi = callPackage ../development/libraries/libkcapi { };
+
   libnats-c = callPackage ../development/libraries/libnats-c { };
 
   liburing = callPackage ../development/libraries/liburing { };


### PR DESCRIPTION
add libkcapi (Linux Kernel Crypto API User Space Interface Library) as a package.
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
libkcapi allows the user-space to access the Linux kernel crypto API.
The esdm package may include support for libkcapi in the jittentropy source in a future release. Therefor having this package upstream would be prefered.
Homepage: http://chronox.de/libkcapi.html
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
