### PR TITLE
deepin.dde-calendar: 5.8.30 -> 5.10.1

### DIFF
--- a/pkgs/desktops/deepin/core/dde-calendar/default.nix
+++ b/pkgs/desktops/deepin/core/dde-calendar/default.nix
@@ -1,53 +1,40 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
-, dtkwidget
-, qt5integration
-, qt5platform-plugins
-, dde-qt-dbus-factory
 , cmake
 , qttools
 , pkg-config
 , wrapQtAppsHook
-, runtimeShell
+, dtkwidget
+, qt5integration
+, qt5platform-plugins
+, dde-qt-dbus-factory
 , qtbase
-, gtest
+, qtsvg
+, libical
+, sqlite
+, runtimeShell
 }:
 
 stdenv.mkDerivation rec {
   pname = "dde-calendar";
-  version = "5.8.30";
+  version = "5.10.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "sha256-8/UXq9W3Gb1Lg/nOji6zcHJts6lgY2uDxvrBxQs3Zio=";
+    hash = "sha256-oPrtPOCLZof4BysWfsCYeoqbJf30r7LijGEEXZlsAAY=";
   };
 
   patches = [
-    (fetchpatch {
-      name = "chore-use-GNUInstallDirs-in-CmakeLists.patch";
-      url = "https://github.com/linuxdeepin/dde-calendar/commit/b9d9555d90a36318eeee62ece49250b4bf8acd10.patch";
-      sha256 = "sha256-pvgxZPczs/lkwNjysNuVu+1AY69VZlxOn7hR9A02/3M=";
-    })
+    ./fix-wrapped-name-not-in-whitelist.diff
   ];
 
   postPatch = ''
-    substituteInPlace calendar-service/src/dbmanager/huanglidatabase.cpp \
-      --replace "/usr/share/dde-calendar/data/huangli.db" "$out/share/dde-calendar/data/huangli.db"
-    substituteInPlace calendar-service/src/main.cpp \
-      --replace "/usr/share/dde-calendar/translations" "$out/share/dde-calendar/translations"
-    substituteInPlace calendar-service/assets/data/com.deepin.dataserver.Calendar.service \
-      --replace "/usr/lib/deepin-daemon/dde-calendar-service" "$out/lib/deepin-daemon/dde-calendar-service"
-    substituteInPlace calendar-client/assets/dbus/com.deepin.Calendar.service \
-      --replace "/usr/bin/dde-calendar" "$out/bin/dde-calendar"
-    substituteInPlace calendar-service/{src/{csystemdtimercontrol.cpp,jobremindmanager.cpp},assets/{data/com.dde.calendarserver.calendar.service,dde-calendar-service.desktop}} \
-      --replace "/bin/bash" "${runtimeShell}"
-
-    substituteInPlace CMakeLists.txt \
-      --replace "ADD_SUBDIRECTORY(tests)" " "
+    for file in $(grep -rl "/bin/bash"); do
+      substituteInPlace $file --replace "/bin/bash" "${runtimeShell}"
+    done
   '';
 
   nativeBuildInputs = [
@@ -58,22 +45,19 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    dtkwidget
+    qt5integration
     qt5platform-plugins
+    dtkwidget
+    qtbase
+    qtsvg
     dde-qt-dbus-factory
-    gtest
+    libical
+    sqlite
   ];
 
   cmakeFlags = [ "-DVERSION=${version}" ];
 
-  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
-  qtWrapperArgs = [
-    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
-  ];
-
-  postFixup = ''
-    wrapQtApp $out/lib/deepin-daemon/dde-calendar-service
-  '';
+  strictDeps = true;
 
   meta = with lib; {
     description = "Calendar for Deepin Desktop Environment";
@@ -83,3 +67,4 @@ stdenv.mkDerivation rec {
     maintainers = teams.deepin.members;
   };
 }
+

--- a/pkgs/desktops/deepin/core/dde-calendar/fix-wrapped-name-not-in-whitelist.diff
+++ b/pkgs/desktops/deepin/core/dde-calendar/fix-wrapped-name-not-in-whitelist.diff
@@ -1,0 +1,13 @@
+diff --git a/calendar-service/src/dbusservice/dservicebase.cpp b/calendar-service/src/dbusservice/dservicebase.cpp
+index ac182881..93a9c2d8 100644
+--- a/calendar-service/src/dbusservice/dservicebase.cpp
++++ b/calendar-service/src/dbusservice/dservicebase.cpp
+@@ -52,6 +52,8 @@ bool DServiceBase::clientWhite(const int index)
+             return true;
+         }
+     }
++    if (getClientName().contains("dde-calendar"))
++    	return true;
+     return false;
+ #else
+     Q_UNUSED(index)


### PR DESCRIPTION
## Description of changes

update to latest version:

https://github.com/linuxdeepin/dde-calendar/compare/5.8.30...5.10.1 
https://github.com/linuxdeepin/dde-calendar/pull/149
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
