### PR TITLE
dcp375cw{lpr,-cupswrapper}: init at 1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10265,6 +10265,12 @@
     githubId = 1651325;
     name = "maralorn";
   };
+  marcovergueira = {
+    email = "vergueira.marco@gmail.com";
+    github = "marcovergueira";
+    githubId = 929114;
+    name = "Marco Vergueira";
+  };
   marcus7070 = {
     email = "marcus@geosol.com.au";
     github = "marcus7070";

--- a/pkgs/misc/cups/drivers/brother/dcp375cw/default.nix
+++ b/pkgs/misc/cups/drivers/brother/dcp375cw/default.nix
@@ -1,0 +1,97 @@
+{ lib, stdenv, fetchurl, cups, dpkg, gnused, makeWrapper, ghostscript, file
+, a2ps, coreutils, gnugrep, which, gawk }:
+
+let
+  version = "1.1.3";
+  model = "dcp375cw";
+in rec {
+  driver = stdenv.mkDerivation {
+    pname = "${model}-lpr";
+    inherit version;
+
+    src = fetchurl {
+      url =
+        "https://download.brother.com/welcome/dlf005427/dcp375cwlpr-${version}-1.i386.deb";
+      sha256 =
+        "6daf0144b5802ea8da394ca14db0e6f0200d4049545649283791f899b7f7bd26";
+    };
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+    buildInputs = [ cups ghostscript a2ps gawk ];
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      substituteInPlace $out/opt/brother/Printers/${model}/lpd/filter${model} \
+      --replace /opt "$out/opt"
+
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/opt/brother/Printers/${model}/lpd/br${model}filter
+
+      mkdir -p $out/lib/cups/filter/
+      ln -s $out/opt/brother/Printers/${model}/lpd/filter${model} $out/lib/cups/filter/brlpdwrapper${model}
+
+      wrapProgram $out/opt/brother/Printers/${model}/lpd/filter${model} \
+        --prefix PATH ":" ${
+          lib.makeBinPath [
+            gawk
+            ghostscript
+            a2ps
+            file
+            gnused
+            gnugrep
+            coreutils
+            which
+          ]
+        }
+    '';
+
+    meta = with lib; {
+      homepage = "http://www.brother.com/";
+      description = "Brother ${model} printer driver";
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      downloadPage =
+        "https://support.brother.com/g/b/downloadlist.aspx?c=gb&lang=en&prod=${model}_all&os=128";
+      maintainers = with maintainers; [ marcovergueira ];
+    };
+  };
+
+  cupswrapper = stdenv.mkDerivation {
+    pname = "${model}-cupswrapper";
+    inherit version;
+
+    src = fetchurl {
+      url =
+        "https://download.brother.com/welcome/dlf005429/dcp375cwcupswrapper-${version}-1.i386.deb";
+      sha256 =
+        "9a255728b595d2667b2caf9d0d332b677e1a6829a3ec1ed6d4e900a44069cf2d";
+    };
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+    buildInputs = [ cups ghostscript a2ps gawk ];
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      for f in $out/opt/brother/Printers/${model}/cupswrapper/cupswrapper${model}; do
+        wrapProgram $f --prefix PATH : ${
+          lib.makeBinPath [ coreutils ghostscript gnugrep gnused ]
+        }
+      done
+
+      mkdir -p $out/share/cups/model
+      ln -s $out/opt/brother/Printers/${model}/cupswrapper/brother_${model}_printer_en.ppd $out/share/cups/model/
+    '';
+
+    meta = with lib; {
+      homepage = "http://www.brother.com/";
+      description = "Brother ${model} printer CUPS wrapper driver";
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      downloadPage =
+        "https://support.brother.com/g/b/downloadlist.aspx?c=gb&lang=en&prod=${model}_all&os=128";
+      maintainers = with maintainers; [ marcovergueira ];
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39729,6 +39729,10 @@ with pkgs;
 
   cups-bjnp = callPackage ../misc/cups/drivers/cups-bjnp { };
 
+  dcp375cwlpr = (pkgsi686Linux.callPackage ../misc/cups/drivers/brother/dcp375cw { }).driver;
+
+  dcp375cw-cupswrapper = (callPackage ../misc/cups/drivers/brother/dcp375cw { }).cupswrapper;
+
   dcp9020cdwlpr = (pkgsi686Linux.callPackage ../misc/cups/drivers/brother/dcp9020cdw { }).driver;
 
   dcp9020cdw-cupswrapper = (callPackage ../misc/cups/drivers/brother/dcp9020cdw { }).cupswrapper;


### PR DESCRIPTION
## Description of changes

Add two packages (dcp375cwlpr and dcp375cw-cupswrapper) to support the printer Brother DCP-375CW.

These make CUPS capable of recognize and operate the printer, after add these packages, the printer needs to be configured on CUPS.

It is compliant with the follow NixOS option,
```
services.printing.drivers = with pkgs; [
    dcp375cwlpr
    dcp375cw-cupswrapper
];
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality, (able to add the printer to CUPS, and print over network)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).