### PR TITLE
lib.getExe: Do not make assumptions about the main program

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -144,5 +144,9 @@ rec {
        => "/nix/store/am9ml4f4ywvivxnkiaqwr0hyxka1xjsf-mustache-go-1.3.0/bin/mustache"
   */
   getExe = x:
-    "${lib.getBin x}/bin/${x.meta.mainProgram or (lib.getName x)}";
+    "${lib.getBin x}/bin/${x.meta.mainProgram or (
+      # This could be turned into an error when 23.05 is at end of life
+      lib.warn "getExe: Package ${lib.strings.escapeNixIdentifier x.meta.name or x.pname or x.name} does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, specify the full path to the program, such as \"\${lib.getBin foo}/bin/bar\"."
+      lib.getName x
+    )}";
 }

--- a/nixos/modules/programs/oddjobd.nix
+++ b/nixos/modules/programs/oddjobd.nix
@@ -10,6 +10,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      { assertion = false;
+        message = "The oddjob service was found to be broken without NixOS test or maintainer. Please take ownership of this service.";
+      }
+    ];
     systemd.packages = [ cfg.package ];
 
     systemd.services.oddjobd = {
@@ -21,7 +26,7 @@ in
       serviceConfig = {
         Type = "dbus";
         BusName = "org.freedesktop.oddjob";
-        ExecStart = "${lib.getExe cfg.package}/bin/oddjobd";
+        ExecStart = "${lib.getBin cfg.package}/bin/oddjobd";
       };
     };
   };

--- a/pkgs/applications/audio/espeak-ng/default.nix
+++ b/pkgs/applications/audio/espeak-ng/default.nix
@@ -75,5 +75,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ aske ];
     platforms = platforms.all;
+    mainProgram = "espeak-ng";
   };
 }

--- a/pkgs/applications/display-managers/greetd/regreet.nix
+++ b/pkgs/applications/display-managers/greetd/regreet.nix
@@ -31,5 +31,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ fufexan ];
     platforms = platforms.linux;
+    mainProgram = "regreet";
   };
 }

--- a/pkgs/applications/emulators/darling/default.nix
+++ b/pkgs/applications/emulators/darling/default.nix
@@ -227,5 +227,6 @@ in stdenv.mkDerivation {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ zhaofengli ];
     platforms = [ "x86_64-linux" ];
+    mainProgram = "darling";
   };
 }

--- a/pkgs/applications/graphics/openscad/default.nix
+++ b/pkgs/applications/graphics/openscad/default.nix
@@ -109,5 +109,6 @@ mkDerivation rec {
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ bjornfor raskin gebner ];
+    mainProgram = "openscad";
   };
 }

--- a/pkgs/applications/graphics/tesseract/tesseract5.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract5.nix
@@ -41,5 +41,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ anselmschueler ];
     platforms = lib.platforms.unix;
+    mainProgram = "tesseract";
   };
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -20,6 +20,7 @@
                                              # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
       maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
       license = lib.licenses.mpl20;
+      mainProgram = "firefox";
     };
     tests = [ nixosTests.firefox ];
     updateScript = callPackage ./update.nix {
@@ -46,6 +47,7 @@
                                              # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
       maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
       license = lib.licenses.mpl20;
+      mainProgram = "firefox";
     };
     tests = [ nixosTests.firefox-beta ];
     updateScript = callPackage ./update.nix {
@@ -74,6 +76,7 @@
                                              # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
       maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
       license = lib.licenses.mpl20;
+      mainProgram = "firefox";
     };
     tests = [ nixosTests.firefox-devedition ];
     updateScript = callPackage ./update.nix {
@@ -104,6 +107,7 @@
       broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".
                                              # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
       license = lib.licenses.mpl20;
+      mainProgram = "firefox";
     };
     tests = [ nixosTests.firefox-esr-102 ];
     updateScript = callPackage ./update.nix {
@@ -132,6 +136,7 @@
       broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".
                                              # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
       license = lib.licenses.mpl20;
+      mainProgram = "firefox";
     };
     tests = [ nixosTests.firefox-esr-115 ];
     updateScript = callPackage ./update.nix {

--- a/pkgs/applications/networking/clash-verge/default.nix
+++ b/pkgs/applications/networking/clash-verge/default.nix
@@ -60,5 +60,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ zendo ];
+    mainProgram = "clash-verge";
   };
 }

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -18,6 +18,7 @@ let
     {
       pythonInterpreter = "${python3.interpreter}";
       configDirName = lib.toLower binaryName;
+      meta.mainProgram = "disable-breaking-updates.py";
     } ''
     mkdir -p $out/bin
     cp ${./disable-breaking-updates.py} $out/bin/disable-breaking-updates.py

--- a/pkgs/applications/networking/irc/thelounge/default.nix
+++ b/pkgs/applications/networking/irc/thelounge/default.nix
@@ -88,5 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ winter raitobezarius ];
     license = licenses.mit;
     inherit (nodejs.meta) platforms;
+    mainProgram = "thelounge";
   };
 })

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -88,5 +88,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = with maintainers; [ disassembler kolaente ma27 techknowlogick ];
     broken = stdenv.isDarwin;
+    mainProgram = "gitea";
   };
 }

--- a/pkgs/applications/virtualization/kvmtool/default.nix
+++ b/pkgs/applications/virtualization/kvmtool/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ astro ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
+    mainProgram = "nvramtool";
   };
 }

--- a/pkgs/applications/window-managers/cage/default.nix
+++ b/pkgs/applications/window-managers/cage/default.nix
@@ -44,5 +44,6 @@ stdenv.mkDerivation rec {
     license     = licenses.mit;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ primeos ];
+    mainProgram = "cage";
   };
 }

--- a/pkgs/desktops/gnome/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome/apps/file-roller/default.nix
@@ -73,5 +73,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = teams.gnome.members ++ teams.pantheon.members;
+    mainProgram = "file-roller";
   };
 }

--- a/pkgs/development/interpreters/perl/intepreter.nix
+++ b/pkgs/development/interpreters/perl/intepreter.nix
@@ -232,6 +232,7 @@ stdenv.mkDerivation (rec {
     maintainers = [ maintainers.eelco ];
     platforms = platforms.all;
     priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
+    mainProgram = "perl";
   };
 } // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
   crossVersion = "c876045741f5159318085d2737b0090f35a842ca"; # June 5, 2022

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -572,5 +572,6 @@ in with passthru; stdenv.mkDerivation {
     license = licenses.psfl;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ fridh ];
+    mainProgram = "python3";
   };
 }

--- a/pkgs/development/libraries/xdg-dbus-proxy/default.nix
+++ b/pkgs/development/libraries/xdg-dbus-proxy/default.nix
@@ -46,5 +46,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.linux;
+    mainProgram = "xdg-dbus-proxy";
   };
 }

--- a/pkgs/development/python-modules/flake8/default.nix
+++ b/pkgs/development/python-modules/flake8/default.nix
@@ -45,5 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pycqa/flake8";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
+    mainProgram = "flake8";
   };
 }

--- a/pkgs/development/tools/continuous-integration/woodpecker/agent.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/agent.nix
@@ -13,5 +13,6 @@ buildGoModule {
 
   meta = common.meta // {
     description = "Woodpecker Continuous Integration agent";
+    mainProgram = "woodpecker-agent";
   };
 }

--- a/pkgs/development/tools/continuous-integration/woodpecker/server.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/server.nix
@@ -23,5 +23,6 @@ buildGoModule {
 
   meta = common.meta // {
     description = "Woodpecker Continuous Integration server";
+    mainProgram = "woodpecker-server";
   };
 }

--- a/pkgs/development/tools/esbuild/default.nix
+++ b/pkgs/development/tools/esbuild/default.nix
@@ -23,5 +23,6 @@ buildGoModule rec {
     changelog = "https://github.com/evanw/esbuild/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ lucus16 marsam undefined-moe ];
+    mainProgram = "esbuild";
   };
 }

--- a/pkgs/development/tools/esbuild/netlify.nix
+++ b/pkgs/development/tools/esbuild/netlify.nix
@@ -29,5 +29,6 @@ buildGoModule rec {
     homepage = "https://github.com/netlify/esbuild";
     license = licenses.mit;
     maintainers = with maintainers; [ roberth ];
+    mainProgram = "esbuild";
   };
 }

--- a/pkgs/development/tools/geckodriver/default.nix
+++ b/pkgs/development/tools/geckodriver/default.nix
@@ -26,5 +26,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/mozilla/geckodriver";
     license = licenses.mpl20;
     maintainers = with maintainers; [ jraygauthier ];
+    mainProgram = "geckodriver";
   };
 }

--- a/pkgs/development/tools/misc/libtool/default.nix
+++ b/pkgs/development/tools/misc/libtool/default.nix
@@ -34,5 +34,7 @@ stdenv.mkDerivation rec {
 
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
+
+    mainProgram = "libtool";
   };
 }

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -68,5 +68,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = [ ];
     platforms = platforms.unix;
+    mainProgram = "libtool";
   };
 }

--- a/pkgs/development/tools/misc/tokei/default.nix
+++ b/pkgs/development/tools/misc/tokei/default.nix
@@ -28,5 +28,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/XAMPPRocky/tokei";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ gebner lilyball ];
+    mainProgram = "tokei";
   };
 }

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -73,5 +73,6 @@ in stdenv.mkDerivation rec {
     # Note from primeos: By updating Chromium I also update Google Chrome and
     # ChromeDriver.
     platforms = attrNames allSpecs;
+    mainProgram = "chromedriver";
   };
 }

--- a/pkgs/os-specific/linux/below/default.nix
+++ b/pkgs/os-specific/linux/below/default.nix
@@ -43,5 +43,6 @@ rustPlatform.buildRustPackage rec {
     description = "A time traveling resource monitor for modern Linux systems";
     license = licenses.asl20;
     homepage = "https://github.com/facebookincubator/below";
+    mainProgram = "below";
   };
 }

--- a/pkgs/servers/code-server/default.nix
+++ b/pkgs/servers/code-server/default.nix
@@ -322,5 +322,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ offline henkery code-asher ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+    mainProgram = "code-server";
   };
 })

--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -42,5 +42,6 @@ buildGoModule rec {
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.mpl20;
     maintainers = with maintainers; [ pradeepchhetri vdemeester nh2 techknowlogick];
+    mainProgram = "consul";
   };
 }

--- a/pkgs/servers/dns/acme-dns/default.nix
+++ b/pkgs/servers/dns/acme-dns/default.nix
@@ -30,5 +30,6 @@ buildGoModule rec {
     changelog = "https://github.com/joohoi/acme-dns/releases/tag/${src.rev}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ emilylange ];
+    mainProgram = "acme-dns";
   };
 }

--- a/pkgs/servers/ldap/lldap/default.nix
+++ b/pkgs/servers/ldap/lldap/default.nix
@@ -110,5 +110,6 @@ in rustPlatform.buildRustPackage (commonDerivationAttrs // {
     license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ emilylange bendlas ];
+    mainProgram = "lldap";
   };
 })

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -73,5 +73,6 @@ buildGoModule rec {
     homepage = "https://grafana.com/products/cloud";
     changelog = "https://github.com/grafana/agent/blob/${src.rev}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ flokli emilylange ];
+    mainProgram = "grafana-agent";
   };
 }

--- a/pkgs/servers/openvscode-server/default.nix
+++ b/pkgs/servers/openvscode-server/default.nix
@@ -219,5 +219,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dguenther ghuntley emilytrau ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    mainProgram = "openvscode-server";
   };
 })

--- a/pkgs/servers/pufferpanel/default.nix
+++ b/pkgs/servers/pufferpanel/default.nix
@@ -98,5 +98,6 @@ buildGoModule rec {
     homepage = "https://www.pufferpanel.com/";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ ckie tie ];
+    mainProgram = "pufferpanel";
   };
 }

--- a/pkgs/servers/web-apps/kavita/default.nix
+++ b/pkgs/servers/web-apps/kavita/default.nix
@@ -73,5 +73,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ misterio77 ];
+    mainProgram = "kavita";
   };
 })

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -161,6 +161,9 @@ self: super:
     + lib.optionalString stdenv.hostPlatform.isStatic ''
       export NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK -lXau -lXdmcp"
     '';
+    meta = attrs.meta // {
+      mainProgram = "xdpyinfo";
+    };
   });
 
   xdm = super.xdm.overrideAttrs (attrs: {
@@ -939,6 +942,12 @@ self: super:
     postInstall = ''
       rm $out/bin/xkeystone
     '';
+  });
+
+  xset = super.xset.overrideAttrs (attrs: {
+    meta = attrs.meta // {
+      mainProgram = "xset";
+    };
   });
 
   # convert Type1 vector fonts to OpenType fonts

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -814,6 +814,7 @@ self: super:
         --replace '_X_NORETURN' '__attribute__((noreturn))' \
         --replace 'n_dirs--;' ""
     '';
+    meta.mainProgram = "lndir";
   });
 
   twm = super.twm.overrideAttrs (attrs: {

--- a/pkgs/tools/backup/tarsnap/default.nix
+++ b/pkgs/tools/backup/tarsnap/default.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation rec {
     license     = lib.licenses.unfree;
     platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thoughtpolice roconnor ];
+    mainProgram = "tarsnap";
   };
 }

--- a/pkgs/tools/misc/coreboot-utils/default.nix
+++ b/pkgs/tools/misc/coreboot-utils/default.nix
@@ -65,6 +65,7 @@ let
     nvramtool = generic {
       pname = "nvramtool";
       meta.description = "Read and write coreboot parameters and display information from the coreboot table in CMOS/NVRAM";
+      meta.mainProgram = "nvramtool";
     };
     superiotool = generic {
       pname = "superiotool";

--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -50,5 +50,6 @@ buildGoModule rec {
     homepage = "https://direnv.net";
     license = licenses.mit;
     maintainers = teams.numtide.members;
+    mainProgram = "direnv";
   };
 }

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -50,5 +50,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ doronbehar ];
     license = licenses.bsd2;
     platforms = platforms.all;
+    mainProgram = "file";
   };
 }

--- a/pkgs/tools/misc/nurl/default.nix
+++ b/pkgs/tools/misc/nurl/default.nix
@@ -57,5 +57,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/nix-community/nurl/blob/v${version}/CHANGELOG.md";
     license = licenses.mpl20;
     maintainers = with maintainers; [ figsoda ];
+    mainProgram = "nurl";
   };
 }

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -126,5 +126,6 @@ rustPlatform.buildRustPackage {
     license = licenses.mpl20;
     maintainers = with maintainers; [ thoughtpolice happysalada ];
     platforms = with platforms; all;
+    mainProgram = "vector";
   };
 }

--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -60,5 +60,6 @@ stdenvNoCC.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl2;
     maintainers = [ maintainers.artturin ];
+    mainProgram = "xvfb-run";
   };
 }

--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -77,5 +77,6 @@ buildPythonPackage rec {
     '';
     license = licenses.unlicense;
     maintainers = with maintainers; [ mkg20001 SuperSandro2000 marsam ];
+    mainProgram = "yt-dlp";
   };
 }

--- a/pkgs/tools/networking/clash-meta/default.nix
+++ b/pkgs/tools/networking/clash-meta/default.nix
@@ -40,5 +40,6 @@ buildGoModule rec {
     homepage = "https://github.com/MetaCubeX/Clash.Meta";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ oluceps ];
+    mainProgram = "clash-meta";
   };
 }

--- a/pkgs/tools/networking/clash/default.nix
+++ b/pkgs/tools/networking/clash/default.nix
@@ -40,5 +40,6 @@ buildGoModule rec {
     changelog = "https://github.com/Dreamacro/clash/releases/tag/v${version}";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ contrun Br1ght0ne ];
+    mainProgram = "clash";
   };
 }

--- a/pkgs/tools/networking/sitespeed-io/default.nix
+++ b/pkgs/tools/networking/sitespeed-io/default.nix
@@ -87,5 +87,6 @@ buildNpmPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ misterio77 ];
     platforms = lib.unique (geckodriver.meta.platforms ++ chromedriver.meta.platforms);
+    mainProgram = "sitespeed-io";
   };
 }

--- a/pkgs/tools/networking/wgautomesh/default.nix
+++ b/pkgs/tools/networking/wgautomesh/default.nix
@@ -21,5 +21,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://git.deuxfleurs.fr/Deuxfleurs/wgautomesh";
     license = licenses.agpl3Only;
     maintainers = [ maintainers.lx ];
+    mainProgram = "wgautomesh";
   };
 }

--- a/pkgs/tools/package-management/harmonia/default.nix
+++ b/pkgs/tools/package-management/harmonia/default.nix
@@ -44,5 +44,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/harmonia";
     license = licenses.mit;
     maintainers = with maintainers; [ mic92 ];
+    mainProgram = "harmonia";
   };
 }

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -241,6 +241,7 @@ self = stdenv.mkDerivation {
     maintainers = with maintainers; [ eelco lovesegfault artturin ];
     platforms = platforms.unix;
     outputsToInstall = [ "out" ] ++ optional enableDocumentation "man";
+    mainProgram = "nix";
   };
 };
 in self

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -43,5 +43,6 @@ python3Packages.buildPythonPackage rec {
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.Technical27 ];
+    mainProgram = "auto-cpufreq";
   };
 }

--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -55,5 +55,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ rob relrod SuperSandro2000 ];
     changelog = "https://github.com/htop-dev/htop/blob/${version}/ChangeLog";
+    mainProgram = "htop";
   };
 }

--- a/pkgs/tools/system/kanata/default.nix
+++ b/pkgs/tools/system/kanata/default.nix
@@ -29,5 +29,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [ linj ];
     platforms = platforms.linux;
+    mainProgram = "kanata";
   };
 }


### PR DESCRIPTION
Before this commit, getExe assumes that if `meta.mainProgram` is unset, it has a main program that's named after the package name.

While this is probable, it leads to a bad error when the assumption does not hold. If the user called `getExe` themselves, they might narrow down the location of the assumption quite easily, but if that's not the case, they'll have to go down the rabbit hole to figure out what went wrong.

For example, a NixOS module may use `lib.getExe` on a package-typed option which is then used in the system configuration. This then typically leads to a failure *after* deployment, which is bad, and it's quite likely that the user will debug the package output contents before digging through the NixOS module, which is bad.
Furthermore the `getExe` call is rather inconspicuous as it does not contain something like "/bin/foo", which is bad.
Also modules can be hard to read for a newbie, which is bad.

All of this can be avoided by requiring `meta.mainProgram`. Many packages already have the attribute, and I would expect 80% of `getExe` usages to be covered by 20% of packages, because plenty of packages aren't used with `getExe` anyway.

Finally we could make an effort to set `mainProgram` semi-automatically using `nix-index`.

## Description of changes

Adds a warning to the unreliable behavior.

```console
[nixpkgs]$ nix repl .
nix-repl> lib.getExe (hello // { meta = {}; })
trace: warning: getExe: Package hello does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, specify the full path to the program, such as "${lib.getBin foo}/bin/bar".
"/nix/store/nj2460zk9fjdl9yyglsi2nh4lp78na24-hello-2.12.1/bin/hello"

```

## Context

- Introduced in https://github.com/NixOS/nixpkgs/pull/167247
  - [Short conversation leading to this PR](https://github.com/NixOS/nixpkgs/pull/167247/files#r1279561455)

- Tangentially related to the point of off-topic: https://github.com/NixOS/nixpkgs/pull/173675

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
