### PR TITLE
[Backport release-23.05] rc-9front: init at 2022-11-01

### DIFF
--- a/pkgs/shells/rc-9front/default.nix
+++ b/pkgs/shells/rc-9front/default.nix
@@ -1,12 +1,11 @@
-{
-lib
+{ lib
 , stdenv
 , fetchgit
 , byacc
 , installShellFiles
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "rc-9front";
   version = "unstable-2022-11-01";
 
@@ -18,6 +17,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ byacc installShellFiles ];
+  enableParallelBuilding = true;
   patches = [ ./path.patch ];
 
   buildPhase = ''

--- a/pkgs/shells/rc-9front/default.nix
+++ b/pkgs/shells/rc-9front/default.nix
@@ -1,0 +1,45 @@
+{
+lib
+, stdenv
+, fetchgit
+, byacc
+, installShellFiles
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rc-9front";
+  version = "unstable-2022-11-01";
+
+  src = fetchgit {
+    url = "git://shithub.us/cinap_lenrek/rc";
+    rev = "69041639483e16392e3013491fcb382efd2b9374";
+    hash = "sha256-xc+EfC4bc9ZA97jCQ6CGCzeLGf+Hx3/syl090/x4ew4=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ byacc installShellFiles ];
+  patches = [ ./path.patch ];
+
+  buildPhase = ''
+    make PREFIX=$out
+  '';
+
+  installPhase = ''
+    install -Dm755 -t $out/bin/ rc
+    installManPage rc.1
+    mkdir -p $out/lib
+    install -m644 rcmain.unix $out/lib/rcmain
+  '';
+
+  passthru.shellPath = "/bin/rc";
+
+  meta = with lib; {
+    description = "The 9front shell";
+    longDescription = "unix port of 9front rc";
+    homepage = "http://shithub.us/cinap_lenrek/rc/HEAD/info.html";
+    license = licenses.mit;
+    maintainers = with maintainers; [ moody ];
+    mainProgram = "rc";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/shells/rc-9front/default.nix
+++ b/pkgs/shells/rc-9front/default.nix
@@ -19,16 +19,17 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ byacc installShellFiles ];
   enableParallelBuilding = true;
   patches = [ ./path.patch ];
-
-  buildPhase = ''
-    make PREFIX=$out
-  '';
+  makeFlags = [ "PREFIX=$(out)" ];
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 -t $out/bin/ rc
     installManPage rc.1
     mkdir -p $out/lib
     install -m644 rcmain.unix $out/lib/rcmain
+
+    runHook postInstall
   '';
 
   passthru.shellPath = "/bin/rc";

--- a/pkgs/shells/rc-9front/path.patch
+++ b/pkgs/shells/rc-9front/path.patch
@@ -1,0 +1,13 @@
+diff --git a/rcmain.unix b/rcmain.unix
+index 7ccbe1b..691f493 100644
+--- a/rcmain.unix
++++ b/rcmain.unix
+@@ -13,7 +13,7 @@ if(~ $rcname ?.out) prompt=('broken! ' '	')
+ if(flag p) path=/bin
+ if not {
+ 	finit
+-	if(~ $#path 0) path=(. /bin /usr/bin /usr/local/bin)
++	if(~ $#path 0) path=`:{/usr/bin/env echo -n $PATH}
+ }
+ fn sigexit
+ if(! ~ $#cflag 0){

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11785,6 +11785,8 @@ with pkgs;
 
   rc = callPackage ../shells/rc { };
 
+  rc-9front = callPackage ../shells/rc-9front { };
+
   rcon = callPackage ../tools/networking/rcon { };
 
   rconc = callPackage ../tools/networking/rconc { };


### PR DESCRIPTION
## Description of changes

Backports #240923 and #242523 now that byacc has been updated in 23.05 as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
