### PR TITLE
libdivsufsort: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/libdivsufsort/default.nix
+++ b/pkgs/development/libraries/libdivsufsort/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl}:
+{lib, stdenv, fetchurl, cmake}:
 
 stdenv.mkDerivation rec {
   pname = "libdivsufsort";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libdivsufsort/libdivsufsort-${version}.tar.bz2";
     sha256 = "1g0q40vb2k689bpasa914yi8sjsmih04017mw20zaqqpxa32rh2m";
   };
+
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     homepage = "https://github.com/y-256/libdivsufsort";

--- a/pkgs/development/libraries/libdivsufsort/default.nix
+++ b/pkgs/development/libraries/libdivsufsort/default.nix
@@ -1,12 +1,14 @@
-{lib, stdenv, fetchurl, cmake}:
+{lib, stdenv, fetchFromGitHub, cmake}:
 
 stdenv.mkDerivation rec {
   pname = "libdivsufsort";
   version = "2.0.1";
 
-  src = fetchurl {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libdivsufsort/libdivsufsort-${version}.tar.bz2";
-    sha256 = "1g0q40vb2k689bpasa914yi8sjsmih04017mw20zaqqpxa32rh2m";
+  src = fetchFromGitHub {
+    owner = "y-256";
+    repo = pname;
+    rev = "${version}";
+    hash = "sha256-4p+L1bq9SBgWSHXx+WYWAe60V2g1AN+zlJvC+F367Tk=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Issue before: malloc not found on architecture

Adding cmake fixed this for me.

make[1]: Entering directory '/build/libdivsufsort-2.0.1/examples'
aarch64-unknown-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../include     -g -O2 -c suftest.c
/nix/store/p6dlr3skfhxpyphipg2bqnj52999banh-bash-5.2-p15/bin/bash ../libtool --tag=CC   --mode=link aarch64-unknown-linux-gnu-gcc  -g -O2   -o suftest suftest.o ../lib/libdivsufsort.la 
libtool: link: aarch64-unknown-linux-gnu-gcc -g -O2 -o suftest suftest.o  ../lib/.libs/libdivsufsort.a
/nix/store/sc1pz0zaqwpai24zh7xx0brjinflmc6v-aarch64-unknown-linux-gnu-binutils-2.40/bin/aarch64-unknown-linux-gnu-ld: suftest.o: in function `main':
/build/libdivsufsort-2.0.1/examples/suftest.c:128: undefined reference to `rpl_malloc'
/nix/store/sc1pz0zaqwpai24zh7xx0brjinflmc6v-aarch64-unknown-linux-gnu-binutils-2.40/bin/aarch64-unknown-linux-gnu-ld: /build/libdivsufsort-2.0.1/examples/suftest.c:129: undefined reference to `rpl_malloc'
/nix/store/sc1pz0zaqwpai24zh7xx0brjinflmc6v-aarch64-unknown-linux-gnu-binutils-2.40/bin/aarch64-unknown-linux-gnu-ld: ../lib/.libs/libdivsufsort.a(libdivsufsort_la-divsufsort.o): in function `divsufsort':
/build/libdivsufsort-2.0.1/lib/divsufsort.c:343: undefined reference to `rpl_malloc'
/nix/store/sc1pz0zaqwpai24zh7xx0brjinflmc6v-aarch64-unknown-linux-gnu-binutils-2.40/bin/aarch64-unknown-linux-gnu-ld: /build/libdivsufsort-2.0.1/lib/divsufsort.c:344: undefined reference to `rpl_malloc'
/nix/store/sc1pz0zaqwpai24zh7xx0brjinflmc6v-aarch64-unknown-linux-gnu-binutils-2.40/bin/aarch64-unknown-linux-gnu-ld: ../lib/.libs/libdivsufsort.a(libdivsufsort_la-divsufsort.o): in function `divbwt':
/build/libdivsufsort-2.0.1/lib/divsufsort.c:371: undefined reference to `rpl_malloc'
/nix/store/sc1pz0zaqwpai24zh7xx0brjinflmc6v-aarch64-unknown-linux-gnu-binutils-2.40/bin/aarch64-unknown-linux-gnu-ld: ../lib/.libs/libdivsufsort.a(libdivsufsort_la-divsufsort.o):/build/libdivsufsort-2.0.1/lib/divsufsort.c:372: more undefined references to `rpl_malloc' follow
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:290: suftest] Error 1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
