### PR TITLE
nixos/acme: Add maxConcurrentRenewals option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -154,6 +154,10 @@ The module update takes care of the new config syntax and the data itself (user 
 
 - `boot.initrd.network.udhcp.enable` allows control over dhcp during stage 1 regardless of what `networking.useDHCP` is set to.
 
+- The module `security.acme` has a new option called `maxConcurrencyLimit` which limits the number of concurrent
+certificate renewal processes that will execute during nixos-rebuild, avoiding large spikes in CPU load when adding or
+chaging many certificates at once. The default has been set to 5.
+
 - Suricata was upgraded from 6.0 to 7.0 and no longer considers HTTP/2 support as experimental, see [upstream release notes](https://forum.suricata.io/t/suricata-7-0-0-released/3715) for more details.
 
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -266,6 +266,36 @@ in {
           }
         ];
 
+        concurrency-limit.configuration = { pkgs, ... }: lib.mkMerge [
+          webserverBasicConfig
+          {
+            security.acme.maxConcurrentRenewals = 1;
+
+            services.nginx.virtualHosts = {
+              # To trigger renew on a.example.test...
+              "a.example.test".serverAliases = [ "e.example.test" ];
+              "f.example.test" = vhostBase // {
+                enableACME = true;
+              };
+              "g.example.test" = vhostBase // {
+                enableACME = true;
+              };
+            };
+
+            systemd.services = {
+              "acme-a.example.test".serviceConfig.ExecStartPre = "+" + (pkgs.writeShellScript "test-a" ''
+                test "$(systemctl is-active acme-{f,g}.example.test.service | grep activating | wc -l)" -le 0
+              '');
+              "acme-f.example.test".serviceConfig.ExecStartPre = "+" + (pkgs.writeShellScript "test-f" ''
+                test "$(systemctl is-active acme-{a,g}.example.test.service | grep activating | wc -l)" -le 0
+              '');
+              "acme-g.example.test".serviceConfig.ExecStartPre = "+" + (pkgs.writeShellScript "test-g" ''
+                test "$(systemctl is-active acme-{a,f}.example.test.service | grep activating | wc -l)" -le 0
+              '');
+            };
+          }
+        ];
+
         # Test lego internal server (listenHTTP option)
         # Also tests useRoot option
         lego-server.configuration = { ... }: {
@@ -297,7 +327,7 @@ in {
 
           services.caddy = {
             enable = true;
-            virtualHosts."a.exmaple.test" = {
+            virtualHosts."a.example.test" = {
               useACMEHost = "example.test";
               extraConfig = ''
                 root * ${documentRoot}
@@ -590,6 +620,15 @@ in {
           check_issuer(webserver, "slow.example.test", "pebble")
           webserver.wait_for_unit("nginx.service")
           check_connection(client, "slow.example.test")
+
+      with subtest("Can limit concurrency on system rebuild"):
+          switch_to(webserver, "concurrency-limit")
+          webserver.wait_for_unit("acme-finished-a.example.test.target")
+          webserver.wait_for_unit("acme-finished-f.example.test.target")
+          webserver.wait_for_unit("acme-finished-g.example.test.target")
+          check_connection(client, "a.example.test")
+          check_connection(client, "f.example.test")
+          check_connection(client, "g.example.test")
 
       with subtest("Works with caddy"):
           switch_to(webserver, "caddy")


### PR DESCRIPTION
Resolves #232505

Implements Systemd After= relations on cert renewal services to limit the number of renewals that can run at once. Respects the "account leader" AKA the cert service elected for account creation. Also added a test case.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
