### PR TITLE
buildMavenPackage: refactor

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -40,7 +40,6 @@ mavenJdk17.buildMavenPackage rec {
   nativeBuildInputs = [
     copyDesktopItems
     makeWrapper
-    mavenJdk17
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/ns-usbloader/default.nix
+++ b/pkgs/applications/misc/ns-usbloader/default.nix
@@ -39,7 +39,6 @@ maven.buildMavenPackage rec {
 
   nativeBuildInputs = [
     copyDesktopItems
-    maven
     makeWrapper
   ];
 

--- a/pkgs/applications/science/electronics/digital/default.nix
+++ b/pkgs/applications/science/electronics/digital/default.nix
@@ -39,7 +39,7 @@ maven.buildMavenPackage rec {
   };
 
   inherit mvnParameters;
-  mvnHash = "sha256-Ej/JePvd9Ieni8FqSaXBDc2T6Cwr8WP54iko8wYiT68=";
+  mvnHash = "sha256-wm/axWJucoW9P98dKqHI4bjrUnmBTfosCOdJg9VBJ+4=";
 
   nativeBuildInputs = [ copyDesktopItems makeWrapper ];
 

--- a/pkgs/applications/science/electronics/digital/default.nix
+++ b/pkgs/applications/science/electronics/digital/default.nix
@@ -41,7 +41,7 @@ maven.buildMavenPackage rec {
   inherit mvnParameters;
   mvnHash = "sha256-Ej/JePvd9Ieni8FqSaXBDc2T6Cwr8WP54iko8wYiT68=";
 
-  nativeBuildInputs = [ copyDesktopItems maven makeWrapper ];
+  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/science/misc/gephi/default.nix
+++ b/pkgs/applications/science/misc/gephi/default.nix
@@ -18,7 +18,7 @@ mavenJdk11.buildMavenPackage rec {
 
   mvnHash = "sha256-/2/Yb26Ry0NHQQ3j0LXnjwC0wQqJiztvTgWixyMJqvg=";
 
-  nativeBuildInputs = [ jdk11 mavenJdk11 ];
+  nativeBuildInputs = [ jdk11 ];
 
   installPhase = ''
     cp -r modules/application/target/gephi $out

--- a/pkgs/development/tools/build-managers/apache-maven/build-package.nix
+++ b/pkgs/development/tools/build-managers/apache-maven/build-package.nix
@@ -16,7 +16,7 @@
 # originally extracted from dbeaver
 # created to allow using maven packages in the same style as rust
 
-stdenv.mkDerivation (rec {
+let
   fetchedMavenDeps = stdenv.mkDerivation ({
     name = "${pname}-${version}-maven-deps";
     inherit src patches;
@@ -44,6 +44,13 @@ stdenv.mkDerivation (rec {
     outputHashMode = "recursive";
     outputHash = mvnHash;
   } // mvnFetchExtraArgs);
+in
+stdenv.mkDerivation (builtins.removeAttrs args [ "mvnFetchExtraArgs" ] // {
+  inherit fetchedMavenDeps;
+
+  nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
+    maven
+  ];
 
   buildPhase = ''
     runHook preBuild
@@ -53,4 +60,8 @@ stdenv.mkDerivation (rec {
 
     runHook postBuild
   '';
-} // builtins.removeAttrs args [ "mvnFetchExtraArgs" ])
+
+  meta = args.meta or { } // {
+    platforms = args.meta.platforms or maven.meta.platforms;
+  };
+})

--- a/pkgs/development/tools/database/schemaspy/default.nix
+++ b/pkgs/development/tools/database/schemaspy/default.nix
@@ -33,7 +33,6 @@ maven.buildMavenPackage rec {
   nativeBuildInputs = [
     makeWrapper
     git
-    maven
 
     # springframework boot gets angry about 1970 sources
     # fix from https://github.com/nix-community/mavenix/issues/25

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -19,7 +19,7 @@ mavenJdk8.buildMavenPackage rec {
 
   mvnHash = "sha256-rRLsCTY3fEAvGRDvNXqpjac2Gb5fdlyhK2wTK5CVN9k=";
 
-  nativeBuildInputs = [ jdk8 mavenJdk8 makeWrapper ];
+  nativeBuildInputs = [ jdk8 makeWrapper ];
 
   installPhase = ''
     mkdir -p "$out/lib/java" "$out/share/java"
@@ -41,11 +41,10 @@ mavenJdk8.buildMavenPackage rec {
     homepage = "https://github.com/martinpaljak/GlobalPlatformPro";
     sourceProvenance = with sourceTypes; [
       fromSource
-      binaryBytecode  # deps
+      binaryBytecode # deps
     ];
     license = with licenses; [ lgpl3 ];
     maintainers = with maintainers; [ ekleog ];
     mainProgram = "gp";
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -17,7 +17,7 @@ mavenJdk8.buildMavenPackage rec {
     sha256 = "1vws6cbgm3mrwc2xz9j1y262vw21x3hjc9m7rqc4hn3m7gjpwsvg";
   };
 
-  mvnHash = "sha256-rRLsCTY3fEAvGRDvNXqpjac2Gb5fdlyhK2wTK5CVN9k=";
+  mvnHash = "sha256-xFcEZpJ0+ApJTDTuA63LgvUwLrxATVKoj5Mh3WZyfq8=";
 
   nativeBuildInputs = [ jdk8 makeWrapper ];
 

--- a/pkgs/development/tools/java/java-language-server/default.nix
+++ b/pkgs/development/tools/java/java-language-server/default.nix
@@ -26,7 +26,7 @@ maven.buildMavenPackage rec {
   mvnParameters = "-DskipTests";
   mvnHash = "sha256-bzYBSrCS9Kp+qnVO60h915Or1VWabphwLEu6lcBULuc=";
 
-  nativeBuildInputs = [ maven jdk makeWrapper ];
+  nativeBuildInputs = [ jdk makeWrapper ];
 
   dontConfigure = true;
   preBuild = ''
@@ -56,6 +56,5 @@ maven.buildMavenPackage rec {
     homepage = "https://github.com/georgewfraser/java-language-server";
     license = licenses.mit;
     maintainers = with maintainers; [ hqurve ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/java/java-language-server/default.nix
+++ b/pkgs/development/tools/java/java-language-server/default.nix
@@ -24,7 +24,7 @@ maven.buildMavenPackage rec {
 
   mvnFetchExtraArgs.dontConfigure = true;
   mvnParameters = "-DskipTests";
-  mvnHash = "sha256-bzYBSrCS9Kp+qnVO60h915Or1VWabphwLEu6lcBULuc=";
+  mvnHash = "sha256-XhAqd67RtETd9XvqbiEuTOwPUsUtoLkhXy2Dde7NLTo=";
 
   nativeBuildInputs = [ jdk makeWrapper ];
 

--- a/pkgs/games/forge-mtg/default.nix
+++ b/pkgs/games/forge-mtg/default.nix
@@ -29,7 +29,7 @@ maven.buildMavenPackage {
   mvnParameters = "-DskipTests";
   mvnHash = "sha256-ajrHnaiJS7ZnR9BjLaXK2bnAKCp5UWQqYpjWbz3z6bw=";
 
-  nativeBuildInputs = [ maven makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     runHook preInstall
@@ -59,7 +59,6 @@ maven.buildMavenPackage {
   meta = with lib; {
     description = "Magic: the Gathering card game with rules enforcement";
     homepage = "https://www.slightlymagic.net/forum/viewforum.php?f=26";
-    platforms = openjdk.meta.platforms;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ eigengrau ];
   };

--- a/pkgs/servers/keycloak/keycloak-metrics-spi/default.nix
+++ b/pkgs/servers/keycloak/keycloak-metrics-spi/default.nix
@@ -13,8 +13,6 @@ maven.buildMavenPackage rec {
 
   mvnHash = "sha256-rwAc2KtKo4vJ0JWwPquMyt+FHVNTmMpzBPbo8lWDN/A=";
 
-  nativeBuildInputs = [ maven ];
-
   installPhase = ''
     runHook preInstall
     install -Dm444 -t "$out" target/keycloak-metrics-spi-*.jar

--- a/pkgs/servers/keycloak/scim-for-keycloak/default.nix
+++ b/pkgs/servers/keycloak/scim-for-keycloak/default.nix
@@ -16,10 +16,6 @@ maven.buildMavenPackage rec {
 
   mvnHash = "sha256-MWxm2q6tx8YcdEsleC2h+s+lp9whi11VQ1yFr8AZUyQ=";
 
-  nativeBuildInputs = [
-    maven
-  ];
-
   installPhase = ''
     EAR=$(find -iname "*.ear")
     install -D "$EAR" "$out/$(basename $EAR)"

--- a/pkgs/servers/keycloak/scim-keycloak-user-storage-spi/default.nix
+++ b/pkgs/servers/keycloak/scim-keycloak-user-storage-spi/default.nix
@@ -16,10 +16,6 @@ maven.buildMavenPackage {
 
   mvnHash = "sha256-vNPSNoOmtD1UMfWvLm8CH7RRatyeu3fnX9zteZpkay0=";
 
-  nativeBuildInputs = [
-    maven
-  ];
-
   installPhase = ''
     install -D "target/scim-user-spi-0.0.1-SNAPSHOT.jar" "$out/scim-user-spi-0.0.1-SNAPSHOT.jar"
   '';

--- a/pkgs/tools/games/slipstream/default.nix
+++ b/pkgs/tools/games/slipstream/default.nix
@@ -15,7 +15,7 @@ mavenWithJdk.buildMavenPackage rec {
 
   mvnHash = "sha256-oDtUitsfZPiDtyfzzw1yMNBCKyP6rHczKZT/SPPJYGE=";
 
-  nativeBuildInputs = [ mavenWithJdk makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     runHook preInstall
@@ -44,6 +44,5 @@ mavenWithJdk.buildMavenPackage rec {
     homepage = "https://github.com/Vhati/Slipstream-Mod-Manager";
     license = licenses.gpl2;
     maintainers = with maintainers; [ mib ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/games/slipstream/default.nix
+++ b/pkgs/tools/games/slipstream/default.nix
@@ -13,7 +13,7 @@ mavenWithJdk.buildMavenPackage rec {
     hash = "sha256-F+o94Oh9qxVdfgwdmyOv+WZl1BjQuzhQWaVrAgScgIU=";
   };
 
-  mvnHash = "sha256-oDtUitsfZPiDtyfzzw1yMNBCKyP6rHczKZT/SPPJYGE=";
+  mvnHash = "sha256-8i3OVSy8RUGVoQzwADszVvNYe50f4nsJie1y7tsOK4U=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/security/cryptomator/default.nix
+++ b/pkgs/tools/security/cryptomator/default.nix
@@ -67,7 +67,6 @@ maven.buildMavenPackage rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    maven
     makeShellWrapper
     wrapGAppsHook
     jdk

--- a/pkgs/tools/security/jd-cli/default.nix
+++ b/pkgs/tools/security/jd-cli/default.nix
@@ -11,7 +11,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-rRttA5H0A0c44loBzbKH7Waoted3IsOgxGCD2VM0U/Q=";
   };
 
-  mvnHash = "sha256-kLpjMj05uC94/5vGMwMlFzLKNFOKeyNvq/vmB6pHTAo=";
+  mvnHash = "sha256-1zn980QP48fWvm45HR1yDHdyzHYPkl/P0RpII+Zu+xc=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/security/jd-cli/default.nix
+++ b/pkgs/tools/security/jd-cli/default.nix
@@ -13,7 +13,7 @@ maven.buildMavenPackage rec {
 
   mvnHash = "sha256-kLpjMj05uC94/5vGMwMlFzLKNFOKeyNvq/vmB6pHTAo=";
 
-  nativeBuildInputs = [ maven makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/jd-cli
@@ -27,7 +27,6 @@ maven.buildMavenPackage rec {
     description = "Simple command line wrapper around JD Core Java Decompiler project";
     homepage = "https://github.com/intoolswetrust/jd-cli";
     license = licenses.gpl3;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ majiir ];
   };
 }


### PR DESCRIPTION
## Description of changes

This refactor removes the need to specify `maven` as a native build input, which is the case for all current packages. The default platforms are also specified.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
