### PR TITLE
nix-your-shell: 1.1.1 -> 1.3.0

### DIFF
--- a/pkgs/shells/nix-your-shell/default.nix
+++ b/pkgs/shells/nix-your-shell/default.nix
@@ -5,16 +5,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "nix-your-shell";
-  version = "1.1.1";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "MercuryTechnologies";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-g5TC+4DGbTAlG39R8QIM5cB3/mtkp/vz8puB0Kr6aag=";
+    sha256 = "sha256-5zHjz0NOKcZCuR6QaLrwOXih3Xoqf2uBrJnxTX/TQok=";
   };
 
-  cargoSha256 = "sha256-AiWKSWwMh6KWCTTRRCBxekv2rukz+ijnRit11K/AnhU=";
+  cargoSha256 = "sha256-4Z/z4VgnJQd8Uc0tMDnx7sChzXtG5ZDL88jTlhPSonM=";
 
   meta = with lib; {
     description = "A `nix` and `nix-shell` wrapper for shells other than `bash`";


### PR DESCRIPTION
## Description of changes


Bash support: https://github.com/MercuryTechnologies/nix-your-shell/releases/tag/v1.2.0
Export `$__ETC_PROFILE_NIX_SOURCED`: https://github.com/MercuryTechnologies/nix-your-shell/releases/tag/v1.2.1
nushell support: https://github.com/MercuryTechnologies/nix-your-shell/releases/tag/v1.3.0


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
