### PR TITLE
djvulibre: patch multiple CVEs

### DIFF
--- a/pkgs/applications/misc/djvulibre/CVE-2021-3500+CVE-2021-32490+CVE-2021-32491+CVE-2021-32492+CVE-2021-32493.patch
+++ b/pkgs/applications/misc/djvulibre/CVE-2021-3500+CVE-2021-32490+CVE-2021-32491+CVE-2021-32492+CVE-2021-32493.patch
@@ -1,0 +1,105 @@
+From cd8b5c97b27a5c1dc83046498b6ca49ad20aa9b6 Mon Sep 17 00:00:00 2001
+From: Leon Bottou <leon@bottou.org>
+Date: Tue, 11 May 2021 14:44:09 -0400
+Subject: [PATCH] Reviewed Fedora patches and adopted some of them (or variants
+ thereof)
+
+ - Patch0: djvulibre-3.5.22-cdefs.patch                  (forward ported)
+Does not make imuch sense. GSmartPointer.h already includes "stddef.h"
+ - Patch6: djvulibre-3.5.27-export-file.patch              (forward ported)
+Incorrect: inkscape command is --export-png, not --export-filename.
+ - Patch8: djvulibre-3.5.27-check-image-size.patch         (forward ported)
+Correct: adopted a variant of this
+ - Patch9: djvulibre-3.5.27-integer-overflow.patch         (forward ported)
+Correct: adopted a variant of this
+ - Patch10: djvulibre-3.5.27-check-input-pool.patch        (forward ported)
+Adopted: input validation never hurts
+ - Patch11: djvulibre-3.5.27-djvuport-stack-overflow.patch (forward ported)
+Dubious: Instead I changed djvufile to prevent a file from including itself
+which is the only way I can imagine to create an file creation loop.
+ - Patch12: djvulibre-3.5.27-unsigned-short-overflow.patch (forward ported)
+Adopted: but without including limits.h
+---
+ libdjvu/DataPool.cpp  | 3 ++-
+ libdjvu/DjVuFile.cpp  | 2 ++
+ libdjvu/GBitmap.cpp   | 2 ++
+ libdjvu/IW44Image.cpp | 4 ++++
+ tools/ddjvu.cpp       | 7 +++++--
+ 5 files changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/libdjvu/DataPool.cpp b/libdjvu/DataPool.cpp
+index 5fcbedf..b58fc45 100644
+--- a/libdjvu/DataPool.cpp
++++ b/libdjvu/DataPool.cpp
+@@ -790,7 +790,8 @@ DataPool::create(const GP<DataPool> & pool, int start, int length)
+ {
+   DEBUG_MSG("DataPool::DataPool: pool=" << (void *)((DataPool *)pool) << " start=" << start << " length= " << length << "\n");
+   DEBUG_MAKE_INDENT(3);
+-
++  if (!pool)
++    G_THROW( ERR_MSG("DataPool.zero_DataPool") );
+   DataPool *xpool=new DataPool();
+   GP<DataPool> retval=xpool;
+   xpool->init();
+diff --git a/libdjvu/DjVuFile.cpp b/libdjvu/DjVuFile.cpp
+index 143346b..2587491 100644
+--- a/libdjvu/DjVuFile.cpp
++++ b/libdjvu/DjVuFile.cpp
+@@ -576,6 +576,8 @@ DjVuFile::process_incl_chunk(ByteStream & str, int file_num)
+     GURL incl_url=pcaster->id_to_url(this, incl_str);
+     if (incl_url.is_empty())	// Fallback. Should never be used.
+       incl_url=GURL::UTF8(incl_str,url.base());
++    if (incl_url == url)        // Infinite loop avoidance
++      G_THROW( ERR_MSG("DjVuFile.malformed") );
+     
+     // Now see if there is already a file with this *name* created
+     {
+diff --git a/libdjvu/GBitmap.cpp b/libdjvu/GBitmap.cpp
+index c2fdbe4..8ad64b2 100644
+--- a/libdjvu/GBitmap.cpp
++++ b/libdjvu/GBitmap.cpp
+@@ -1284,6 +1284,8 @@ GBitmap::decode(unsigned char *runs)
+   // initialize pixel array
+   if (nrows==0 || ncolumns==0)
+     G_THROW( ERR_MSG("GBitmap.not_init") );
++  if (ncolumns + border != (unsigned short)(ncolumns+border))
++    G_THROW("GBitmap: image size exceeds maximum (corrupted file?)");
+   bytes_per_row = ncolumns + border;
+   if (runs==0)
+     G_THROW( ERR_MSG("GBitmap.null_arg") );
+diff --git a/libdjvu/IW44Image.cpp b/libdjvu/IW44Image.cpp
+index e8d4b44..4a1797e 100644
+--- a/libdjvu/IW44Image.cpp
++++ b/libdjvu/IW44Image.cpp
+@@ -676,9 +676,13 @@ IW44Image::Map::image(signed char *img8, int rowsize, int pixsep, int fast)
+   // Allocate reconstruction buffer
+   short *data16;
+   size_t sz = bw * bh;
++  if (sz == 0)
++    G_THROW("IW44Image: image size is zero (corrupted file?)");
+   if (sz / (size_t)bw != (size_t)bh) // multiplication overflow
+     G_THROW("IW44Image: image size exceeds maximum (corrupted file?)");
+   GPBuffer<short> gdata16(data16,sz);
++  if (data16 == 0)
++    G_THROW("IW44Image: unable to allocate image buffer");
+   // Copy coefficients
+   int i;
+   short *p = data16;
+diff --git a/tools/ddjvu.cpp b/tools/ddjvu.cpp
+index 7109952..e7b489b 100644
+--- a/tools/ddjvu.cpp
++++ b/tools/ddjvu.cpp
+@@ -393,8 +393,11 @@ render(ddjvu_page_t *page, int pageno)
+   } else if (style == DDJVU_FORMAT_GREY8)
+     rowsize = rrect.w;
+   else
+-    rowsize = rrect.w * 3; 
+-  if (! (image = (char*)malloc(rowsize * rrect.h)))
++    rowsize = rrect.w * 3;
++  size_t bufsize = (size_t)rowsize * rrect.h;
++  if (bufsize / rowsize != rrect.h)
++    die(i18n("Integer overflow when allocating image buffer for page %d"), pageno);
++  if (! (image = (char*)malloc(bufsize)))
+     die(i18n("Cannot allocate image buffer for page %d"), pageno);
+ 
+   /* Render */

--- a/pkgs/applications/misc/djvulibre/default.nix
+++ b/pkgs/applications/misc/djvulibre/default.nix
@@ -32,6 +32,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  patches = [
+    ./CVE-2021-3500+CVE-2021-32490+CVE-2021-32491+CVE-2021-32492+CVE-2021-32493.patch
+  ];
+
   meta = with lib; {
     description = "The big set of CLI tools to make/modify/optimize/show/export DJVU files";
     homepage = "https://djvu.sourceforge.net";


### PR DESCRIPTION
## Description of changes

Add patches from https://sourceforge.net/p/djvu/djvulibre-git/ci/cd8b5c97b27a5c1dc83046498b6ca49ad20aa9b6.
These changes address the following CVEs: 
- [CVE-2021-3500](https://nvd.nist.gov/vuln/detail/CVE-2021-3500)
- [CVE-2021-32490](https://nvd.nist.gov/vuln/detail/CVE-2021-32490)
- [CVE-2021-32491](https://nvd.nist.gov/vuln/detail/CVE-2021-32491)
- [CVE-2021-32492](https://nvd.nist.gov/vuln/detail/CVE-2021-32492)
- [CVE-2021-32493](https://nvd.nist.gov/vuln/detail/CVE-2021-32493)

Ref: https://github.com/NixOS/nixpkgs/issues/132114

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
