### PR TITLE
python310Packages.attrs: 22.2.0 -> 23.1.0

### DIFF
--- a/pkgs/development/python-modules/attrs/default.nix
+++ b/pkgs/development/python-modules/attrs/default.nix
@@ -3,22 +3,31 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, setuptools
+, hatchling
 }:
 
 buildPythonPackage rec {
   pname = "attrs";
-  version = "22.2.0";
-  disabled = pythonOlder "3.6";
+  version = "23.1.0";
+  disabled = pythonOlder "3.7";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ySJ7/C8BmTwD9o2zfR0VyWkBiDI8BnxkHxo1ylgYX5k=";
+    hash = "sha256-YnmDbVgVE6JvG/I1+azTM7yRFWg/FPfo+uRsmPxQ4BU=";
   };
 
+  patches = [
+    # hatch-vcs and hatch-fancy-pypi-readme depend on pytest, which depends on attrs
+    ./remove-hatch-plugins.patch
+  ];
+
+  postPatch = ''
+    substituteAllInPlace pyproject.toml
+  '';
+
   nativeBuildInputs = [
-    setuptools
+    hatchling
   ];
 
   outputs = [
@@ -47,6 +56,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python attributes without boilerplate";
     homepage = "https://github.com/python-attrs/attrs";
+    changelog = "https://github.com/python-attrs/attrs/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/attrs/remove-hatch-plugins.patch
+++ b/pkgs/development/python-modules/attrs/remove-hatch-plugins.patch
@@ -1,0 +1,74 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index fb8fae3..998211f 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: MIT
+ 
+ [build-system]
+-requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme"]
++requires = ["hatchling"]
+ build-backend = "hatchling.build"
+ 
+ 
+@@ -26,7 +26,8 @@ classifiers = [
+     "Typing :: Typed",
+ ]
+ dependencies = ["importlib_metadata;python_version<'3.8'"]
+-dynamic = ["version", "readme"]
++dynamic = ["readme"]
++version = "@version@"
+ 
+ [project.optional-dependencies]
+ tests-no-zope = [
+@@ -67,50 +68,9 @@ Changelog = "https://www.attrs.org/en/stable/changelog.html"
+ Funding = "https://github.com/sponsors/hynek"
+ Tidelift = "https://tidelift.com/subscription/pkg/pypi-attrs?utm_source=pypi-attrs&utm_medium=pypi"
+ 
+-
+-[tool.hatch.version]
+-source = "vcs"
+-raw-options = { local_scheme = "no-local-version" }
+-
+ [tool.hatch.build.targets.wheel]
+ packages = ["src/attr", "src/attrs"]
+ 
+-[tool.hatch.metadata.hooks.fancy-pypi-readme]
+-content-type = "text/markdown"
+-
+-# PyPI doesn't support the <picture> tag.
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-text = """<p align="center">
+-  <a href="https://www.attrs.org/">
+-    <img src="https://raw.githubusercontent.com/python-attrs/attrs/main/docs/_static/attrs_logo.svg" width="35%" alt="attrs" />
+-  </a>
+-</p>
+-"""
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "README.md"
+-start-after = "<!-- teaser-begin -->"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-text = """
+-
+-## Release Information
+-
+-"""
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "CHANGELOG.md"
+-pattern = "\n(###.+?\n)## "
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-text = """
+-
+----
+-
+-[Full changelog](https://www.attrs.org/en/stable/changelog.html)
+-"""
+-
+-
+ # Make coverage play nicely with pytest-xdist.
+ [tool.hatch.build.targets.wheel.hooks.autorun]
+ dependencies = ["hatch-autorun"]


### PR DESCRIPTION
Changelog: https://github.com/python-attrs/attrs/releases/tag/23.1.0

It uses hatchling to build from this version.
Plugins like hatch-vcs use pytest for checkPhase and fall into circular import, so I applied a patch to remove it.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
