### PR TITLE
tpm2-tss: fix build on nix 2.3

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -68,6 +68,10 @@ stdenv.mkDerivation rec {
       --replace '@PREFIX@' $out/lib
     substituteInPlace ./bootstrap \
       --replace 'git describe --tags --always --dirty' 'echo "${version}"'
+
+    # without this building on nix 2.3 will fail
+    substituteInPlace ./test/integration/main-fapi.c \
+      --replace "/tmp/fapi_tmpdir.XXXXXX" "/build/fapi_tmpdir.XXXXXX"
   '';
 
   configureFlags = lib.optionals doInstallCheck [


### PR DESCRIPTION
## Description of changes

Continuing #244478, I'm trying to make current Nixpkgs build cleanly on old versions of Nix with sandboxing enabled, so that you could do a self-contained update of your outdated NixOS systems easily.

I was surprised to see that exactly the same derivation of `tpm2-tss` fails to build on `nix` 2.3 and succeeds on `nix` 2.15.
This fixes it.
Apparently on nix 2.3 `/tmp` points somewhere different enough for the tests to fail.

At first I wanted to make it optional on `builtins.nixVersion` to make this a noop on `master`, but then evaluating derivation on `nix` 2.15 and building on an old `nix-daemon` will fail, so I rebased it onto `staging` and added a mass-rebuild cleanup patch as well.

Ping @Artturin from the previous PR.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).