### PR TITLE
gitlab: 16.1.2 -> 16.1.3

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,15 +1,15 @@
 {
-  "version": "16.1.2",
-  "repo_hash": "sha256-A9JkBwGym+CPpb5B7+Kwt8Ej4PGSHc3ZOgUA28hdyN8=",
-  "yarn_hash": "1cqyf06810ls94nkys0l4p86ni902q32aqjp66m7j1x6ldh248al",
+  "version": "16.1.3",
+  "repo_hash": "sha256-PI0nmwfk8uu74NJkavbbJR9/jDN9SS0Z9Axe4UmT2kk=",
+  "yarn_hash": "0wykn0vq16n8mz4jfh7dfyp9javzhqlfwmc5i1zm07gld91nirlm",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v16.1.2-ee",
+  "rev": "v16.1.3-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "16.1.2",
-    "GITLAB_PAGES_VERSION": "16.1.2",
+    "GITALY_SERVER_VERSION": "16.1.3",
+    "GITLAB_PAGES_VERSION": "16.1.3",
     "GITLAB_SHELL_VERSION": "14.23.0",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "4.3.5",
-    "GITLAB_WORKHORSE_VERSION": "16.1.2"
+    "GITLAB_WORKHORSE_VERSION": "16.1.3"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  version = "16.1.2";
+  version = "16.1.3";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -24,7 +24,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      sha256 = "sha256-/yCmFbmKTp8V8CjdhoAPpAdwNEcaP/wB0oAeTLdMESo=";
+      sha256 = "sha256-g9K1dFcrUkWJInPrwg9fz/TEK35GrjqFpUS2bnemwLQ=";
     };
 
     vendorSha256 = "sha256-6oOFQGPwiMRQrESXsQsGzvWz9bCb0VTYIyyG/C2b3nA=";

--- a/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "16.1.2";
+  version = "16.1.3";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    sha256 = "sha256-T33/SnV+aWUjfRKxVOQNWaPtFnounMkCXAeQCQ9w5RY=";
+    sha256 = "sha256-FSdew0HMbgEAzVoDhINDIQQs8Q63AHu8mu/dKo+wP9k=";
   };
 
   vendorHash = "sha256-SN4r9hcTTQUr3miv2Cm7iBryyh7yG1xx9lCvq3vQwc0=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "16.1.2";
+  version = "16.1.3";
 
   src = fetchFromGitLab {
     owner = data.owner;


### PR DESCRIPTION
## Description of changes
https://gitlab.com/gitlab-org/gitlab/-/blob/v16.1.3-ee/CHANGELOG.md

Fixes [CVE-2023-0632](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0632)
Fixes [CVE-2023-1210](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1210)
Fixes [CVE-2023-2022](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2022)
Fixes [CVE-2023-2164](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2164)
Fixes [CVE-2023-3364](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3364)
Fixes [CVE-2023-3385](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3385)
Fixes [CVE-2023-3401](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3401)
Fixes [CVE-2023-3500](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3500)
Fixes [CVE-2023-3900](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3900)
Fixes [CVE-2023-3993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3993)
Fixes [CVE-2023-3994](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3994)
Fixes [CVE-2023-4002](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4002)
Fixes [CVE-2023-4008](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4008)
Fixes [CVE-2023-4011](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4011)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
