### PR TITLE
farge: fix dependencies & font issue

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8457,6 +8457,12 @@
     githubId = 662666;
     name = "Justinas Stankevičius";
   };
+  justinlime = {
+    email = "justinlime1999@gmail.com";
+    github = "justinlime";
+    githubId = 119710965;
+    name = "Justin Fields";
+  };
   justinlovinger = {
     email = "git@justinlovinger.com";
     github = "JustinLovinger";

--- a/pkgs/tools/misc/farge/default.nix
+++ b/pkgs/tools/misc/farge/default.nix
@@ -1,8 +1,9 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, bash
+, makeBinaryWrapper
 , bc
+, libnotify
 , feh
 , grim
 , imagemagick
@@ -24,14 +25,24 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-vCMuFMGcI4D4EzbSsXeNGKNS6nBFkfTcAmSzb9UMArc=";
   };
 
-  buildInputs = [ bash bc feh imagemagick ]
-    ++ lib.optionals waylandSupport [ grim slurp wl-clipboard ]
-    ++ lib.optionals x11Support [ xcolor ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  # Ensure the following programs are found within $PATH
+  wrapperPath = lib.makeBinPath ([
+    bc
+    feh
+    #Needed to fix convert: unable to read font `(null)' @ error/annotate.c/RenderFreetype issue
+    (imagemagick.override { ghostscriptSupport = true;})
+    libnotify #Needed for the notify-send function call from the script
+  ] ++ lib.optionals waylandSupport [ grim slurp wl-clipboard ]
+    ++ lib.optionals x11Support [ xcolor ]);
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
     install -m755 farge $out/bin
+    wrapProgram $out/bin/farge \
+        --prefix PATH : "${finalAttrs.wrapperPath}"
     runHook postInstall
   '';
 
@@ -40,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/sdushantha/farge";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ jtbx ];
+    maintainers = with maintainers; [ jtbx justinlime ];
     mainProgram = "farge";
   };
 })


### PR DESCRIPTION
## Description of changes

When trying to install/run the program before, the `buildInputs` were not added to `$PATH`, therefore the program would not function unless manually installing the dependencies.
This adds a wrapper to ensure the binaries are found in `$PATH`. Also, fixed a runtime error ```convert: unable to read font `(null)' @ error/annotate.c/RenderFreetype```
that would occur when trying to run the script, solved with an override of the `imagemagick` package.

## Things done

Tested by installing the package without any previous dependencies installed, and running through all available CMD arguments for the script

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
