### PR TITLE
haskell.compiler.ghc*Binary: make sure meta can always be evaluated

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -421,7 +421,10 @@ stdenv.mkDerivation rec {
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-${version}";
-  } // lib.optionalAttrs (binDistUsed.isHadrian or false) {
+  }
+  # We duplicate binDistUsed here since we have a sensible default even if no bindist is avaible,
+  # this makes sure that getting the `meta` attribute doesn't throw even on unsupported platforms.
+  // lib.optionalAttrs (ghcBinDists.${distSetName}.${stdenv.hostPlatform.system}.isHadrian or false) {
     # Normal GHC derivations expose the hadrian derivation used to build them
     # here. In the case of bindists we just make sure that the attribute exists,
     # as it is used for checking if a GHC derivation has been built with hadrian.

--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -417,7 +417,10 @@ stdenv.mkDerivation rec {
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-${version}";
-  } // lib.optionalAttrs (binDistUsed.isHadrian or false) {
+  }
+  # We duplicate binDistUsed here since we have a sensible default even if no bindist is avaible,
+  # this makes sure that getting the `meta` attribute doesn't throw even on unsupported platforms.
+  // lib.optionalAttrs (ghcBinDists.${distSetName}.${stdenv.hostPlatform.system}.isHadrian or false) {
     # Normal GHC derivations expose the hadrian derivation used to build them
     # here. In the case of bindists we just make sure that the attribute exists,
     # as it is used for checking if a GHC derivation has been built with hadrian.

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -403,7 +403,10 @@ stdenv.mkDerivation rec {
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-${version}";
-  } // lib.optionalAttrs (binDistUsed.isHadrian or false) {
+  }
+  # We duplicate binDistUsed here since we have a sensible default even if no bindist is avaible,
+  # this makes sure that getting the `meta` attribute doesn't throw even on unsupported platforms.
+  // lib.optionalAttrs (ghcBinDists.${distSetName}.${stdenv.hostPlatform.system}.isHadrian or false) {
     # Normal GHC derivations expose the hadrian derivation used to build them
     # here. In the case of bindists we just make sure that the attribute exists,
     # as it is used for checking if a GHC derivation has been built with hadrian.


### PR DESCRIPTION
The `meta` set of the binary GHCs is mostly independent of the used bindist (except for `pname` which includes `variantSuffix`). Thus we should make sure it can be evaluated even if no bindist is available for the platform, i.e. evaluating `outPath` may cause an evaluation failure, but `meta.platforms` not. Use case at present is to make `lib.meta.availableOn` work everywhere for any GHC (the normal GHCs inherit their platforms list from their respective boot compiler, at least for now).

To fix this we need to make sure that shallowly evaluating `passthru` doesn't force `binDistUsed`, since `mkDerivation` needs to merge `passthru` into the resulting derivation attribute set, thus forcing the attribute names of `passthru`. We can easily do this by accessing what we want to learn from `ghcBinDists` manually and using `or` to fall back to a sensible default.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
