### PR TITLE
{bambootracker,bambootracker-qt6}: Adapt to upcoming RtAudio 6.0.0

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , pkg-config
 , qmake
 , qt5compat ? null
@@ -24,6 +25,18 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
     hash = "sha256-Ymi1tjJCgStF0Rtseelq/YuTtBs2PrbF898TlbjyYUw=";
   };
+
+  patches = lib.optionals (lib.versionAtLeast rtaudio.version "6") [
+    # RtAudio 6.0.0 is a breaking API change, this commit makes a hard switch to the new API
+    # Remove when BambooTracker > 0.6.1, RtAudio >= 6.0.0
+    # Maybe revert the patch if BambooTracker is bumped before RtAudio bump is merged?
+    (fetchpatch {
+      name = "0001-bambootracker-RtAudio-6.0.0-support.patch";
+      url = "https://github.com/BambooTracker/BambooTracker/commit/cac47862a4d77d62d5d6fc488946b2e312c8f5af.patch";
+      includes = [ "BambooTracker/audio/audio_stream_rtaudio.cpp" ];
+      hash = "sha256-JK6MoPit9UXlSepKO5PldzQPgGvnqS171YiCwAKyUJc=";
+    })
+  ];
 
   postPatch = lib.optionalString (lib.versionAtLeast qtbase.version "6.0") ''
     # Work around lrelease finding in qmake being broken by using pre-Qt5.12 code path


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/245075 is proposing to bump `rtaudio` to the recently-released 6.0.0, which brings API breakage with it. I don't know how long we'll delay that bump considering that it currently breaks *all* packages that depend on `rtaudio`, or when the next `bambootracker` bump happens, so this patch tries to prepare `bambootracker` and `bambootracker-qt6` for the former by applying a patch when `rtaudio.version >= 6`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
