### PR TITLE
inkscape: fix broken patching

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -4,6 +4,7 @@
 , boost
 , cairo
 , cmake
+, desktopToDarwinBundle
 , fetchurl
 , gettext
 , ghostscript
@@ -78,16 +79,15 @@ stdenv.mkDerivation rec {
       # e.g., those from the "Effects" menu.
       python3 = "${python3Env}/bin/python";
     })
+    (substituteAll {
+      # Fix path to ps2pdf binary
+      src = ./fix-ps2pdf-path.patch;
+      inherit ghostscript;
+    })
   ];
 
   postPatch = ''
     patchShebangs share/extensions
-    substituteInPlace share/extensions/eps_input.inx \
-      --replace "location=\"path\">ps2pdf" "location=\"absolute\">${ghostscript}/bin/ps2pdf"
-    substituteInPlace share/extensions/ps_input.inx \
-      --replace "location=\"path\">ps2pdf" "location=\"absolute\">${ghostscript}/bin/ps2pdf"
-    substituteInPlace share/extensions/ps_input.py \
-      --replace "call('ps2pdf'" "call('${ghostscript}/bin/ps2pdf'"
     patchShebangs share/templates
     patchShebangs man/fix-roff-punct
 
@@ -107,7 +107,9 @@ stdenv.mkDerivation rec {
   ] ++ (with perlPackages; [
     perl
     XMLParser
-  ]);
+  ]) ++ lib.optionals stdenv.isDarwin [
+    desktopToDarwinBundle
+  ];
 
   buildInputs = [
     boehmgc

--- a/pkgs/applications/graphics/inkscape/fix-ps2pdf-path.patch
+++ b/pkgs/applications/graphics/inkscape/fix-ps2pdf-path.patch
@@ -1,0 +1,36 @@
+diff -Naur inkscape-1.2.2_2022-12-01_b0a8486541.orig/share/extensions/eps_input.inx inkscape-1.2.2_2022-12-01_b0a8486541/share/extensions/eps_input.inx
+--- inkscape-1.2.2_2022-12-01_b0a8486541.orig/share/extensions/eps_input.inx	2023-08-02 22:22:32.000000000 +0400
++++ inkscape-1.2.2_2022-12-01_b0a8486541/share/extensions/eps_input.inx	2023-08-02 22:23:34.000000000 +0400
+@@ -3,7 +3,7 @@
+     <name>EPS Input</name>
+     <id>org.inkscape.input.eps</id>
+     <dependency type="extension">org.inkscape.input.pdf</dependency>
+-    <dependency type="executable" location="path">ps2pdf</dependency>
++    <dependency type="executable" location="path">@ghostscript@/bin/ps2pdf</dependency>
+     <param name="crop" type="bool" gui-hidden="true">true</param>
+     <param name="autorotate" type="optiongroup" appearance="combo" gui-text="Determine page orientation from text direction"
+     gui-description="The PS/EPS importer can try to determine the page orientation such that the majority of the text runs left-to-right.">
+diff -Naur inkscape-1.2.2_2022-12-01_b0a8486541.orig/share/extensions/ps_input.inx inkscape-1.2.2_2022-12-01_b0a8486541/share/extensions/ps_input.inx
+--- inkscape-1.2.2_2022-12-01_b0a8486541.orig/share/extensions/ps_input.inx	2023-08-02 22:22:33.000000000 +0400
++++ inkscape-1.2.2_2022-12-01_b0a8486541/share/extensions/ps_input.inx	2023-08-02 22:24:00.000000000 +0400
+@@ -3,7 +3,7 @@
+     <name>PostScript Input</name>
+     <id>org.inkscape.input.postscript_input</id>
+     <dependency type="extension">org.inkscape.input.pdf</dependency>
+-    <dependency type="executable" location="path">ps2pdf</dependency>
++    <dependency type="executable" location="path">@ghostscript@/bin/ps2pdf</dependency>
+     <param name="autorotate" type="optiongroup" appearance="combo" gui-text="Determine page orientation from text direction"
+     gui-description="The PS/EPS importer can try to determine the page orientation such that the majority of the text runs left-to-right.">
+         <option value="None">Disabled</option>
+diff -Naur inkscape-1.2.2_2022-12-01_b0a8486541.orig/share/extensions/ps_input.py inkscape-1.2.2_2022-12-01_b0a8486541/share/extensions/ps_input.py
+--- inkscape-1.2.2_2022-12-01_b0a8486541.orig/share/extensions/ps_input.py	2023-08-02 22:22:32.000000000 +0400
++++ inkscape-1.2.2_2022-12-01_b0a8486541/share/extensions/ps_input.py	2023-08-02 22:23:48.000000000 +0400
+@@ -79,7 +79,7 @@
+         else:
+             try:
+                 call(
+-                    "ps2pdf",
++                    "@ghostscript@/bin/ps2pdf",
+                     crop,
+                     "-dAutoRotatePages=/" + self.options.autorotate,
+                     input_file,


### PR DESCRIPTION
## Description of changes
* fix broken patching (`share/extensions/ps_input.py`)
* add `desktopToDarwinBundle`

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
