### PR TITLE
[23.05] wolfssl: add patch for CVE-2023-3724

### DIFF
--- a/pkgs/development/libraries/wolfssl/5.5.4-CVE-2023-3724.patch
+++ b/pkgs/development/libraries/wolfssl/5.5.4-CVE-2023-3724.patch
@@ -1,0 +1,40 @@
+based on upstream 00f1eddee429ff51390b20caadd2eb6afe51e1aa with
+minor adjustments to apply to 5.5.4
+
+diff --git a/src/tls.c b/src/tls.c
+index 27c1002b2..f8a9aaa48 100644
+--- a/src/tls.c
++++ b/src/tls.c
+@@ -8346,6 +8346,9 @@ static int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
+         if (!WOLFSSL_NAMED_GROUP_IS_PQC(group))
+ #endif
+             ret = TLSX_KeyShare_Use(ssl, group, 0, NULL, NULL);
++
++        if (ret == 0)
++            ssl->session->namedGroup = ssl->namedGroup = group;
+     }
+     else {
+         /* Not a message type that is allowed to have this extension. */
+diff --git a/src/tls13.c b/src/tls13.c
+index 42eb7ffce..194870a69 100644
+--- a/src/tls13.c
++++ b/src/tls13.c
+@@ -4725,8 +4725,18 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+         }
+ #endif
+ 
++        /* sanity check on PSK / KSE */
++        if (
++    #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
++            ssl->options.pskNegotiated == 0 &&
++    #endif
++            ssl->session->namedGroup == 0) {
++            return EXT_MISSING;
++        }
++
+         ssl->keys.encryptionOn = 1;
+         ssl->options.serverState = SERVER_HELLO_COMPLETE;
++
+     }
+     else {
+         ssl->options.tls1_3 = 1;

--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-sR/Gjk50kLej5oJzDH1I6/V+7OIRiwtyeg5tEE3fmHk=";
   };
 
+  patches = [
+    ./5.5.4-CVE-2023-3724.patch
+  ];
+
   postPatch = ''
     patchShebangs ./scripts
     # ocsp tests require network access


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2023-3724

Functions in question have changed little between 5.5.4 and 5.6.2.

See #239027 for master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
