### PR TITLE
beluga: 1.0 -> 1.1

### DIFF
--- a/pkgs/applications/science/logic/beluga/default.nix
+++ b/pkgs/applications/science/logic/beluga/default.nix
@@ -1,28 +1,30 @@
-{ lib, fetchFromGitHub, ocamlPackages, rsync }:
+{ lib, fetchFromGitHub, ocamlPackages }:
 
 ocamlPackages.buildDunePackage rec {
   pname = "beluga";
-  version = "1.0";
+  version = "1.1";
 
   src = fetchFromGitHub {
-    owner  = "Beluga-lang";
-    repo   = "Beluga";
-    rev    = "v${version}";
-    sha256 = "1ziqjfv8jwidl8lj2mid2shhgqhv31dfh5wad2zxjpvf6038ahsw";
+    owner = "Beluga-lang";
+    repo = "Beluga";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-GN4ZOlhs8ktAcCu7iE4lh6HxhTu+KCJJbIvcI4MGcr0=";
   };
 
   duneVersion = "3";
 
   buildInputs = with ocamlPackages; [
-    gen sedlex extlib dune-build-info linenoise
+    gen
+    sedlex
+    extlib
+    dune-build-info
+    linenoise
+    omd
+    uri
+    ounit2
+    yojson
   ];
 
-  postPatch = ''
-    patchShebangs ./TEST ./run_harpoon_test.sh
-  '';
-
-  checkPhase = "./TEST";
-  nativeCheckInputs = [ rsync ];
   doCheck = true;
 
   postInstall = ''
@@ -32,9 +34,10 @@ ocamlPackages.buildDunePackage rec {
 
   meta = with lib; {
     description = "A functional language for reasoning about formal systems";
-    homepage    = "http://complogic.cs.mcgill.ca/beluga/";
-    license     = licenses.gpl3Plus;
+    homepage = "https://complogic.cs.mcgill.ca/beluga";
+    changelog = "https://github.com/Beluga-lang/Beluga/releases/tag/v${version}";
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.bcdarwin ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

Routine maintenance.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

