### PR TITLE
d2: fix version ldflag

### DIFF
--- a/pkgs/tools/text/d2/default.nix
+++ b/pkgs/tools/text/d2/default.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X oss.terrastruct.com/d2/lib/version.Version=${version}"
+    "-X oss.terrastruct.com/d2/lib/version.Version=v${version}"
   ];
 
   nativeBuildInputs = [ installShellFiles ];
@@ -41,7 +41,10 @@ buildGoModule rec {
     export TESTDATA_ACCEPT=1
   '';
 
-  passthru.tests.version = testers.testVersion { package = d2; };
+  passthru.tests.version = testers.testVersion {
+    package = d2;
+    version = "v${version}";
+  };
 
   meta = with lib; {
     description = "A modern diagram scripting language that turns text to diagrams";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds the `v` prefix to version ldflag, otherwise it creates a diff with the pre-built binaries from upstream (which uses the full Git tag) in the SVG header:

```diff
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><svg xmlns=["http://www.w3.org/2000/svg"](http://www.w3.org/2000/svg) xmlns:xlink=["http://www.w3.org/1999/xlink"](http://www.w3.org/1999/xlink) d2Version="0.5.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1147 1671"><svg id="d2-svg" class="d2-1395872583" width="1147" height="1671" viewBox="-68 -89 1147 1671"><rect x="-68.000000" y="-89.000000" width="1147.000000" height="1671.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+<?xml version="1.0" encoding="utf-8"?><svg xmlns=["http://www.w3.org/2000/svg"](http://www.w3.org/2000/svg) xmlns:xlink=["http://www.w3.org/1999/xlink"](http://www.w3.org/1999/xlink) d2Version="v0.5.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1147 1671"><svg id="d2-svg" class="d2-1395872583" width="1147" height="1671" viewBox="-68 -89 1147 1671"><rect x="-68.000000" y="-89.000000" width="1147.000000" height="1671.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
 .d2-1395872583 .text {
     font-family: "d2-1395872583-font-regular";
 }
```

```diff
-d2Version="0.5.1"
+d2Version="v0.5.1"
```

It is especially a problem when collaborating with others in Git. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
