### PR TITLE
nixos/mautrix-whatsapp: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -18,6 +18,8 @@
 
 - [wayfire](https://wayfire.org), A modular and extensible wayland compositor. Available as [programs.wayfire](#opt-programs.wayfire.enable).
 
+- [mautrix-whatsapp](https://docs.mau.fi/bridges/go/whatsapp/index.html) A Matrix-WhatsApp puppeting bridge
+
 - [GoToSocial](https://gotosocial.org/), an ActivityPub social network server, written in Golang. Available as [services.gotosocial](#opt-services.gotosocial.enable).
 
 - [Typesense](https://github.com/typesense/typesense), a fast, typo-tolerant search engine for building delightful search experiences. Available as [services.typesense](#opt-services.typesense.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -600,6 +600,7 @@
   ./services/matrix/dendrite.nix
   ./services/matrix/mautrix-facebook.nix
   ./services/matrix/mautrix-telegram.nix
+  ./services/matrix/mautrix-whatsapp.nix
   ./services/matrix/mjolnir.nix
   ./services/matrix/mx-puppet-discord.nix
   ./services/matrix/pantalaimon.nix
@@ -1479,5 +1480,5 @@
   ./virtualisation/waydroid.nix
   ./virtualisation/xe-guest-utilities.nix
   ./virtualisation/xen-dom0.nix
-  { documentation.nixos.extraModules = [ ./virtualisation/qemu-vm.nix ]; }
+  {documentation.nixos.extraModules = [./virtualisation/qemu-vm.nix];}
 ]

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1480,5 +1480,5 @@
   ./virtualisation/waydroid.nix
   ./virtualisation/xe-guest-utilities.nix
   ./virtualisation/xen-dom0.nix
-  {documentation.nixos.extraModules = [./virtualisation/qemu-vm.nix];}
+  { documentation.nixos.extraModules = [ ./virtualisation/qemu-vm.nix ]; }
 ]

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -67,6 +67,10 @@ in {
       example = {
         settings = {
           homeserver.address = "https://matrix.myhomeserver.org";
+          appservice.database = {
+            type = "postgres";
+            uri = "postgresql:///mautrix_whatsapp?host=/run/postgresql";
+          };
           bridge.permissions = {
             "@admin:myhomeserver.org" = "admin";
           };

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -18,7 +18,46 @@ in {
 
     settings = lib.mkOption {
       type = settingsFormat.type;
-      default = {};
+      default = {
+        appservice = {
+          address = "http://localhost:${toString appservicePort}";
+          hostname = "[::]";
+          port = appservicePort;
+          database = {
+            type = "sqlite3";
+            uri = "${dataDir}/mautrix-whatsapp.db";
+          };
+          id = "whatsapp";
+          bot = {
+            username = "whatsappbot";
+            displayname = "WhatsApp Bridge Bot";
+          };
+          as_token = "";
+          hs_token = "";
+        };
+        bridge = {
+          username_template = "whatsapp_{{.}}";
+          displayname_template = "{{if .BusinessName}}{{.BusinessName}}{{else if .PushName}}{{.PushName}}{{else}}{{.JID}}{{end}} (WA)";
+          double_puppet_server_map = {};
+          login_shared_secret_map = {};
+          command_prefix = "!wa";
+          permissions."*" = "relay";
+          relay.enabled = true;
+        };
+        logging = {
+          min_level = "info";
+          writers = [
+            {
+              type = "stdout";
+              format = "pretty-colored";
+            }
+            {
+              type = "file";
+              format = "json";
+            }
+          ];
+        };
+      };
       description = lib.mdDoc ''
         {file}`config.yaml` configuration as a Nix attribute set.
         Configuration options should match those described in
@@ -79,47 +118,7 @@ in {
 
   config = lib.mkIf cfg.enable {
     services.mautrix-whatsapp.settings = {
-      homeserver = {
-        domain = lib.mkDefault config.services.matrix-synapse.settings.server_name;
-      };
-      appservice = {
-        address = lib.mkDefault "http://localhost:${toString appservicePort}";
-        hostname = lib.mkDefault "[::]";
-        port = lib.mkDefault appservicePort;
-        database = {
-          type = lib.mkDefault "sqlite3";
-          uri = lib.mkDefault "${dataDir}/mautrix-whatsapp.db";
-        };
-        id = lib.mkDefault "whatsapp";
-        bot = {
-          username = lib.mkDefault "whatsappbot";
-          displayname = lib.mkDefault "WhatsApp Bridge Bot";
-        };
-        as_token = lib.mkDefault "";
-        hs_token = lib.mkDefault "";
-      };
-      bridge = {
-        username_template = lib.mkDefault "whatsapp_{{.}}";
-        displayname_template = lib.mkDefault "{{if .BusinessName}}{{.BusinessName}}{{else if .PushName}}{{.PushName}}{{else}}{{.JID}}{{end}} (WA)";
-        double_puppet_server_map = lib.mkDefault {};
-        login_shared_secret_map = lib.mkDefault {};
-        command_prefix = lib.mkDefault "!wa";
-        permissions."*" = lib.mkDefault "relay";
-        relay.enabled = lib.mkDefault true;
-      };
-      logging = {
-        min_level = lib.mkDefault "info";
-        writers = [
-          {
-            type = lib.mkDefault "stdout";
-            format = lib.mkDefault "pretty-colored";
-          }
-          {
-            type = lib.mkDefault "file";
-            format = lib.mkDefault "json";
-          }
-        ];
-      };
+      homeserver.domain = lib.mkDefault config.services.matrix-synapse.settings.server_name;
     };
 
     systemd.services.mautrix-whatsapp = {

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -1,0 +1,148 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.mautrix-whatsapp;
+  dataDir = "/var/lib/mautrix-whatsapp";
+  settingsFormat = pkgs.formats.json {};
+
+  registrationFile = "${dataDir}/whatsapp-registration.yaml";
+  settingsFile = settingsFormat.generate "config.json" cfg.settings;
+
+  startupScript = ''
+    ${pkgs.yq}/bin/yq -s '.[0].appservice.as_token = .[1].as_token
+      | .[0].appservice.hs_token = .[1].hs_token
+      | .[0]' ${settingsFile} ${registrationFile} \
+      > ${dataDir}/config.yml
+
+    ${pkgs.mautrix-whatsapp}/bin/mautrix-whatsapp \
+      --config='${dataDir}/config.yml' \
+      --registration='${registrationFile}'
+  '';
+in {
+  options.services.mautrix-whatsapp = {
+    enable = mkEnableOption "Mautrix-whatsapp, a puppeting bridge between Matrix and WhatsApp.";
+
+    settings = mkOption rec {
+      apply = recursiveUpdate default;
+      inherit (settingsFormat) type;
+
+      description = lib.mdDoc ''
+        {file}`config.yaml` configuration as a Nix attribute set.
+        Configuration options should match those described in
+        [example-config.yaml](https://github.com/mautrix/whatsapp/blob/master/example-config.yaml).
+      '';
+      default = {
+        homeserver = {
+          domain = config.services.matrix-synapse.settings.server_name;
+        };
+        appservice = rec {
+          address = "http://localhost:29318";
+          hostname = "0.0.0.0";
+          port = 29318;
+          database = {
+            type = "sqlite3";
+            uri = "${dataDir}/mautrix-whatsapp.db";
+          };
+          id = "whatsapp";
+          bot = {
+            username = "whatsappbot";
+            displayname = "WhatsApp Bot";
+          };
+          as_token = "";
+          hs_token = "";
+        };
+        bridge = {
+          username_template = "whatsapp_{{.}}";
+          displayname_template = "{{if .Notify}}{{.Notify}}{{else}}{{.Jid}}{{end}}";
+          command_prefix = "!wa";
+          permissions."*" = "relay";
+        };
+        relay = {
+          enabled = true;
+          management = "!whatsappbot:${toString (config.services.matrix-synapse.settings.server_name)}";
+        };
+        logging = {
+          directory = "${dataDir}/logs";
+          file_name_format = "{{.Date}}-{{.Index}}.log";
+          file_date_format = "2006-01-02";
+          file_mode = 0384;
+          timestamp_format = "Jan _2, 2006 15:04:05";
+          print_level = "info";
+        };
+      };
+      example = {
+        settings = {
+          homeserver.address = https://matrix.myhomeserver.org;
+          bridge.permissions = {
+            "@admin:myhomeserver.org" = "admin";
+          };
+        };
+      };
+    };
+
+    serviceDependencies = mkOption {
+      type = with types; listOf str;
+      default = optional config.services.matrix-synapse.enable "matrix-synapse.service";
+      defaultText = literalExpression ''
+        optional config.services.matrix-synapse.enable "matrix-synapse.service"
+      '';
+      description = lib.mdDoc ''
+        List of Systemd services to require and wait for when starting the application service.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.mautrix-whatsapp = {
+      description = "Mautrix-WhatsApp Service - A WhatsApp bridge for Matrix";
+
+      wantedBy = ["multi-user.target"];
+      wants = ["network-online.target"] ++ cfg.serviceDependencies;
+      after = ["network-online.target"] ++ cfg.serviceDependencies;
+
+      preStart = ''
+        # generate the appservice's registration file if absent
+        if [ ! -f '${registrationFile}' ]; then
+          ${pkgs.mautrix-whatsapp}/bin/mautrix-whatsapp \
+            --generate-registration \
+            --config='${settingsFile}' \
+            --registration='${registrationFile}'
+        fi
+        chmod 640 ${registrationFile}
+      '';
+
+      script = startupScript;
+
+      serviceConfig = {
+        Type = "simple";
+        #DynamicUser = true;
+        PrivateTmp = true;
+        StateDirectory = baseNameOf dataDir;
+        WorkingDirectory = "${dataDir}";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        User = "mautrix-whatsapp";
+        Group = "matrix-synapse";
+        SupplementaryGroups = "matrix-synapse";
+        UMask = 0027;
+        Restart = "always";
+      };
+    };
+
+    users.groups.mautrix-whatsapp = {};
+    users.users.mautrix-whatsapp = {
+      isSystemUser = true;
+      group = "mautrix-whatsapp";
+      home = dataDir;
+    };
+    services.matrix-synapse.settings.app_service_config_files = ["${registrationFile}"];
+  };
+}


### PR DESCRIPTION
Hi,

there already exists two merge requests regarding init of mautrix-whatsapp:

- https://github.com/NixOS/nixpkgs/pull/176025 seems abandoned since the original author does not reply anymore.
- https://github.com/NixOS/nixpkgs/pull/187416 configuration does not match current configuration of mautrix-whatsapp regarding logging.

I don't know what the canonical way of dealing with this situation is, but I would like to get a mautrix-whatsapp module introduced. That's why I did my best to pull together all suggestions from those two pull requests and also update them to be compatible with the current version of mautrix-whatsapp. Major changes were in the log configuration.

I'm currently running this configuration successfully on my server.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

