### PR TITLE
libblockdev: 3.0.1 -> 3.0.2

### DIFF
--- a/pkgs/development/libraries/libblockdev/default.nix
+++ b/pkgs/development/libraries/libblockdev/default.nix
@@ -1,18 +1,43 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, gtk-doc
-, docbook_xml_dtd_43, python3, gobject-introspection, glib, udev, kmod, parted
-, cryptsetup, lvm2, util-linux, libbytesize, libndctl, nss, volume_key
-, libxslt, docbook_xsl, gptfdisk, libyaml, autoconf-archive
-, thin-provisioning-tools, makeWrapper, e2fsprogs, libnvme, keyutils
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, gtk-doc
+, docbook_xml_dtd_43
+, python3
+, gobject-introspection
+, glib
+, udev
+, kmod
+, parted
+, cryptsetup
+, lvm2
+, util-linux
+, libbytesize
+, libndctl
+, nss
+, volume_key
+, libxslt
+, docbook_xsl
+, gptfdisk
+, libyaml
+, autoconf-archive
+, thin-provisioning-tools
+, makeBinaryWrapper
+, e2fsprogs
+, libnvme
+, keyutils
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libblockdev";
   version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "storaged-project";
     repo = "libblockdev";
-    rev = "${version}-1";
-    sha256 = "sha256-tqF96yeBPilF0zQ53RNN7IZ2wVgWQOwbGkvoywN/i+0=";
+    rev = "${finalAttrs.version}-1";
+    hash = "sha256-tqF96yeBPilF0zQ53RNN7IZ2wVgWQOwbGkvoywN/i+0=";
   };
 
   outputs = [ "out" "dev" "devdoc" ];
@@ -22,13 +47,35 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    autoreconfHook pkg-config gtk-doc libxslt docbook_xsl docbook_xml_dtd_43
-    python3 gobject-introspection autoconf-archive makeWrapper
+    autoconf-archive
+    autoreconfHook
+    docbook_xsl
+    docbook_xml_dtd_43
+    gobject-introspection
+    gtk-doc
+    libxslt
+    makeBinaryWrapper
+    pkg-config
+    python3
   ];
 
   buildInputs = [
-    e2fsprogs glib udev keyutils kmod parted gptfdisk cryptsetup lvm2 util-linux libbytesize
-    libndctl libnvme nss volume_key libyaml
+    cryptsetup
+    e2fsprogs
+    glib
+    gptfdisk
+    keyutils
+    kmod
+    libbytesize
+    libndctl
+    libnvme
+    libyaml
+    lvm2
+    nss
+    parted
+    udev
+    util-linux
+    volume_key
   ];
 
   postInstall = ''
@@ -36,12 +83,12 @@ stdenv.mkDerivation rec {
       ${lib.makeBinPath [ thin-provisioning-tools ]}
   '';
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/storaged-project/libblockdev/raw/${finalAttrs.src.rev}/NEWS.rst";
     description = "A library for manipulating block devices";
     homepage = "http://storaged.org/libblockdev/";
-    changelog = "https://github.com/storaged-project/libblockdev/raw/${src.rev}/NEWS.rst";
-    license = with licenses; [ lgpl2Plus gpl2Plus ]; # lgpl2Plus for the library, gpl2Plus for the utils
-    maintainers = with maintainers; [ johnazoidberg ];
-    platforms = platforms.linux;
+    license = with lib.licenses; [ lgpl2Plus gpl2Plus ]; # lgpl2Plus for the library, gpl2Plus for the utils
+    maintainers = with lib.maintainers; [ johnazoidberg ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/development/libraries/libblockdev/default.nix
+++ b/pkgs/development/libraries/libblockdev/default.nix
@@ -6,13 +6,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "libblockdev";
-  version = "3.0.1";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "storaged-project";
     repo = "libblockdev";
     rev = "${version}-1";
-    sha256 = "sha256-WnHcRKRxfdSRmOW2K/vn1WQ4iPm0uS0Td0cWXaeo5hk=";
+    sha256 = "sha256-tqF96yeBPilF0zQ53RNN7IZ2wVgWQOwbGkvoywN/i+0=";
   };
 
   outputs = [ "out" "dev" "devdoc" ];


### PR DESCRIPTION
## Description of changes
Updated libblockdev and fixed "failure to list volumes in file manager" according to https://bugs.gentoo.org/910554#c6
The update has been tested on my machine and the volumes are listed again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
