### PR TITLE
playwright: 1.34.3 > 1.37.0

### DIFF
--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -16,7 +16,7 @@ in
 buildPythonPackage rec {
   pname = "playwright";
   # run ./pkgs/development/python-modules/playwright/update.sh to update
-  version = "1.36.0";
+  version = "1.37.0";
   format = "setuptools";
   disabled = pythonOlder "3.7";
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "microsoft";
     repo = "playwright-python";
     rev = "v${version}";
-    hash = "sha256-/umpMkD+WEpBmw2cRb71PtOMd1sRNfwmURKdaRy4Qsc=";
+    hash = "sha256-7egK76A3+C+JPbCNFXDd4qTjepBRSZgtQmFrE/jWJN4=";
   };
 
   patches = [
@@ -88,6 +88,7 @@ buildPythonPackage rec {
       driver = playwright-driver;
       browsers = playwright-driver.browsers;
     };
+    updateScript = ./update.sh;
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/playwright/update.sh
+++ b/pkgs/development/python-modules/playwright/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused nix-prefetch common-updater-scripts node2nix
+#!nix-shell -i bash -p curl gnused nix-prefetch common-updater-scripts node2nix jq
 set -euo pipefail
 
 root="$(dirname "$(readlink -f "$0")")"

--- a/pkgs/development/web/playwright-test/node-packages.json
+++ b/pkgs/development/web/playwright-test/node-packages.json
@@ -1,3 +1,3 @@
 [
-  {"@playwright/test": "1.34.3"}
+  {"@playwright/test": "1.37.0"}
 ]

--- a/pkgs/development/web/playwright-test/node-packages.nix
+++ b/pkgs/development/web/playwright-test/node-packages.nix
@@ -4,13 +4,13 @@
 
 let
   sources = {
-    "@types/node-20.2.5" = {
+    "@types/node-20.5.0" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "20.2.5";
+      version = "20.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz";
-        sha512 = "JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==";
+        url = "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz";
+        sha512 = "Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==";
       };
     };
     "fsevents-2.3.2" = {
@@ -22,30 +22,30 @@ let
         sha512 = "xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==";
       };
     };
-    "playwright-core-1.34.3" = {
+    "playwright-core-1.37.0" = {
       name = "playwright-core";
       packageName = "playwright-core";
-      version = "1.34.3";
+      version = "1.37.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/playwright-core/-/playwright-core-1.34.3.tgz";
-        sha512 = "2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==";
+        url = "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.0.tgz";
+        sha512 = "1c46jhTH/myQw6sesrcuHVtLoSNfJv8Pfy9t3rs6subY7kARv0HRw5PpyfPYPpPtQvBOmgbE6K+qgYUpj81LAA==";
       };
     };
   };
 in
 {
-  "@playwright/test-1.34.3" = nodeEnv.buildNodePackage {
+  "@playwright/test-1.37.0" = nodeEnv.buildNodePackage {
     name = "_at_playwright_slash_test";
     packageName = "@playwright/test";
-    version = "1.34.3";
+    version = "1.37.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@playwright/test/-/test-1.34.3.tgz";
-      sha512 = "zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==";
+      url = "https://registry.npmjs.org/@playwright/test/-/test-1.37.0.tgz";
+      sha512 = "181WBLk4SRUyH1Q96VZl7BP6HcK0b7lbdeKisn3N/vnjitk+9HbdlFz/L5fey05vxaAhldIDnzo8KUoy8S3mmQ==";
     };
     dependencies = [
-      sources."@types/node-20.2.5"
+      sources."@types/node-20.5.0"
       sources."fsevents-2.3.2"
-      sources."playwright-core-1.34.3"
+      sources."playwright-core-1.37.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -30,15 +30,15 @@ let
     {
     pname = "playwright-driver";
     # run ./pkgs/development/python-modules/playwright/update.sh to update
-    version = "1.34.3";
+    version = "1.37.0";
 
     src = fetchurl {
       url = "https://playwright.azureedge.net/builds/driver/${filename}";
       sha256 = {
-        x86_64-linux = "1xh05v3yqa8gkwayhl4nffgjcnlakpyyi17hwzh0wqzrbwwn0cs8";
-        aarch64-linux = "18jxbmhiqda5pzrv6b3n7xi14xg4zvlh6sn7hc3b3hckl77vl933";
-        x86_64-darwin = "0fy5nxbvp1kxplavj832gxiznjqpvl0ww869hsfj0h1fibhly7cy";
-        aarch64-darwin = "11msl4pnmr8cmlw32xq2qvfz3g3fy0azvq134a47c0fnpj2gd5zl";
+        x86_64-linux = "1lkmanr402ar9njwb7dgyzparjyr1r9krz9ad7b8c6hi3fjvrj0y";
+        aarch64-linux = "13nfva9jfmjyjxm1my0aq8ngn6ha0fdrpfv28gm351n0j9cjlvqh";
+        x86_64-darwin = "0q1qmgypngxs9ipb6dlhk1xccyzw6frzr835ijifpypgp4xmz2gi";
+        aarch64-darwin = "1mq1868s06wgfgi3nhdrzsdqi3cl08lrkiz5q06mg1s724b2sf0v";
       }.${system} or throwSystem;
     };
 


### PR DESCRIPTION
## Description of changes

Updated with the script in ./pkgs/development/python-modules/playwright/update.sh
Previous pr by bot only updated the main package, not the driver en web test package. https://github.com/NixOS/nixpkgs/pull/239517

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I have used it in an overlay and the update works.