### PR TITLE
ocamlPackages.kcas: init at 0.6.1

### DIFF
--- a/pkgs/development/ocaml-modules/domain-local-timeout/default.nix
+++ b/pkgs/development/ocaml-modules/domain-local-timeout/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage, ocaml, fetchurl
+, mtime, psq, thread-table
+, alcotest, mdx
+, domain-local-await
+}:
+
+buildDunePackage rec {
+  pname = "domain-local-timeout";
+  version = "0.1.0";
+
+  minimalOCamlVersion = "4.12";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/domain-local-timeout/releases/download/${version}/domain-local-timeout-${version}.tbz";
+    hash = "sha256-UTqcHdGAN/LrvumPhW4Cy6RY8RJ/iVO5zTJKrhPRTjk=";
+  };
+
+  propagatedBuildInputs = [ mtime psq thread-table ];
+
+  doCheck = lib.versionAtLeast ocaml.version "5.0";
+  nativeCheckInputs = [ mdx.bin ];
+  checkInputs = [ alcotest domain-local-await mdx ];
+
+  meta = {
+    homepage = "https://github.com/ocaml-multicore/domain-local-timeout";
+    description = "A scheduler independent timeout mechanism";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/kcas/default.nix
+++ b/pkgs/development/ocaml-modules/kcas/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildDunePackage, fetchurl
+, domain-local-await, domain-local-timeout
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "kcas";
+  version = "0.6.1";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/kcas/releases/download/${version}/kcas-${version}.tbz";
+    hash = "sha256-u3Z8uAvITRUhOcB2EUYjWtpxIFJMvm2O/kyNr/AELWI=";
+  };
+
+  propagatedBuildInputs = [ domain-local-await domain-local-timeout ];
+
+  doCheck = true;
+  checkInputs = [ alcotest ];
+
+  meta = {
+    homepage = "https://github.com/ocaml-multicore/kcas";
+    description = "STM based on lock-free MCAS";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -799,6 +799,8 @@ let
 
     kafka_lwt = callPackage ../development/ocaml-modules/kafka/lwt.nix { };
 
+    kcas = callPackage ../development/ocaml-modules/kcas { };
+
     ke = callPackage ../development/ocaml-modules/ke { };
 
     kicadsch = callPackage ../development/ocaml-modules/kicadsch { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -343,6 +343,8 @@ let
 
     domain-local-await = callPackage ../development/ocaml-modules/domain-local-await { };
 
+    domain-local-timeout = callPackage ../development/ocaml-modules/domain-local-timeout { };
+
     domain-name = callPackage ../development/ocaml-modules/domain-name { };
 
     domainslib = callPackage ../development/ocaml-modules/domainslib { };


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
