### PR TITLE
treewide: fix some builds in darwin sandbox

### DIFF
--- a/pkgs/development/python-modules/adguardhome/default.nix
+++ b/pkgs/development/python-modules/adguardhome/default.nix
@@ -42,6 +42,8 @@ buildPythonPackage rec {
     yarl
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     aresponses
     pytest-asyncio

--- a/pkgs/development/python-modules/aio-geojson-client/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-client/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
     haversine
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     aresponses
     mock

--- a/pkgs/development/python-modules/aio-geojson-generic-client/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-generic-client/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
     pytz
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     aresponses
     pytest-asyncio

--- a/pkgs/development/python-modules/aio-geojson-geonetnz-quakes/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-geonetnz-quakes/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
     pytz
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     aresponses
     pytest-asyncio

--- a/pkgs/development/python-modules/aio-geojson-geonetnz-volcano/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-geonetnz-volcano/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
     pytz
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     aresponses
     mock

--- a/pkgs/development/python-modules/aio-geojson-nsw-rfs-incidents/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-nsw-rfs-incidents/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
     pytz
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     aresponses
     pytest-asyncio

--- a/pkgs/development/python-modules/aio-geojson-usgs-earthquakes/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-usgs-earthquakes/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
     pytz
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/aio-georss-client/default.nix
+++ b/pkgs/development/python-modules/aio-georss-client/default.nix
@@ -35,6 +35,8 @@ buildPythonPackage rec {
     dateparser
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     aresponses
     mock

--- a/pkgs/development/python-modules/aio-georss-gdacs/default.nix
+++ b/pkgs/development/python-modules/aio-georss-gdacs/default.nix
@@ -28,6 +28,8 @@ buildPythonPackage rec {
     dateparser
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     aresponses
     pytest-asyncio

--- a/pkgs/development/python-modules/aiohttp-retry/default.nix
+++ b/pkgs/development/python-modules/aiohttp-retry/default.nix
@@ -25,6 +25,8 @@ buildPythonPackage rec {
     aiohttp
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytest-aiohttp
     pytestCheckHook

--- a/pkgs/development/python-modules/aiojobs/default.nix
+++ b/pkgs/development/python-modules/aiojobs/default.nix
@@ -37,6 +37,8 @@ buildPythonPackage rec {
     async-timeout
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
     pytest-aiohttp

--- a/pkgs/development/python-modules/amqp/default.nix
+++ b/pkgs/development/python-modules/amqp/default.nix
@@ -3,6 +3,7 @@
 , case
 , fetchPypi
 , pytestCheckHook
+, pytest-rerunfailures
 , pythonOlder
 , vine
 }:
@@ -23,9 +24,12 @@ buildPythonPackage rec {
     vine
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     case
     pytestCheckHook
+    pytest-rerunfailures
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -58,6 +58,8 @@ buildPythonPackage rec {
     ];
   };
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     openssh
     openssl

--- a/pkgs/development/python-modules/curio/default.nix
+++ b/pkgs/development/python-modules/curio/default.nix
@@ -26,13 +26,16 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   disabledTests = [
-     "test_aside_basic" # times out
-     "test_write_timeout" # flaky, does not always time out
-     "test_aside_cancel" # fails because modifies PYTHONPATH and cant find pytest
-     "test_ssl_outgoing" # touches network
-     "test_unix_echo" # socket bind error on hydra when built with other packages
-     "test_unix_ssl_server" # socket bind error on hydra when built with other packages
-   ];
+    "test_aside_basic" # times out
+    "test_write_timeout" # flaky, does not always time out
+    "test_aside_cancel" # fails because modifies PYTHONPATH and cant find pytest
+    "test_ssl_outgoing" # touches network
+    "test_unix_echo" # socket bind error on hydra when built with other packages
+    "test_unix_ssl_server" # socket bind error on hydra when built with other packages
+  ] ++ lib.optionals stdenv.isDarwin [
+    # connects to python.org:1, expects an OsError, hangs in the darwin sandbox
+    "test_create_bad_connection"
+  ];
 
   pythonImportsCheck = [ "curio" ];
 

--- a/pkgs/development/python-modules/datadog/default.nix
+++ b/pkgs/development/python-modules/datadog/default.nix
@@ -34,6 +34,8 @@ buildPythonPackage rec {
     requests
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     click
     freezegun

--- a/pkgs/development/python-modules/devolo-plc-api/default.nix
+++ b/pkgs/development/python-modules/devolo-plc-api/default.nix
@@ -44,6 +44,8 @@ buildPythonPackage rec {
     zeroconf
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytest-asyncio
     pytest-httpx

--- a/pkgs/development/python-modules/django-cacheops/default.nix
+++ b/pkgs/development/python-modules/django-cacheops/default.nix
@@ -42,6 +42,8 @@ buildPythonPackage rec {
     six
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
     pytest-django

--- a/pkgs/development/python-modules/falcon/default.nix
+++ b/pkgs/development/python-modules/falcon/default.nix
@@ -45,6 +45,8 @@ buildPythonPackage rec {
     cython
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   preCheck = ''
     export HOME=$TMPDIR
     cp -R tests examples $TMPDIR

--- a/pkgs/development/python-modules/feedparser/default.nix
+++ b/pkgs/development/python-modules/feedparser/default.nix
@@ -22,6 +22,8 @@ buildPythonPackage rec {
     sgmllib3k
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   checkPhase = ''
     # Tests are failing
     # AssertionError: unexpected '~' char in declaration

--- a/pkgs/development/python-modules/google-auth-httplib2/default.nix
+++ b/pkgs/development/python-modules/google-auth-httplib2/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage rec {
     httplib2
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     flask
     mock

--- a/pkgs/development/python-modules/graphene-django/default.nix
+++ b/pkgs/development/python-modules/graphene-django/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , buildPythonPackage
 , pythonAtLeast
 , pythonOlder
@@ -61,11 +62,14 @@ buildPythonPackage rec {
   ];
 
   disabledTests = lib.optionals (pythonAtLeast "3.11") [
-    # Pèython 3.11 support, https://github.com/graphql-python/graphene-django/pull/1365
+    # Python 3.11 support, https://github.com/graphql-python/graphene-django/pull/1365
     "test_django_objecttype_convert_choices_enum_naming_collisions"
     "test_django_objecttype_choices_custom_enum_name"
     "test_django_objecttype_convert_choices_enum_list"
     "test_schema_representation"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # this test touches files in the "/" directory and fails in darwin sandbox
+    "test_should_filepath_convert_string"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -26,6 +26,10 @@ buildPythonPackage rec {
     hash = "sha256-1Pl+l28J7crfO2UY/9/D019IzOHWOwjR+UvVEHICTqU=";
   };
 
+  postPatch = ''
+    sed -i "/--cov/d" setup.cfg
+  '';
+
   propagatedBuildInputs = [
     pyparsing
   ];
@@ -40,12 +44,10 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   # Don't run tests for older Pythons
   doCheck = pythonAtLeast "3.9";
-
-  postPatch = ''
-    sed -i "/--cov/d" setup.cfg
-  '';
 
   disabledTests = [
     # ValueError: Unable to load PEM file.

--- a/pkgs/development/python-modules/httpx-socks/default.nix
+++ b/pkgs/development/python-modules/httpx-socks/default.nix
@@ -54,6 +54,8 @@ buildPythonPackage rec {
     ];
   };
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     flask
     hypercorn

--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -79,6 +79,8 @@ buildPythonPackage rec {
     xmltodict
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     freezegun
     pytestCheckHook

--- a/pkgs/development/python-modules/nose2/default.nix
+++ b/pkgs/development/python-modules/nose2/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage rec {
     six
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   checkPhase = ''
     ${python.interpreter} -m unittest
   '';

--- a/pkgs/development/python-modules/nvchecker/default.nix
+++ b/pkgs/development/python-modules/nvchecker/default.nix
@@ -49,6 +49,8 @@ buildPythonPackage rec {
     tomli
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     flaky
     pytest-asyncio

--- a/pkgs/development/python-modules/prometheus-client/default.nix
+++ b/pkgs/development/python-modules/prometheus-client/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage rec {
     hash = "sha256-0qh6OorIIs3WfneZavzwTTZFwIRXCJzezks/qihu8xo=";
   };
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -46,6 +46,8 @@ buildPythonPackage rec {
     curl
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     bottle
     pytestCheckHook

--- a/pkgs/development/python-modules/pyquery/default.nix
+++ b/pkgs/development/python-modules/pyquery/default.nix
@@ -33,6 +33,8 @@ buildPythonPackage rec {
     lxml
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [ "pyquery" ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pyro5/default.nix
+++ b/pkgs/development/python-modules/pyro5/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage rec {
     serpent
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/pytest-recording/default.nix
+++ b/pkgs/development/python-modules/pytest-recording/default.nix
@@ -33,6 +33,8 @@ buildPythonPackage rec {
     attrs
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   checkInputs = [
     pytestCheckHook
     pytest-httpbin

--- a/pkgs/development/python-modules/pytest-remotedata/default.nix
+++ b/pkgs/development/python-modules/pytest-remotedata/default.nix
@@ -32,6 +32,8 @@ buildPythonPackage rec {
     six
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/pytest-tornasync/default.nix
+++ b/pkgs/development/python-modules/pytest-tornasync/default.nix
@@ -21,6 +21,8 @@ buildPythonPackage rec {
     tornado
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytest
     tornado

--- a/pkgs/development/python-modules/pywemo/default.nix
+++ b/pkgs/development/python-modules/pywemo/default.nix
@@ -37,6 +37,8 @@ buildPythonPackage rec {
     lxml
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     hypothesis
     pytest-vcr

--- a/pkgs/development/python-modules/pyzipper/default.nix
+++ b/pkgs/development/python-modules/pyzipper/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage rec {
     pycryptodomex
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/rangehttpserver/default.nix
+++ b/pkgs/development/python-modules/rangehttpserver/default.nix
@@ -22,6 +22,8 @@ buildPythonPackage rec {
     setuptools
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
     requests

--- a/pkgs/development/python-modules/rope/default.nix
+++ b/pkgs/development/python-modules/rope/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
     pytoolconfig
   ] ++ pytoolconfig.optional-dependencies.global;
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytest-timeout
     pytestCheckHook

--- a/pkgs/development/python-modules/snakeviz/default.nix
+++ b/pkgs/development/python-modules/snakeviz/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
     tornado
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     ipython
     pytestCheckHook

--- a/pkgs/development/python-modules/sockio/default.nix
+++ b/pkgs/development/python-modules/sockio/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage rec {
       --replace "--durations=2 --verbose" ""
   '';
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook

--- a/pkgs/development/python-modules/sshfs/default.nix
+++ b/pkgs/development/python-modules/sshfs/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , asyncssh
 , bcrypt
 , buildPythonPackage
@@ -7,6 +8,7 @@
 , mock-ssh-server
 , pytest-asyncio
 , pytestCheckHook
+, setuptools
 , setuptools-scm
 }:
 
@@ -24,6 +26,7 @@ buildPythonPackage rec {
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
+    setuptools
     setuptools-scm
   ];
 
@@ -33,10 +36,17 @@ buildPythonPackage rec {
     fsspec
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     mock-ssh-server
     pytest-asyncio
     pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # test fails with sandbox enabled
+    "test_checksum"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/terminado/default.nix
+++ b/pkgs/development/python-modules/terminado/default.nix
@@ -31,11 +31,12 @@ buildPythonPackage rec {
     "terminado"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytest-timeout
     pytestCheckHook
   ];
-
 
   meta = with lib; {
     description = "Terminals served by Tornado websockets";

--- a/pkgs/development/python-modules/umodbus/default.nix
+++ b/pkgs/development/python-modules/umodbus/default.nix
@@ -25,6 +25,8 @@ buildPythonPackage rec {
     pyserial
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/unearth/default.nix
+++ b/pkgs/development/python-modules/unearth/default.nix
@@ -36,6 +36,8 @@ buildPythonPackage rec {
     cached-property
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     flask
     pytest-httpserver

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -97,6 +97,8 @@ buildPythonPackage rec {
     shortuuid
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     azure-containerregistry
     azure-core

--- a/pkgs/development/python-modules/wsgidav/default.nix
+++ b/pkgs/development/python-modules/wsgidav/default.nix
@@ -40,6 +40,8 @@ buildPythonPackage rec {
     pyyaml
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [
     cheroot
     pytestCheckHook


### PR DESCRIPTION
## Description of changes

I was building lots of packages locally and found a couple that failed in the Darwin sandbox.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
