### PR TITLE
postgresqlPackages.pg_jsonschema: init at unstable-2023-07-23

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_jsonschema.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_jsonschema.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPgrxExtension }:
+
+buildPgrxExtension rec {
+  pname = "pg_jsonschema";
+  version = "unstable-2023-07-23";
+  inherit postgresql;
+
+  src = fetchFromGitHub {
+    owner  = "supabase";
+    repo   = pname;
+    rev    = "13044b7e2ce720e13e91130b4ea674783cf4a583";
+    hash   = "sha256-SxftRBWBZoDtF7mirKSavUJ/vZbWIC3TKy7L66uwQfc=";
+  };
+
+  cargoHash = "sha256-B0gn4DBryB9l27Hi2FMnSZfqwI/pAxCjr3f2t2+m8Og=";
+
+  # FIXME (aseipp): testsuite tries to write files into /nix/store; we'll have
+  # to fix this a bit later.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "JSON Schema Validation for PostgreSQL";
+    homepage    = "https://github.com/supabase/${pname}";
+    maintainers = with maintainers; [ thoughtpolice ];
+    platforms   = postgresql.meta.platforms;
+    license     = licenses.postgresql;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -50,6 +50,8 @@ self: super: {
 
     pg_net = super.callPackage ./ext/pg_net.nix { };
 
+    pg_jsonschema = super.callPackage ./ext/pg_jsonschema.nix { };
+
     pgtap = super.callPackage ./ext/pgtap.nix { };
 
     pipelinedb = super.callPackage ./ext/pipelinedb.nix { };


### PR DESCRIPTION
## Description of changes

This is the first intra-repository user of `buildPgrxExtension`, so that's nice!

I'm also trying to see if we can get this working on all 4 platforms, since that's what most of the other extensions work with.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
