### PR TITLE
zip: fix build with clang 16

### DIFF
--- a/pkgs/tools/archivers/zip/default.nix
+++ b/pkgs/tools/archivers/zip/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     ];
     sha256 = "0sb3h3067pzf3a7mlxn1hikpcjrsvycjcnj9hl9b1c3ykcgvps7h";
   };
-  patchPhase = ''
+  prePatch = ''
     substituteInPlace unix/Makefile --replace 'CC = cc' ""
   '';
 
@@ -26,7 +26,14 @@ stdenv.mkDerivation rec {
     "INSTALL=cp"
   ];
 
-  patches = lib.optionals (enableNLS && !stdenv.isCygwin) [ ./natspec-gentoo.patch.bz2 ];
+  patches = [
+    # Trying to use `memset` without declaring it is flagged as an error with clang 16, causing
+    # the `configure` script to incorrectly define `ZMEM`. That causes the build to fail due to
+    # incompatible redeclarations of `memset`, `memcpy`, and `memcmp` in `zip.h`.
+    ./fix-memset-detection.patch
+    # Implicit declaration of `closedir` and `opendir` cause dirent detection to fail with clang 16.
+    ./fix-implicit-declarations.patch
+  ] ++ lib.optionals (enableNLS && !stdenv.isCygwin) [ ./natspec-gentoo.patch.bz2 ];
 
   buildInputs = lib.optional enableNLS libnatspec
     ++ lib.optional stdenv.isCygwin libiconv;

--- a/pkgs/tools/archivers/zip/fix-implicit-declarations.patch
+++ b/pkgs/tools/archivers/zip/fix-implicit-declarations.patch
@@ -1,0 +1,21 @@
+--- a/unix/configure	2009-04-16 15:25:12.000000000 -0400
++++ b/unix/configure	2023-05-30 15:18:33.670321348 -0400
+@@ -408,7 +408,7 @@
+ echo Check for errno declaration
+ cat > conftest.c << _EOF_
+ #include <errno.h>
+-main()
++int main()
+ {
+   errno = 0;
+   return 0;
+@@ -419,6 +419,8 @@
+ 
+ echo Check for directory libraries
+ cat > conftest.c << _EOF_
++#include <sys/types.h>
++#include <dirent.h>
+ int main() { return closedir(opendir(".")); }
+ _EOF_
+ 
+

--- a/pkgs/tools/archivers/zip/fix-memset-detection.patch
+++ b/pkgs/tools/archivers/zip/fix-memset-detection.patch
@@ -1,0 +1,15 @@
+diff -ur a/unix/configure b/unix/configure
+--- a/unix/configure	2008-06-19 21:32:20.000000000 -0600
++++ b/unix/configure	2023-07-11 10:02:57.809867694 -0600
+@@ -519,7 +519,10 @@
+ 
+ 
+ echo Check for memset
+-echo "int main(){ char k; memset(&k,0,0); return 0; }" > conftest.c
++cat > conftest.c << _EOF_
++#include <string.h>
++int main(){ char k; memset(&k,0,0); return 0; }
++_EOF_
+ $CC -o conftest conftest.c >/dev/null 2>/dev/null
+ [ $? -ne 0 ] && CFLAGS="${CFLAGS} -DZMEM"
+ 


### PR DESCRIPTION
## Description of changes

Fix implicit declarations of `memset` and `open/closedir` resulting in incorrect feature detection and conflicts with libc headers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
