### PR TITLE
restic: 0.15.2 -> 0.16.0

### DIFF
--- a/pkgs/tools/backup/restic/0001-Skip-testing-restore-with-permission-failure.patch
+++ b/pkgs/tools/backup/restic/0001-Skip-testing-restore-with-permission-failure.patch
@@ -1,18 +1,18 @@
-From 8e6186be04e2819b6e3586e5d1aeb8a824e1979f Mon Sep 17 00:00:00 2001
+From 72f7d8abee34107b815e49540f2fad7f1ab0b2cc Mon Sep 17 00:00:00 2001
 From: Simon Bruder <simon@sbruder.de>
 Date: Thu, 25 Feb 2021 09:20:51 +0100
 Subject: [PATCH] Skip testing restore with permission failure
 
 The test fails in sandboxed builds.
 ---
- cmd/restic/integration_test.go | 1 +
+ cmd/restic/cmd_restore_integration_test.go | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/cmd/restic/integration_test.go b/cmd/restic/integration_test.go
-index 7d198d33..1588ccb1 100644
---- a/cmd/restic/integration_test.go
-+++ b/cmd/restic/integration_test.go
-@@ -1170,6 +1170,7 @@ func TestRestoreLatest(t *testing.T) {
+diff --git a/cmd/restic/cmd_restore_integration_test.go b/cmd/restic/cmd_restore_integration_test.go
+index 2c7cbe1fb..f25f13754 100644
+--- a/cmd/restic/cmd_restore_integration_test.go
++++ b/cmd/restic/cmd_restore_integration_test.go
+@@ -200,6 +200,7 @@ func TestRestoreLatest(t *testing.T) {
  }
  
  func TestRestoreWithPermissionFailure(t *testing.T) {
@@ -21,5 +21,5 @@ index 7d198d33..1588ccb1 100644
  	defer cleanup()
  
 -- 
-2.29.2
+2.41.0
 

--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -3,13 +3,13 @@
 
 buildGoModule rec {
   pname = "restic";
-  version = "0.15.2";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "restic";
     repo = "restic";
     rev = "v${version}";
-    hash = "sha256-YJBHk/B8+q5f0k5i5hpucsJK4T/cRu9Jv7+O6vlT64Q=";
+    hash = "sha256-kxxQlU3bKBjCb1aEtcLBmcnPg4KFgFlbFhs9MmbAgk8=";
   };
 
   patches = [
@@ -17,7 +17,7 @@ buildGoModule rec {
     ./0001-Skip-testing-restore-with-permission-failure.patch
   ];
 
-  vendorHash = "sha256-GWFaCfiE8Ph2uBTBI0E47pH+EJsMsMr1NDuaIGvyXRM=";
+  vendorHash = "sha256-m5smEyAt9RxgvUf1pZqIhgja2h8MWfEgjJ4jUgrPMPY=";
 
   subPackages = [ "cmd/restic" ];
 
@@ -26,7 +26,7 @@ buildGoModule rec {
   passthru.tests.restic = nixosTests.restic;
 
   postPatch = ''
-    rm cmd/restic/integration_fuse_test.go
+    rm cmd/restic/cmd_mount_integration_test.go
   '';
 
   postInstall = ''


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/restic/restic/compare/v0.15.2...v0.16.0

Changelog: https://github.com/restic/restic/blob/v0.16.0/CHANGELOG.md


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @kilianar 