### PR TITLE
numba: Fix build with numpy 1.25

### DIFF
--- a/pkgs/development/python-modules/llvmlite/default.nix
+++ b/pkgs/development/python-modules/llvmlite/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchPypi
+, fetchFromGitHub
 , buildPythonPackage
 , python
 , llvm
@@ -12,13 +12,19 @@
 
 buildPythonPackage rec {
   pname = "llvmlite";
-  version = "0.40.1";
+  # The main dependency of llvmlite is numba, which we currently package an
+  # untagged version of it (for numpy>1.25 support). That numba version
+  # requires at least this version of llvmlite (also not yet officially
+  # released, but at least tagged).
+  version = "0.41.0dev0";
 
   disabled = isPyPy || !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-XNsNRd9gIJnYM9UL2egTU6XgNiQtPAA8WylPxh0ZhrQ=";
+  src = fetchFromGitHub {
+    owner = "numba";
+    repo = "llvmlite";
+    rev = "v${version}";
+    hash = "sha256-fsH+rqouweNENU+YlWr7m0bC0YdreQLNp1n2rwrOiFw=";
   };
 
   nativeBuildInputs = [ llvm ];

--- a/pkgs/development/python-modules/llvmlite/default.nix
+++ b/pkgs/development/python-modules/llvmlite/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "llvmlite";
-  version = "0.39.1";
+  version = "0.40.1";
 
   disabled = isPyPy || !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-tDq9fILoBSYcQl1QM1vppsT4QmTjTW1uR1IHMAAF1XI=";
+    hash = "sha256-XNsNRd9gIJnYM9UL2egTU6XgNiQtPAA8WylPxh0ZhrQ=";
   };
 
   nativeBuildInputs = [ llvm ];

--- a/pkgs/development/python-modules/numba-scipy/default.nix
+++ b/pkgs/development/python-modules/numba-scipy/default.nix
@@ -6,6 +6,7 @@
 , numba
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -25,14 +26,13 @@ buildPythonPackage rec {
     numba
   ];
 
-  postPatch = ''
-    # https://github.com/numba/numba-scipy/pull/76
-    substituteInPlace setup.py \
-      --replace "scipy>=0.16,<=1.7.3" "scipy>=0.16"
-  '';
-
   nativeCheckInputs = [
     pytestCheckHook
+    pythonRelaxDepsHook
+  ];
+  pythonRelaxDeps = [
+    "scipy"
+    "numba"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6068,7 +6068,7 @@ self: super: with self; {
 
   llvmlite = callPackage ../development/python-modules/llvmlite {
     # llvmlite always requires a specific version of llvm.
-    llvm = pkgs.llvm_11;
+    llvm = pkgs.llvm_14;
   };
 
   lmdb = callPackage ../development/python-modules/lmdb {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
