### PR TITLE
Fixes for pkgsLLVM with llvmPackages_{15,16,git}

### DIFF
--- a/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
@@ -68,6 +68,13 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
+  ] ++ lib.optionals ((stdenv.hostPlatform.useLLVM or false) ||
+                      (stdenv.hostPlatform.isDarwin && enableShared)) [
+    # libcxxabi's CMake looks as though it treats -nostdlib++ as implying -nostdlib,
+    # but that does not appear to be the case for example when building
+    # pkgsLLVM.libcxxabi (which uses clangNoCompilerRtWithLibc).
+    "-DCMAKE_EXE_LINKER_FLAGS=-nostdlib"
+    "-DCMAKE_SHARED_LINKER_FLAGS=-nostdlib"
   ] ++ lib.optionals stdenv.hostPlatform.isWasm [
     "-DLIBCXXABI_ENABLE_THREADS=OFF"
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"

--- a/pkgs/development/compilers/llvm/15/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/15/libunwind/default.nix
@@ -40,6 +40,11 @@ stdenv.mkDerivation rec {
     cd ../runtimes
   '';
 
+  postInstall = lib.optionalString (enableShared && !stdenv.hostPlatform.isDarwin) ''
+    # libcxxabi wants to link to libunwind_shared.so (?).
+    ln -s $out/lib/libunwind.so $out/lib/libunwind_shared.so
+  '';
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake ninja python3 ];

--- a/pkgs/development/compilers/llvm/16/default.nix
+++ b/pkgs/development/compilers/llvm/16/default.nix
@@ -254,6 +254,14 @@ in let
         [ "-rtlib=compiler-rt"
           "-Wno-unused-command-line-argument"
           "-B${targetLlvmLibraries.compiler-rt}/lib"
+
+          # Combat "__cxxabi_config.h not found". Maybe this could be fixed by
+          # copying these headers into libcxx? Note that building libcxx
+          # outside of monorepo isn't supported anymore, might be related to
+          # https://github.com/llvm/llvm-project/issues/55632
+          # ("16.0.3 libcxx, libcxxabi: circular build dependencies")
+          # Looks like the machinery changed in https://reviews.llvm.org/D120727.
+          "-I${lib.getDev targetLlvmLibraries.libcxx.cxxabi}/include/c++/v1"
         ]
         ++ lib.optional (!stdenv.targetPlatform.isWasm) "--unwindlib=libunwind"
         ++ lib.optional

--- a/pkgs/development/compilers/llvm/16/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/16/libcxxabi/default.nix
@@ -68,6 +68,13 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
+  ] ++ lib.optionals ((stdenv.hostPlatform.useLLVM or false) ||
+                      (stdenv.hostPlatform.isDarwin && enableShared)) [
+    # libcxxabi's CMake looks as though it treats -nostdlib++ as implying -nostdlib,
+    # but that does not appear to be the case for example when building
+    # pkgsLLVM.libcxxabi (which uses clangNoCompilerRtWithLibc).
+    "-DCMAKE_EXE_LINKER_FLAGS=-nostdlib"
+    "-DCMAKE_SHARED_LINKER_FLAGS=-nostdlib"
   ] ++ lib.optionals stdenv.hostPlatform.isWasm [
     "-DLIBCXXABI_ENABLE_THREADS=OFF"
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"

--- a/pkgs/development/compilers/llvm/16/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/16/libunwind/default.nix
@@ -40,6 +40,11 @@ stdenv.mkDerivation rec {
     cd ../runtimes
   '';
 
+  postInstall = lib.optionalString (enableShared && !stdenv.hostPlatform.isDarwin) ''
+    # libcxxabi wants to link to libunwind_shared.so (?).
+    ln -s $out/lib/libunwind.so $out/lib/libunwind_shared.so
+  '';
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake ninja python3 ];

--- a/pkgs/development/compilers/llvm/git/default.nix
+++ b/pkgs/development/compilers/llvm/git/default.nix
@@ -313,6 +313,19 @@ in let
       # what stdenv we use here, as long as CMake is happy.
       cxx-headers = callPackage ./libcxx {
         inherit llvm_meta;
+        # Note that if we use the regular stdenv here we'll get cycle errors
+        # when attempting to use this compiler in the stdenv.
+        #
+        # The final stdenv pulls `cxx-headers` from the package set where
+        # hostPlatform *is* the target platform which means that `stdenv` at
+        # that point attempts to use this toolchain.
+        #
+        # So, we use `stdenv_` (the stdenv containing `clang` from this package
+        # set, defined below) to sidestep this issue.
+        #
+        # Because we only use `cxx-headers` in `libcxxabi` (which depends on the
+        # clang stdenv _anyways_), this is okay.
+        stdenv = stdenv_;
         headersOnly = true;
       };
 

--- a/pkgs/development/compilers/llvm/git/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxx/default.nix
@@ -2,7 +2,7 @@
 , monorepoSrc, runCommand
 , cmake, ninja, python3, fixDarwinDylibNames, version
 , cxxabi ? if stdenv.hostPlatform.isFreeBSD then libcxxrt else libcxxabi
-, libcxxabi, libcxxrt
+, libcxxabi, libcxxrt, libunwind
 , enableShared ? !stdenv.hostPlatform.isStatic
 
 # If headersOnly is true, the resulting package would only include the headers.
@@ -62,7 +62,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ninja python3 ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  buildInputs = lib.optionals (!headersOnly) [ cxxabi ];
+  buildInputs =
+    lib.optionals (!headersOnly) [ cxxabi ]
+    ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [ libunwind ];
+
 
   cmakeFlags = let
     # See: https://libcxx.llvm.org/BuildingLibcxx.html#cmdoption-arg-libcxx-cxx-abi-string
@@ -75,8 +78,18 @@ stdenv.mkDerivation rec {
     "-DLIBCXX_CXX_ABI=${if headersOnly then "none" else libcxx_cxx_abi_opt}"
   ] ++ lib.optional (!headersOnly && cxxabi.libName == "c++abi") "-DLIBCXX_CXX_ABI_INCLUDE_PATHS=${cxxabi.dev}/include/c++/v1"
     ++ lib.optional (stdenv.hostPlatform.isMusl || stdenv.hostPlatform.isWasi) "-DLIBCXX_HAS_MUSL_LIBC=1"
-    ++ lib.optional (stdenv.hostPlatform.useLLVM or false) "-DLIBCXX_USE_COMPILER_RT=ON"
-    ++ lib.optionals stdenv.hostPlatform.isWasm [
+    ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
+      "-DLIBCXX_USE_COMPILER_RT=ON"
+      # (Backport fix from 16, which has LIBCXX_ADDITIONAL_LIBRARIES, but 15
+      # does not appear to)
+      # There's precedent for this in llvm-project/libcxx/cmake/caches.
+      # In a monorepo build you might do the following in the libcxxabi build:
+      #   -DLLVM_ENABLE_PROJECTS=libcxxabi;libunwinder
+      #   -DLIBCXXABI_STATICALLY_LINK_UNWINDER_IN_STATIC_LIBRARY=On
+      # libcxx appears to require unwind and doesn't pull it in via other means.
+      # "-DLIBCXX_ADDITIONAL_LIBRARIES=unwind"
+      "-DCMAKE_SHARED_LINKER_FLAGS=-lunwind"
+    ] ++ lib.optionals stdenv.hostPlatform.isWasm [
       "-DLIBCXX_ENABLE_THREADS=OFF"
       "-DLIBCXX_ENABLE_FILESYSTEM=OFF"
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -68,6 +68,13 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
+  ] ++ lib.optionals ((stdenv.hostPlatform.useLLVM or false) ||
+                      (stdenv.hostPlatform.isDarwin && enableShared)) [
+    # libcxxabi's CMake looks as though it treats -nostdlib++ as implying -nostdlib,
+    # but that does not appear to be the case for example when building
+    # pkgsLLVM.libcxxabi (which uses clangNoCompilerRtWithLibc).
+    "-DCMAKE_EXE_LINKER_FLAGS=-nostdlib"
+    "-DCMAKE_SHARED_LINKER_FLAGS=-nostdlib"
   ] ++ lib.optionals stdenv.hostPlatform.isWasm [
     "-DLIBCXXABI_ENABLE_THREADS=OFF"
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"

--- a/pkgs/development/compilers/llvm/git/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/git/libunwind/default.nix
@@ -40,6 +40,11 @@ stdenv.mkDerivation rec {
     cd ../runtimes
   '';
 
+  postInstall = lib.optionalString (enableShared && !stdenv.hostPlatform.isDarwin) ''
+    # libcxxabi wants to link to libunwind_shared.so (?).
+    ln -s $out/lib/libunwind.so $out/lib/libunwind_shared.so
+  '';
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake ninja python3 ];


### PR DESCRIPTION
## Description of changes

cc maintainers @dtzWill @ericson2314 @lovek323 @primeos @qyliss @raitobezarius @rrbutani @sternenseemann

With the following overlay, I'm able to build and run `pkgsLLVM.nix` (i.e, nontrivial C++ software) with LLVM 16.

As others have observed, the runtimes build machinery changed quite a bit in recent LLVM versions, so it was a little tricky to make this work, and I've had to tweak the build a bit. I suspect my tweaks may be have the potential to break other platforms, so help wanted!

Overlay:

```nix
import /home/pwaller/.local/src/nixpkgs {
  overlays = [(self: super: {
    llvmPackages = self.llvmPackages_16;

    libseccomp = super.libseccomp.overrideAttrs (final: prev: {
      # Some failing tests, not investigated.
      doCheck = false;
    });

    lowdown = super.lowdown.overrideAttrs (final: prev: {
      # Breaks detection of strlcpy (it gets optimized away during conf test).
      hardeningDisable = [ "fortify" ];
    });

    boost = super.boost.overrideAttrs (final: prev: {
      # Required, otherwise clang can't find the linker.
      # Because boost sets --target=x86_64-pc-linux, and the linker is named
      # x86_64-unknown-linux-gnu-lld.
      NIX_CFLAGS_LINK = prev.NIX_CFLAGS_LINK + " --target=${self.stdenv.hostPlatform.config}";
    });

    db48 = super.db48.overrideAttrs (final: prev: {
      configureFlags = prev.configureFlags
        ++ self.lib.optional (super.db48.stdenv.hostPlatform.useLLVM or false)
          # See https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213
          "CFLAGS=-Wno-error=implicit-function-declaration";
    });

    shadow = super.shadow.overrideAttrs (final: prev: {
      configureFlags = prev.configureFlags
        ++ self.lib.optional (super.shadow.stdenv.hostPlatform.useLLVM or false)
          # See https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213
          "CFLAGS=-Wno-error=implicit-function-declaration";
    });

    nix = super.nix.overrideAttrs (final: prev: {
      # Some tests failing (possibly because they want libgcc_s for pthread cancel?).
      postPatch = (prev.postPatch or "") + ''
        #  rm -r $sourceRoot/tests/{build-remote-content-addressed-fixed.sh,build-remote-input-addressed.sh}
        sed -i '/build-remote-input-addressed.sh/d' tests/local.mk
        sed -i '/build-remote-content-addressed-fixed.sh/d' tests/local.mk
        sed -i '/build-remote-content-addressed-floating.sh/d' tests/local.mk
      '';
    });
  })];
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
