### PR TITLE
onlyoffice-bin: 7.2.0 -> 7.4.1

### DIFF
--- a/pkgs/applications/office/onlyoffice-bin/7_2.nix
+++ b/pkgs/applications/office/onlyoffice-bin/7_2.nix
@@ -177,6 +177,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Office suite that combines text, spreadsheet and presentation editors allowing to create, view and edit local documents";
+    longDescription = ''
+      The latest versions of OnlyOffice are currently broken on wlroots environments (e.g. Hyprland, Sway).
+      If you are using a different environment, you can get the latest version using `onlyoffice-bin_latest`.
+    '';
     homepage = "https://www.onlyoffice.com/";
     downloadPage = "https://github.com/ONLYOFFICE/DesktopEditors/releases";
     changelog = "https://github.com/ONLYOFFICE/DesktopEditors/blob/master/CHANGELOG.md";

--- a/pkgs/applications/office/onlyoffice-bin/7_4.nix
+++ b/pkgs/applications/office/onlyoffice-bin/7_4.nix
@@ -1,0 +1,215 @@
+{ stdenv
+, lib
+, fetchurl
+, buildFHSEnv
+  # Alphabetic ordering below
+, alsa-lib
+, at-spi2-atk
+, atk
+, autoPatchelfHook
+, cairo
+, curl
+, dbus
+, dconf
+, dpkg
+, fontconfig
+, gcc-unwrapped
+, gdk-pixbuf
+, glib
+, glibc
+, gsettings-desktop-schemas
+, gst_all_1
+, gtk2
+, gtk3
+, libpulseaudio
+, libudev0-shim
+, libdrm
+, makeWrapper
+, mesa
+, nspr
+, nss
+, pulseaudio
+, qt5
+, wrapGAppsHook
+, xkeyboard_config
+, xorg
+}:
+let
+
+  # Note on fonts:
+  #
+  # OnlyOffice does not distribute unfree fonts, but makes it easy to pick up
+  # any fonts you install. See:
+  #
+  # * https://helpcenter.onlyoffice.com/en/installation/docs-community-install-fonts-linux.aspx
+  # * https://www.onlyoffice.com/blog/2020/04/how-to-add-new-fonts-to-onlyoffice-desktop-editors/
+  #
+  # As recommended there, you should download
+  #
+  #     arial.ttf, calibri.ttf, cour.ttf, symbol.ttf, times.ttf, wingding.ttf
+  #
+  # into `~/.local/share/fonts/`, otherwise the default template fonts, and
+  # things like bullet points, will not look as expected.
+
+  # TODO: Find out which of these fonts we'd be allowed to distribute along
+  #       with this package, or how to make this easier for users otherwise.
+
+  # Not using the `noto-fonts-cjk` package from nixpkgs, because it was
+  # reported that its `.ttc` file is not picked up by OnlyOffice, see:
+  # https://github.com/NixOS/nixpkgs/pull/116343#discussion_r593979816
+  noto-fonts-cjk = fetchurl {
+    url =
+      let
+        version = "v20201206-cjk";
+      in
+      "https://github.com/googlefonts/noto-cjk/raw/${version}/NotoSansCJKsc-Regular.otf";
+    sha256 = "sha256-aJXSVNJ+p6wMAislXUn4JQilLhimNSedbc9nAuPVxo4=";
+  };
+
+  runtimeLibs = lib.makeLibraryPath [
+    curl
+    glibc
+    gcc-unwrapped.lib
+    libudev0-shim
+    pulseaudio
+  ];
+
+  derivation = stdenv.mkDerivation rec {
+    pname = "onlyoffice-desktopeditors";
+    version = "7.4.1";
+    minor = null;
+    src = fetchurl {
+      url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_amd64.deb";
+      sha256 = "sha256-vaBF3GJyLBldWdEruOeVpRvwGNwaRl7IKPguDLRoe8M=";
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      dpkg
+      makeWrapper
+      wrapGAppsHook
+    ];
+
+    buildInputs = [
+      alsa-lib
+      at-spi2-atk
+      atk
+      cairo
+      dbus
+      dconf
+      fontconfig
+      gdk-pixbuf
+      glib
+      gsettings-desktop-schemas
+      gst_all_1.gst-plugins-base
+      gst_all_1.gstreamer
+      gtk2
+      gtk3
+      libpulseaudio
+      libdrm
+      nspr
+      nss
+      mesa # libgbm
+      qt5.qtbase
+      qt5.qtdeclarative
+      qt5.qtsvg
+      qt5.qtwayland
+      xorg.libX11
+      xorg.libxcb
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXScrnSaver
+      xorg.libXtst
+    ];
+
+    dontWrapQtApps = true;
+
+    unpackPhase = ''
+      dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
+    '';
+
+    preConfigure = ''
+      cp --no-preserve=mode,ownership ${noto-fonts-cjk} opt/onlyoffice/desktopeditors/fonts/
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/{bin,lib,share}
+
+      mv usr/bin/* $out/bin
+      mv usr/share/* $out/share/
+      mv opt/onlyoffice/desktopeditors $out/share
+
+      for f in $out/share/desktopeditors/asc-de-*.png; do
+        size=$(basename "$f" ".png" | cut -d"-" -f3)
+        res="''${size}x''${size}"
+        mkdir -pv "$out/share/icons/hicolor/$res/apps"
+        ln -s "$f" "$out/share/icons/hicolor/$res/apps/onlyoffice-desktopeditors.png"
+      done;
+
+      substituteInPlace $out/bin/onlyoffice-desktopeditors \
+        --replace "/opt/onlyoffice/" "$out/share/"
+
+      ln -s $out/share/desktopeditors/DesktopEditors $out/bin/DesktopEditors
+
+      runHook postInstall
+    '';
+
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+        --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb" \
+        --set QTCOMPOSE "${xorg.libX11.out}/share/X11/locale" \
+        --set QT_QPA_PLATFORM "xcb"
+        # the bundled version of qt does not support wayland
+      )
+    '';
+
+    passthru.updateScript = ./update.sh;
+  };
+
+in
+
+# In order to download plugins, OnlyOffice uses /usr/bin/curl so we have to wrap it.
+# Curl still needs to be in runtimeLibs because the library is used directly in other parts of the code.
+buildFHSEnv {
+  name = derivation.name;
+
+  targetPkgs = pkgs': [
+    curl
+    derivation
+  ];
+
+  runScript = "/bin/onlyoffice-desktopeditors";
+
+  extraInstallCommands = ''
+    mv $out/bin/$name $out/bin/onlyoffice-desktopeditors
+    mkdir -p $out/share
+    ln -s ${derivation}/share/icons $out/share
+    cp -r ${derivation}/share/applications $out/share
+    substituteInPlace $out/share/applications/onlyoffice-desktopeditors.desktop \
+        --replace "/usr/bin/onlyoffice-desktopeditors" "$out/bin/onlyoffice-desktopeditors"
+  '';
+
+  meta = with lib; {
+    description = "Office suite that combines text, spreadsheet and presentation editors allowing to create, view and edit local documents";
+    longDescription = ''
+      This version is broken on wlroots environments (e.g. Hyprland, Sway).
+      If you are using one of these environments, please use `onlyoffice-bin` instead.
+    '';
+    homepage = "https://www.onlyoffice.com/";
+    downloadPage = "https://github.com/ONLYOFFICE/DesktopEditors/releases";
+    changelog = "https://github.com/ONLYOFFICE/DesktopEditors/blob/master/CHANGELOG.md";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ nh2 gtrunsec ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33694,7 +33694,10 @@ with pkgs;
 
   okteto = callPackage ../development/tools/okteto { };
 
-  onlyoffice-bin = callPackage ../applications/office/onlyoffice-bin { };
+  onlyoffice-bin_7_2 = callPackage ../applications/office/onlyoffice-bin/7_2.nix { };
+  onlyoffice-bin_7_4 = callPackage ../applications/office/onlyoffice-bin/7_4.nix { };
+  onlyoffice-bin = onlyoffice-bin_7_2;
+  onlyoffice-bin_latest = onlyoffice-bin_7_4;
 
   onmetal-image = callPackage ../tools/virtualization/onmetal-image { };
 


### PR DESCRIPTION
## Description of changes

* Bumped version to 7.4.1 ([changelog](https://github.com/ONLYOFFICE/DesktopEditors/blob/master/CHANGELOG.md#741))
* Added `libgbm` (`mesa`) as a dependency for the newly-bundled `libcef`
* Wrapped in `buildFHSEnv` because the plugin download feature [directly references `/usr/bin/curl`](https://github.com/ONLYOFFICE/core/blob/7a822494aabb1edce441a12e44aa05c3a6501766/Common/Network/FileTransporter/src/transport_external.h#L76) (I am new to Nix, this seemed like the best solution to me but I may be wrong)

Maintainers: @nh2 @GTrunSec 
Closes: #225249

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
