### PR TITLE
[23.05] qt6: 6.5.1 -> 6.5.2

### DIFF
--- a/pkgs/development/libraries/qt-6/fetch.sh
+++ b/pkgs/development/libraries/qt-6/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.qt.io/official_releases/qt/6.5/6.5.1/submodules/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.qt.io/official_releases/qt/6.5/6.5.2/submodules/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
@@ -5,12 +5,12 @@
 
 qtModule rec {
   pname = "qtmqtt";
-  version = "6.5.1";
+  version = "6.5.2";
   src = fetchFromGitHub {
     owner = "qt";
     repo = "qtmqtt";
     rev = "v${version}";
-    hash = "sha256-tXCLb4ZWgdPSfnlGKsKNW9kJ57cm8+d8y416O42NZvk=";
+    hash = "sha256-yyerVzz+nGT5kjNo24zYqZcJmrE50KCp38s3+samjd0=";
   };
   qtInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/qt-6/srcs.nix
+++ b/pkgs/development/libraries/qt-6/srcs.nix
@@ -1,310 +1,318 @@
 # DO NOT EDIT! This file is generated automatically.
-# Command: ./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-6/
+# Command: ./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-6
 { fetchurl, mirror }:
 
 {
   qt3d = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qt3d-everywhere-src-6.5.1.tar.xz";
-      sha256 = "16v875hv58f1cnb76c8pd63v44fncfdrv29b008bamxs23lf2m3y";
-      name = "qt3d-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qt3d-everywhere-src-6.5.2.tar.xz";
+      sha256 = "047rwawrlm7n0vifxmsqvs3w3j5c16x8qkpx8xazq6xd47dn9w11";
+      name = "qt3d-everywhere-src-6.5.2.tar.xz";
+    };
+  };
+  qt5 = {
+    version = "6.5.2";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qt5-everywhere-src-6.5.2.tar.xz";
+      sha256 = "15da8xd213fg2yfna3zvvr5mnhdfdai0i4m1paqfxr10sl81p515";
+      name = "qt5-everywhere-src-6.5.2.tar.xz";
     };
   };
   qt5compat = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qt5compat-everywhere-src-6.5.1.tar.xz";
-      sha256 = "10zvah04mnyg5apkwq015kxs03y467naicxy8ljfzazgbwljp6df";
-      name = "qt5compat-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qt5compat-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1i4izabbmf1dayzlj1miz7hsm4cy0qb7i72pwyl2fp05w8pf9axr";
+      name = "qt5compat-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtactiveqt-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0yii7ihvzncwqhrb1635my5arr6lymr2d3wnwpcn42b7l6krsk6d";
-      name = "qtactiveqt-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtactiveqt-everywhere-src-6.5.2.tar.xz";
+      sha256 = "04zhbwhnjlc561bs2f4y82mzlf18byy6g5gh37yq9r3gfz54002x";
+      name = "qtactiveqt-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtbase = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtbase-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1vdzxrcfhn6ym7p8jzr3xxx1r4r435fx461lwfgii8838cgzlmnv";
-      name = "qtbase-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtbase-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0s8jwzdcv97dfy8n3jjm8zzvllv380l73mwdva7rs2nqnhlwgd1x";
+      name = "qtbase-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtcharts = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtcharts-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0xfgj970ip0fn2gxrsilg1gvq4w2849vs6gysn0qhnz7qw7m0nxi";
-      name = "qtcharts-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtcharts-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0bddlrwda5bh5bdwdx86ixdpm3zg5nygzb754y5nkjlw06zgfnkp";
+      name = "qtcharts-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtconnectivity-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0yl2i4qdmvdzspnr0jpf031gd2cndkx4hppy5sdjppy4g2dlrmrg";
-      name = "qtconnectivity-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtconnectivity-everywhere-src-6.5.2.tar.xz";
+      sha256 = "16fwbz9pr6pi19119mp6w0crq9nsb35fw8cgpfpkq99d6li4jbnv";
+      name = "qtconnectivity-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtdatavis3d-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0cx3bmbwg0y99495zp1gafs4bfn75dbf6r6dfgy1ii9i66y2lcsj";
-      name = "qtdatavis3d-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtdatavis3d-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1s8wlpc4nibnxaghkxmaxda5dkkn64jw6qgmzw39vi5vvhc3khb8";
+      name = "qtdatavis3d-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtdeclarative-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0yff5nbcspl3w3231wvgvac38q0lskxx1l2wm1lx2raac7wlh490";
-      name = "qtdeclarative-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtdeclarative-everywhere-src-6.5.2.tar.xz";
+      sha256 = "06c7xfqn2a5s2m8j1bcvx3pyjqg1rgqkjvp49737gb4z9vjiz8gk";
+      name = "qtdeclarative-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtdoc = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtdoc-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0c9ckm7rcp3vi7qipzqyqpar2f5l426s8vgdz71q1ccx432a0kj1";
-      name = "qtdoc-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtdoc-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0cydg39f4cpv965pr97qn3spm5fzlxvhamifjfdsrzgskc5nm0v3";
+      name = "qtdoc-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtgrpc = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtgrpc-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1r27m7c1ab1gk2hzi4d9mpvk1kc5zypx6d6q9wa7kv26d4d2vgls";
-      name = "qtgrpc-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtgrpc-everywhere-src-6.5.2.tar.xz";
+      sha256 = "016jw2ny7paky54pk4pa499273919s8ag2ksx361ir6d0ydrdcks";
+      name = "qtgrpc-everywhere-src-6.5.2.tar.xz";
     };
   };
   qthttpserver = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qthttpserver-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0z7wrvfln7mr7n1i1pijx36c6wi66dm91mdir5f8gqk15i84zpj7";
-      name = "qthttpserver-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qthttpserver-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1b6w0999n5vw5xb93m0rc896l6ci3jld657y8645rl3q29fjpypq";
+      name = "qthttpserver-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtimageformats = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtimageformats-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1daxijk9mb2gb65pxjdqw4r5vjs3vi20d4lixq6mh0xdk717yzw9";
-      name = "qtimageformats-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtimageformats-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0hv7mkn72126rkhy5gmjmbvzy7v17mkk3q2pkmzy99f64j4w1q5a";
+      name = "qtimageformats-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtlanguageserver = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtlanguageserver-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1j9bhd4k30ana08nppqqll6v5nxr9dzxqxsh12i2cihjr9mcr9lr";
-      name = "qtlanguageserver-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtlanguageserver-everywhere-src-6.5.2.tar.xz";
+      sha256 = "196iicwpqca2ydpca41qs6aqxxq8ycknw6lm2v00h1w3m86frdbk";
+      name = "qtlanguageserver-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtlocation = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtlocation-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1x0j6r0gll469aq75viyyyw1gfl180rcyq0h83z35664jzx1i2mn";
-      name = "qtlocation-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtlocation-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1yvdv1gqj7dij7v4cq9rlnqfb77c0v9b7n56jccvy5v6q9j7s7c9";
+      name = "qtlocation-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtlottie = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtlottie-everywhere-src-6.5.1.tar.xz";
-      sha256 = "10bbq952iv3f2v42nqirld0qy363g03zdq6hlh1lfcbmgc8gif0h";
-      name = "qtlottie-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtlottie-everywhere-src-6.5.2.tar.xz";
+      sha256 = "16z8fhaa40ig0cggb689zf8j3cid6fk6pmh91b8342ymy1fdqfh0";
+      name = "qtlottie-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtmultimedia-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1k71chjdh66yv13li38ig507wpsr7cn87nqkvcfxmkf8w5hca7qb";
-      name = "qtmultimedia-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtmultimedia-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0xc9k4mlncscxqbp8q46yjd89k4jb8j0ggbi5ad874lycym013wl";
+      name = "qtmultimedia-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtnetworkauth-everywhere-src-6.5.1.tar.xz";
-      sha256 = "18viv41qazcbix9l21g5vz1r6zp6mxnbl2c2j3ip1yln7rmbac57";
-      name = "qtnetworkauth-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtnetworkauth-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0g18kh3zhcfi9ni8cqbbjdc1l6jf99ijv5shcl42jk6219b4pk2f";
+      name = "qtnetworkauth-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtpositioning = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtpositioning-everywhere-src-6.5.1.tar.xz";
-      sha256 = "08m41rx1yd28dr53pfrdfvgkmnszqyax88jhqczcb048w50gjg05";
-      name = "qtpositioning-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtpositioning-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1yhlfs8izc054qv1krf5qv6zzjlvmz013h74fwamn74dfh1kyjbh";
+      name = "qtpositioning-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtquick3d = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtquick3d-everywhere-src-6.5.1.tar.xz";
-      sha256 = "07ncn3gl3yvdq8ly3rn7693lzq0slghmw9ljq119s4bbsnk2ddji";
-      name = "qtquick3d-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtquick3d-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1nh0vg2m1lf8m40bxbwsam5pwdzjammhal69k2pb5s0rjifs7q3m";
+      name = "qtquick3d-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtquick3dphysics = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtquick3dphysics-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1j0kfqdwx8x7bagw8qjkywsd2fzih2yp36vza2hil56m35s8ibcl";
-      name = "qtquick3dphysics-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtquick3dphysics-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0dri8v0pmvc1h1cdhdchvd4xi5f62c1wrk0jd01lh95i6sc1403m";
+      name = "qtquick3dphysics-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtquickeffectmaker = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtquickeffectmaker-everywhere-src-6.5.1.tar.xz";
-      sha256 = "18lhvf9mlprmg0jba9biciscns12zvwr5jj81kkvv0mv8h3yrg2i";
-      name = "qtquickeffectmaker-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtquickeffectmaker-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1gvcszqj6khqisxkpwi67xad0247hpq5zcz4v2vhbgkxq8kwfiym";
+      name = "qtquickeffectmaker-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtquicktimeline = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtquicktimeline-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0lfm997p5x5nn4zlz2p1djd3757b0m00347xkfy9n6y5fsidny8h";
-      name = "qtquicktimeline-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtquicktimeline-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1fhmy01nqcr9q1193m9fkhbvqd9208kaigprqxkjjm61bn8awif9";
+      name = "qtquicktimeline-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtremoteobjects-everywhere-src-6.5.1.tar.xz";
-      sha256 = "16v2qzn5lf5bxrdff4fr624x5n262qvhinrk0vfmcdvrb2plgkvq";
-      name = "qtremoteobjects-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtremoteobjects-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0k29sk02n54vj1w6vh6xycsjpyfqlijc13fnxh1q7wpgg4gizx60";
+      name = "qtremoteobjects-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtscxml = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtscxml-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0xr4005b640r1h7nbfmgjban9mihxgm4sfqizw30xhsjpg4a6ghw";
-      name = "qtscxml-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtscxml-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1jxx9p7zi40r990ky991xd43mv6i8hdpnj2fhl7sf4q9fpng4c58";
+      name = "qtscxml-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtsensors = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtsensors-everywhere-src-6.5.1.tar.xz";
-      sha256 = "19dbci4487anpkm85n1yly1mm5zx1f5dgx08v5ar5462f61wlnn9";
-      name = "qtsensors-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtsensors-everywhere-src-6.5.2.tar.xz";
+      sha256 = "19iamfl4znqbfflnnpis6qk3cqri7kzbg0nsgf42lc5lzdybs1j0";
+      name = "qtsensors-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtserialbus = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtserialbus-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0zqmbqnaf8ln6kdf5nc9k4q618d7jd4dmc2gsmgcf2mz55w9dzyv";
-      name = "qtserialbus-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtserialbus-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1zndnw1zx5x9daidcm0jq7jcr06ihw0nf6iksrx591f1rl3n6hph";
+      name = "qtserialbus-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtserialport = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtserialport-everywhere-src-6.5.1.tar.xz";
-      sha256 = "19ijnjy5bqv7g74q2ax4pvmggphpccckszxilj0vkqnl8q34smf3";
-      name = "qtserialport-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtserialport-everywhere-src-6.5.2.tar.xz";
+      sha256 = "17nc5kmha6fy3vzkxfr2gxyzdsahs1x66d5lhcqk0szak8b58g06";
+      name = "qtserialport-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtshadertools = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtshadertools-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0ljhysyiwxawws0481hyk1xbycc21jg6gq5fsn8yyi2rhdhng075";
-      name = "qtshadertools-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtshadertools-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0g8aziqhds2fkx11y4p2akmyn2p1qqf2fjxv72f9pibnhpdv0gya";
+      name = "qtshadertools-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtspeech = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtspeech-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1djp6ijjvl94zajbvgz80xnzd2fpkq8fnnpxnq9jg5jny6jhn4k7";
-      name = "qtspeech-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtspeech-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1cnlc9x0wswzl7j2imi4kvs9zavs4z1mhzzfpwr6d9zlfql9rzw8";
+      name = "qtspeech-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtsvg = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtsvg-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1vq8jvz13hp9nj9r77f0nx7nq3pciy4sk1j6d2dzbw243m4jk3fm";
-      name = "qtsvg-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtsvg-everywhere-src-6.5.2.tar.xz";
+      sha256 = "18v337lfk8krg0hff5jx6fi7gn6x3djn03x3psrhlbmgjc8crd28";
+      name = "qtsvg-everywhere-src-6.5.2.tar.xz";
     };
   };
   qttools = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qttools-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0a93xg65z19bldwhc77x87khjwkx3hs01z1gjdznza5jhjgdyi2p";
-      name = "qttools-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qttools-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0ha3v488vnm4pgdpyjgf859sak0z2fwmbgcyivcd93qxflign7sm";
+      name = "qttools-everywhere-src-6.5.2.tar.xz";
     };
   };
   qttranslations = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qttranslations-everywhere-src-6.5.1.tar.xz";
-      sha256 = "16ylh1hf7r4g8s0h6wgkngwy1p75qnq6byz1q14wwzk3q8s2qzjj";
-      name = "qttranslations-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qttranslations-everywhere-src-6.5.2.tar.xz";
+      sha256 = "1sxy2ljn5ajvn4yjb8fx86l56viyvqh5r9hf5x67azkmgrilaz1k";
+      name = "qttranslations-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtvirtualkeyboard-everywhere-src-6.5.1.tar.xz";
-      sha256 = "1h9whvpdy37vazl095qqvsl8d2b298v2i25fsvr04x9ns3b47cl9";
-      name = "qtvirtualkeyboard-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtvirtualkeyboard-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0sb2c901ma30dcbf4yhznw0pad09iz55alvkzyw2d992gqwf0w05";
+      name = "qtvirtualkeyboard-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtwayland = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtwayland-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0kcp1adgszcrwv89f2m3rp2ldbrbnb7prkr8065w5j9ik2hiw7vw";
-      name = "qtwayland-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtwayland-everywhere-src-6.5.2.tar.xz";
+      sha256 = "16iwar19sgjvxgmbr6hmd3hsxp6ahdjwl1lra2wapl3zzf3bw81h";
+      name = "qtwayland-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtwebchannel-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0jpc231gmgy540x9im8ld1fjmxqjaw1c40r6d2g5gxrpwxkl6drb";
-      name = "qtwebchannel-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtwebchannel-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0qwfnwva7v5f2g5is17yy66mnmc9c1yf9aagaw5qanskdvxdk261";
+      name = "qtwebchannel-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtwebengine = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtwebengine-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0clcxkybgn5ny22rbdckxczqsf5gc3f55q7r02l5q7q6biqbs61g";
-      name = "qtwebengine-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtwebengine-everywhere-src-6.5.2.tar.xz";
+      sha256 = "17qxf3asyxq6kcqqvml170n7rnzih3nr4srp9r5v80pmas5l7jg7";
+      name = "qtwebengine-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtwebsockets-everywhere-src-6.5.1.tar.xz";
-      sha256 = "06fsc42x571af78rlx8ah7i9nqc9qnzqvd1mmrx12xd6a2r6d3vb";
-      name = "qtwebsockets-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtwebsockets-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0xjwifxj2ssshys6f6kjr6ri2vq1wfshxky6mcscjm7vvyqdfjr0";
+      name = "qtwebsockets-everywhere-src-6.5.2.tar.xz";
     };
   };
   qtwebview = {
-    version = "6.5.1";
+    version = "6.5.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.5/6.5.1/submodules/qtwebview-everywhere-src-6.5.1.tar.xz";
-      sha256 = "0r1six7k9nz1n64c8ff1j24x2dfrr931aiwygpsf36bim27bdbvb";
-      name = "qtwebview-everywhere-src-6.5.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.5/6.5.2/submodules/qtwebview-everywhere-src-6.5.2.tar.xz";
+      sha256 = "0cgn1px8zk2khmswi9zawi9cnx9p26y4lb3a0kr4kfklm1rf00jr";
+      name = "qtwebview-everywhere-src-6.5.2.tar.xz";
     };
   };
 }

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , buildPythonPackage
-, isPy27
 , fetchPypi
 , pkg-config
 , dbus
@@ -15,9 +14,7 @@
 , pythonOlder
 , withMultimedia ? true
 , withWebSockets ? true
-# FIXME: Once QtLocation is available for Qt6 enable this
-# https://bugreports.qt.io/browse/QTBUG-96795
-#, withLocation ? true
+, withLocation ? true
 # Not currently part of PyQt6
 #, withConnectivity ? true
 , withPrintSupport ? true
@@ -26,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "PyQt6";
-  version = "6.5.0";
+  version = "6.5.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-uXy0vpssiZeQTqZozzsKSuWCIZb3eSWQ0F7N5iFqn7w=";
+    hash = "sha256-4WagVownvMjbACcaUEOTYiZpC2pKdM4KXK60CAQKl8M=";
   };
 
   patches = [
@@ -83,7 +80,7 @@ buildPythonPackage rec {
   # ++ lib.optional withConnectivity qtconnectivity
   ++ lib.optional withMultimedia qtmultimedia
   ++ lib.optional withWebSockets qtwebsockets
-  # ++ lib.optional withLocation qtlocation
+  ++ lib.optional withLocation qtlocation
   ;
 
   buildInputs = with qt6Packages; [
@@ -97,7 +94,7 @@ buildPythonPackage rec {
   ]
   # ++ lib.optional withConnectivity qtconnectivity
   ++ lib.optional withWebSockets qtwebsockets
-  # ++ lib.optional withLocation qtlocation
+  ++ lib.optional withLocation qtlocation
   ;
 
   propagatedBuildInputs = [
@@ -132,7 +129,7 @@ buildPythonPackage rec {
   ++ lib.optional withWebSockets "PyQt6.QtWebSockets"
   ++ lib.optional withMultimedia "PyQt6.QtMultimedia"
   # ++ lib.optional withConnectivity "PyQt6.QtConnectivity"
-  # ++ lib.optional withLocation "PyQt6.QtPositioning"
+  ++ lib.optional withLocation "PyQt6.QtPositioning"
   ;
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "PyQt6";
-  version = "6.5.1";
+  version = "6.5.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-4WagVownvMjbACcaUEOTYiZpC2pKdM4KXK60CAQKl8M=";
+    hash = "sha256-FIfuc1D5/7ZtYKtBdlGSUsKzcXYsvo+DQP2VH2OAEoA=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

Backport of qt6 patch release

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
