### PR TITLE
autogen: apply more patches to avoid crashes

### DIFF
--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -10,23 +10,39 @@ stdenv.mkDerivation rec {
   };
 
   patches = let
-    dp = { ver ? "1%255.18.16-4", pname, name ? (pname + ".diff"), sha256 }: fetchurl {
+    dp = { ver ? "1%255.18.16-5", name, sha256 }: fetchurl {
       url = "https://salsa.debian.org/debian/autogen/-/raw/debian/${ver}"
-          + "/debian/patches/${pname}.diff?inline=false";
+          + "/debian/patches/${name}?inline=false";
       inherit name sha256;
     };
   in [
     (dp {
-      pname = "20_no_Werror";
+      name = "20_no_Werror.diff";
       sha256 = "08z4s2ifiqyaacjpd9pzr59w8m4j3548kkaq1bwvp2gjn29m680x";
     })
     (dp {
-      pname = "30_ag_macros.m4_syntax_error";
+      name = "30_ag_macros.m4_syntax_error.diff";
       sha256 = "1z8vmbwbkz3505wd33i2xx91mlf8rwsa7klndq37nw821skxwyh3";
     })
     (dp {
-      pname = "31_allow_overriding_AGexe_for_crossbuild";
+      name = "31_allow_overriding_AGexe_for_crossbuild.diff";
       sha256 = "0h9wkc9bqb509knh8mymi43hg6n6sxg2lixvjlchcx7z0j7p8xkf";
+    })
+    (dp {
+      name = "40_suse_01-autogen-catch-race-error.patch";
+      sha256 = "1cfkym2zds1f85md1m74snxzqmzlj7wd5jivgmyl342856848xav";
+    })
+    (dp {
+      name = "40_suse_03-gcc9-fix-wrestrict.patch";
+      sha256 = "1ifdwi6gf96jc78jw7q4bfi5fgdldlf2nl55y20h6xb78kv0pznd";
+    })
+    (dp {
+      name = "40_suse_05-sprintf-overflow.patch";
+      sha256 = "136m62k68w1h5k7iapynvbyipidw35js6pq21lsc6rpxvgp0n469";
+    })
+    (dp {
+      name = "40_suse_06-autogen-avoid-GCC-code-analysis-bug.patch";
+      sha256 = "1d65zygzw2rpa00s0jy2y1bg29vkbhnjwlb5pv22rfv87zbk6z9q";
     })
     # Next upstream release will contain guile-3 support. We apply non-invasive
     # patch meanwhile.


### PR DESCRIPTION

## Description of changes

autogen is an old software and triggers many checks, notably in getdefs, when used with _FORTIFY_SOURCE. Apply more correctness patches coming from Suse through Debian.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Ping @RaitoBezarius for review.