### PR TITLE
nixos/toplevel: only pass `kernelParams` if `boot.kernel.enable`

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -4,37 +4,8 @@ with lib;
 
 let
   systemBuilder =
-    let
-      kernelPath = "${config.boot.kernelPackages.kernel}/" +
-        "${config.system.boot.loader.kernelFile}";
-      initrdPath = "${config.system.build.initialRamdisk}/" +
-        "${config.system.boot.loader.initrdFile}";
-    in ''
+    ''
       mkdir $out
-
-      # Containers don't have their own kernel or initrd.  They boot
-      # directly into stage 2.
-      ${optionalString config.boot.kernel.enable ''
-        if [ ! -f ${kernelPath} ]; then
-          echo "The bootloader cannot find the proper kernel image."
-          echo "(Expecting ${kernelPath})"
-          false
-        fi
-
-        ln -s ${kernelPath} $out/kernel
-        ln -s ${config.system.modulesTree} $out/kernel-modules
-        ${optionalString (config.hardware.deviceTree.package != null) ''
-          ln -s ${config.hardware.deviceTree.package} $out/dtbs
-        ''}
-
-        echo -n "$kernelParams" > $out/kernel-params
-
-        ln -s ${initrdPath} $out/initrd
-
-        ln -s ${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets $out
-
-        ln -s ${config.hardware.firmware}/lib/firmware $out/firmware
-      ''}
 
       ${if config.boot.initrd.systemd.enable then ''
         cp ${config.system.build.bootStage2} $out/prepare-root
@@ -83,7 +54,6 @@ let
 
     systemd = config.systemd.package;
 
-    kernelParams = config.boot.kernelParams;
     nixosLabel = config.system.nixos.label;
 
     inherit (config.system) extraDependencies;

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -309,6 +309,38 @@ in
 
         system.modulesTree = [ kernel ] ++ config.boot.extraModulePackages;
 
+        # Not required for, e.g., containers as they don't have their own kernel or initrd.
+        # They boot directly into stage 2.
+        system.systemBuilderArgs.kernelParams = config.boot.kernelParams;
+        system.systemBuilderCommands =
+          let
+            kernelPath = "${config.boot.kernelPackages.kernel}/" +
+              "${config.system.boot.loader.kernelFile}";
+            initrdPath = "${config.system.build.initialRamdisk}/" +
+              "${config.system.boot.loader.initrdFile}";
+          in
+          ''
+            if [ ! -f ${kernelPath} ]; then
+              echo "The bootloader cannot find the proper kernel image."
+              echo "(Expecting ${kernelPath})"
+              false
+            fi
+
+            ln -s ${kernelPath} $out/kernel
+            ln -s ${config.system.modulesTree} $out/kernel-modules
+            ${optionalString (config.hardware.deviceTree.package != null) ''
+              ln -s ${config.hardware.deviceTree.package} $out/dtbs
+            ''}
+
+            echo -n "$kernelParams" > $out/kernel-params
+
+            ln -s ${initrdPath} $out/initrd
+
+            ln -s ${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets $out
+
+            ln -s ${config.hardware.firmware}/lib/firmware $out/firmware
+          '';
+
         # Implement consoleLogLevel both in early boot and using sysctl
         # (so you don't need to reboot to have changes take effect).
         boot.kernelParams =


### PR DESCRIPTION
## Description of changes

This avoids creating a build-time reference on `boot.kernelParams` if the configuration does not use a kernel, i.e., `boot.kernel.enable` is set to `false`.

I ran a bunch of tests (`simple`, `basic`, `systemd`, `switchTest`, `grub`, `containers-ephemeral`, ...) which still pass.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
