### PR TITLE
bitwuzla: unstable-2022-10-03 -> 0.1.0

### DIFF
--- a/pkgs/applications/science/logic/bitwuzla/default.nix
+++ b/pkgs/applications/science/logic/bitwuzla/default.nix
@@ -2,62 +2,67 @@
 , fetchFromGitHub
 , lib
 , python3
-, cmake
-, lingeling
-, btor2tools
-, symfpu
-, gtest
+, meson
+, ninja
+, git
 , gmp
+, gtest
 , cadical
-, minisat
-, picosat
+, symfpu
+, kissat
 , cryptominisat
-, zlib
 , pkg-config
-  # "*** internal error in 'lglib.c': watcher stack overflow" on aarch64-linux
-, withLingeling ? !stdenv.hostPlatform.isAarch64
+, writeTextDir
 }:
 
 stdenv.mkDerivation rec {
   pname = "bitwuzla";
-  version = "unstable-2022-10-03";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "bitwuzla";
     repo = "bitwuzla";
-    rev = "3bc0f9f1aca04afabe1aff53dd0937924618b2ad";
-    hash = "sha256-UXZERl7Nedwex/oUrcf6/GkDSgOQ537WDYm117RfvWo=";
+    rev = "${version}";
+    hash = "sha256-+c7fOuQUXtPq0GL/AXH4PjRQL1VDtB2RBSm2xlCtLH4=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ python3 meson ninja pkg-config git gtest ];
   buildInputs = [
-    cadical
+    gmp.dev
     cryptominisat
-    picosat
-    minisat
-    btor2tools
-    symfpu
-    gmp
-    zlib
-  ] ++ lib.optional withLingeling lingeling;
+  ];
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DPicoSAT_INCLUDE_DIR=${lib.getDev picosat}/include/picosat"
-    "-DBtor2Tools_INCLUDE_DIR=${lib.getDev btor2tools}/include/btor2parser"
-    "-DBtor2Tools_LIBRARIES=${lib.getLib btor2tools}/lib/libbtor2parser${stdenv.hostPlatform.extensions.sharedLibrary}"
-  ] ++ lib.optional doCheck "-DTESTING=YES";
+  # I guess these should go in the outputs of the respective packages...
+  cadical-pc = writeTextDir "cadical.pc" ''
+    Name: cadical
+    Version: 1.5.3
+    Description: cadical
+    Libs: -L${cadical.lib}/lib -lcadical
+    Cflags: -I${cadical.dev}/include
+  '';
+  kissat-pc = writeTextDir "kissat.pc" ''
+    Name: kissat
+    Version: 3.0.0
+    Description: kissat
+    Libs: -L${kissat.lib}/lib -lkissat
+    Cflags: -I${kissat.dev}/include
+  '';
+  symfpu-pc = writeTextDir "symfpu.pc" ''
+    Name: symfpu
+    Version: 0.0.1
+    Description: symfpu
+    Cflags: -I${symfpu}
+  '';
 
-  nativeCheckInputs = [ python3 gtest ];
-  # two tests fail on darwin and 3 on aarch64-linux
-  doCheck = stdenv.hostPlatform.isLinux && (!stdenv.hostPlatform.isAarch64);
-  preCheck = let
-    var = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
-  in
-    ''
-      export ${var}=$(readlink -f lib)
-      patchShebangs ..
-    '';
+  configurePhase = ''
+    runHook preConfigure
+
+    export PKG_CONFIG_PATH=${kissat-pc}:${symfpu-pc}:${cadical-pc}:$PKG_CONFIG_PATH
+    python3 ./configure.py --shared --prefix $out
+    cd build
+
+    runHook postConfigure
+  '';
 
   meta = with lib; {
     description = "A SMT solver for fixed-size bit-vectors, floating-point arithmetic, arrays, and uninterpreted functions";


### PR DESCRIPTION
## Description of changes

Bumps bitwuzla to it's latest release ([notes](https://github.com/bitwuzla/bitwuzla/blob/4eda0536800576cb2531ab9ce13292da8f21f0eb/NEWS.md)).

This is a ground up rewrite and also has a new (meson based) build system. Meson seems to be very picky about needing `pkg-config` files for dependencies, so I had to write a few custom ones where they were missing. I'm not sure what the desired protocol is here. Should I move these into the derivations of the dependencies themselves?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
