### PR TITLE
libfprint-2-tod1-broadcom: init at 5.8.012.0

### DIFF
--- a/pkgs/development/libraries/libfprint-2-tod1-broadcom/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-broadcom/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchgit
+, libfprint-tod
+, openssl
+}:
+
+stdenv.mkDerivation {
+  pname = "libfprint-2-tod1-broadcom";
+  version = "5.12.018.0";
+
+  src = fetchgit {
+    url = "https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-broadcom/+git/libfprint-2-tod1-broadcom";
+    rev = "86acc29291dbaf6216b7fadf50ef1e7222f6eb2a";
+    hash = "sha256-nCkAqAi1AD3qMIU3maMuOUY6zG6+wDkqUMaHEKcLTko=";
+  };
+
+  buildPhase = let
+    # We prepare our library path in the let clause to avoid it become part of the input of mkDerivation
+    libPath = lib.makeLibraryPath [
+      # libfprint-2-tod.so.1
+      libfprint-tod
+      # libcrypto.so.3
+      openssl
+    ];
+  in ''
+    patchelf --set-rpath "${libPath}" \
+      usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-2-tod-1-broadcom.so
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/libfprint-2/tod-1/"
+    mkdir -p "$out/lib/udev/rules.d/"
+    mkdir -p "$out/var/lib/fprint/fw/"
+    mkdir -p "$out/bin/"
+
+    cp usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-2-tod-1-broadcom.so "$out/lib/libfprint-2/tod-1/"
+    cp lib/udev/rules.d/60-libfprint-2-device-broadcom.rules "$out/lib/udev/rules.d/"
+    cp var/lib/fprint/fw/* "$out/var/lib/fprint/fw/"
+    cp debian/update-fw.py "$out/bin/"
+
+    runHook postInstall
+  '';
+
+  passthru.driverPath = "/lib/libfprint-2/tod-1";
+
+  meta = with lib; {
+    description = "Proprietary driver for the fingerprint reader on a few Dell Latitude models - direct from Dell's Ubuntu repo";
+    homepage = "https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-broadcom/+git/libfprint-2-tod1-broadcom/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ totoroot ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22403,6 +22403,8 @@ with pkgs;
 
   libfprint-tod = callPackage ../development/libraries/libfprint-tod { };
 
+  libfprint-2-tod1-broadcom = callPackage ../development/libraries/libfprint-2-tod1-broadcom { };
+
   libfprint-2-tod1-goodix = callPackage ../development/libraries/libfprint-2-tod1-goodix { };
 
   libfprint-2-tod1-goodix-550a = callPackage ../development/libraries/libfprint-2-tod1-goodix-550a { };


### PR DESCRIPTION
## Description of changes

This adds another driver for `libfprint-2-tod1`, which is supposed to be used as Touch OEM Drivers (TOD) package in the NixOS module `services.fprintd.tod.driver`. This enables fingerprint support for the Dell Latitude 7440 and some other notebook models.

I managed to get the driver running by supplying the needed statically linked libraries, but hit a road block when fprintd tries to load the driver's firmware:
```
○ fprintd.service - Fingerprint Authentication Daemon
     Loaded: loaded (/etc/systemd/system/fprintd.service; linked; preset: enabled)
    Drop-In: /nix/store/if17mdl7z0j9q27m36z6b0gh4jiipvp2-system-units/fprintd.service.d
             └─overrides.conf
     Active: inactive (dead)
       Docs: man:fprintd(1)

Aug 01 07:49:28 nixos systemd[1]: Starting Fingerprint Authentication Daemon...
Aug 01 07:49:28 nixos fprintd[160929]: In cvif_IsUshThere(), cv_get_ush_ver() status: (0x0)
Aug 01 07:49:28 nixos fprintd[160929]: Control Vault getting chip type
Aug 01 07:49:28 nixos fprintd[160929]: Citadel A0 CID7 Chip Found....
Aug 01 07:49:28 nixos fprintd[160929]: Can not find SBI file (bcmsbiCitadelA0_7.otp)
Aug 01 07:49:28 nixos fprintd[160929]: Missing files necessary for complete firmware update
Aug 01 07:49:28 nixos fprintd[160929]:                 FwUpgradeError. Check Firmware Files or CID used or Hardware etc. Error: 0x1c
Aug 01 07:49:28 nixos fprintd[160929]: Ignoring device due to initialization error: An unspecified error occurred!
Aug 01 07:49:28 nixos systemd[1]: Started Fingerprint Authentication Daemon.
Aug 01 07:50:15 nixos systemd[1]: fprintd.service: Deactivated successfully.
```

When the package is built, the firmware files are copied to the correct location, but it seems like fprintd cannot find them. Any help would be greatly appreciated!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
