### PR TITLE
lib/path/tests: Use lib/tests/release.nix init code

### DIFF
--- a/lib/path/tests/default.nix
+++ b/lib/path/tests/default.nix
@@ -18,7 +18,14 @@ pkgs.runCommand "lib-path-tests" {
   ];
 } ''
   # Needed to make Nix evaluation work
-  export NIX_STATE_DIR=$(mktemp -d)
+  export TEST_ROOT=$(pwd)/test-tmp
+  export NIX_BUILD_HOOK=
+  export NIX_CONF_DIR=$TEST_ROOT/etc
+  export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+  export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+  export NIX_STATE_DIR=$TEST_ROOT/var/nix
+  export NIX_STORE_DIR=$TEST_ROOT/store
+  export PAGER=cat
 
   cp -r ${libpath} lib
   export TEST_LIB=$PWD/lib

--- a/lib/path/tests/default.nix
+++ b/lib/path/tests/default.nix
@@ -15,7 +15,6 @@ pkgs.runCommand "lib-path-tests" {
     nix
     jq
     bc
-    pkgs.cacert
   ];
 } ''
   # Needed to make Nix evaluation work

--- a/lib/path/tests/default.nix
+++ b/lib/path/tests/default.nix
@@ -15,6 +15,7 @@ pkgs.runCommand "lib-path-tests" {
     nix
     jq
     bc
+    pkgs.cacert
   ];
 } ''
   # Needed to make Nix evaluation work

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -23,7 +23,6 @@ let
         })
       ];
       nativeBuildInputs = [
-        pkgs.cacert
         nix
       ];
       strictDeps = true;

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -23,6 +23,7 @@ let
         })
       ];
       nativeBuildInputs = [
+        pkgs.cacert
         nix
       ];
       strictDeps = true;


### PR DESCRIPTION

## Description of changes

Should fix the CI failure in dependent https://github.com/NixOS/nix/pull/8569

Ideally this should be a setup hook, but that proved non-trivial; prioritizing the fix first.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
