### PR TITLE
[Backport release-23.05] firefox-devedition-bin-unwrapped: 114.0b7 -> 116.0b8

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,1015 +1,1015 @@
 {
-  version = "115.0b9";
+  version = "116.0b5";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ach/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ach/firefox-116.0b5.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "3261783b345a17fdf1c009e232f505accf9602f5b99926c9165966f658c10660";
+      sha256 = "9bbb4940b939082c23bb7ab08c938a128f703c28d502aada9f0216cf0e4b1946";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/af/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/af/firefox-116.0b5.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "a5ed1f6021a0429105958f06370cd769a410fef428647c2f0b70b0d211b700ea";
+      sha256 = "8d1bfe44fb21e800e4985a95c9ce01f5a69c697abd6f8892804dde3f4b9d47ee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/an/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/an/firefox-116.0b5.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "5ff1bf05623c7f56e4b6ab9d6f42c8083f16c0a318e3d69603846a6755e5a6c1";
+      sha256 = "17831e8c36aea42896df71579f9853fab03f87e64a5956f818b05b5b7cacb6e3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ar/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ar/firefox-116.0b5.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "3cfae66a420b4aef85b686ec70899399d73e3a249667b1d59dbde60a5c76a7e1";
+      sha256 = "0fe4d6196254d6980e0f73e6b6d372a30b44f227a333333503bc5453122d50fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ast/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ast/firefox-116.0b5.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "fb68e1f04a6ad253bea73de6a67ddc0f6bef9c33b601834e5e962bc26e382120";
+      sha256 = "57691d55d54d0ea31cee189c03e7e7d23ab7e72d23b05244238d0ec38e257e36";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/az/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/az/firefox-116.0b5.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "841f885ca7d9ae6341006d6f555ee28277ad43b62c7412578ca28c0d8fd72a3c";
+      sha256 = "0d613e0fd22a59f95105f6324e6ce6160de3d38c28e94ce4ba0e8aaf50d34fc7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/be/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/be/firefox-116.0b5.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "a46ea40c5797c4d20aa5a50ef0a518cea2aa94b649928cd348f8bd162dc7cf6e";
+      sha256 = "12987c844112f1d1db5341cbdb98f84fc44569a3017fa600a492c0e44ba864fc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/bg/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/bg/firefox-116.0b5.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "ecbaf41f86ae3876399a48e25096ddccb84898bf48f960614b532a7585fe816d";
+      sha256 = "a76964cfcde92d4f53b09c3f36cdb5ffbf427a0edf0c37f8c8c784c821e617b4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/bn/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/bn/firefox-116.0b5.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "c4ff91b49b3bd419376d5aafcf7ab8b9561c6b5a65e9c039d913a7f07a13fc13";
+      sha256 = "3e841d48991e9dd6c5d686bee196b29e10419a7d851181bf33a5f8fdfbb821e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/br/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/br/firefox-116.0b5.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "fb3698d73576880729816a9ab786db2ce88de0cea13de31abadeedf0a7a303e3";
+      sha256 = "4136e8e0add6e062c707b7b37ff9bd1b509b095ee6a7736f8ffe118d0692092f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/bs/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/bs/firefox-116.0b5.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "77d55350ee16af38a6351ab9eded24a58fc4d8af7ad05def70790ae331a869f1";
+      sha256 = "67346962f0799b903b46bbcc830e3ac2ec718d554e09d97df6deeb5fb223461d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ca-valencia/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ca-valencia/firefox-116.0b5.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "6fe09c62fd6dc516ddd973ac3ec465f27b32da7052f683c612acc6983c44e12a";
+      sha256 = "c1b5edce12aa15d3be46c48903f7cbf0f229f8a25f8eeaa2c7fe8b1e7688a7af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ca/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ca/firefox-116.0b5.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "bf8b9384f059a6f1787e8e866c06b5abbaf54e21884f0d7eaba19594990b40b0";
+      sha256 = "01d688c83a2c380cca544d4b201a6206854513e9a6473cbaddaf7a98d4b5c2c8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/cak/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/cak/firefox-116.0b5.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "8fe435548760c72c5ec18481362a4afc2b7612a051764678a7e91856ba44d1f9";
+      sha256 = "03fb4e7158a98ac51e81bfa49c46e615526abf5c778f7432c39c4b2affea9c3e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/cs/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/cs/firefox-116.0b5.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "f08ff7c335ac64f9659457b230d40df0b0cfe5846649cd312a7f7d97e904bf2e";
+      sha256 = "e8b46a90cf1e79915c48eb86dd521307cc6a690eb80cc60551e6619e3c82d2f7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/cy/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/cy/firefox-116.0b5.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "ee243dc918d8e871c4b8f4724dd0dd967d3a7bc687fa3e43ca2612c28d7716ef";
+      sha256 = "1359b57e63c93d12ceab4c0a9bbe34fdb10dd63ea4e1acb2880c25fa2f97b9ad";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/da/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/da/firefox-116.0b5.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "bc198336b743bae036d0cb497669b1c4c2050b6d18759cc2a1b9dbd49415a096";
+      sha256 = "6543dd8fd55c3c48a97841c0bfddefb4d89f5343af8fdb44be251027b254ed78";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/de/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/de/firefox-116.0b5.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "3209f6815500cb55ec563bab6623b253799c23b6b8ee1866e45a58b9ff3ca15c";
+      sha256 = "6f741ea240ceda836a6eda5d6adf9f2752562b490b5cae1c4ddec161e8c00ad8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/dsb/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/dsb/firefox-116.0b5.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "7587640a7f87461e02f86951edc01d3ed9e30cffc5650582248ae0fd203c35ea";
+      sha256 = "5dd1b14a2bf861f579be41f4d0de2970ffdc99ab176d409164a1d406bcb9d4cb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/el/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/el/firefox-116.0b5.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "e8600328f45b2eeeacb23598b04365bb0167a5ca8436ae3704849d40d2989c12";
+      sha256 = "0b59041d0ad1a4bff0f9a596f9baa373d6c3195bd8e9026adc8cf83e228c5b09";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/en-CA/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/en-CA/firefox-116.0b5.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "6b88cb7ac6bec45da66eb4eed6ee25d3d2cc1d0b6b575648a48c056ebba877d8";
+      sha256 = "2a8826db1c76d4b87470916963be08e5796d75e39905d703cf773a06512a1f33";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/en-GB/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/en-GB/firefox-116.0b5.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "4d9716f7d8442e51f5abedda746fd8b4b49dd0ba7282469911322a5ece60ade9";
+      sha256 = "a4275c8d1e7349c1caaf762d1f9ed988d28e243afb559d9ceeb4599e768570a7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/en-US/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/en-US/firefox-116.0b5.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "bd4d35be16a99e1d27e3a7798c833d33d68eab75c05f0254ec9b578dab46ee2a";
+      sha256 = "dcdee4d1074af06ebd7f1d5381cfc3dce04fae9adad32a6017dfb58173a49857";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/eo/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/eo/firefox-116.0b5.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "06d2f67f746effebe5057e7cca882825fd3704093f1da74e498e2086513f6b80";
+      sha256 = "8353acec011db126b600b3d8fe00b19b906beaabc1b7b76a378307492b708808";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/es-AR/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/es-AR/firefox-116.0b5.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "2ee76dddd83129e0134ebcc26173690c2d07f8a41209ed59b1eee7ed84c326e7";
+      sha256 = "5450443e0d7b04f630fa271786594005292cee235cfd4024e3beea6084e1fae9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/es-CL/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/es-CL/firefox-116.0b5.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "0762e5068bfda380d21d503be376de9450892fc8d97921305ee859b2fafe3c10";
+      sha256 = "8f17c5a0e34518a867598f29390b9c46157a3d80f57cf49a577db8b7910cec10";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/es-ES/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/es-ES/firefox-116.0b5.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "546dd436b0a79c0aa5d2302726df9b39530d3e1598929a023083f64bcda5ad02";
+      sha256 = "732986fad6fa0b945d184fd3e337023da57aece055f1eebad004537e166e0183";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/es-MX/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/es-MX/firefox-116.0b5.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "89a4c2060e67052bc593dd5c60e5d66c58a905d9e815549613180201c06528c7";
+      sha256 = "978ee64f2a4d7b38f7bfd73a332b8c0595fd7003e55864e87f2ab72c7c1df3f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/et/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/et/firefox-116.0b5.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "daff14a8dc34d4afaf755c7594602832e563449979aa28ccf23657910e0cb30a";
+      sha256 = "cac892189fbc4509319d38b1659dd3252dbafad89191a38e409f2231e7f94f59";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/eu/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/eu/firefox-116.0b5.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "4fea1330e1e478e9c9ce7b413783ad5765e6e2bff9315ad4478d6fcefc0b942e";
+      sha256 = "3ea4a47e25963262e924cc05ea81c495c98df3a92c6f2917e0be428da98caf5d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fa/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fa/firefox-116.0b5.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "d03038fe91c470e996240d02777e1b38f1437eb011975bba2d5996f61c3980d6";
+      sha256 = "a3d7917f338c4cca2cc2f60cf67568956c304cd12ec88f031d54ff0e0d520775";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ff/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ff/firefox-116.0b5.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "748129d502dd7488143ce801f5aeac1e71bd36af42fb73a6bb9a617fe0d08b43";
+      sha256 = "d0851545c5f9a3712f0f43c58efa16217d85866db9eae058e4872df2a1c25012";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fi/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fi/firefox-116.0b5.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "6ef0793728d28d5a36d60391b62f0712d0c606b6dede4b5d9004d9a6d6fa29a3";
+      sha256 = "a3ca9dfffd544ca40b51a54110bcc1ee6c7e9ac0b2bfc639b044d348f02d1bfb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fr/firefox-116.0b5.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "c24aae6472eb6636ab9ebb5967ff9c8fa16f28a53e72d8dfdb8335de8c1b49b6";
+      sha256 = "efaad8637c20badd49ebed750d35347e23122b1dc2950701d11c72dca19b48a7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fur/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fur/firefox-116.0b5.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "ff3cb1ab8085d085c95b0759dae1665c395340ac055060b0dc51b46206c69a3c";
+      sha256 = "a13936666cfd92972075814fe3d28b9772098c04e1316d5c4e18cfd51bff4e2f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fy-NL/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fy-NL/firefox-116.0b5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "429a023342f6502d6d9e9df68a84208d77381e8e8cd7bc5edc9f78b9f6acbe38";
+      sha256 = "5a77f56fdf724fb4c1ba22031cde09b1162bed1687bd8731bcc4a2d181158db9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ga-IE/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ga-IE/firefox-116.0b5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "2ef0cba881e1f67a60ca8faa54d8b9743dcec988d107a1cb3f9e49c346dfb2e4";
+      sha256 = "cf3f528c10925b6e2f7dc29af6d7482de3078a6f7a6558aec5bfa0a6fc208869";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/gd/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/gd/firefox-116.0b5.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "c66225d3f91755f7e47d33d16a4452e31f8f421fc8fbc27aec1d48aef80732b4";
+      sha256 = "1ac32ab45474be72375e60fb918d1e0e05660224b7fb2e9bd4ea3ee843586274";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/gl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/gl/firefox-116.0b5.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "0614fe4ea1ff3497937cb3b0cc0dc70bbb44a60c6b0cf1cb6ba010883c2a6bd5";
+      sha256 = "4e3ec830483236cbd9a8cb8a11073f9df86782eb7c9945e83e28ea4110fec17a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/gn/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/gn/firefox-116.0b5.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "2932db546f27e6baa685b2ce07dfa5354ed79d9294e4da98411feda650907eee";
+      sha256 = "0f7f99a5e476cc326aaaa1daa5c46acea01c251faa764e446b1fa54eb68fbc2d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/gu-IN/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/gu-IN/firefox-116.0b5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "91ea1884c84ee2facfb93906fec602b744f33251462ca66e182766ec0dfbd4e5";
+      sha256 = "9901b3fde114d69588e415ac6c9e5eafa112b5a07137add8f381ccdfe1871837";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/he/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/he/firefox-116.0b5.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b33baafbd6c1e5872cff7b25da6656f907890ba701b112bee71d6ec33664f344";
+      sha256 = "c510b05ea5e7c3e8fd9a0bb2407580c4c505e6fac4287ff342d98f89a33db8e1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hi-IN/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hi-IN/firefox-116.0b5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "ce6d162d80fe56790a123659540132d208cbbb1dda98e0af9112c1a12b74448a";
+      sha256 = "e2e9cd72cb878e5e4a9e1df380d63592981d93782b07345a3276675e0d4d9612";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hr/firefox-116.0b5.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "45cebe7715ffb22bec28d861c064b726658478f5b3ecdb8581e46666b33e6d0f";
+      sha256 = "71d79bb87a0bf0f1bc35fb5e649637c355f0f159d1d259e316dc6ffa634730b4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hsb/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hsb/firefox-116.0b5.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "cf7e0e79171581d162d78d9ce1666281e99690ae18eacc8c8b8b14b53366bb65";
+      sha256 = "b789306192759b7a8362c0e96218b672ff4aaa59284940d7be0d017d8d308364";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hu/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hu/firefox-116.0b5.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "cb02162c8aeb7c9dcbb4f07ab2ce7ff5243eac1fb7e925725d330534bbda1d49";
+      sha256 = "68a4da300754165c7ba93e3273d90bd3d9863c457b25d6dc24113dcb9eefc68c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hy-AM/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hy-AM/firefox-116.0b5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "57c970229bfad215f41110197ca38d19d7663ad58031b793c1e07211f9a6915e";
+      sha256 = "4ba2a4dd17eb4eb4e17a6fccc0b7e614727be2960491d54438283e233b544171";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ia/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ia/firefox-116.0b5.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "a4aae8cd7e9f957dc492b4d3a8abf9297b16c8af18dd72c14d199be382952670";
+      sha256 = "d5e8255fc4b2af1c5e96568434cacbe0c5472f367816cd8faf13b45c65b22633";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/id/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/id/firefox-116.0b5.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "ee71cf8b893709781d3202123496b40467be8e647e998041c1835a5f0c7bae1c";
+      sha256 = "ec930eeafe23b850fd01d43651cbd1f60f0eb8956163d3344813aff759fde5ff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/is/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/is/firefox-116.0b5.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "7b0ef6b4c632be9abcdad58505e979b8be1e51c6087152361abc93c77ea4e054";
+      sha256 = "e98564458a6dec775226cd74406eca684928db89a11012ceef8cdb1bd5e9240d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/it/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/it/firefox-116.0b5.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "7f2bfe2b6d18f3193497811045657f11aebe36ddc717288bf9e0a1b723d54b38";
+      sha256 = "c2b88116a25894a3ae969c4868079c35998f26f9ace4f3ab59480c482d8616e5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ja/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ja/firefox-116.0b5.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "00575f2011885bd6521675480318ec87b2f589cccc1acaa1029073392bb95505";
+      sha256 = "9bed9d4dcc76a47977d5e3f3950655a3e19f2ef59a321a049d5f0f872276bdb8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ka/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ka/firefox-116.0b5.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "d4c472bbb7815f30bf17e8608e64484d00cca4dc53bfb8561aa49c0632937bbd";
+      sha256 = "c2f91ac70e57a7687d6760712d9bc09df29ee9ec529e28019727eef165bc68c9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/kab/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/kab/firefox-116.0b5.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "a9fdd041f034da4aadfaa5605938c972de29f74aeab0d7d162f45cff9d6c6b08";
+      sha256 = "07470a1a7f911035b072d506d34807941bde1b44ef4be194283402e3485176ac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/kk/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/kk/firefox-116.0b5.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "e47883bedc5f0defc89137ab73942b6f7dbbd30454c74907dda29dc3c2910d46";
+      sha256 = "54145722c779687f888cb7c46b2fc9f73eb66b52692af87076a9adfd4307b3a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/km/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/km/firefox-116.0b5.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "a0f69970c8918b2039fd80eb9d607a1daa0182a7b257a2aa4539239b74ea7a9d";
+      sha256 = "985252e7b7b0c6c46bd47e4262ea40aeda4617c111c5f387479f6b60f3afb8d3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/kn/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/kn/firefox-116.0b5.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "04ea63c7c94f791ec573b6a517a621093592d8c66ceb26222b948af615195bc7";
+      sha256 = "f0521cb6d6b359f7e1f5102d0890aed881779ea3bce29f6c45111ecd63f9de3e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ko/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ko/firefox-116.0b5.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "5169a1ae59680553f95d500ef0bac522013c3d5d807b7a35fb50e6ec5ce1580e";
+      sha256 = "4178338298ac6b210509594b19f71f71ca9abef831e301b357f746ddbcd12fc2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/lij/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/lij/firefox-116.0b5.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "2ed0611e24cebed0571aa013d53b47bf251e06e99452da7d979175edc2ae3efe";
+      sha256 = "18ae0adefd8f0fcc1f92c2a2dec922c5db6bbee570e8d76902bb473272eb3cf6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/lt/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/lt/firefox-116.0b5.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "4a7653f0dc9ca981458f2efe35b5b47a1b7d172694cb0355e4513e4c7e1bbc56";
+      sha256 = "2a725af3be4460d9c26e794e5a5c990a14c724b0d7c4831a140e32a4783d4f75";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/lv/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/lv/firefox-116.0b5.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "12e9894131c393938d5b9c21f73d5adf37dc88eafa7e2e293de2f610ec3e88d8";
+      sha256 = "51a081450b7278b78dfc42ee5f7f69a34c6c7c2857290fde920858178834eed4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/mk/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/mk/firefox-116.0b5.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "7e43b77516241a85f9b3db188aa26e7acce59a36980aaf25f2ff9621c4ee6cb0";
+      sha256 = "61499e809c0c49563f113684fed133e0d768afd4d4131f7c98622bced65e77a2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/mr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/mr/firefox-116.0b5.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "a49d84347d28eb5365c4ef2a7fe76aa64de0f54332f084cd85ae5621efd3c686";
+      sha256 = "e10507db2730ae374c4327df5f8f3636d75834aac26123a0fdf467a246102eea";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ms/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ms/firefox-116.0b5.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "3ff2ffb215f866c6fa5adac7ec7a7fc0a39ed401974c172d93fc4b4d3d57bffc";
+      sha256 = "96b7d5c090e4ab79448a5a0a96805d8edd2448dccb26bb0a01bbe235ede1cdb7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/my/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/my/firefox-116.0b5.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "ecbd63710a8fe280f6fef60dc54a425685001badd65be1031552e02f85a0fc68";
+      sha256 = "9fe9497421e76e64108fb0731c61dff275cd6c7f60c84eb5f2cf452bdbd1b937";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/nb-NO/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/nb-NO/firefox-116.0b5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "bb29ed3c0fe4233e367f6ad661f89ea126c2be352e1067fbbc9ec9dcfcd72504";
+      sha256 = "f29a33b95aaa0dc20d5a29ecc75b12ff86d390a7962ff08fc0b4bb040c21422d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ne-NP/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ne-NP/firefox-116.0b5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "ed3a3e0dbe0072e86d75a69d51c03bcc73a10629e86da688cbd2396fc682b937";
+      sha256 = "ad43efbf81fb877940435da8b87ebf844502da60e5b5683dcadb8bf37d796d3f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/nl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/nl/firefox-116.0b5.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "2f902587282a5b16c817c11768d8ce16ef81f1470f8d5612e6913b75bb15b6ce";
+      sha256 = "210d99944bb56d418f47ea7bf8880a4422ce0048ff7275b368ed16b5b9cf92f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/nn-NO/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/nn-NO/firefox-116.0b5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "138890e225c83672cd9815f863da6c4c74355149c3c291eceff19292eefeca85";
+      sha256 = "69c2cf3edb67e1cd22ce8776a2e45b57ec770f08edf0d4007b86b3dd5ab54f8e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/oc/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/oc/firefox-116.0b5.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "a89e607861ebf85db19162459f4eed4be56e9eea50fbd3fdf2a8ab4d21fc9c81";
+      sha256 = "4cdc3d9833f6d813dffe9f65d5ca1f4deb4290fd5127282b5f74b936186e44c9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/pa-IN/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/pa-IN/firefox-116.0b5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "271267b605d6be613a486c583726457dda2950bba5cc90014556576d3bbe77db";
+      sha256 = "4425772fdb76f06696113b254162d1b12eb5daab5ca47ae8da6a427730b7c34a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/pl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/pl/firefox-116.0b5.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "474ef435db1e6ee7e6742efd9c04786b13f9b5ef448c1982bf7c7ff1167bb8a5";
+      sha256 = "60b5f5cd2a332252cb6deb181268783a1620b10b519fc03d09dc872b803a63cb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/pt-BR/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/pt-BR/firefox-116.0b5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "52b33a56bdad6f8332a408c7b0fc85465c61632feaefc1ce8e4abcf2d78de554";
+      sha256 = "c34aa4b9328ecb50f147d11f36b40068ede5d8cc7f999bfe01e9cd4fe066646b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/pt-PT/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/pt-PT/firefox-116.0b5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "c70aeec5a8cdb6ed9743dbcc838773afc4a32701c5b2f7b8b74697226f5291ae";
+      sha256 = "f801f96207e13f32a4c92a8c3d81771593c867dc078a29c6621c680442cf8b1f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/rm/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/rm/firefox-116.0b5.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "da6cdfb1287575c11b8f6b88924200be69507a676668401d5cf0a87c9cd27b62";
+      sha256 = "530f69183566b76738863ab1d35cfeea34388089caabb845835946cac6ea765f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ro/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ro/firefox-116.0b5.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "6a3e1380df08c65de203b8c49e8513fdd30f8e2d7cfcb458cf7aac9c02d65c43";
+      sha256 = "21716632a24ea27d57573bacfac55051dd136decced8fdf5f4d117e86f014f05";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ru/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ru/firefox-116.0b5.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "04ec9801aa9ef740479d2964092f1d37314d9f5608dcdbc271f75c845c223468";
+      sha256 = "d7fcaef1c71d07cf42b3e7bfc74f305ef75199451b25f573adba45535c49ee46";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sc/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sc/firefox-116.0b5.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "bac95c057c7cb5dcdc03ef91a28cee391d8cd8ee33695141eebb2a1d4747a655";
+      sha256 = "6fd1c1647a8ae2586cda50403a564ad37b7fbfc3ced2c62ae2dec1934cab3a12";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sco/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sco/firefox-116.0b5.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "dc99f46f47f4f3f845c08df2c1d26ec903d4887d070f8654cf8282672fef44d0";
+      sha256 = "ca4263b1d21ff1cce8bc43c503363447dc19724abae91c900e3c2632038b2908";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/si/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/si/firefox-116.0b5.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "5c548f2550040e223a2b41260ad0dbe13b4b7232667ae8ee03052b5735b3c684";
+      sha256 = "051200eb96f21c795494b01b94a48d0331cd0c3bc4b9ced8b5e2342e126edae1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sk/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sk/firefox-116.0b5.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "65cb7a04e00ff54bc1953b2141140d205416d6cd266ca5248df55287d444455e";
+      sha256 = "615a078479f73d61459d59756e58dacd712245f95510e226d93e26758de43eb4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sl/firefox-116.0b5.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "21c521e1c9d0d00c98ad41fc1facdba382c9a3cec18675f2c6d3738483f44541";
+      sha256 = "06249e9b5254da179b924207f81819cd1f4abcc2956bd113e5362e728a531064";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/son/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/son/firefox-116.0b5.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "f76c060927d2221f280211695cc9e0e50355c92ccbb5f8e6c690b588361b9f52";
+      sha256 = "ecc73e86bfd2e7b7d3344b1f6aacaab6a6d0e11d0bb9df468a5d9c76e5cf388d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sq/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sq/firefox-116.0b5.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "835c28cb504d6f8e5e228f4d95d587f94108d0ba8b17c52ee078c50d725c8eec";
+      sha256 = "be624e20ab9355b499dcb3861fb9edaf50ef5cf8e65c5dea511df18a1b25bacc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sr/firefox-116.0b5.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "3ed73b58da534050f3dc07b3e29e32bd9344a0d168bd1409d422aff161dc52d0";
+      sha256 = "9ec8b3ca6e3c8af537ed7e6a0ea08caeb76425a18e0de35a3e1f05250b5358d4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sv-SE/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sv-SE/firefox-116.0b5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "cb546c00cd1ea3a1b04f490eeb0ea4fa4586d91db70c1840e3be83a99c208785";
+      sha256 = "3750ff90c0fb47e21c57ea6c84bdabfb1459f741aa1d82cc2a1fc969cd6d0438";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/szl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/szl/firefox-116.0b5.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "266b4fd89775ff8fe86865be9985308b3ba8b0d9e6b285b0a0a8426de0689358";
+      sha256 = "ccd80051479f0b57c610b4bb9776f002d1e019a3b2c38188f21c14992caa5193";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ta/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ta/firefox-116.0b5.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "15e1e659b27371d13ac61ed22e647d21f9ac6a7f700aab6b568e7c999da07cfe";
+      sha256 = "e6247aee65cf2dd3708d591f3674b1c33eb6d52261690e5bca10a22b66ced04a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/te/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/te/firefox-116.0b5.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "61fb6db588bd72e126845fa068555ae56261f84561ac7a2e9c123d8c5a928c5c";
+      sha256 = "20b5f9c1f14c82fb200b1be5eecfcc6dbed59459c7aff4c5a9f4ab5e19f9967b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/tg/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/tg/firefox-116.0b5.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "4437b55d295bf1a608272babbeb61849105760f61de96cbc0590f7b0697c2175";
+      sha256 = "49bc2d4a95506ff6bad793f8afe31c2bddbfc6a732c37779891abc44c6e0d71f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/th/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/th/firefox-116.0b5.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "76fbab23a314327b53526a15ae516b5a0b978b91c124ab66d109d3182388f449";
+      sha256 = "6910f36379df34ab1f97b8b6ebc25eb9dd9b83cbe857b453a4c71c702aac4481";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/tl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/tl/firefox-116.0b5.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "42995f3a32f241d80cc2cf8038929a6b8f9bc344c68886421edb7f61bd418d0d";
+      sha256 = "788b50ab7fb170b49cce6cbf2785204b25b23bd7120eb18c8ec29a15118b739f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/tr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/tr/firefox-116.0b5.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "f667f5d068bbbd7f4280ee19faf0577cc53c488d70487b11f3e4cf1a094a1d22";
+      sha256 = "c1ff5a3d891bd88a8fa6f89b2f561600ff9221a77c6edd4d2d217f40a1953aaa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/trs/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/trs/firefox-116.0b5.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "c76e652062d738b4f5ab0687b2b95d9aa8d296a4fd8ec04e992be8c84be53bfd";
+      sha256 = "56f819381a564e4de3ff5968aea21b71312e6381ab29a2739890844310b2cc7c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/uk/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/uk/firefox-116.0b5.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "4ad6b1290d4dfd25eef07ea9a5d0ee4293be2c250c389cefa08e25217544b4eb";
+      sha256 = "8f6ba4cee9824470abb62f5610b3bdde1f4df6a15209a3ccc56af06f776280ec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ur/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ur/firefox-116.0b5.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "5bef46dd6cf29b22cd536bbe37e6fee900b6d8e84ba8442384952b1f306786b2";
+      sha256 = "d2d5bd799a9bd1de740066128a281f8acaa70fcbd8f7d0ad1afe2e6ba451735e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/uz/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/uz/firefox-116.0b5.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "9767a07f1ebfcc680373cd47109135a30145ea324e629967e2d1c36075ad78a5";
+      sha256 = "52acacd060c7ee6dc80164885c74594e4ba066ee981f65110d085ff3aedeb57e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/vi/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/vi/firefox-116.0b5.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "ead52311bbb4add4da56254e1d3acdd935a9883532655e44118d4f7f5aae057e";
+      sha256 = "ee0d42e366670c54473814675a9ddf5feb56c340ac756dbdd873307ab0493b07";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/xh/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/xh/firefox-116.0b5.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "3b452c31cb53d02fa1bd5f219580ebe7a3d11ebde176af1c0ab6ae5e346141f9";
+      sha256 = "f8e050a6c12488301a0a52ef6b617bcfc11353da6d7614b0badf521e91010971";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/zh-CN/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/zh-CN/firefox-116.0b5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "3fd731abc57c1faf186f8cb3323b90c381bb628639c4ed5c129b18ef567dc328";
+      sha256 = "e98dfc8a86537636f608cd47b92002656e9641b93a5010ff91e4612adb9b1f47";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/zh-TW/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/zh-TW/firefox-116.0b5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "a67576592777894c0b2641e9b932119d5406256426284feabacdba039bdbd12a";
+      sha256 = "8f8a1e1ae1daae93bcd0d0aa33e14eb8475bacfa7332b6430614b5a608aaf546";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ach/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ach/firefox-116.0b5.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "17e7a543f336ec7f0811f9c926c064e06fa7eee57f32fc8de46bd78604b48d86";
+      sha256 = "d5ccd23f477053d2fd29536b096947448bda84bc8bd496f6d67ede2645003e38";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/af/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/af/firefox-116.0b5.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "bca35181175d9b345371fb2182050fb1a5614e8664d06b693891d8d6f6b69da9";
+      sha256 = "3531a77ac162a13721060f5a1cf42a0412b00d3545be9361658499c875f65b5f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/an/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/an/firefox-116.0b5.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "26e48a5f8fb5edb64e69ba4ae8f5439c2528686cbaa0c90e41c273340b9c0e80";
+      sha256 = "7213b9df3794d3882e5f7264e13525d170f7d3b6f6509e9ee6dd9aee5d3b40d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ar/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ar/firefox-116.0b5.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "1e93158883208d127608406754f714f6f612d07d772083157b3cf6b92622c062";
+      sha256 = "4092fbdf1a2c9984c0636932e3098c6685a50b4ccd47955d4c218b8e22a4ab88";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ast/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ast/firefox-116.0b5.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "6bee4565718962573f4d10417bf95671014bb7ca468f8d187f51a82cda132abc";
+      sha256 = "c5e12f623e0497ba9058c3346c54756c35ec986d9ad6ba8f318e9150911469a8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/az/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/az/firefox-116.0b5.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "7525dfcde4b31d8c73a381b7fbc89cc65b71cd26027cea9145d62df19677c07a";
+      sha256 = "48afd4136bf550d0fbc54ab00fa60ecbdfcf9a5588d2b69eb178834843a3d199";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/be/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/be/firefox-116.0b5.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "a3a5a5b2747909ea8126915838975eea54967a3f40371c551d948392097174b1";
+      sha256 = "f68b8e8167a14e414a2c2829e9a8a9471fb53509f02276f12097964982ce6bdf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/bg/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/bg/firefox-116.0b5.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "b080ab6182685723a0bd78d2e2904d3e774cb2e65385a1da69e27d5e7ad25058";
+      sha256 = "04a8f6a9f3ee83cb449e395248da7e49db5639026c40fa923722b25f6b487102";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/bn/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/bn/firefox-116.0b5.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "198c12fd8933b9359a01ddacca2d93670e9b516b0e35fb47800e7f8002b985bc";
+      sha256 = "a0ca76eb610b85077a84a6b154e0cb789bca6763b9804e750e2dfada7ff294d3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/br/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/br/firefox-116.0b5.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "da5dc615e9a7cb4b18c72cc464ef4131cf067987b4a79e24ec403f2ce67f22f4";
+      sha256 = "35b8bc7b4d533b51ee3c5d36fc72625c981674859d71aa8fa4cc35117bf28fb6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/bs/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/bs/firefox-116.0b5.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "61a1ea85bec18d8ecd72e251c41e87dec15fb196346eec3748122ad7bab3bd24";
+      sha256 = "6100aa7629763300623f6c3880208897e7a12da9bab1bdc616b480ab7ad8f2fa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ca-valencia/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ca-valencia/firefox-116.0b5.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "89f3c62ab1b27dd2e442ea6a02bd543948a320848aa990eca774f3b383de509f";
+      sha256 = "d389421bc508d6bdd0f56bb93dc5a5b2643e15597ce7ba6dd230c9b54d693425";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ca/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ca/firefox-116.0b5.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "d0bb93b0b39121e17826068bccaac6c5a6cb74efe1db55d712ad55bd6c9f360b";
+      sha256 = "776219a92a9cbb3e58fb54cd1f5513a3a26cdec1935040062718b0b1893bc6f0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/cak/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/cak/firefox-116.0b5.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "fba20a8efcc5436a67ebfcf3401ddf90d5477c17275db29ad1f8c018d86b968b";
+      sha256 = "be34c1f421d99257a3d05a82c48552a5f3aceaf54c0db6cc2137fb3972d29be1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/cs/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/cs/firefox-116.0b5.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "8343c999dd10fd6a211ac7487bdc83ccba7e134c24b5eaa569ed31aca506f3fa";
+      sha256 = "8cc51892774938280fadfb5c98ab848d03310b6b8d0897f80d36b65519df05da";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/cy/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/cy/firefox-116.0b5.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "1f58c87d68014200fed16032e5ca4c9e485f4e91787ddaf738d2fdb7514e4e4d";
+      sha256 = "18b6c599d989abd0f9212d75e406237f417fe7160984ec8c4cbc4845d256e8bb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/da/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/da/firefox-116.0b5.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "7db8b21b73c3004f3531cf32827629644a7358ef1bf3271fd7bb172bef8e2882";
+      sha256 = "a3ce7852cc6ab16d6946921ebffa36465acbfe6f9f819dc9091e27f1d31884df";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/de/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/de/firefox-116.0b5.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "f88123a6b5184dc178e502ec6093e2718fc3f99f0d3176d38ff029f34bb11a63";
+      sha256 = "99cba98a623de06364eb6d000eabfa853fc80b7599fb170763a8f626089b28dd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/dsb/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/dsb/firefox-116.0b5.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "6c74b469f77bafe18d59b22bdf9151cb476f7c1ea247fb32b9dbc218845eae80";
+      sha256 = "975c25e04aa35ab9724d0550bf98b2e4556f0a5af87ae77664f43d56354bdcbe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/el/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/el/firefox-116.0b5.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "83519c3e685b934b25a5956f895fe162c2c63aff15daa6172bba6b8aed8361bb";
+      sha256 = "ce33673dc2b2f0a65e54b620012b194f1a84a84f01bbb72166c2edb4d3ab12fe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/en-CA/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/en-CA/firefox-116.0b5.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "cfbc22627e3fb441b068c76ed0ec394235ac04687f36827fcd19d3465b506bc9";
+      sha256 = "d064bb526f0750d32d2708e63c80e002ca6156f7fc20fee12692bdce16b0ef2d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/en-GB/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/en-GB/firefox-116.0b5.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "211ca3ecb60ce08229c48694f9e98383a405a1169757993093023c6958bd83c5";
+      sha256 = "be2c784aa7e8a48d8955f51cbddcca82e063454a75671c5896d7a80005c7e1b0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/en-US/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/en-US/firefox-116.0b5.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "b76efdd3ed4fe4b229bd34c09d5a8b4874a5d2b933ce11c805dcc9e214a13167";
+      sha256 = "ac8df5f2f46588f4daa2e4ffe9dff1ce9ca75283d6db6cae77b5d77a5e5640a2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/eo/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/eo/firefox-116.0b5.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "89107d910464e4ebb5d096dc6c5f8a535a890f6e5815f099d1d322033f1c6346";
+      sha256 = "51a3b48855144ef476c4011e978fd01aed48ec84844dc673e46b76eeceb5366f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/es-AR/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/es-AR/firefox-116.0b5.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "3c922a252466678b458d55b54f076c34be8fa75f47aeda4a76b41bbb52f60e7b";
+      sha256 = "45febca3ece693d03ed1ce694d3741f10173593692aef6a54c2a9723a1b93e37";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/es-CL/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/es-CL/firefox-116.0b5.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "b9d2ad41cbe7f0cb55137e909a62eadb4f0423d3d9c67ccf6a5a411d88f03fac";
+      sha256 = "441b1292248d7b8c5819dca9639dc0701cf6f456fa7dde0c5d74c677cb074bb0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/es-ES/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/es-ES/firefox-116.0b5.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "19c3d36eb45111879afc3e04694410926a70935ff1842679f9b7ba215dc3c966";
+      sha256 = "6007fae26404f2562d7bbb14f3e0dcc734a763ca444c2709ce8d2bfd5276447a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/es-MX/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/es-MX/firefox-116.0b5.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "049a2be51c829f74d5dc678fcde872f859a1296585f0a40b33da336c4afeeff9";
+      sha256 = "aa5122e8685fababaf97cc3937261e0aef65b52c7a43a9d843d6cb0a264e753e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/et/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/et/firefox-116.0b5.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "274a363c208a5897b0c6ac91ee929a95a7fdb21b38da4f2ef1874e08f3a5aa00";
+      sha256 = "b8142f93a80ccb685063c41ce5fb18607cc270f25be21784d8c2e4a0045a5aff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/eu/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/eu/firefox-116.0b5.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "306d13490def48de3d270d42c30b4e170fbb5bc897f16f50a52833863f11fbc1";
+      sha256 = "1b4af468d79b052992d4c9500b13e43fbbbcebf73df3f669d771d452d9b39dd6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fa/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fa/firefox-116.0b5.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "7908985e1e1f80174ec42e17b34c099b31230f687f2f30a1e3e6a0d862a86b85";
+      sha256 = "b9c1a7c410e1f7262408ae273ae671b0ef95b3711151c76a6206a5f3def16faf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ff/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ff/firefox-116.0b5.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "36fb5af5cb9a38da54eb7f67b53e67ec1bb1028dfe72a84bacba7e0b25da7510";
+      sha256 = "944612ff8fed847a8548548faa58fecb2e6c39f7343a853e93a7a4bf18c1f2e2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fi/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fi/firefox-116.0b5.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "dd454e28cdfae46cb6718a9412c690e294e913850ca3ba267636194978f9a185";
+      sha256 = "c88ce10e9646456a0160f175189aa0cb5b06a88a1bf14445f74e330bd48b08d1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fr/firefox-116.0b5.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "67c6a33df93f763115ba238e246ffee4e0e1fa77ee99d3c806b908d29eebf2e9";
+      sha256 = "45c559bf2f31ec5f1cd6cc8df0bbc87a882aaf751dae5723d0fee9282d93c3f6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fur/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fur/firefox-116.0b5.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "6487d3fa0ff5dc685c40eedb6ad27a5d32791c99419981a3d0164e9c3f8a5a1c";
+      sha256 = "b675ea2673823fc6b27de90aa731d68d7e9046b246e448aecd776b09c5da988d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fy-NL/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fy-NL/firefox-116.0b5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "f98063953936a4262156a98c502956718798aafc595c1de78ce6d3da8b05addc";
+      sha256 = "07504da6c327f42384be1ed87176d781e0e9c6414801712ec534555e543b31f8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ga-IE/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ga-IE/firefox-116.0b5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "6ff07a2e79bfe63bae5267ccd564856b78319d51d3e28e78a4ccd27e719d63fe";
+      sha256 = "404e47c18ad46935c6bc3a528bb99fedd27374247b2bf0b5304128b8dbfa6e1a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/gd/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/gd/firefox-116.0b5.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "ef006a9142e00519ec26b3d5763d5d97f4c183cd8bd75830432a216ac0269b77";
+      sha256 = "93cc4c9a9ec99c6f738a8acf6eeae71226fbdcdae136387d0c28648c372e6279";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/gl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/gl/firefox-116.0b5.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "77cb4df6e9792a24385f2187d29a741dc35e174e94921199d106a124914081af";
+      sha256 = "9fcbbea723d39fb34fce0435121818982add249e456b2ed1f6a1b1652ff342c9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/gn/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/gn/firefox-116.0b5.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "63d23044b70d6441e16a9c54cfee67b0717367eefa30aaed1c437951ad48077c";
+      sha256 = "f962fe0de779a95ce14d828a82ed336573781f83adde61db10abc4a686b6a2dc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/gu-IN/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/gu-IN/firefox-116.0b5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "41c2b7c389452c795196cc833e1606cef182044e2fe7156c3c0f2314dd13620d";
+      sha256 = "6373fff69de803cc5a077ea45eff6ad2ca37caec1b8a9523a7f91d1924377ec9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/he/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/he/firefox-116.0b5.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "c4a96fa30e331396823822a7fa817ef605fee22aa7a9d6f1586a8ef10e95353b";
+      sha256 = "9f952724b440cf83cff675ec888910a6bff20233860b258001962cf6ff12e56d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hi-IN/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hi-IN/firefox-116.0b5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "b1e6ef21d8e2065bc2c45d0158e57b76c9941e2b765773d804561509de1e3d90";
+      sha256 = "7dba0c18877f3b74622e8812f01b3a562c0d0956f0d1f1e64cce3b4b044cd41b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hr/firefox-116.0b5.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "83c4777c249e646cd8f5447ffb2b2c481481bc02234b44c8138f2c75bc635b7e";
+      sha256 = "e69297da941dcdea8ac900b170e0d59ccd432112f52608915cdd6695c70cabc1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hsb/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hsb/firefox-116.0b5.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "e257a64be5b2038d54b88dff7ec9b8b122388a202c9a882cd579a9b1dfd8d25a";
+      sha256 = "e03ab81a6615f71cf31b20e2aa3fdb4ead8a0d7f7b9e61616f8e72d2d8709dd8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hu/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hu/firefox-116.0b5.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "feaa3d8f0db374c210e09e6342952d0c28553bed9f0ec0bbbb44d2b35997c390";
+      sha256 = "ae3937ac22ab3db1de9a2f7117acaf3eae5bfc0dab8833e3bf4ef438fe2f8807";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hy-AM/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hy-AM/firefox-116.0b5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "0ed7080b2e9ba21be5478287ecf73668bda820a277be2e54178bf0fab4f34c94";
+      sha256 = "08928a362b5b7e29e11b676a17667d3fdc385551cdb84db11fc2d7b8bad79524";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ia/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ia/firefox-116.0b5.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "3f2f25773b9b73bd8d1e341911e93354a1dc097b253b57700cb815f82144e8fd";
+      sha256 = "b48f4a080bbbe202ee75c3c0ec50de81b410a2545f37b40a458a41ad29dea131";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/id/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/id/firefox-116.0b5.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d205ef5ded567eea9fe80171d05ac280699608bf4d6eb5ba7f6c63919d55bcaf";
+      sha256 = "861770952348540b1417051571d1efd2cc4c63441d088e772bf1b3ab3cced327";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/is/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/is/firefox-116.0b5.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "af7491d89927bf7f1bf565b96c1b62c0b2cbbe25899fbb32fd66c83e888fd068";
+      sha256 = "fe4e2cbf086372d9b98c25dbf8ec7a0797d2caeefe218363b35227c5b1e3616a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/it/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/it/firefox-116.0b5.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "77e5f9bdab83443dd9981edd8caddbf0790803e46a76b850d4a4b8e7ad351701";
+      sha256 = "c36758e897406dd7d9fabc6c4c0793d5f24ecc007dd542420106040de9a81c19";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ja/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ja/firefox-116.0b5.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "39ecaed499e93eb14d92159cf8f497dd2d2fd19902c91091156ab77f10f9afdc";
+      sha256 = "09410a026f5c902ffb41c2b4138ad3fd975fe9a49e79174b8ccc6971d02f2570";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ka/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ka/firefox-116.0b5.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "d7db4f86389f08bcddf9ee5219785d21b90bb1b7b6869d885c30e58f1190fd80";
+      sha256 = "1c34ab1ab3d784cb07ad7031654b574df610c03b7ff03bf401b9fec9db259685";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/kab/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/kab/firefox-116.0b5.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "74e2f57f13d98618b7eba06ab7bd18fd16fd30d62b6e2e115ee024b2606ee42d";
+      sha256 = "1fb851a99d4acabacbe0c6bb6cc88d712e01620e94815c9407473351d4a81826";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/kk/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/kk/firefox-116.0b5.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "6ccd6f7dc14e82921e5d5f1d9142c78452efd5734d3155a42334cdc20a1fc778";
+      sha256 = "67ac4003b2bb6ee5badb3c5da99b73074432be939a7cd419bd5efd6abbf3b8fb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/km/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/km/firefox-116.0b5.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "52fd3969ed3aa96706a6ba4dde7d21e087e9332bcd9b6aad09eec52ce86481ec";
+      sha256 = "120d5643b12df4376dcf3d25d3f560a629c42e0b68c5294b90710b30663e9c14";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/kn/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/kn/firefox-116.0b5.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "ccf849109d9137fd6076aca1692f0f5e42b0b1e8de57a026ccc476725fbe1b3b";
+      sha256 = "c82cfc77e70b9a1305b6937c4e6ac8486e3326a10c0538a51d2c3db7998e5687";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ko/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ko/firefox-116.0b5.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a38bad7452a970aeba3ba8acd785406369e14c17b39a2c80a8659b8d5b4a6c59";
+      sha256 = "1e4e2c50c392b85e09cbfed6231cb75d4b5cc4f88118975b6bc7c1937f904ef3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/lij/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/lij/firefox-116.0b5.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "7ca32c5449c87c56f8ae02876541dcad44624894e8aa53e98b86c68efdb2a9a4";
+      sha256 = "cd702b70546704302005ce139f4d8cfcee0f63a707890314d24a6cef411393f0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/lt/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/lt/firefox-116.0b5.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "ca025cedb7346f0d893424a6f8d8f72f366299bb458e8ed276e9c4ada4adeb3d";
+      sha256 = "0b739761d743e9ca0af510e7c9be3061810e2c88321245c15fb7c7de1800a185";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/lv/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/lv/firefox-116.0b5.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "e3f8f33ac314b00084717ac95cd1cb9693b66d594672f2fc8d7ac40e12faaabf";
+      sha256 = "79c5f4f8a490a87048851420c03fe63976bbb4bea655d9d9f6865c32d6a06608";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/mk/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/mk/firefox-116.0b5.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "910e29ee4f001e793dd2107d5dc4710a55c48b6c6e7c7ce868d5b6d7b26a32f9";
+      sha256 = "46a00b6c16ebafe6c7f5f3bc3da6fa4dd12380d15c923ae409ed7c0e4dcc5906";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/mr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/mr/firefox-116.0b5.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "c0f66431a89b9e58a061fbc686c3b4f5eafe73109c6d42c1e33a1476af2bcd96";
+      sha256 = "303f6c94c47a43e7510d1d1f0d0f6ccf8d745991827949dc60150975f598678b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ms/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ms/firefox-116.0b5.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "62f879313be865df6a36a04b7c58e6ac2a8aca9a78a31778a836109c12ae0049";
+      sha256 = "ab6895c7a6afb7713b5d2fedd12cfe1b58a8b026fbadf6652f4aa6d39dd0edea";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/my/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/my/firefox-116.0b5.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "aa580077aa2225a34fc3474526cf0d4a9133eea2dacea334a1860d0d42133ec9";
+      sha256 = "e867458bd09b47fb130263951acfa0e1060aeafea63e3bf992a94359db2b41c6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/nb-NO/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/nb-NO/firefox-116.0b5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "38df96dfa748102005423e1eb005f3b2ed7fbdbef0c43fa63a67a97843660ab5";
+      sha256 = "726830a51febadb78a9fffc1ea9b6a09e92c7341a5eca9f32b78f9beaa7b5821";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ne-NP/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ne-NP/firefox-116.0b5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "08eccf2f4731f361ade7e44b9ef3a86daa24f8982976df8fb774981108336c0a";
+      sha256 = "d316311340d53f4061e7d721bde9156d1998ab80b7d4c3705eed084cc96bcae0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/nl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/nl/firefox-116.0b5.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "a0f29ac57ddc99ceebfc88f3256bc60bf208e191feb41e7a4908807d4939cf7c";
+      sha256 = "fc4ae1f08cec773c2a46cebd18ce88aa6c21471123f79269e27340c7ebeed285";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/nn-NO/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/nn-NO/firefox-116.0b5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "501b1b2e1eceb3ccc78be39f7661546df7fcd9718b1f7471b1ba439c72696b5f";
+      sha256 = "77a9d8683b1918a1f63e486bf3557999f9272130ffb050379ce91c1e1815d91d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/oc/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/oc/firefox-116.0b5.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "41aac014749b1608f0988b35a5dd8e5740288ec5c75fad88fced807d5181d286";
+      sha256 = "38a09ac3a8004c8720c16e6d9f466e0d590921cd03690e89392f7054dc4e6d44";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/pa-IN/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/pa-IN/firefox-116.0b5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "5643262e38794224210f9cd74e223f20855131fe8874ed0fb14bea9ec2e625b1";
+      sha256 = "74ce7b2855153e594a10513db2823dd917af41c0706dbddc67dc76d37a8aff78";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/pl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/pl/firefox-116.0b5.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "53526a4d5a6fbf37def22d67ede8b5a3f50991d0fc5bd009afe70833a829d9c3";
+      sha256 = "8115cc8993082713d0ffcfc154ac7e893c9bebe51a727959ba949cabc7414862";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/pt-BR/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/pt-BR/firefox-116.0b5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "a8f8984833753dfbd62383de25e26ac19caaf4d0f6cab7fc2414ef1f25b0dcdb";
+      sha256 = "4a5928c7397c52bbf1f77e445aa9481aae76d18183252d00d38c69539c1a4421";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/pt-PT/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/pt-PT/firefox-116.0b5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "8c2ebf9314ed42a283b80928f849bd6c6121951df02c583dd2b128e8a1df0a40";
+      sha256 = "07bcf3d965b96937895f9377334aa604b1d54ba10ce1a84f1477cea335912e85";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/rm/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/rm/firefox-116.0b5.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "4f9ab0819b18687f4179f3518066687d669b0a18ed4669f89ae6091c122a1eaf";
+      sha256 = "142ef46293b65eb916fdbcebacf53127350b7549e0073c82be83f8ae8ca7e2d1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ro/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ro/firefox-116.0b5.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "f65d82895f64938f38642f9f71c2e60fdf4b8003abf6b8bbad3ab5e2b930211c";
+      sha256 = "237dc722c2217a528fb20e520a79192b1eff085babf954a3ddb98ce152fdfcf2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ru/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ru/firefox-116.0b5.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "a7fee511ffd3534b5ced0bb7e2aacebe44ca00542bff070013e17927dbfd0fbd";
+      sha256 = "b7e954893adfa5a1099d55d3e6666908a9daf40b87056b8b0d9356b05209cdae";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sc/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sc/firefox-116.0b5.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "40e9ccaf48ec845f137f2e3c728d1d489952ff97c3215363afe1a2dde8056826";
+      sha256 = "76fbba366247140ed84223a8bce8b156a17468dfde8d1b5fd54bff3fb1408dc1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sco/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sco/firefox-116.0b5.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "d3597779d604b2dc7d06c2ac78bd4b9664d3570bc2996e7e4dd2e4965a025c94";
+      sha256 = "d6fc67cd55209e22875aeb225bf82935d111cca77e00f41c4ba97dcbed156458";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/si/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/si/firefox-116.0b5.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "a7028a84812664639d92c7f555b235cbed91df548893b5871c691e3944f54dd1";
+      sha256 = "3675f892cc5f0bfa98c8075df297651a4ba0d2f5c099208efa01b33f60fcc1c2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sk/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sk/firefox-116.0b5.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "2eac153bbea200ea378a16a512ad9fbc3a1002467c62424256601d742d85d41f";
+      sha256 = "f217606f8f8ccfabdaa1a4c5a23af8fdd3eacf1502e4da6e28f8504a74a7e9da";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sl/firefox-116.0b5.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "d5f42957d54527771ee5fd370c7dea232ee7691a6fb4127219e726c83095653f";
+      sha256 = "c5a089bb04ba83c899b0fab4a81335474a1a0a24c75afcc5bef2864ae7af2c1c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/son/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/son/firefox-116.0b5.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "3b622be3bf8e54bafa9e6e1db61d1cd819a3f4bd4bd4bc57390c1e2850c8d715";
+      sha256 = "c73c98ef68e886e3f4ac01f7aa42992c6f9b75a18403c82c0bc54aa9d1630524";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sq/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sq/firefox-116.0b5.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "2950857920ad1e2b378954c5508300641f544d38e9bb6d9aa553de2fe376a605";
+      sha256 = "b7c7bcb08a3b81d266aedefb7de9566b2d11781c66dacf94e52c9c60474a2e13";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sr/firefox-116.0b5.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "42199dac4518948e260132a0c59178490070a85f7b94f96bbb0c22977cb83781";
+      sha256 = "5c8a3db26ba7acd76dba7f9a4affa2fb932e76cd40becd9052444efd5f1eb7cf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sv-SE/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sv-SE/firefox-116.0b5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "3423cfbf26cf6f7518a97a13d9e1aaaeac61d02d3e620390365093bc1d0be2c3";
+      sha256 = "9796c48e19a4860bceb7cb3199ca0d3605522185cf6b5be1e8d5ed036bc523fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/szl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/szl/firefox-116.0b5.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "bbf4e142d570dd877cbafa84680fd71d507d412ace7b6b2bddd70e5d209dc083";
+      sha256 = "3d5b4cc385399b4b543f66c707c3d5fb2b6920f7d7344fdbb4aa5f34e5666c9a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ta/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ta/firefox-116.0b5.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "8e92f220d85f7f8fa0608861089dfb2fe746dcfc6302071d05e31d27cf6c1dee";
+      sha256 = "34033dd438cff4740a366d91eadd0e34c2fe3e24fdd41b5dfeb10a2d425e7388";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/te/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/te/firefox-116.0b5.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "f1e10ae0f6fba48b9a3440edf688a3b7b40688b9616454a6b01c732cf0520884";
+      sha256 = "d10fbb522c1032f4dbd9e46e597efdb6f8eab3d885b09ca355efbad415bbb7ba";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/tg/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/tg/firefox-116.0b5.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "54e40ac4c4a69943aba21131fce4701f4fa63959789790ecfcdcd65d8b9018b3";
+      sha256 = "d793064e3de193e7ac8d2046be611211200d5079d20ddac293fd54dc040653db";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/th/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/th/firefox-116.0b5.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "f936481ede653c9214aa625f6bc1f723dc7188493f380dbc6561d43ac58bf950";
+      sha256 = "d466b47233a8d3fc3d55aa2fcd08086811306f813a8118fb6235d1733a2d274e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/tl/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/tl/firefox-116.0b5.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "1a67c0707b407d86a1410a148cb81c087199c70197233c8d3b2bc1d9f6384c51";
+      sha256 = "d395cb79206236f8af0f17cfb76c332df6e49271b102de3fcdfbe6072c81b400";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/tr/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/tr/firefox-116.0b5.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "91e5b5524934c63f90394a7320d7a726079f72ef9ce75ac0ce3393a13d9bcfd0";
+      sha256 = "ca3e8d335945d265b6fe1d86af58e0dbd4f6c046d5b308c32e13b398fdd1b54b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/trs/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/trs/firefox-116.0b5.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "31b009a17aa3c9439b26d2ade3fbb74256ccb79402c258d9975c79d3ec3023a0";
+      sha256 = "eafacd352f3cc054499f87c6765a5b41c40229743849d689f69c14fe1975ed03";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/uk/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/uk/firefox-116.0b5.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "8559ba5e0776ae7d2cfd8384d45b76fddcf39fd6364f2d748f6e8e791eca5158";
+      sha256 = "c4d09799da087987c5de2aa5db90b9f7866fc345fe98820da77581aea1d45e38";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ur/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ur/firefox-116.0b5.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "236f401e8dbfa78eb6d87712c1e84c0481d2681cbad0cac25e3e5395c9fc3ac5";
+      sha256 = "75856c9b34b3117e10a403b6c1859e3c1d8faa6cad8cae345b22a4b31bd119a3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/uz/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/uz/firefox-116.0b5.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "39ae3db99d7bb50bdf5238382fbdf59c40ad748a99bd9bde39c1025e5afcecb0";
+      sha256 = "26974ca448092c64b131d040ca6f88848695c25703610490c1d55b68d2be5546";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/vi/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/vi/firefox-116.0b5.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "4d16eaddc4489c19224feddfa53edbf0736f2447a804316ad25e68bd131ee1d5";
+      sha256 = "1bd77f418464127d9712ff09c9e9225d501615b83bc0bf9917e7bed4f4a52c73";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/xh/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/xh/firefox-116.0b5.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "40103ad901ce03622b63b49b59c875d08a8827a9a75b0d3068520dc36a61e4ee";
+      sha256 = "75575150eb9810d2201832f4af3319645cfff875dc37000e4939a42c3d697832";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/zh-CN/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/zh-CN/firefox-116.0b5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "19c65f89c860e42de97f19e543c530113c8fe876bd28af62fafe572d7dc1c33b";
+      sha256 = "ed111f3ebabaa3468ece986491afc5d2bcb40dbe63b5914e63842db5b62d4d64";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/zh-TW/firefox-115.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/zh-TW/firefox-116.0b5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "b49b074f7ae19a0da9a7c9e0cebb4048a7d75e44c695804a78ea3c450e62c5ad";
+      sha256 = "cc93da69a1dbf2de7bd0a300209cffed7202b6602d90b535610029e6ace510a6";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,1015 +1,1015 @@
 {
-  version = "116.0b5";
+  version = "116.0b8";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ach/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ach/firefox-116.0b8.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "9bbb4940b939082c23bb7ab08c938a128f703c28d502aada9f0216cf0e4b1946";
+      sha256 = "783fafe72cc549ff74f098702aeaccea2b8f311d23a056b30af2c9e7b62eacc4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/af/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/af/firefox-116.0b8.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "8d1bfe44fb21e800e4985a95c9ce01f5a69c697abd6f8892804dde3f4b9d47ee";
+      sha256 = "ba5eb43c70df2ae753636c724661ae15137a01593095b4ecfa220078c114bbfe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/an/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/an/firefox-116.0b8.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "17831e8c36aea42896df71579f9853fab03f87e64a5956f818b05b5b7cacb6e3";
+      sha256 = "7aa2e2e31938265f20b141b23cfc034dc8f0175fd4567b8ec890d88d1bbb6352";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ar/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ar/firefox-116.0b8.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "0fe4d6196254d6980e0f73e6b6d372a30b44f227a333333503bc5453122d50fd";
+      sha256 = "35b1043e914aa829b0259034bd9eda7b081e48b5e168085e3feca6cd26681188";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ast/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ast/firefox-116.0b8.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "57691d55d54d0ea31cee189c03e7e7d23ab7e72d23b05244238d0ec38e257e36";
+      sha256 = "10817532b38c4976aad3f31cf136a71ef1d29244cc43007f3ce6288033f2013a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/az/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/az/firefox-116.0b8.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "0d613e0fd22a59f95105f6324e6ce6160de3d38c28e94ce4ba0e8aaf50d34fc7";
+      sha256 = "cabe80c4bbee51523fc73526650ab920734dc3a8f3f15858b46710ccd42607fb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/be/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/be/firefox-116.0b8.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "12987c844112f1d1db5341cbdb98f84fc44569a3017fa600a492c0e44ba864fc";
+      sha256 = "99b8e4d584204964c005d89a693422cf302baf3e15127cba408a621966aec345";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/bg/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/bg/firefox-116.0b8.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a76964cfcde92d4f53b09c3f36cdb5ffbf427a0edf0c37f8c8c784c821e617b4";
+      sha256 = "6d059456f5203e97d10f1a1ec9da11c7e1c9f89c7db21dafe8e8d7fc4d7b8b7a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/bn/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/bn/firefox-116.0b8.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "3e841d48991e9dd6c5d686bee196b29e10419a7d851181bf33a5f8fdfbb821e7";
+      sha256 = "a78f02d162990e239c23f50f948133371cb4840201ef5d4660d389525f81c153";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/br/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/br/firefox-116.0b8.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "4136e8e0add6e062c707b7b37ff9bd1b509b095ee6a7736f8ffe118d0692092f";
+      sha256 = "73f281d2c3d773ef3fc162942c19c80e896244ab0978a42c039623421ec63540";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/bs/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/bs/firefox-116.0b8.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "67346962f0799b903b46bbcc830e3ac2ec718d554e09d97df6deeb5fb223461d";
+      sha256 = "9a31ae6de84a5e725e5a0ba73211f1d51b45c9061facfd99b0801d076c30dd70";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ca-valencia/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ca-valencia/firefox-116.0b8.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "c1b5edce12aa15d3be46c48903f7cbf0f229f8a25f8eeaa2c7fe8b1e7688a7af";
+      sha256 = "c3c73d0540ea9b28654ffc6867ea210c2fe8423e99c1223abfc6d436ab5c7c0d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ca/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ca/firefox-116.0b8.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "01d688c83a2c380cca544d4b201a6206854513e9a6473cbaddaf7a98d4b5c2c8";
+      sha256 = "fcc53a1c9c7d1437b29390a2e96642ecd09be2f3387c556ea71f6a0e75ed5470";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/cak/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/cak/firefox-116.0b8.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "03fb4e7158a98ac51e81bfa49c46e615526abf5c778f7432c39c4b2affea9c3e";
+      sha256 = "0730137f2a1f819cadd8666f6df334e5ca0fe6eac36bee59083df2a8b61125f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/cs/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/cs/firefox-116.0b8.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "e8b46a90cf1e79915c48eb86dd521307cc6a690eb80cc60551e6619e3c82d2f7";
+      sha256 = "b7fef5032a419cbe6c945a1822afe70798d0b0279dfe04e24057a2b36bf1cff7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/cy/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/cy/firefox-116.0b8.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "1359b57e63c93d12ceab4c0a9bbe34fdb10dd63ea4e1acb2880c25fa2f97b9ad";
+      sha256 = "e43091757ef211350ca89047496bb0b6ad886f1c0173f902f1f1b799855717db";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/da/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/da/firefox-116.0b8.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "6543dd8fd55c3c48a97841c0bfddefb4d89f5343af8fdb44be251027b254ed78";
+      sha256 = "dec0d5afb79a23890921a690ec1675b6f72603fd2195c9732e3bde99c39e6867";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/de/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/de/firefox-116.0b8.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "6f741ea240ceda836a6eda5d6adf9f2752562b490b5cae1c4ddec161e8c00ad8";
+      sha256 = "6fd3dcd7317dffb7b7d716e824c079e8ce9cdf08615664ced1ba9fc8f7061834";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/dsb/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/dsb/firefox-116.0b8.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "5dd1b14a2bf861f579be41f4d0de2970ffdc99ab176d409164a1d406bcb9d4cb";
+      sha256 = "36c144ca752dc201303641a24d24f0b9cd2d4602d20875a8df21b6205f976187";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/el/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/el/firefox-116.0b8.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "0b59041d0ad1a4bff0f9a596f9baa373d6c3195bd8e9026adc8cf83e228c5b09";
+      sha256 = "2d4c0ab6812f6d7eab85cef74a16b380226356e8fb7108a386e7f9487fb88c41";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/en-CA/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/en-CA/firefox-116.0b8.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "2a8826db1c76d4b87470916963be08e5796d75e39905d703cf773a06512a1f33";
+      sha256 = "0b5547602f126b8d36b32da8f96f9201584be0fbf903d9c2b4e27bd66066cca4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/en-GB/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/en-GB/firefox-116.0b8.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "a4275c8d1e7349c1caaf762d1f9ed988d28e243afb559d9ceeb4599e768570a7";
+      sha256 = "10d2a7127dc98804f52baa77d4717f0bfae3910483e3d5915b66de4143f7c93d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/en-US/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/en-US/firefox-116.0b8.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "dcdee4d1074af06ebd7f1d5381cfc3dce04fae9adad32a6017dfb58173a49857";
+      sha256 = "fdde9c378b5b184e8ed81d62eb03dd39bae52496e742ed960fd16eeb299c6662";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/eo/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/eo/firefox-116.0b8.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "8353acec011db126b600b3d8fe00b19b906beaabc1b7b76a378307492b708808";
+      sha256 = "c760521a164131115568545c98e155305c1f0097c470f57f71cfb77f02cfcf7b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/es-AR/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/es-AR/firefox-116.0b8.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "5450443e0d7b04f630fa271786594005292cee235cfd4024e3beea6084e1fae9";
+      sha256 = "da3404dd34002458648ba597638b2abed92b274e67d36fd5ec1b0be9a2b5d263";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/es-CL/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/es-CL/firefox-116.0b8.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "8f17c5a0e34518a867598f29390b9c46157a3d80f57cf49a577db8b7910cec10";
+      sha256 = "18de61ebd0172a4e3d131775b82a52877d10b5af06d45f2932d8b6e7e7c78c67";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/es-ES/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/es-ES/firefox-116.0b8.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "732986fad6fa0b945d184fd3e337023da57aece055f1eebad004537e166e0183";
+      sha256 = "94d5d2f3b0698c9ec7b8342bdbb53f1f16d368f069f5ae68ab734bdf9483829b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/es-MX/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/es-MX/firefox-116.0b8.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "978ee64f2a4d7b38f7bfd73a332b8c0595fd7003e55864e87f2ab72c7c1df3f4";
+      sha256 = "3247fd3db24f78b8c92aa0c863362bce276abbe1df1cec657aedcfc4092bbd62";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/et/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/et/firefox-116.0b8.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "cac892189fbc4509319d38b1659dd3252dbafad89191a38e409f2231e7f94f59";
+      sha256 = "8e125108248395ee751b3167bdee6c50db55d3ed7d3f7b911eaa439dca57c986";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/eu/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/eu/firefox-116.0b8.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "3ea4a47e25963262e924cc05ea81c495c98df3a92c6f2917e0be428da98caf5d";
+      sha256 = "3e7082d435b902743661875efac6644b7bc1ea818df15bbe1658441c9bf59bde";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fa/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/fa/firefox-116.0b8.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "a3d7917f338c4cca2cc2f60cf67568956c304cd12ec88f031d54ff0e0d520775";
+      sha256 = "12c1313fd43a583c73153db1a054e73fbffeb4ce537185a44c3d0e56d7e68fd6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ff/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ff/firefox-116.0b8.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "d0851545c5f9a3712f0f43c58efa16217d85866db9eae058e4872df2a1c25012";
+      sha256 = "0fc4f82fc15bd1129f9e5c8682436a7488a7899c21b2e6d745be06679003e5a0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fi/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/fi/firefox-116.0b8.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "a3ca9dfffd544ca40b51a54110bcc1ee6c7e9ac0b2bfc639b044d348f02d1bfb";
+      sha256 = "cb0e10c7463fbcd4391f1296edd5fbd9b061403043fdd32d1647ac33438d13e4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/fr/firefox-116.0b8.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "efaad8637c20badd49ebed750d35347e23122b1dc2950701d11c72dca19b48a7";
+      sha256 = "1fbfb59fa426938fc9443ed89730684374c8d9f818416c3712d6f5a3dcefc171";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fur/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/fur/firefox-116.0b8.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "a13936666cfd92972075814fe3d28b9772098c04e1316d5c4e18cfd51bff4e2f";
+      sha256 = "d46ba375a8663af7b7290057d438bee721c47f06e47156c1f2529c564b8ef84a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/fy-NL/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/fy-NL/firefox-116.0b8.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "5a77f56fdf724fb4c1ba22031cde09b1162bed1687bd8731bcc4a2d181158db9";
+      sha256 = "891cef1c601f5aef20babc2bb2cea4350f6be2df0ee2745cda762965456eef4d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ga-IE/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ga-IE/firefox-116.0b8.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "cf3f528c10925b6e2f7dc29af6d7482de3078a6f7a6558aec5bfa0a6fc208869";
+      sha256 = "3e2d424a6f9e7446c841975940e05a0ac5557c6b787a8f0ea336ad0a74c3d763";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/gd/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/gd/firefox-116.0b8.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "1ac32ab45474be72375e60fb918d1e0e05660224b7fb2e9bd4ea3ee843586274";
+      sha256 = "48ec2a0f0fd01d37886cd0c6288c4f3f07e0927151b3911d0d5f136fc9b552ea";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/gl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/gl/firefox-116.0b8.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "4e3ec830483236cbd9a8cb8a11073f9df86782eb7c9945e83e28ea4110fec17a";
+      sha256 = "bd793c6d6a6835c234ac042d9b19fef07edf3759d64eec7bbad5c5b80055958f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/gn/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/gn/firefox-116.0b8.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "0f7f99a5e476cc326aaaa1daa5c46acea01c251faa764e446b1fa54eb68fbc2d";
+      sha256 = "03c799723012115e3c39e7baf3ee238c6671d2a2d60cf28e53255eae3ee841af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/gu-IN/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/gu-IN/firefox-116.0b8.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "9901b3fde114d69588e415ac6c9e5eafa112b5a07137add8f381ccdfe1871837";
+      sha256 = "f76eccb306e5771cbb4ef8fcd7c458a745096d367889bfb150f521ce809ed72c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/he/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/he/firefox-116.0b8.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "c510b05ea5e7c3e8fd9a0bb2407580c4c505e6fac4287ff342d98f89a33db8e1";
+      sha256 = "405f2f8c2ebe5ac75d290216cb00a732b6a0ab0ce0c31021144c22cd32148f08";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hi-IN/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/hi-IN/firefox-116.0b8.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "e2e9cd72cb878e5e4a9e1df380d63592981d93782b07345a3276675e0d4d9612";
+      sha256 = "90ff3b5712a2589ed92144f0aaabcf235d5f2b6c85d1e9b6170ec1007ff55013";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/hr/firefox-116.0b8.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "71d79bb87a0bf0f1bc35fb5e649637c355f0f159d1d259e316dc6ffa634730b4";
+      sha256 = "0f82ca12edc6b994d7f4a2d03130f13af6625bf0d78b1b66c12df6c1f0a2b8f1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hsb/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/hsb/firefox-116.0b8.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "b789306192759b7a8362c0e96218b672ff4aaa59284940d7be0d017d8d308364";
+      sha256 = "9d0d2b9e09a4e866672b05a00c251be14ca6c2a6a8089b256aaa8c6bc60fe347";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hu/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/hu/firefox-116.0b8.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "68a4da300754165c7ba93e3273d90bd3d9863c457b25d6dc24113dcb9eefc68c";
+      sha256 = "c499cbfea46ad3e5293788b91174c3dc6c7445569b048c1c6dab6cac478c1eaa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/hy-AM/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/hy-AM/firefox-116.0b8.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "4ba2a4dd17eb4eb4e17a6fccc0b7e614727be2960491d54438283e233b544171";
+      sha256 = "7d6d60f0d21fd0d18102cbb389162c45ae34439befe1f06b3a122760a778cd4c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ia/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ia/firefox-116.0b8.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "d5e8255fc4b2af1c5e96568434cacbe0c5472f367816cd8faf13b45c65b22633";
+      sha256 = "8ddb29f773d500d84229daa3004f713e1055284c81b179ffa88bac16ca9cb6ef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/id/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/id/firefox-116.0b8.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "ec930eeafe23b850fd01d43651cbd1f60f0eb8956163d3344813aff759fde5ff";
+      sha256 = "40e10e71fd044971a0478263f22b8d4ddbc98b576a71dcf28310031a0ccfb814";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/is/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/is/firefox-116.0b8.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "e98564458a6dec775226cd74406eca684928db89a11012ceef8cdb1bd5e9240d";
+      sha256 = "9f872412cd7e25db78c4f5cfde4cde861e370e1457dbfdd5b49bd438fcabe232";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/it/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/it/firefox-116.0b8.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "c2b88116a25894a3ae969c4868079c35998f26f9ace4f3ab59480c482d8616e5";
+      sha256 = "27be12df82f7fa59915823c00b373ac8e4c2bbca3bcea142c441ba0a031f02c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ja/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ja/firefox-116.0b8.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "9bed9d4dcc76a47977d5e3f3950655a3e19f2ef59a321a049d5f0f872276bdb8";
+      sha256 = "b75cb65b4b1773e2cfce92b160b3ba4c7711094ace670c06808c7c60244ad892";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ka/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ka/firefox-116.0b8.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "c2f91ac70e57a7687d6760712d9bc09df29ee9ec529e28019727eef165bc68c9";
+      sha256 = "e5c9e420e59796f820df97ff17e9d061bc69fb3b31b94687fc391433dd765796";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/kab/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/kab/firefox-116.0b8.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "07470a1a7f911035b072d506d34807941bde1b44ef4be194283402e3485176ac";
+      sha256 = "9424ff5895bcdeabf6c9edda9cffb5283b6739cb394fe2e187af9928d1c0ea4d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/kk/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/kk/firefox-116.0b8.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "54145722c779687f888cb7c46b2fc9f73eb66b52692af87076a9adfd4307b3a5";
+      sha256 = "3fc00f77723da01eb77f0682bba12132450b87cfd4f99e04d7aa7c474025477b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/km/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/km/firefox-116.0b8.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "985252e7b7b0c6c46bd47e4262ea40aeda4617c111c5f387479f6b60f3afb8d3";
+      sha256 = "96cb1b1bd5d0409f3bb7d335297316a559a4647c65000061af07a1853173df07";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/kn/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/kn/firefox-116.0b8.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "f0521cb6d6b359f7e1f5102d0890aed881779ea3bce29f6c45111ecd63f9de3e";
+      sha256 = "718fca6a3ef97fa42e5bdb69b4a5fc7b397f377d7be938cd715dab53039bbe08";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ko/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ko/firefox-116.0b8.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "4178338298ac6b210509594b19f71f71ca9abef831e301b357f746ddbcd12fc2";
+      sha256 = "816fac7a8d27c59bc8d307d76434161a1ec32407c5e2088bf02c6e331a119e2d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/lij/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/lij/firefox-116.0b8.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "18ae0adefd8f0fcc1f92c2a2dec922c5db6bbee570e8d76902bb473272eb3cf6";
+      sha256 = "b37a653e7d6c0610bbb68ea5d41993a5fb6e53ea0186ce84842082606b3d0070";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/lt/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/lt/firefox-116.0b8.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "2a725af3be4460d9c26e794e5a5c990a14c724b0d7c4831a140e32a4783d4f75";
+      sha256 = "7f6b6e7ace1fee50573cae31c0e082b064688b5543b55b6d9a5425fc93923b29";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/lv/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/lv/firefox-116.0b8.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "51a081450b7278b78dfc42ee5f7f69a34c6c7c2857290fde920858178834eed4";
+      sha256 = "35ca7b9b6e6a99bfecd4fbdb720d93224a381d88b4da0782afcb638081acfaa0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/mk/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/mk/firefox-116.0b8.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "61499e809c0c49563f113684fed133e0d768afd4d4131f7c98622bced65e77a2";
+      sha256 = "86886b4cad7e074784009dc50c354acb41d487ca14d0627b0529fface2bb0326";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/mr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/mr/firefox-116.0b8.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "e10507db2730ae374c4327df5f8f3636d75834aac26123a0fdf467a246102eea";
+      sha256 = "50d03522645998d9646d3d6c298f92ccfb8aebf337ea47fb9ab21279368dd2b3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ms/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ms/firefox-116.0b8.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "96b7d5c090e4ab79448a5a0a96805d8edd2448dccb26bb0a01bbe235ede1cdb7";
+      sha256 = "59cac55981b82ac9ae986338aa990fedd8f3f0f3b6201117019e911c0c13ddbd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/my/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/my/firefox-116.0b8.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "9fe9497421e76e64108fb0731c61dff275cd6c7f60c84eb5f2cf452bdbd1b937";
+      sha256 = "7064e8780012a3ee55f0ec14cb618ea1b1a2879646e39c2b3b841dfe2995f612";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/nb-NO/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/nb-NO/firefox-116.0b8.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "f29a33b95aaa0dc20d5a29ecc75b12ff86d390a7962ff08fc0b4bb040c21422d";
+      sha256 = "b108bbcb2775eb8b64b19ded43b9a89539384b9306bd63757026314796df8b6a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ne-NP/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ne-NP/firefox-116.0b8.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "ad43efbf81fb877940435da8b87ebf844502da60e5b5683dcadb8bf37d796d3f";
+      sha256 = "1f4833fdea30f167e1c15f9af992377df395b94f1ce029b6ae81cf38d44bede0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/nl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/nl/firefox-116.0b8.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "210d99944bb56d418f47ea7bf8880a4422ce0048ff7275b368ed16b5b9cf92f4";
+      sha256 = "3f1425281ad90d4ea205f2b591c4c9281cdaf97f25078b87b3762f4f3d3bf895";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/nn-NO/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/nn-NO/firefox-116.0b8.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "69c2cf3edb67e1cd22ce8776a2e45b57ec770f08edf0d4007b86b3dd5ab54f8e";
+      sha256 = "f6fa4d4000d0bd21971b3eeda1f314e79f54d4616d055941703443faa02524eb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/oc/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/oc/firefox-116.0b8.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "4cdc3d9833f6d813dffe9f65d5ca1f4deb4290fd5127282b5f74b936186e44c9";
+      sha256 = "ef5d78f0c1fc6d6b47909bd3341d178beb2d5c92bd4f786bf8bc9461c6527660";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/pa-IN/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/pa-IN/firefox-116.0b8.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "4425772fdb76f06696113b254162d1b12eb5daab5ca47ae8da6a427730b7c34a";
+      sha256 = "bb1f162a9ec677014655b92b029a66a049241662068d373258d235d09421f331";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/pl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/pl/firefox-116.0b8.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "60b5f5cd2a332252cb6deb181268783a1620b10b519fc03d09dc872b803a63cb";
+      sha256 = "4c3fbba975477a8634d88ad0f72ddf82112ec0f7a9085689ded315956a20069a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/pt-BR/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/pt-BR/firefox-116.0b8.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "c34aa4b9328ecb50f147d11f36b40068ede5d8cc7f999bfe01e9cd4fe066646b";
+      sha256 = "5685d19e631292df5c480a652d7060bf70dd93ec2a57eb4610aa207644c81e42";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/pt-PT/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/pt-PT/firefox-116.0b8.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "f801f96207e13f32a4c92a8c3d81771593c867dc078a29c6621c680442cf8b1f";
+      sha256 = "80cbc7f396886625bb773739cb5f7156f12080c2f11b85c6cd41722e969594d8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/rm/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/rm/firefox-116.0b8.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "530f69183566b76738863ab1d35cfeea34388089caabb845835946cac6ea765f";
+      sha256 = "e509dd0d8616ee6288081dc5273f7e46eb1042bee74c4be2f48610b434a89349";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ro/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ro/firefox-116.0b8.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "21716632a24ea27d57573bacfac55051dd136decced8fdf5f4d117e86f014f05";
+      sha256 = "9b9b47ab0b81dd7fa64ebd6d80344176bd91632148eca4fb9ca78f529592f1e0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ru/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ru/firefox-116.0b8.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "d7fcaef1c71d07cf42b3e7bfc74f305ef75199451b25f573adba45535c49ee46";
+      sha256 = "4786d4064fb1089daad201cacd2f60d3285087d09b336788ae9df786d4b8df28";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sc/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/sc/firefox-116.0b8.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "6fd1c1647a8ae2586cda50403a564ad37b7fbfc3ced2c62ae2dec1934cab3a12";
+      sha256 = "bf868837d57501d9a55e0f28178bc303a8f4b60f073d73be23ebcc6a2d460e36";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sco/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/sco/firefox-116.0b8.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "ca4263b1d21ff1cce8bc43c503363447dc19724abae91c900e3c2632038b2908";
+      sha256 = "73ca6695ea2b9e30bdebe5bb1ede87d88fb384e3d70326df999d019d503cd1e1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/si/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/si/firefox-116.0b8.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "051200eb96f21c795494b01b94a48d0331cd0c3bc4b9ced8b5e2342e126edae1";
+      sha256 = "65b6973a7d8fbc18aa5f2a443c7eaf476c745522beeae10cc279404eb645f52e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sk/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/sk/firefox-116.0b8.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "615a078479f73d61459d59756e58dacd712245f95510e226d93e26758de43eb4";
+      sha256 = "27407a9b9cead769d1b94aaa5877e26dc258bd8f6858410cd71e1ea94cb9326d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/sl/firefox-116.0b8.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "06249e9b5254da179b924207f81819cd1f4abcc2956bd113e5362e728a531064";
+      sha256 = "60d9823f62954f623657c37f538569d245905fc5a7b9cde2af48cfd0cc8a5e92";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/son/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/son/firefox-116.0b8.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "ecc73e86bfd2e7b7d3344b1f6aacaab6a6d0e11d0bb9df468a5d9c76e5cf388d";
+      sha256 = "bbf0152b2e6ca6946a3ce29d4f620caa962d90061b1b693d52170b8fe2a41d61";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sq/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/sq/firefox-116.0b8.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "be624e20ab9355b499dcb3861fb9edaf50ef5cf8e65c5dea511df18a1b25bacc";
+      sha256 = "c206d9599afd32ab2858a1e111dc278742dba4cc437811064e48986468de8d1e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/sr/firefox-116.0b8.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "9ec8b3ca6e3c8af537ed7e6a0ea08caeb76425a18e0de35a3e1f05250b5358d4";
+      sha256 = "110bbbcde858e6af03e41931f5080596fa67bed346557a7aec97461afa2a79af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/sv-SE/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/sv-SE/firefox-116.0b8.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "3750ff90c0fb47e21c57ea6c84bdabfb1459f741aa1d82cc2a1fc969cd6d0438";
+      sha256 = "5c651f131d35e2e07b44be88f9edd0d2e06d501c322df95361b08429d8dd6d16";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/szl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/szl/firefox-116.0b8.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "ccd80051479f0b57c610b4bb9776f002d1e019a3b2c38188f21c14992caa5193";
+      sha256 = "5f1c6a39c0d884092c59eef03195a29f69f84b42f0fd00340e5eb4dc2ba3f9a6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ta/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ta/firefox-116.0b8.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "e6247aee65cf2dd3708d591f3674b1c33eb6d52261690e5bca10a22b66ced04a";
+      sha256 = "f0e68440fd9358ef64d84655f8c66293409588616815c18c4c717bae8ff03db4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/te/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/te/firefox-116.0b8.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "20b5f9c1f14c82fb200b1be5eecfcc6dbed59459c7aff4c5a9f4ab5e19f9967b";
+      sha256 = "8948e86dfa7020ba51d1d12c33897df1c8bf362c4ade75bfa56a64ea17d10965";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/tg/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/tg/firefox-116.0b8.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "49bc2d4a95506ff6bad793f8afe31c2bddbfc6a732c37779891abc44c6e0d71f";
+      sha256 = "6934e0d86ffb2fb5699cc34c01c20f52cd98dfef29dabf50c93bb105df65f978";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/th/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/th/firefox-116.0b8.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "6910f36379df34ab1f97b8b6ebc25eb9dd9b83cbe857b453a4c71c702aac4481";
+      sha256 = "086a563878785c97d703776b78e0ace037350e341028b17bee338f67e24e101f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/tl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/tl/firefox-116.0b8.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "788b50ab7fb170b49cce6cbf2785204b25b23bd7120eb18c8ec29a15118b739f";
+      sha256 = "3e0a1d51054c9bac5f4a6d88db0c661071d3860aac9f4c515de456cec8c1056b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/tr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/tr/firefox-116.0b8.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c1ff5a3d891bd88a8fa6f89b2f561600ff9221a77c6edd4d2d217f40a1953aaa";
+      sha256 = "6f4df4d9088ba0f89d866279140f9269938fd5976ddd636302cd54f78449bdb7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/trs/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/trs/firefox-116.0b8.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "56f819381a564e4de3ff5968aea21b71312e6381ab29a2739890844310b2cc7c";
+      sha256 = "fcc9b6b9b862aa50b876c599d1e038894ac66f3bc3798c0cd9415be54710bee5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/uk/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/uk/firefox-116.0b8.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "8f6ba4cee9824470abb62f5610b3bdde1f4df6a15209a3ccc56af06f776280ec";
+      sha256 = "c39d1efece7dff0e40ce4f9ce1014dca3443571e5f6376a5ce7e71eaa40fa36b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/ur/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/ur/firefox-116.0b8.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "d2d5bd799a9bd1de740066128a281f8acaa70fcbd8f7d0ad1afe2e6ba451735e";
+      sha256 = "83e7c3fc581e02ec12b54bdc1c0c1cc2844f93d5a0a093f4a35e8f8ec4b91ac9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/uz/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/uz/firefox-116.0b8.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "52acacd060c7ee6dc80164885c74594e4ba066ee981f65110d085ff3aedeb57e";
+      sha256 = "17139a6ce5c19a764627f118b6ba5f146193e0e4aae05b5b4bb99069641fa22e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/vi/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/vi/firefox-116.0b8.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "ee0d42e366670c54473814675a9ddf5feb56c340ac756dbdd873307ab0493b07";
+      sha256 = "f9aaaa8613d78b8d09ecf3c05d7eb21c72c49fbbcedb625fdcde765d025c19b0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/xh/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/xh/firefox-116.0b8.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "f8e050a6c12488301a0a52ef6b617bcfc11353da6d7614b0badf521e91010971";
+      sha256 = "03b9e239beeebbb5c84bd8012aeff07aa84e32c391ac3e56ced253414ff96411";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/zh-CN/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/zh-CN/firefox-116.0b8.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e98dfc8a86537636f608cd47b92002656e9641b93a5010ff91e4612adb9b1f47";
+      sha256 = "bb4037bd5b4c6b2a1696cd00cbc6b95883435ad6aa2077808e487c6a38b8d836";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-x86_64/zh-TW/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-x86_64/zh-TW/firefox-116.0b8.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "8f8a1e1ae1daae93bcd0d0aa33e14eb8475bacfa7332b6430614b5a608aaf546";
+      sha256 = "16ac8b35444e14bf2752330178ee2bb6ad8c2cb88e674729dd4a644505544a54";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ach/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ach/firefox-116.0b8.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "d5ccd23f477053d2fd29536b096947448bda84bc8bd496f6d67ede2645003e38";
+      sha256 = "0c0a2b8e096d5c3346e4d844ae56bb9a625748a18b73a14f2e89ca746572fd8c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/af/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/af/firefox-116.0b8.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "3531a77ac162a13721060f5a1cf42a0412b00d3545be9361658499c875f65b5f";
+      sha256 = "208620628fcead4315540eb7401da1752b261c69c5c2986f68083872b572f82d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/an/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/an/firefox-116.0b8.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "7213b9df3794d3882e5f7264e13525d170f7d3b6f6509e9ee6dd9aee5d3b40d5";
+      sha256 = "9320cf2b42c255ee9e0929df2b160a07d9a30dce7a2d2be32b61b416a1731ef0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ar/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ar/firefox-116.0b8.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "4092fbdf1a2c9984c0636932e3098c6685a50b4ccd47955d4c218b8e22a4ab88";
+      sha256 = "2f229c476a7dedb66ba534b4015e3fd09a0fd593cebc02b28093cb309c052f5d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ast/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ast/firefox-116.0b8.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "c5e12f623e0497ba9058c3346c54756c35ec986d9ad6ba8f318e9150911469a8";
+      sha256 = "ec5f6fec474a49c78cf3120fb2ced0e5c404bfe8a807d81cfa6631d59379dabd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/az/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/az/firefox-116.0b8.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "48afd4136bf550d0fbc54ab00fa60ecbdfcf9a5588d2b69eb178834843a3d199";
+      sha256 = "fd60f7541646db9f29adc0a6f623e4e4737dc1a9e6c17e83ba8daef8ebed9674";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/be/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/be/firefox-116.0b8.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "f68b8e8167a14e414a2c2829e9a8a9471fb53509f02276f12097964982ce6bdf";
+      sha256 = "4d2e18dcec4c535a8f7ad21375c82a0b66dd05213bfc4eac0994970b121c958a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/bg/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/bg/firefox-116.0b8.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "04a8f6a9f3ee83cb449e395248da7e49db5639026c40fa923722b25f6b487102";
+      sha256 = "2409be25134e05b2b269ea806f9e8186ae70ceb0d72e73c224e9550cee22e6fe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/bn/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/bn/firefox-116.0b8.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "a0ca76eb610b85077a84a6b154e0cb789bca6763b9804e750e2dfada7ff294d3";
+      sha256 = "10eac1a0017272080490ecabb37fb59bd400b95cd407215610d45b3bf0c8725b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/br/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/br/firefox-116.0b8.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "35b8bc7b4d533b51ee3c5d36fc72625c981674859d71aa8fa4cc35117bf28fb6";
+      sha256 = "904df7036b7939de1a02874685f7f5ac91a5d3a02c15279077389a7510d26c23";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/bs/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/bs/firefox-116.0b8.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "6100aa7629763300623f6c3880208897e7a12da9bab1bdc616b480ab7ad8f2fa";
+      sha256 = "b035424a7bb15ed57841f3432778c12ab442e3b077efbf87c7b88ac9f94a69a8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ca-valencia/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ca-valencia/firefox-116.0b8.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "d389421bc508d6bdd0f56bb93dc5a5b2643e15597ce7ba6dd230c9b54d693425";
+      sha256 = "745ddf789da919fc6cc66ae4162118f72e78472b1e9e05193393414d194b6079";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ca/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ca/firefox-116.0b8.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "776219a92a9cbb3e58fb54cd1f5513a3a26cdec1935040062718b0b1893bc6f0";
+      sha256 = "ac7b56e2e57accc4921d67b4c3ef755cd2a2e2f48a586512a661eebbde3c12cb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/cak/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/cak/firefox-116.0b8.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "be34c1f421d99257a3d05a82c48552a5f3aceaf54c0db6cc2137fb3972d29be1";
+      sha256 = "f49a693c1f35d4032f6c14c3c386ce4d90f636b0a599cb4b274896eaef577964";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/cs/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/cs/firefox-116.0b8.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "8cc51892774938280fadfb5c98ab848d03310b6b8d0897f80d36b65519df05da";
+      sha256 = "c2894e2615514647767ca7242b43594dbdd44d7ac5464978652ec4a45b809a86";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/cy/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/cy/firefox-116.0b8.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "18b6c599d989abd0f9212d75e406237f417fe7160984ec8c4cbc4845d256e8bb";
+      sha256 = "a57e216a0491065f55ac089fc47cc20221aa0749287eefd525a96f83998438a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/da/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/da/firefox-116.0b8.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "a3ce7852cc6ab16d6946921ebffa36465acbfe6f9f819dc9091e27f1d31884df";
+      sha256 = "d6b7f238daf7d2b3ac4acff0bd3b5f53e9a2e237d6600158b5d8d51ba3bd2a71";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/de/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/de/firefox-116.0b8.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "99cba98a623de06364eb6d000eabfa853fc80b7599fb170763a8f626089b28dd";
+      sha256 = "975d5953eaa87720a176e64fc5a690dc4f56b42c81eaf51f7c1f32a64f0e732c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/dsb/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/dsb/firefox-116.0b8.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "975c25e04aa35ab9724d0550bf98b2e4556f0a5af87ae77664f43d56354bdcbe";
+      sha256 = "bfb44874285f855ffaa4d4f97b381866657ad6abae56fde3250f989ce1f202b6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/el/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/el/firefox-116.0b8.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "ce33673dc2b2f0a65e54b620012b194f1a84a84f01bbb72166c2edb4d3ab12fe";
+      sha256 = "5f5c9b0248cd437de78d8c763f2a9acb98605e290105de37cf731bc9325909d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/en-CA/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/en-CA/firefox-116.0b8.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "d064bb526f0750d32d2708e63c80e002ca6156f7fc20fee12692bdce16b0ef2d";
+      sha256 = "71f3d43ba68c1d6f9b427ab4fbcd90d0ee21184098f09b766294cda8ca61f3d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/en-GB/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/en-GB/firefox-116.0b8.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "be2c784aa7e8a48d8955f51cbddcca82e063454a75671c5896d7a80005c7e1b0";
+      sha256 = "d2a83c9a66545c4b6ee498e7e422e233514df2d81b17b1cac475f29f03ddbfc0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/en-US/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/en-US/firefox-116.0b8.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "ac8df5f2f46588f4daa2e4ffe9dff1ce9ca75283d6db6cae77b5d77a5e5640a2";
+      sha256 = "a4c1f1dea0e85753e629edd03484290bca83a413cb006980f698b64ddfa5727a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/eo/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/eo/firefox-116.0b8.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "51a3b48855144ef476c4011e978fd01aed48ec84844dc673e46b76eeceb5366f";
+      sha256 = "e0eead919d90adc222cb46cf4743e8cd6d821a50e003b6a35c42219416952c2e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/es-AR/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/es-AR/firefox-116.0b8.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "45febca3ece693d03ed1ce694d3741f10173593692aef6a54c2a9723a1b93e37";
+      sha256 = "a71304bdb3c744ba2891712e4aec611e1dafc2ca1a2dd5fd0d40f892c9d61be9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/es-CL/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/es-CL/firefox-116.0b8.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "441b1292248d7b8c5819dca9639dc0701cf6f456fa7dde0c5d74c677cb074bb0";
+      sha256 = "338f097d49bc1078cfe8b138f2f5a58800568db250ef713b1ca122f6a9095651";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/es-ES/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/es-ES/firefox-116.0b8.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "6007fae26404f2562d7bbb14f3e0dcc734a763ca444c2709ce8d2bfd5276447a";
+      sha256 = "2031708cab1df3856f77918a9b5c9cb040487baf9dc429c0de66a22820e8fefb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/es-MX/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/es-MX/firefox-116.0b8.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "aa5122e8685fababaf97cc3937261e0aef65b52c7a43a9d843d6cb0a264e753e";
+      sha256 = "6c71dbf5beaa5d7cb1b1c8fc36cfb607dea9ac2d9ff7240d68b0d420ec536695";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/et/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/et/firefox-116.0b8.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "b8142f93a80ccb685063c41ce5fb18607cc270f25be21784d8c2e4a0045a5aff";
+      sha256 = "270e9caa64540565bb2c6764232a00aef93adedadec309ec6326773fba971bf0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/eu/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/eu/firefox-116.0b8.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "1b4af468d79b052992d4c9500b13e43fbbbcebf73df3f669d771d452d9b39dd6";
+      sha256 = "f64c17f7058330db36389bf11ae2b1bb6ef3fa26010585bb0be4585d205c95d1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fa/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/fa/firefox-116.0b8.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "b9c1a7c410e1f7262408ae273ae671b0ef95b3711151c76a6206a5f3def16faf";
+      sha256 = "70a47b22b30f1ea92eff40ec007afa23463258bbc56adc674a3eec1fe9ac126c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ff/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ff/firefox-116.0b8.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "944612ff8fed847a8548548faa58fecb2e6c39f7343a853e93a7a4bf18c1f2e2";
+      sha256 = "46090237cc4d2a0dc9c13f8afe5be945cdd70978e2a9baea54fcc1ef7159a44a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fi/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/fi/firefox-116.0b8.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "c88ce10e9646456a0160f175189aa0cb5b06a88a1bf14445f74e330bd48b08d1";
+      sha256 = "723f62db55c2f355440435acfb9bc03ab2a631ee7ecc79f181f2c23f3dd235b6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/fr/firefox-116.0b8.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "45c559bf2f31ec5f1cd6cc8df0bbc87a882aaf751dae5723d0fee9282d93c3f6";
+      sha256 = "78ef7ed01f092f01aa71c1ed66e42ed6a027c40b2a907da6bbec67cffd661694";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fur/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/fur/firefox-116.0b8.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "b675ea2673823fc6b27de90aa731d68d7e9046b246e448aecd776b09c5da988d";
+      sha256 = "72095007c78f5946fbfc49fe69e012ca333b08bf3d03ba7f21cf5b20189af74f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/fy-NL/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/fy-NL/firefox-116.0b8.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "07504da6c327f42384be1ed87176d781e0e9c6414801712ec534555e543b31f8";
+      sha256 = "03fcb4c6a97af1b345c2ec9d37c4791249a85ac8a3bd465b983f17993510dafb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ga-IE/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ga-IE/firefox-116.0b8.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "404e47c18ad46935c6bc3a528bb99fedd27374247b2bf0b5304128b8dbfa6e1a";
+      sha256 = "245d301cc3a9679e2235e828e0d0a2b80dd5f9754d31e45c07f60e7fc4c65237";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/gd/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/gd/firefox-116.0b8.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "93cc4c9a9ec99c6f738a8acf6eeae71226fbdcdae136387d0c28648c372e6279";
+      sha256 = "1071ae5fd0bee778b35b57a3b47ea4152e711425df97a50d8bc9b93669678a56";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/gl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/gl/firefox-116.0b8.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "9fcbbea723d39fb34fce0435121818982add249e456b2ed1f6a1b1652ff342c9";
+      sha256 = "84c2bf8e48abf3030e435345f0bdc34c476e0871607dc091154e8c78b321ad37";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/gn/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/gn/firefox-116.0b8.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "f962fe0de779a95ce14d828a82ed336573781f83adde61db10abc4a686b6a2dc";
+      sha256 = "859f837ab629a4e5ea41c5f772ca23e0fd3edca4dace810d731c250def86ad77";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/gu-IN/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/gu-IN/firefox-116.0b8.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "6373fff69de803cc5a077ea45eff6ad2ca37caec1b8a9523a7f91d1924377ec9";
+      sha256 = "c24fe537aa1ad67ffe44730e5c2d2ea5522442eab6a8f46b2d24f2e595ff1e53";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/he/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/he/firefox-116.0b8.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "9f952724b440cf83cff675ec888910a6bff20233860b258001962cf6ff12e56d";
+      sha256 = "14fb45d66d8b8bbfd3c3a0bce1d26b6a73ec32509b1e5e8f9fb7428793ce1c9a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hi-IN/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/hi-IN/firefox-116.0b8.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "7dba0c18877f3b74622e8812f01b3a562c0d0956f0d1f1e64cce3b4b044cd41b";
+      sha256 = "60d01a268600b024457aac492610c1836d475f1d6d6079b9c12aff0dfec99ddd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/hr/firefox-116.0b8.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "e69297da941dcdea8ac900b170e0d59ccd432112f52608915cdd6695c70cabc1";
+      sha256 = "70b590a513026738081a6913d33f13206067676d50d5e10b7bfe1b83866a4289";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hsb/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/hsb/firefox-116.0b8.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "e03ab81a6615f71cf31b20e2aa3fdb4ead8a0d7f7b9e61616f8e72d2d8709dd8";
+      sha256 = "62ff26461256e02eb5e60b299f4d75f863aedcce15782abb7f57c5c561ebe661";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hu/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/hu/firefox-116.0b8.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "ae3937ac22ab3db1de9a2f7117acaf3eae5bfc0dab8833e3bf4ef438fe2f8807";
+      sha256 = "09ebcfb57226b8311f32cfe1bf59c00524d181490df7ca6426a90bcf4e45f9ac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/hy-AM/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/hy-AM/firefox-116.0b8.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "08928a362b5b7e29e11b676a17667d3fdc385551cdb84db11fc2d7b8bad79524";
+      sha256 = "5bd13c51e8aad1e4b80f63880f01d99ae661fc96522a38d04af881056e6926cd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ia/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ia/firefox-116.0b8.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "b48f4a080bbbe202ee75c3c0ec50de81b410a2545f37b40a458a41ad29dea131";
+      sha256 = "f8d503dcec629ef03f408f7defa55a1846b16f4e6fc188672f692dcf941d4fec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/id/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/id/firefox-116.0b8.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "861770952348540b1417051571d1efd2cc4c63441d088e772bf1b3ab3cced327";
+      sha256 = "8621fe31d67fa9d2c7cdfd5fae5a462217be43902a539ace0f020616d22c1f0c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/is/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/is/firefox-116.0b8.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "fe4e2cbf086372d9b98c25dbf8ec7a0797d2caeefe218363b35227c5b1e3616a";
+      sha256 = "600d1b16fd901ed73d07bc197502b518dee8b42855752f1e30e958e7677a8eaf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/it/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/it/firefox-116.0b8.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "c36758e897406dd7d9fabc6c4c0793d5f24ecc007dd542420106040de9a81c19";
+      sha256 = "3983a826a923c88817caa2f23c1aa260d6d9c9321b1fffcec4081a4cdfaa02fb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ja/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ja/firefox-116.0b8.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "09410a026f5c902ffb41c2b4138ad3fd975fe9a49e79174b8ccc6971d02f2570";
+      sha256 = "2c33019f2b7bf9aa812974a12b2d2aad9f1ff3a7ebd41574614ae72a7e4e5edb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ka/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ka/firefox-116.0b8.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "1c34ab1ab3d784cb07ad7031654b574df610c03b7ff03bf401b9fec9db259685";
+      sha256 = "2498d47452a0be1ad8658de7c89315634d57f84795cf8ae49fec2961879c4486";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/kab/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/kab/firefox-116.0b8.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "1fb851a99d4acabacbe0c6bb6cc88d712e01620e94815c9407473351d4a81826";
+      sha256 = "497c4f010dea7301ac386d4474af64dc410eafdd48e9ddae72e04373688a0e34";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/kk/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/kk/firefox-116.0b8.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "67ac4003b2bb6ee5badb3c5da99b73074432be939a7cd419bd5efd6abbf3b8fb";
+      sha256 = "4e352fbfe5f3e2b3d4b96528c3a3a67b728aaeecbc306bbdc43dd327f816a8b4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/km/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/km/firefox-116.0b8.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "120d5643b12df4376dcf3d25d3f560a629c42e0b68c5294b90710b30663e9c14";
+      sha256 = "c681b7034891677b683de340660769ea9df4cf6be7a32997cb49fcbb8d0b71b5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/kn/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/kn/firefox-116.0b8.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "c82cfc77e70b9a1305b6937c4e6ac8486e3326a10c0538a51d2c3db7998e5687";
+      sha256 = "c98951bfa3dccad95ddbc2001e17667e83562ab3cddb8bb201c90f78a67aaa68";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ko/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ko/firefox-116.0b8.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "1e4e2c50c392b85e09cbfed6231cb75d4b5cc4f88118975b6bc7c1937f904ef3";
+      sha256 = "fa1e52a38fbcd1a42cd56a4d0804931eae22bf636d8a7c8165d4ce4e07752864";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/lij/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/lij/firefox-116.0b8.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "cd702b70546704302005ce139f4d8cfcee0f63a707890314d24a6cef411393f0";
+      sha256 = "f06cbc26a678651e57f282e29d751cc692f13907cd3eb6afa6af386b842623fb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/lt/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/lt/firefox-116.0b8.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "0b739761d743e9ca0af510e7c9be3061810e2c88321245c15fb7c7de1800a185";
+      sha256 = "2b4b529d7b647f8ed0f0eeadad48cdaa534f8954e1db21e5ea7424e5839f778c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/lv/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/lv/firefox-116.0b8.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "79c5f4f8a490a87048851420c03fe63976bbb4bea655d9d9f6865c32d6a06608";
+      sha256 = "8e6b3624977b4423a5f05140f93ad347139e2e578254d5f33fa3338d9b093a4d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/mk/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/mk/firefox-116.0b8.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "46a00b6c16ebafe6c7f5f3bc3da6fa4dd12380d15c923ae409ed7c0e4dcc5906";
+      sha256 = "65b8695c6c58e78a90cd483e9fb8fdfd37eff00ce0a7545ec62882ecd72dd796";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/mr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/mr/firefox-116.0b8.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "303f6c94c47a43e7510d1d1f0d0f6ccf8d745991827949dc60150975f598678b";
+      sha256 = "9d88bc9eaee0bad5a0c61e6b7d4026ebf54b6f22a7733f56bfe40ea68daf42f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ms/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ms/firefox-116.0b8.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "ab6895c7a6afb7713b5d2fedd12cfe1b58a8b026fbadf6652f4aa6d39dd0edea";
+      sha256 = "e79dea6300e672987a513fdcba7bda05b75ef6e9c0fb38c2df7114a15183e562";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/my/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/my/firefox-116.0b8.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "e867458bd09b47fb130263951acfa0e1060aeafea63e3bf992a94359db2b41c6";
+      sha256 = "055ba28ac73a851fdadcdc8aae1ce79d871584f691f76074f24645fedef10d33";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/nb-NO/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/nb-NO/firefox-116.0b8.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "726830a51febadb78a9fffc1ea9b6a09e92c7341a5eca9f32b78f9beaa7b5821";
+      sha256 = "a82e73acae0ffb58159aadac297c128e2cc9e5d4dea2413b292b29b09e23a9e5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ne-NP/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ne-NP/firefox-116.0b8.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "d316311340d53f4061e7d721bde9156d1998ab80b7d4c3705eed084cc96bcae0";
+      sha256 = "93ccfc001ba7d32d66b3cf45f5865d6c0aab12396e266dced7c1d8a868f360ae";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/nl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/nl/firefox-116.0b8.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "fc4ae1f08cec773c2a46cebd18ce88aa6c21471123f79269e27340c7ebeed285";
+      sha256 = "2402ca771d46ea4fe7cf96682ed600ddcfa78be25e858db3785dfc27b1d9f942";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/nn-NO/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/nn-NO/firefox-116.0b8.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "77a9d8683b1918a1f63e486bf3557999f9272130ffb050379ce91c1e1815d91d";
+      sha256 = "bf1e895912690886a67ecbaab1a729efc2ca5becbc2c490d465d96c8d77ef917";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/oc/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/oc/firefox-116.0b8.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "38a09ac3a8004c8720c16e6d9f466e0d590921cd03690e89392f7054dc4e6d44";
+      sha256 = "68aa0f76dacd1d85b0adcbe374eeeeb8f7c190f8b2308b38f41e72740dab3e5e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/pa-IN/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/pa-IN/firefox-116.0b8.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "74ce7b2855153e594a10513db2823dd917af41c0706dbddc67dc76d37a8aff78";
+      sha256 = "6b6b8a5e2935750269b4169d21bae8f516dfb65a6a8e70cfb4663834f8bc0c18";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/pl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/pl/firefox-116.0b8.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "8115cc8993082713d0ffcfc154ac7e893c9bebe51a727959ba949cabc7414862";
+      sha256 = "1870dc61eb189a37b63ab20f3aa87030c4fb09c5d1bc4d0527655b901309ee75";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/pt-BR/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/pt-BR/firefox-116.0b8.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "4a5928c7397c52bbf1f77e445aa9481aae76d18183252d00d38c69539c1a4421";
+      sha256 = "28fdd9a5f7dcca3187945b65e7c8816e946b255cae1c5b9c9b8ec6a92a5ff6bd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/pt-PT/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/pt-PT/firefox-116.0b8.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "07bcf3d965b96937895f9377334aa604b1d54ba10ce1a84f1477cea335912e85";
+      sha256 = "b0c033e92dd6abb7f9f2af530acf8f274c08ad54e62ea08a4b320846fc1ea64a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/rm/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/rm/firefox-116.0b8.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "142ef46293b65eb916fdbcebacf53127350b7549e0073c82be83f8ae8ca7e2d1";
+      sha256 = "a7c855777d12581a01544f513ec3baabea5d3f57c33dec7b8ada1b1bb9945710";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ro/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ro/firefox-116.0b8.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "237dc722c2217a528fb20e520a79192b1eff085babf954a3ddb98ce152fdfcf2";
+      sha256 = "a47b7b3272d5775c15340036a133fdf44534d34feb98ab840ce0a9992937132f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ru/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ru/firefox-116.0b8.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "b7e954893adfa5a1099d55d3e6666908a9daf40b87056b8b0d9356b05209cdae";
+      sha256 = "b3379b9f78375145387b6a984a7b085ff6d405b571031db5c4b7d7ceb6224dc4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sc/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/sc/firefox-116.0b8.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "76fbba366247140ed84223a8bce8b156a17468dfde8d1b5fd54bff3fb1408dc1";
+      sha256 = "b311db8c8c7f03f42d97c875f5f46b513e460807d107795988ba1cef3473c98d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sco/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/sco/firefox-116.0b8.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "d6fc67cd55209e22875aeb225bf82935d111cca77e00f41c4ba97dcbed156458";
+      sha256 = "fbb7a1b3ed8c44f3d9d40390a814b4f80839a625117d416536ace5eeaa7ed3c8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/si/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/si/firefox-116.0b8.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "3675f892cc5f0bfa98c8075df297651a4ba0d2f5c099208efa01b33f60fcc1c2";
+      sha256 = "19392df60f5c2a23f09fdfa532d10ee3b55e2238cefd3dc3ed5b1f5af74d94ce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sk/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/sk/firefox-116.0b8.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "f217606f8f8ccfabdaa1a4c5a23af8fdd3eacf1502e4da6e28f8504a74a7e9da";
+      sha256 = "c166e58e5670367abebf7db0a3285e597427bcc5bc7cf4e2c9b860e70077129c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/sl/firefox-116.0b8.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "c5a089bb04ba83c899b0fab4a81335474a1a0a24c75afcc5bef2864ae7af2c1c";
+      sha256 = "4fbdf094bc6c84f9aba17e25351523a624fcf6f8f630476492fc8e362c7eb1db";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/son/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/son/firefox-116.0b8.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "c73c98ef68e886e3f4ac01f7aa42992c6f9b75a18403c82c0bc54aa9d1630524";
+      sha256 = "fcf9203e3c4dbb78f0d455bf3c4fbfd71a68f5c8714470c1a4da9ab9d19936f8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sq/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/sq/firefox-116.0b8.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "b7c7bcb08a3b81d266aedefb7de9566b2d11781c66dacf94e52c9c60474a2e13";
+      sha256 = "9bd3014b3c7ac774819fa3ffb58f0b78e001548eabb1f4c485d066fc6e06d450";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/sr/firefox-116.0b8.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "5c8a3db26ba7acd76dba7f9a4affa2fb932e76cd40becd9052444efd5f1eb7cf";
+      sha256 = "ef6c2c18e2210713358e26f5125e5bf40b8040dd676fda6f98c4f92e920f6d04";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/sv-SE/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/sv-SE/firefox-116.0b8.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "9796c48e19a4860bceb7cb3199ca0d3605522185cf6b5be1e8d5ed036bc523fd";
+      sha256 = "3bcd3249dbc5eef8fa097478018c4aa6a2d424c079b0e508c26e98252eb354c8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/szl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/szl/firefox-116.0b8.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "3d5b4cc385399b4b543f66c707c3d5fb2b6920f7d7344fdbb4aa5f34e5666c9a";
+      sha256 = "454ee6d52f72d3854f55e365c9437a4de04b159ae0abf9853f3fb7b6851f98b9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ta/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ta/firefox-116.0b8.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "34033dd438cff4740a366d91eadd0e34c2fe3e24fdd41b5dfeb10a2d425e7388";
+      sha256 = "9ecf7fd052f43a535edd7c4f7ae18bfccf5c9ed48e9f6d1c3780fb6720fc8f9d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/te/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/te/firefox-116.0b8.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "d10fbb522c1032f4dbd9e46e597efdb6f8eab3d885b09ca355efbad415bbb7ba";
+      sha256 = "c636b93e111a5f620393c04aabb409d9d11ab1e0c0054ff67b523b0547208a57";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/tg/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/tg/firefox-116.0b8.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "d793064e3de193e7ac8d2046be611211200d5079d20ddac293fd54dc040653db";
+      sha256 = "ab8668e2814e069b5138ba9611b6bb6800beec133e73e244be03f30736a4ebf6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/th/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/th/firefox-116.0b8.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "d466b47233a8d3fc3d55aa2fcd08086811306f813a8118fb6235d1733a2d274e";
+      sha256 = "e35ce21da96d7b761287d5bd0de0094e9a30987257d0664c90a85d2a69a6881b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/tl/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/tl/firefox-116.0b8.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "d395cb79206236f8af0f17cfb76c332df6e49271b102de3fcdfbe6072c81b400";
+      sha256 = "42fd3cf31008e8ce33084fe8fae854ee55383464881365c7fd7481a19d0da704";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/tr/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/tr/firefox-116.0b8.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "ca3e8d335945d265b6fe1d86af58e0dbd4f6c046d5b308c32e13b398fdd1b54b";
+      sha256 = "abdd8ef33253d4d13b479ea7ced5546c2421d1b48eb6c15004126e8091888f00";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/trs/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/trs/firefox-116.0b8.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "eafacd352f3cc054499f87c6765a5b41c40229743849d689f69c14fe1975ed03";
+      sha256 = "1b196f8c2e995b7d28a1b017d07d56d54c4002c296e5f802fcaf9c3aed1ec27a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/uk/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/uk/firefox-116.0b8.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "c4d09799da087987c5de2aa5db90b9f7866fc345fe98820da77581aea1d45e38";
+      sha256 = "3db05ef363c728b40ba970d007d5e50071f6213719ee71dbee6a08eb4173bbf1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/ur/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/ur/firefox-116.0b8.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "75856c9b34b3117e10a403b6c1859e3c1d8faa6cad8cae345b22a4b31bd119a3";
+      sha256 = "73cde52a8f833f747c4306efa6ed8960e03740d58b30118f0340ff64e223b922";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/uz/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/uz/firefox-116.0b8.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "26974ca448092c64b131d040ca6f88848695c25703610490c1d55b68d2be5546";
+      sha256 = "ab094700a3b5f36c36d6611b4e1b4e4b8c08edc0f5ba9935c4c28683fdcc509e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/vi/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/vi/firefox-116.0b8.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "1bd77f418464127d9712ff09c9e9225d501615b83bc0bf9917e7bed4f4a52c73";
+      sha256 = "ad1870c4b6f0b2775df9f692e094aa87aeaf26dab88dcbe13c2fc0bfa6f3792d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/xh/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/xh/firefox-116.0b8.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "75575150eb9810d2201832f4af3319645cfff875dc37000e4939a42c3d697832";
+      sha256 = "028c805aa8c0deebd0aadc0f026275e7c1c51871e36614052752ed5a7d0aacff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/zh-CN/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/zh-CN/firefox-116.0b8.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "ed111f3ebabaa3468ece986491afc5d2bcb40dbe63b5914e63842db5b62d4d64";
+      sha256 = "93b51c5705157a300263d1c5bdd83f395468d53efd4c47d4de543c8c02ea7e8d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b5/linux-i686/zh-TW/firefox-116.0b5.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/116.0b8/linux-i686/zh-TW/firefox-116.0b8.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "cc93da69a1dbf2de7bd0a300209cffed7202b6602d90b535610029e6ace510a6";
+      sha256 = "d6f68330f6860cff493276c8282c0fe662c56b43720791fb1f216b959caf903a";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,1015 +1,1015 @@
 {
-  version = "115.0b7";
+  version = "115.0b9";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ach/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ach/firefox-115.0b9.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "122514763d09bf7579ae4ba6acdb81deb24304c8a1dbbac57cb57f65583ebbc7";
+      sha256 = "3261783b345a17fdf1c009e232f505accf9602f5b99926c9165966f658c10660";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/af/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/af/firefox-115.0b9.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "904b6d2fcafd4bf9964ee9f7821d3a0cddb58d54a0ba551c1ebf29e698b3d6a8";
+      sha256 = "a5ed1f6021a0429105958f06370cd769a410fef428647c2f0b70b0d211b700ea";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/an/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/an/firefox-115.0b9.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "c0bee1f77504cb5146e20ac8f1be69eb1f411137a824bd361dd2f13b01a5872a";
+      sha256 = "5ff1bf05623c7f56e4b6ab9d6f42c8083f16c0a318e3d69603846a6755e5a6c1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ar/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ar/firefox-115.0b9.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "b89cc1ff73a2bb666d388bf94d57b31631f3668aee0b563d47df314c5de37916";
+      sha256 = "3cfae66a420b4aef85b686ec70899399d73e3a249667b1d59dbde60a5c76a7e1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ast/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ast/firefox-115.0b9.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "5dc80a963225af8fecc52f3b54d5d8bd66c47c6d275cc4538e7cc740ab63ae6b";
+      sha256 = "fb68e1f04a6ad253bea73de6a67ddc0f6bef9c33b601834e5e962bc26e382120";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/az/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/az/firefox-115.0b9.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "c98d4ad6b5ccafd9443d3e83adc914e42958c0055461627eb5bc5d24c3157297";
+      sha256 = "841f885ca7d9ae6341006d6f555ee28277ad43b62c7412578ca28c0d8fd72a3c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/be/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/be/firefox-115.0b9.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "818a63af8e5c956c11d7d752b39a51d2f44f8f7b80b99a5ac5ab6b1734c00e68";
+      sha256 = "a46ea40c5797c4d20aa5a50ef0a518cea2aa94b649928cd348f8bd162dc7cf6e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/bg/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/bg/firefox-115.0b9.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "9cc2ac8238c8be89bcd58bb1e7318990f25b3f67f0145bfce4ec8f871173e9ba";
+      sha256 = "ecbaf41f86ae3876399a48e25096ddccb84898bf48f960614b532a7585fe816d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/bn/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/bn/firefox-115.0b9.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "cbccfe6021ba4a5a9d86078b84a775cda721cf06266f430bff6134c94418534f";
+      sha256 = "c4ff91b49b3bd419376d5aafcf7ab8b9561c6b5a65e9c039d913a7f07a13fc13";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/br/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/br/firefox-115.0b9.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "2b1d595fbcb04a0f2ff0315b0d9c32513d308c2d39bc693d5ce052d22e9748c9";
+      sha256 = "fb3698d73576880729816a9ab786db2ce88de0cea13de31abadeedf0a7a303e3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/bs/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/bs/firefox-115.0b9.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "8e685061063661d8d9f923de7637eeab76a5e4f3fde92c2c87897df66475d2f3";
+      sha256 = "77d55350ee16af38a6351ab9eded24a58fc4d8af7ad05def70790ae331a869f1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ca-valencia/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ca-valencia/firefox-115.0b9.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "41ffc401beaf6b690c4b8407382dbef4150d7959f927185fd1d66ef12342345b";
+      sha256 = "6fe09c62fd6dc516ddd973ac3ec465f27b32da7052f683c612acc6983c44e12a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ca/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ca/firefox-115.0b9.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "469deb711f4f3d3f31c30e63bfa2e4e0792a9c69ab06edb887cf461528de6d00";
+      sha256 = "bf8b9384f059a6f1787e8e866c06b5abbaf54e21884f0d7eaba19594990b40b0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/cak/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/cak/firefox-115.0b9.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "190b997583df2b0941abca64cc9ef248829b114aaf7324a7865ab7e87e145870";
+      sha256 = "8fe435548760c72c5ec18481362a4afc2b7612a051764678a7e91856ba44d1f9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/cs/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/cs/firefox-115.0b9.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "b440439cf0ba533332b84306c0a65d9a0b544ed0cdb72254513ebed39a2d89be";
+      sha256 = "f08ff7c335ac64f9659457b230d40df0b0cfe5846649cd312a7f7d97e904bf2e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/cy/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/cy/firefox-115.0b9.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "29921d84845813b5b0b492569f461ddead2154ee53c16fcbf7d8945992186ea0";
+      sha256 = "ee243dc918d8e871c4b8f4724dd0dd967d3a7bc687fa3e43ca2612c28d7716ef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/da/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/da/firefox-115.0b9.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "808d3a0e00160415934c282a61cf31a261d2e00607cec1ff2e30f3f1099ce869";
+      sha256 = "bc198336b743bae036d0cb497669b1c4c2050b6d18759cc2a1b9dbd49415a096";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/de/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/de/firefox-115.0b9.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "17dac31b776bdfa6628df42db716c577a7d0b13f97f6f5df79a88d9985d92fd2";
+      sha256 = "3209f6815500cb55ec563bab6623b253799c23b6b8ee1866e45a58b9ff3ca15c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/dsb/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/dsb/firefox-115.0b9.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "065aae1bf40bf141a7bfb3c0424418874b61f6374f138f3b3fd80039984a33d5";
+      sha256 = "7587640a7f87461e02f86951edc01d3ed9e30cffc5650582248ae0fd203c35ea";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/el/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/el/firefox-115.0b9.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "dd0e120d769ae13ed8dc977426376dc9e7e6c61e308d2649de0547357511ed94";
+      sha256 = "e8600328f45b2eeeacb23598b04365bb0167a5ca8436ae3704849d40d2989c12";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/en-CA/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/en-CA/firefox-115.0b9.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "8a74bb56574c143e6c98c2e64e9d414963cabe09fdb17af04bf1c4d35cd6606b";
+      sha256 = "6b88cb7ac6bec45da66eb4eed6ee25d3d2cc1d0b6b575648a48c056ebba877d8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/en-GB/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/en-GB/firefox-115.0b9.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "69de0e17e5959683eaae357884d467c16203ca0cb84b03a76080feb7f86e0020";
+      sha256 = "4d9716f7d8442e51f5abedda746fd8b4b49dd0ba7282469911322a5ece60ade9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/en-US/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/en-US/firefox-115.0b9.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "e402244a4ae93ee272e3d39d15d891ab17d6e77101506201aa664335c110b685";
+      sha256 = "bd4d35be16a99e1d27e3a7798c833d33d68eab75c05f0254ec9b578dab46ee2a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/eo/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/eo/firefox-115.0b9.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "85b2b3d035084dbb04dea0c9397ad42d1fa8d2c7516ddba2ef9e4ce9f5bf4cc3";
+      sha256 = "06d2f67f746effebe5057e7cca882825fd3704093f1da74e498e2086513f6b80";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/es-AR/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/es-AR/firefox-115.0b9.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "ece4ab12d660a629dba5149f3b34afca81047178a9ded433f1cf50ddfeb17132";
+      sha256 = "2ee76dddd83129e0134ebcc26173690c2d07f8a41209ed59b1eee7ed84c326e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/es-CL/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/es-CL/firefox-115.0b9.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f70665d28a7bfa257830c6e54317cd617ae2088a9610ea5838303e7e433cbc05";
+      sha256 = "0762e5068bfda380d21d503be376de9450892fc8d97921305ee859b2fafe3c10";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/es-ES/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/es-ES/firefox-115.0b9.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "a268ebe720b8f8a1ac375b035dfb3372dc6f2bb5e040583fcfba77748f61b5c6";
+      sha256 = "546dd436b0a79c0aa5d2302726df9b39530d3e1598929a023083f64bcda5ad02";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/es-MX/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/es-MX/firefox-115.0b9.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "d510da5318fadc8731ac469a00c0991aa21281bd8b024f139f3a19c711b81509";
+      sha256 = "89a4c2060e67052bc593dd5c60e5d66c58a905d9e815549613180201c06528c7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/et/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/et/firefox-115.0b9.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "127f2fffd7397cd08f248d1b33ad3255d1c637cb1508bef94383efc1c4b91566";
+      sha256 = "daff14a8dc34d4afaf755c7594602832e563449979aa28ccf23657910e0cb30a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/eu/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/eu/firefox-115.0b9.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "2ed7466c942a91aa975d9133d2153c13ddd32facaf030b6c5ba5da46c1df1290";
+      sha256 = "4fea1330e1e478e9c9ce7b413783ad5765e6e2bff9315ad4478d6fcefc0b942e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fa/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fa/firefox-115.0b9.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "b3f69b8bd137f76e0a6e81673791ab6f702f55fc677b145c4bdaa1cbdb76b7b2";
+      sha256 = "d03038fe91c470e996240d02777e1b38f1437eb011975bba2d5996f61c3980d6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ff/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ff/firefox-115.0b9.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "de2aea7b91ff3c6901b988df82a232dc3758b0991762474f19d148a416f3593a";
+      sha256 = "748129d502dd7488143ce801f5aeac1e71bd36af42fb73a6bb9a617fe0d08b43";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fi/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fi/firefox-115.0b9.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "cf7921ea0984f20dabbf05e06c0b8fc48ddaab8f26f2bc075f10ce01748bcea6";
+      sha256 = "6ef0793728d28d5a36d60391b62f0712d0c606b6dede4b5d9004d9a6d6fa29a3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fr/firefox-115.0b9.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "fe4c4b5bcc6966a11f31312f8f7fba69428afd7b176a738c4dba9b8928cd2609";
+      sha256 = "c24aae6472eb6636ab9ebb5967ff9c8fa16f28a53e72d8dfdb8335de8c1b49b6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fur/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fur/firefox-115.0b9.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "527d85a087e83f9d41297c0dfc3416764a3171e6206338b4ef02005ec0832197";
+      sha256 = "ff3cb1ab8085d085c95b0759dae1665c395340ac055060b0dc51b46206c69a3c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fy-NL/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/fy-NL/firefox-115.0b9.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "f1ae19d25063c41eb657148cefeb03e1747d8402537feb65328b1c23b4ce01e0";
+      sha256 = "429a023342f6502d6d9e9df68a84208d77381e8e8cd7bc5edc9f78b9f6acbe38";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ga-IE/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ga-IE/firefox-115.0b9.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "09799ddd69e9a2bff1b48a0aac9cff07b456980b2dd2cc8a51fedf3a614762c5";
+      sha256 = "2ef0cba881e1f67a60ca8faa54d8b9743dcec988d107a1cb3f9e49c346dfb2e4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/gd/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/gd/firefox-115.0b9.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "d0d6322d0d36c1575da178d24473ab58bdaef487abd93fb632890c5c8f690898";
+      sha256 = "c66225d3f91755f7e47d33d16a4452e31f8f421fc8fbc27aec1d48aef80732b4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/gl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/gl/firefox-115.0b9.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "d2cf62ddb2e9869daaec8fca514a9f3e8a2d612f5ace1a666f185937a9e51ad8";
+      sha256 = "0614fe4ea1ff3497937cb3b0cc0dc70bbb44a60c6b0cf1cb6ba010883c2a6bd5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/gn/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/gn/firefox-115.0b9.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "35015ccaa1b57e4ab115104854fd9e48a2028f0f5cba6d149c6b055d336aba24";
+      sha256 = "2932db546f27e6baa685b2ce07dfa5354ed79d9294e4da98411feda650907eee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/gu-IN/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/gu-IN/firefox-115.0b9.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "3f52af5b750787b6481c6aea6dac60d5400d1cdd4f8568d67a7199cda4c08998";
+      sha256 = "91ea1884c84ee2facfb93906fec602b744f33251462ca66e182766ec0dfbd4e5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/he/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/he/firefox-115.0b9.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "ef047afbacd6813fd90d4f2e2fb6a95a0044b98a68d768194f78f890da773c1c";
+      sha256 = "b33baafbd6c1e5872cff7b25da6656f907890ba701b112bee71d6ec33664f344";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hi-IN/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hi-IN/firefox-115.0b9.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "300d14c88bfba6844c465a74f9e01c0f1abbfe0e9d3a4ba3e7d54c4db361e63c";
+      sha256 = "ce6d162d80fe56790a123659540132d208cbbb1dda98e0af9112c1a12b74448a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hr/firefox-115.0b9.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "ded7ce7143b232f8f73152ab2b6a7322ba668045d6ea8765331ddd77c04318ea";
+      sha256 = "45cebe7715ffb22bec28d861c064b726658478f5b3ecdb8581e46666b33e6d0f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hsb/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hsb/firefox-115.0b9.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "7ae5b81c5f3b434ec4335d8ad8b7f87aadbc6684fd8ac80cbb23ea940d34afaf";
+      sha256 = "cf7e0e79171581d162d78d9ce1666281e99690ae18eacc8c8b8b14b53366bb65";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hu/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hu/firefox-115.0b9.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4e2055f60081dc47f441c5dbde77a05625de8052e583d38f21f431b8d8338570";
+      sha256 = "cb02162c8aeb7c9dcbb4f07ab2ce7ff5243eac1fb7e925725d330534bbda1d49";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hy-AM/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/hy-AM/firefox-115.0b9.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "af041f39f9c6e9f01f57f68521d4487c3bc7866834f7087cb68b8b7e77bf5308";
+      sha256 = "57c970229bfad215f41110197ca38d19d7663ad58031b793c1e07211f9a6915e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ia/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ia/firefox-115.0b9.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "6f106b9e05b13365d2b706c549e1e2c06cdcec6d169ca2af36a677fcd94d3e18";
+      sha256 = "a4aae8cd7e9f957dc492b4d3a8abf9297b16c8af18dd72c14d199be382952670";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/id/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/id/firefox-115.0b9.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "7351554145c01f6eb58e386afdda62d62143c0beb4c06068fdccd8de561ad188";
+      sha256 = "ee71cf8b893709781d3202123496b40467be8e647e998041c1835a5f0c7bae1c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/is/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/is/firefox-115.0b9.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "1fdf7e0c5ce813d24f39b477a09d5516d3b04f735258e019fb48a642fc3995a9";
+      sha256 = "7b0ef6b4c632be9abcdad58505e979b8be1e51c6087152361abc93c77ea4e054";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/it/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/it/firefox-115.0b9.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "bbe16791acaa2286975e881a9e216e640939d6aa6e8fd6a5860d5639a800a6f1";
+      sha256 = "7f2bfe2b6d18f3193497811045657f11aebe36ddc717288bf9e0a1b723d54b38";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ja/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ja/firefox-115.0b9.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "8d07b5d24b7cf634e171ae373ac1427d94936536d4891cf4913229716f24c8a5";
+      sha256 = "00575f2011885bd6521675480318ec87b2f589cccc1acaa1029073392bb95505";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ka/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ka/firefox-115.0b9.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "c4fb2eb926da09fe89231e904b7c70e918a4fccdf46741b22322341a8ad477c5";
+      sha256 = "d4c472bbb7815f30bf17e8608e64484d00cca4dc53bfb8561aa49c0632937bbd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/kab/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/kab/firefox-115.0b9.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "d1e09821b1505f9883a5f9fc5afb4469a32fa11b20522675308cfdd095737096";
+      sha256 = "a9fdd041f034da4aadfaa5605938c972de29f74aeab0d7d162f45cff9d6c6b08";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/kk/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/kk/firefox-115.0b9.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "4ad0d7cfc930419421393cfc52198922a6412ff856986c0ceb781bab5bf3e71d";
+      sha256 = "e47883bedc5f0defc89137ab73942b6f7dbbd30454c74907dda29dc3c2910d46";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/km/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/km/firefox-115.0b9.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "575b8d6d63b1cb466bd9a125301412e34a5c1b117c9658594b98d0bca4031fa3";
+      sha256 = "a0f69970c8918b2039fd80eb9d607a1daa0182a7b257a2aa4539239b74ea7a9d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/kn/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/kn/firefox-115.0b9.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "8e9129886c22f96285d80ef88a4dd06fac84f7cd729c9129d3df90cd89234cdf";
+      sha256 = "04ea63c7c94f791ec573b6a517a621093592d8c66ceb26222b948af615195bc7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ko/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ko/firefox-115.0b9.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "fff40d603d8032410a41182cd18b87319f30293499cc44e8dec72191c4341652";
+      sha256 = "5169a1ae59680553f95d500ef0bac522013c3d5d807b7a35fb50e6ec5ce1580e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/lij/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/lij/firefox-115.0b9.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "7c991cefdd82ced1175fd5a2b6cde335ca3498124d0d25485c48a75d518b90fe";
+      sha256 = "2ed0611e24cebed0571aa013d53b47bf251e06e99452da7d979175edc2ae3efe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/lt/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/lt/firefox-115.0b9.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "f11932255c50c7e8ec2346bcaf6066d7f6622be0470d49245a342fea13e0cafa";
+      sha256 = "4a7653f0dc9ca981458f2efe35b5b47a1b7d172694cb0355e4513e4c7e1bbc56";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/lv/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/lv/firefox-115.0b9.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "354361e574a71f9a38bf662f476fea8f2e1f0cffffe8f0407a0af841b5d17a33";
+      sha256 = "12e9894131c393938d5b9c21f73d5adf37dc88eafa7e2e293de2f610ec3e88d8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/mk/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/mk/firefox-115.0b9.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "bed4a99caac6a736f8ac7926611390d6ed5f3a41803210d9eb0f821588f1c0c7";
+      sha256 = "7e43b77516241a85f9b3db188aa26e7acce59a36980aaf25f2ff9621c4ee6cb0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/mr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/mr/firefox-115.0b9.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "2aebefb7f785db786314b999791b9ce1d51a724dff6a869cfc9d79b1c7bcaa0c";
+      sha256 = "a49d84347d28eb5365c4ef2a7fe76aa64de0f54332f084cd85ae5621efd3c686";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ms/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ms/firefox-115.0b9.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "3198469f7df6cd7e995dc8d4ffc67b67456fbaf18b3cf6e98bec886f185ba908";
+      sha256 = "3ff2ffb215f866c6fa5adac7ec7a7fc0a39ed401974c172d93fc4b4d3d57bffc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/my/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/my/firefox-115.0b9.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "65acb1cb85e1605ef34d4d6c3c8f7ab9f7869a2674457bfcacf414850e8bfac7";
+      sha256 = "ecbd63710a8fe280f6fef60dc54a425685001badd65be1031552e02f85a0fc68";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/nb-NO/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/nb-NO/firefox-115.0b9.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "cf1e6001d8b0a4868fc3a65a6c478aebd3a9fbe93270e5fc63d339163381ebff";
+      sha256 = "bb29ed3c0fe4233e367f6ad661f89ea126c2be352e1067fbbc9ec9dcfcd72504";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ne-NP/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ne-NP/firefox-115.0b9.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "d70be6b3d6ed56d4c69cdb0cc13388c99e9b3ba3b1c911dc5faee9e2837b823d";
+      sha256 = "ed3a3e0dbe0072e86d75a69d51c03bcc73a10629e86da688cbd2396fc682b937";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/nl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/nl/firefox-115.0b9.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "946314bb95a600d0e14565cde387493224a4832d68e5773729194e86ac445899";
+      sha256 = "2f902587282a5b16c817c11768d8ce16ef81f1470f8d5612e6913b75bb15b6ce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/nn-NO/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/nn-NO/firefox-115.0b9.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "4db45b58ccac4e8677fb0c714d5426f87545738678aa15bc180713b3241da4a4";
+      sha256 = "138890e225c83672cd9815f863da6c4c74355149c3c291eceff19292eefeca85";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/oc/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/oc/firefox-115.0b9.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "e292675fc6de21e9cb9d500c8ed5607708eb712491496ed7fb4e9ebe94829d09";
+      sha256 = "a89e607861ebf85db19162459f4eed4be56e9eea50fbd3fdf2a8ab4d21fc9c81";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/pa-IN/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/pa-IN/firefox-115.0b9.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "a32bd566a2716398721061f39e0bf091c1ffee6d0c21e0078d341cecd104ce9e";
+      sha256 = "271267b605d6be613a486c583726457dda2950bba5cc90014556576d3bbe77db";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/pl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/pl/firefox-115.0b9.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "94b292f2ae66fac9edd774ea61200fa6cf40e5052b1a8e32f74503b82d2fbe94";
+      sha256 = "474ef435db1e6ee7e6742efd9c04786b13f9b5ef448c1982bf7c7ff1167bb8a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/pt-BR/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/pt-BR/firefox-115.0b9.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "644ae31a6d0e45b250d08a4754d5a51646d3419c9815e520b32260368ffa01d0";
+      sha256 = "52b33a56bdad6f8332a408c7b0fc85465c61632feaefc1ce8e4abcf2d78de554";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/pt-PT/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/pt-PT/firefox-115.0b9.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "2ea948ac5e9c0ac096f1493f19d199de475010dd18153adec5eb0504de6fb36f";
+      sha256 = "c70aeec5a8cdb6ed9743dbcc838773afc4a32701c5b2f7b8b74697226f5291ae";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/rm/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/rm/firefox-115.0b9.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "c6e7478d5df741621f864f1faa981d15862a6dd0678cfefe166226da271b6105";
+      sha256 = "da6cdfb1287575c11b8f6b88924200be69507a676668401d5cf0a87c9cd27b62";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ro/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ro/firefox-115.0b9.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "0f83dd8852fd1c66f482854ac3c44744ec2ad601179e001e9709bff43037d532";
+      sha256 = "6a3e1380df08c65de203b8c49e8513fdd30f8e2d7cfcb458cf7aac9c02d65c43";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ru/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ru/firefox-115.0b9.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "5d8b83c9f05251dfd9c190b8acedc44ff9f6d5980984ade0bc5fc11bf7544d32";
+      sha256 = "04ec9801aa9ef740479d2964092f1d37314d9f5608dcdbc271f75c845c223468";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sc/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sc/firefox-115.0b9.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "966a9dfb0e95fdb587cdfdce973084f8b010bb02ca680ccf51f5a37afeaa0980";
+      sha256 = "bac95c057c7cb5dcdc03ef91a28cee391d8cd8ee33695141eebb2a1d4747a655";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sco/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sco/firefox-115.0b9.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "e7d1875db9080579d23eff236ea27df5376beee8102ab73bc083e02bed6074d1";
+      sha256 = "dc99f46f47f4f3f845c08df2c1d26ec903d4887d070f8654cf8282672fef44d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/si/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/si/firefox-115.0b9.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "ef542ddb73a903aa602ad49560c4db55967ecee82c4523c2a53c9d79ec0d7df1";
+      sha256 = "5c548f2550040e223a2b41260ad0dbe13b4b7232667ae8ee03052b5735b3c684";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sk/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sk/firefox-115.0b9.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "c2535ff13c6fadeb58eb8311fc4d508e68c1da15f6269a08b0a1d7c8872f43d5";
+      sha256 = "65cb7a04e00ff54bc1953b2141140d205416d6cd266ca5248df55287d444455e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sl/firefox-115.0b9.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c2aaa30acc6ba35e6b982c352182fde7e9c13e38acdbd403bc098a717c0e12e6";
+      sha256 = "21c521e1c9d0d00c98ad41fc1facdba382c9a3cec18675f2c6d3738483f44541";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/son/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/son/firefox-115.0b9.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "a6e5340f68eabcf22013bcb0a13ee23158b70f8b89e18b6c6d023cf3bc3ae266";
+      sha256 = "f76c060927d2221f280211695cc9e0e50355c92ccbb5f8e6c690b588361b9f52";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sq/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sq/firefox-115.0b9.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "5b28edd11ae13beb02c233d8801d264f783d83fe0bc92b5a4c39c00054d998ff";
+      sha256 = "835c28cb504d6f8e5e228f4d95d587f94108d0ba8b17c52ee078c50d725c8eec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sr/firefox-115.0b9.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "1337a560e49651b79027d03c660eb3c156d89bda9796513ed559bb875c317a7a";
+      sha256 = "3ed73b58da534050f3dc07b3e29e32bd9344a0d168bd1409d422aff161dc52d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sv-SE/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/sv-SE/firefox-115.0b9.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "c2eca0314f7281713359c855bf859b627c89bbb9ffb7fb2fdb0766a970b846a7";
+      sha256 = "cb546c00cd1ea3a1b04f490eeb0ea4fa4586d91db70c1840e3be83a99c208785";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/szl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/szl/firefox-115.0b9.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "2328a0fd772949705858256985c75b519a8fa79773a30fc996a8747b62ca7511";
+      sha256 = "266b4fd89775ff8fe86865be9985308b3ba8b0d9e6b285b0a0a8426de0689358";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ta/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ta/firefox-115.0b9.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "8d5da66309669987c08b33ca2c2c25aadc0b8ddfa21cb27936ec2839a16868a0";
+      sha256 = "15e1e659b27371d13ac61ed22e647d21f9ac6a7f700aab6b568e7c999da07cfe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/te/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/te/firefox-115.0b9.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "3dfe3f18d1f74b7820c08d897f89347b04c6d32d13050a5e8f3c981c430649b7";
+      sha256 = "61fb6db588bd72e126845fa068555ae56261f84561ac7a2e9c123d8c5a928c5c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/tg/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/tg/firefox-115.0b9.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "ff6608ba3d74afa9c2ff71cd59e7811e34d7d459f436916f56ef6e83fcb8a0da";
+      sha256 = "4437b55d295bf1a608272babbeb61849105760f61de96cbc0590f7b0697c2175";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/th/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/th/firefox-115.0b9.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "69d87203c7efb4b3ccc89e5c75b245e1e2ce4d3c2487b92dd8bafb5f590d4753";
+      sha256 = "76fbab23a314327b53526a15ae516b5a0b978b91c124ab66d109d3182388f449";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/tl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/tl/firefox-115.0b9.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "9c5d9b3e7da4314a19c521ada717e3c79f93767878efabcc7d16a70e35eb0227";
+      sha256 = "42995f3a32f241d80cc2cf8038929a6b8f9bc344c68886421edb7f61bd418d0d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/tr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/tr/firefox-115.0b9.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "31e16254eaf7f989339d53e1628a4e7fbd3f5aff643dc00d20e81a660ae5dc84";
+      sha256 = "f667f5d068bbbd7f4280ee19faf0577cc53c488d70487b11f3e4cf1a094a1d22";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/trs/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/trs/firefox-115.0b9.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "2fc1065103cd904a80e19025cbd2371916649e970731d45007354b8da0790c5f";
+      sha256 = "c76e652062d738b4f5ab0687b2b95d9aa8d296a4fd8ec04e992be8c84be53bfd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/uk/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/uk/firefox-115.0b9.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "10e5e8200aebd70002da84b225c7b1addfcbb27d7d2ea873c46abee5521419ed";
+      sha256 = "4ad6b1290d4dfd25eef07ea9a5d0ee4293be2c250c389cefa08e25217544b4eb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ur/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/ur/firefox-115.0b9.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "8a6172109767166b030555bca6ed3d33f7529f1b4f13f1df3eb15fd8b872b30c";
+      sha256 = "5bef46dd6cf29b22cd536bbe37e6fee900b6d8e84ba8442384952b1f306786b2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/uz/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/uz/firefox-115.0b9.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "331fe36d19f99fc6dcad54603e33fc22f70b637db503e428dcb8be814a931bbe";
+      sha256 = "9767a07f1ebfcc680373cd47109135a30145ea324e629967e2d1c36075ad78a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/vi/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/vi/firefox-115.0b9.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "d5f218abefb0fbbf4e20a6dd3343d5e039be48eb142e922779159b6080f8b2cd";
+      sha256 = "ead52311bbb4add4da56254e1d3acdd935a9883532655e44118d4f7f5aae057e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/xh/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/xh/firefox-115.0b9.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "b9f2e4441e95995bf10ca64c1c4d525260260f1ad7b3b4242f42cbf23683c176";
+      sha256 = "3b452c31cb53d02fa1bd5f219580ebe7a3d11ebde176af1c0ab6ae5e346141f9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/zh-CN/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/zh-CN/firefox-115.0b9.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "61c974be7866df1e9943584aeef0308f35b01220af52a9075036b8cb6089b831";
+      sha256 = "3fd731abc57c1faf186f8cb3323b90c381bb628639c4ed5c129b18ef567dc328";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/zh-TW/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-x86_64/zh-TW/firefox-115.0b9.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "83c29f71d3c4cc70ecc143a1de9c6c6d4a75c2867ee2522025d0db80b8885b46";
+      sha256 = "a67576592777894c0b2641e9b932119d5406256426284feabacdba039bdbd12a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ach/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ach/firefox-115.0b9.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "766f80671cbe04fbfc67e624a956ce29f954ceaee5d0ddf4241932848780da79";
+      sha256 = "17e7a543f336ec7f0811f9c926c064e06fa7eee57f32fc8de46bd78604b48d86";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/af/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/af/firefox-115.0b9.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "75d1bb061978aab04f10949cf8c2137ceead5bb8665666bc7dd32579e8fd9801";
+      sha256 = "bca35181175d9b345371fb2182050fb1a5614e8664d06b693891d8d6f6b69da9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/an/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/an/firefox-115.0b9.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "a3f0cc844a02473ce3ebb664ce7a900b356c3ac90ec3661300d73d55e94bae0e";
+      sha256 = "26e48a5f8fb5edb64e69ba4ae8f5439c2528686cbaa0c90e41c273340b9c0e80";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ar/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ar/firefox-115.0b9.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "bfcca8582181c95e368b56b3f6c6081fea3713ac8bd299040e5f1ecd0d8dff66";
+      sha256 = "1e93158883208d127608406754f714f6f612d07d772083157b3cf6b92622c062";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ast/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ast/firefox-115.0b9.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "75b5af037d45ddff395b3860b23544a26af6c368859020791682df02adc8b6e4";
+      sha256 = "6bee4565718962573f4d10417bf95671014bb7ca468f8d187f51a82cda132abc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/az/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/az/firefox-115.0b9.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "0c4affed92a86027df30734650ed288285ad4069078fb9ac62b53dac2ed4258f";
+      sha256 = "7525dfcde4b31d8c73a381b7fbc89cc65b71cd26027cea9145d62df19677c07a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/be/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/be/firefox-115.0b9.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "97153254ad6ca81111f3ae19eb8de9bb4de72bf4537b24aa9e3dd01e94f439f4";
+      sha256 = "a3a5a5b2747909ea8126915838975eea54967a3f40371c551d948392097174b1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/bg/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/bg/firefox-115.0b9.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "6afa075d73580afac23de00c40eb2a3b0bd24c8f2cd621229f4d59feb975248a";
+      sha256 = "b080ab6182685723a0bd78d2e2904d3e774cb2e65385a1da69e27d5e7ad25058";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/bn/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/bn/firefox-115.0b9.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "e266ead9a8510954e0f7c4f9ad46847cdaf1cd5387b3146e86ce1a452fe1517b";
+      sha256 = "198c12fd8933b9359a01ddacca2d93670e9b516b0e35fb47800e7f8002b985bc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/br/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/br/firefox-115.0b9.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "ea2dfd9c080db569f7b47b3d2dcb30344a075b3bc84160bf494119dff36d22e7";
+      sha256 = "da5dc615e9a7cb4b18c72cc464ef4131cf067987b4a79e24ec403f2ce67f22f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/bs/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/bs/firefox-115.0b9.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "d8e107e4c66fc31a525487e127a313fc747bb425ed4e4a241aa20302ac6fcb4d";
+      sha256 = "61a1ea85bec18d8ecd72e251c41e87dec15fb196346eec3748122ad7bab3bd24";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ca-valencia/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ca-valencia/firefox-115.0b9.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "78479255d3b60f9891173e0e4923f925540864bf62b194bf223fd6b9395739b9";
+      sha256 = "89f3c62ab1b27dd2e442ea6a02bd543948a320848aa990eca774f3b383de509f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ca/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ca/firefox-115.0b9.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "d0471c522d73edc1710de9e9d209bdc61c292cf9f1a0811b07deb586ea585f0d";
+      sha256 = "d0bb93b0b39121e17826068bccaac6c5a6cb74efe1db55d712ad55bd6c9f360b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/cak/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/cak/firefox-115.0b9.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "1776b0ada0643e6854ff815079cc73b1a0c6e6b05329f75b7d641ae090d1eb9d";
+      sha256 = "fba20a8efcc5436a67ebfcf3401ddf90d5477c17275db29ad1f8c018d86b968b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/cs/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/cs/firefox-115.0b9.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "2606c6a8da7d0b64e4f531f70a01b29c93c6d04caaa3214f79457635b3d9c45c";
+      sha256 = "8343c999dd10fd6a211ac7487bdc83ccba7e134c24b5eaa569ed31aca506f3fa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/cy/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/cy/firefox-115.0b9.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "09bc95a8b4059ae1c64d20b3f3588588f8e92f4f8aa09e2ead2c5fa1a42b3a1c";
+      sha256 = "1f58c87d68014200fed16032e5ca4c9e485f4e91787ddaf738d2fdb7514e4e4d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/da/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/da/firefox-115.0b9.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "3e4c76dfdf3b345144894efcfd6cada1ca0a0c73375049eaa2665bac22eb2011";
+      sha256 = "7db8b21b73c3004f3531cf32827629644a7358ef1bf3271fd7bb172bef8e2882";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/de/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/de/firefox-115.0b9.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "ca36dd0eb8a9ec4ff4498f6d3bce316ccece46464762a8acc2ccab5cdb546caf";
+      sha256 = "f88123a6b5184dc178e502ec6093e2718fc3f99f0d3176d38ff029f34bb11a63";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/dsb/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/dsb/firefox-115.0b9.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "698749896235b4c4ec620594cf323e33b8c46f4b79d7c0a475b1212ec670ca9b";
+      sha256 = "6c74b469f77bafe18d59b22bdf9151cb476f7c1ea247fb32b9dbc218845eae80";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/el/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/el/firefox-115.0b9.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "a9be42f9abe53862543febe9749146ba9dc7d6cf9b193ea112c8e2b69d36b1c3";
+      sha256 = "83519c3e685b934b25a5956f895fe162c2c63aff15daa6172bba6b8aed8361bb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/en-CA/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/en-CA/firefox-115.0b9.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "353a82f2ff7d2379c48502bf78325326f7315f8a36d729c4b9ca9b9024784345";
+      sha256 = "cfbc22627e3fb441b068c76ed0ec394235ac04687f36827fcd19d3465b506bc9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/en-GB/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/en-GB/firefox-115.0b9.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "00c7893222755ed929e62a6af53a3533fef9061f7e540ebd91408e490b611e07";
+      sha256 = "211ca3ecb60ce08229c48694f9e98383a405a1169757993093023c6958bd83c5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/en-US/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/en-US/firefox-115.0b9.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "66867368b6703d0d98cad37f2d79ff4d8d1e957a5574e692e8fa68f443dd2802";
+      sha256 = "b76efdd3ed4fe4b229bd34c09d5a8b4874a5d2b933ce11c805dcc9e214a13167";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/eo/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/eo/firefox-115.0b9.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "b72c950fe71929acc6f026cd24ad035958912baee7e137dab1b5764330ba59f9";
+      sha256 = "89107d910464e4ebb5d096dc6c5f8a535a890f6e5815f099d1d322033f1c6346";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/es-AR/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/es-AR/firefox-115.0b9.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "d7292b6702b9197176e8698bafa483a773d17b795d1cb9f3631d2355f32d8860";
+      sha256 = "3c922a252466678b458d55b54f076c34be8fa75f47aeda4a76b41bbb52f60e7b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/es-CL/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/es-CL/firefox-115.0b9.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "60d87b67c78bd83d778114fe3c9ab541c62de2941bf45cd73b86dec3c456a7a8";
+      sha256 = "b9d2ad41cbe7f0cb55137e909a62eadb4f0423d3d9c67ccf6a5a411d88f03fac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/es-ES/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/es-ES/firefox-115.0b9.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "511193c69fb2505c9e3eab11ffb297fd977374b2363afb48fa532c9672766959";
+      sha256 = "19c3d36eb45111879afc3e04694410926a70935ff1842679f9b7ba215dc3c966";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/es-MX/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/es-MX/firefox-115.0b9.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "4cc7c4dc8ddb20d518caff66a0c7610fb579e02ceee68a671e71a0e8e58ebaa6";
+      sha256 = "049a2be51c829f74d5dc678fcde872f859a1296585f0a40b33da336c4afeeff9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/et/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/et/firefox-115.0b9.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "60ad867801e303318e64a8683972800517b589ffe28c50cbeb7b783e55857e0e";
+      sha256 = "274a363c208a5897b0c6ac91ee929a95a7fdb21b38da4f2ef1874e08f3a5aa00";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/eu/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/eu/firefox-115.0b9.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "842e0720f6c8d1007424360e18c1efa0ffcc7f4859f0786b60c9bc0869ceeeb7";
+      sha256 = "306d13490def48de3d270d42c30b4e170fbb5bc897f16f50a52833863f11fbc1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fa/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fa/firefox-115.0b9.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "9a08eb4457b763d9b0ee80d457e78db0fbfd72ed2c8cd82fa1257db8bb80eadb";
+      sha256 = "7908985e1e1f80174ec42e17b34c099b31230f687f2f30a1e3e6a0d862a86b85";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ff/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ff/firefox-115.0b9.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "de3b2516f729a8adb44cc48cd7e10f3ccf3dd2732c62b3762003656e68a81e3b";
+      sha256 = "36fb5af5cb9a38da54eb7f67b53e67ec1bb1028dfe72a84bacba7e0b25da7510";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fi/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fi/firefox-115.0b9.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "85a474f3b862339dde6326c08649c0b725a53cf435bd321895803df256263000";
+      sha256 = "dd454e28cdfae46cb6718a9412c690e294e913850ca3ba267636194978f9a185";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fr/firefox-115.0b9.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "e65a5b55d56590a33f11965b9216241164e73f4420ef98b8c10b054c13031171";
+      sha256 = "67c6a33df93f763115ba238e246ffee4e0e1fa77ee99d3c806b908d29eebf2e9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fur/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fur/firefox-115.0b9.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "ad6de2291db9c70b3300aea38d900cbef498a883e2501c18b2059cd6c62b7a4f";
+      sha256 = "6487d3fa0ff5dc685c40eedb6ad27a5d32791c99419981a3d0164e9c3f8a5a1c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fy-NL/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/fy-NL/firefox-115.0b9.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "237b65fb160ac3c1bcc1322cef20f61a4805bbd479ce6fc6bcef3223d24de876";
+      sha256 = "f98063953936a4262156a98c502956718798aafc595c1de78ce6d3da8b05addc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ga-IE/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ga-IE/firefox-115.0b9.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "e826759c8a9a3e598e752731040ca13592a50c756fa7901307af2d2872f8af52";
+      sha256 = "6ff07a2e79bfe63bae5267ccd564856b78319d51d3e28e78a4ccd27e719d63fe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/gd/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/gd/firefox-115.0b9.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "7faaaa95ba7327c6d6af322f08f92c87b4e4d53236a26530fa27a58bc5cf10a3";
+      sha256 = "ef006a9142e00519ec26b3d5763d5d97f4c183cd8bd75830432a216ac0269b77";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/gl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/gl/firefox-115.0b9.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "332a5004f455c7acb473d54a888471725383342f1a655e37a7edb87cb622a32b";
+      sha256 = "77cb4df6e9792a24385f2187d29a741dc35e174e94921199d106a124914081af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/gn/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/gn/firefox-115.0b9.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "c418d37b8c3330aca72cc9e77ed157a734d2b97d575e518d9253a8ae5ccaa5be";
+      sha256 = "63d23044b70d6441e16a9c54cfee67b0717367eefa30aaed1c437951ad48077c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/gu-IN/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/gu-IN/firefox-115.0b9.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "aa39556e59573ead2ff607d59aa4568d727b32bd8a0ba412bde30ca002b6f04e";
+      sha256 = "41c2b7c389452c795196cc833e1606cef182044e2fe7156c3c0f2314dd13620d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/he/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/he/firefox-115.0b9.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "b5e0e651b673d0b48959125bd82933bb2b2d459e640691b8a947097f8e85caf6";
+      sha256 = "c4a96fa30e331396823822a7fa817ef605fee22aa7a9d6f1586a8ef10e95353b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hi-IN/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hi-IN/firefox-115.0b9.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "fc50dae40101df14d9e3c5fac8e517e40114c9c2655ec7d382364a0200fec2c0";
+      sha256 = "b1e6ef21d8e2065bc2c45d0158e57b76c9941e2b765773d804561509de1e3d90";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hr/firefox-115.0b9.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "f5d5d31a2d6a5106f0f1bd1f92bff2fc4f884cffff1a4d01cd56c704a2406fb6";
+      sha256 = "83c4777c249e646cd8f5447ffb2b2c481481bc02234b44c8138f2c75bc635b7e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hsb/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hsb/firefox-115.0b9.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "9a4b66696d56b4fb00de5da9d1adb95c63615b5c95844ed775d022d2b3cdf2ad";
+      sha256 = "e257a64be5b2038d54b88dff7ec9b8b122388a202c9a882cd579a9b1dfd8d25a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hu/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hu/firefox-115.0b9.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "18c1a825605311c284a39dd98be577eabd084edf6a2763675a41eb11005b61c3";
+      sha256 = "feaa3d8f0db374c210e09e6342952d0c28553bed9f0ec0bbbb44d2b35997c390";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hy-AM/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/hy-AM/firefox-115.0b9.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "ddd868aba059b01235abc51bc7845b2e8e2661501376d1a7f9e057805610c6af";
+      sha256 = "0ed7080b2e9ba21be5478287ecf73668bda820a277be2e54178bf0fab4f34c94";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ia/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ia/firefox-115.0b9.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "1ece208c87df53b1eea98a86f81d283d4c65f39da7e33100dfa45ef54e4fb17e";
+      sha256 = "3f2f25773b9b73bd8d1e341911e93354a1dc097b253b57700cb815f82144e8fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/id/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/id/firefox-115.0b9.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "cbbf691bd10e1c51885e090708896521d1b530454b7fcdda643ea789e800b533";
+      sha256 = "d205ef5ded567eea9fe80171d05ac280699608bf4d6eb5ba7f6c63919d55bcaf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/is/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/is/firefox-115.0b9.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "15ce697b391e285b40a2915e866097886ac8878af9940e9f16bb12d9feb33188";
+      sha256 = "af7491d89927bf7f1bf565b96c1b62c0b2cbbe25899fbb32fd66c83e888fd068";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/it/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/it/firefox-115.0b9.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "a1f4c30734bcc8885e0ad1f6b1207b11a49281990ce8fa0ec417a325247ac701";
+      sha256 = "77e5f9bdab83443dd9981edd8caddbf0790803e46a76b850d4a4b8e7ad351701";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ja/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ja/firefox-115.0b9.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "dc325041fd7844628201436a6c51cb48e573d19d37cac1a5828b8e13543b6212";
+      sha256 = "39ecaed499e93eb14d92159cf8f497dd2d2fd19902c91091156ab77f10f9afdc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ka/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ka/firefox-115.0b9.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "501a166313bde6e858f4573a1ce04d694dfdc49b31e871021365de27158a4c30";
+      sha256 = "d7db4f86389f08bcddf9ee5219785d21b90bb1b7b6869d885c30e58f1190fd80";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/kab/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/kab/firefox-115.0b9.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "aa8de7d888f12946f204f9b6c0e564d837ec6c4bf41ce9c75b5b2d7162f641cb";
+      sha256 = "74e2f57f13d98618b7eba06ab7bd18fd16fd30d62b6e2e115ee024b2606ee42d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/kk/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/kk/firefox-115.0b9.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "618f63b1f9bd340d2df30f58bf69a2851031034c32f45640f228e701cecabd1c";
+      sha256 = "6ccd6f7dc14e82921e5d5f1d9142c78452efd5734d3155a42334cdc20a1fc778";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/km/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/km/firefox-115.0b9.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "7fc94e906558352871b41f72a700e1ac4b583abc422796b5477f9250c4c44791";
+      sha256 = "52fd3969ed3aa96706a6ba4dde7d21e087e9332bcd9b6aad09eec52ce86481ec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/kn/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/kn/firefox-115.0b9.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "87a410b6ae3966cf84a8e1002d84567cf761b5fcd667aae2e5664be68d9afd27";
+      sha256 = "ccf849109d9137fd6076aca1692f0f5e42b0b1e8de57a026ccc476725fbe1b3b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ko/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ko/firefox-115.0b9.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a299aa07f8ef801a3d9fb9e77b488b967b34cc5e8cdf935a22aaa9716474edef";
+      sha256 = "a38bad7452a970aeba3ba8acd785406369e14c17b39a2c80a8659b8d5b4a6c59";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/lij/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/lij/firefox-115.0b9.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "3915c22d264c36f7e9cbb7d99174ec0bddde12c7174a87c140b0b61f3eb22b79";
+      sha256 = "7ca32c5449c87c56f8ae02876541dcad44624894e8aa53e98b86c68efdb2a9a4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/lt/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/lt/firefox-115.0b9.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "17ee70412c6ae1cb2866dea9ddedb96b1295e3a82c20a7428bfd53f6227fb10e";
+      sha256 = "ca025cedb7346f0d893424a6f8d8f72f366299bb458e8ed276e9c4ada4adeb3d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/lv/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/lv/firefox-115.0b9.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "fa2c43b4785aa2955d6edb5aceedc74424a5532b5bd1dd72c69a5487afd9ce77";
+      sha256 = "e3f8f33ac314b00084717ac95cd1cb9693b66d594672f2fc8d7ac40e12faaabf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/mk/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/mk/firefox-115.0b9.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "7d05fbb0e6427b0f6b7ec7891aa1c43b8453eb9e0ca16769e11153216f5d4d24";
+      sha256 = "910e29ee4f001e793dd2107d5dc4710a55c48b6c6e7c7ce868d5b6d7b26a32f9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/mr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/mr/firefox-115.0b9.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "be9ec1ef87c1fc0a8846b5c2d13ab9418251b0124602dbace17fe2adb9837054";
+      sha256 = "c0f66431a89b9e58a061fbc686c3b4f5eafe73109c6d42c1e33a1476af2bcd96";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ms/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ms/firefox-115.0b9.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "91b5cd6538e769d540bdbdeea13228ef1e203327228dca131b03a54748bfc00b";
+      sha256 = "62f879313be865df6a36a04b7c58e6ac2a8aca9a78a31778a836109c12ae0049";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/my/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/my/firefox-115.0b9.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "2f333838aad3aef86ee3f7c1c7ef3b864eb961599558bfa5c90b042fd704918f";
+      sha256 = "aa580077aa2225a34fc3474526cf0d4a9133eea2dacea334a1860d0d42133ec9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/nb-NO/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/nb-NO/firefox-115.0b9.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "20ec4989f7dbf8e815c304d69cbc5b589fa2d598e128798b9088c5bd9c47ad00";
+      sha256 = "38df96dfa748102005423e1eb005f3b2ed7fbdbef0c43fa63a67a97843660ab5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ne-NP/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ne-NP/firefox-115.0b9.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "ab4b6dd5d5c80f2e9396dae33820aa752469abd63f8a49f640a70433028abd5a";
+      sha256 = "08eccf2f4731f361ade7e44b9ef3a86daa24f8982976df8fb774981108336c0a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/nl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/nl/firefox-115.0b9.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "88a9fc8dbab36defb43100a0b9a4c0251050d0511507911f883afb86f34a3f9c";
+      sha256 = "a0f29ac57ddc99ceebfc88f3256bc60bf208e191feb41e7a4908807d4939cf7c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/nn-NO/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/nn-NO/firefox-115.0b9.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "cae591940e48901b8d04440a040587d290de0f001590dca011b3a37d0b083ae9";
+      sha256 = "501b1b2e1eceb3ccc78be39f7661546df7fcd9718b1f7471b1ba439c72696b5f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/oc/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/oc/firefox-115.0b9.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "5ca57dd54a4026d13175ab6b0bb670f1141c4444e82594b364f98718cdab15a9";
+      sha256 = "41aac014749b1608f0988b35a5dd8e5740288ec5c75fad88fced807d5181d286";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/pa-IN/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/pa-IN/firefox-115.0b9.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "5e8d395fddc21c0539fd8c7a32daf3a2ccf814f46356ba71e75afb3598f3351d";
+      sha256 = "5643262e38794224210f9cd74e223f20855131fe8874ed0fb14bea9ec2e625b1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/pl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/pl/firefox-115.0b9.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "da98f688a22e7a8bdb7beb09414ffab345490a2c53cc39efa597ab0e1a83db33";
+      sha256 = "53526a4d5a6fbf37def22d67ede8b5a3f50991d0fc5bd009afe70833a829d9c3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/pt-BR/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/pt-BR/firefox-115.0b9.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "79e21f7fe4e6482e6601f72ba5497eecb0cd3e0e46bf9065ae7174102d1f8cc8";
+      sha256 = "a8f8984833753dfbd62383de25e26ac19caaf4d0f6cab7fc2414ef1f25b0dcdb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/pt-PT/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/pt-PT/firefox-115.0b9.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "108f6cedee686bcd812bba13ecaea0ee15e43721c2869b70e65989bf4d95e408";
+      sha256 = "8c2ebf9314ed42a283b80928f849bd6c6121951df02c583dd2b128e8a1df0a40";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/rm/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/rm/firefox-115.0b9.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "104b098afc8b72520c563a9bb8e7498fc567ef7ce78a837f747874d9df13b1b9";
+      sha256 = "4f9ab0819b18687f4179f3518066687d669b0a18ed4669f89ae6091c122a1eaf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ro/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ro/firefox-115.0b9.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "d30e3778196be42250b4676dfaac46fcff90c15ee0789660a55f6527ed91b953";
+      sha256 = "f65d82895f64938f38642f9f71c2e60fdf4b8003abf6b8bbad3ab5e2b930211c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ru/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ru/firefox-115.0b9.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "58c96bd756e3ad2c26e638915025b08e695015e37cbaff2e9f3155c5b4dec016";
+      sha256 = "a7fee511ffd3534b5ced0bb7e2aacebe44ca00542bff070013e17927dbfd0fbd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sc/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sc/firefox-115.0b9.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "d55b42a82a2aff14ee2991dfa10d3b9f4807b6886d71d3e9b1c364693a2fa1d0";
+      sha256 = "40e9ccaf48ec845f137f2e3c728d1d489952ff97c3215363afe1a2dde8056826";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sco/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sco/firefox-115.0b9.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "4b7cccd707f614ca67b7a75b58c0a968ac3d449074f58e62d530c0461951cba3";
+      sha256 = "d3597779d604b2dc7d06c2ac78bd4b9664d3570bc2996e7e4dd2e4965a025c94";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/si/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/si/firefox-115.0b9.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "a8243c2ac65eaae4559e4d1230f67fdccf2620d4db1f47b99a72d6a426768d51";
+      sha256 = "a7028a84812664639d92c7f555b235cbed91df548893b5871c691e3944f54dd1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sk/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sk/firefox-115.0b9.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "4389010fca2b09bc8776a3d6b8490d1f6aa6fc19ce8fab6a65a5261f8526424b";
+      sha256 = "2eac153bbea200ea378a16a512ad9fbc3a1002467c62424256601d742d85d41f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sl/firefox-115.0b9.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "10aae36750f15e0695b1b2180a9fd87d21af2ac98ec32e1503bda7e41d8fc5c7";
+      sha256 = "d5f42957d54527771ee5fd370c7dea232ee7691a6fb4127219e726c83095653f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/son/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/son/firefox-115.0b9.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "5ab5c15d581093ff28d2fbb2ec12e2ede5183595b8483a3c45f246c749ba1218";
+      sha256 = "3b622be3bf8e54bafa9e6e1db61d1cd819a3f4bd4bd4bc57390c1e2850c8d715";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sq/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sq/firefox-115.0b9.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "6d5fc4466f878d8a27add0c9f8a2f1b19e48333ae677b49009bd5bcff8932d10";
+      sha256 = "2950857920ad1e2b378954c5508300641f544d38e9bb6d9aa553de2fe376a605";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sr/firefox-115.0b9.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "c8c2ccc4d0d30313e0b4f4a884c472fb89fa3a358aeef84fcc96a8d44d6e2bfe";
+      sha256 = "42199dac4518948e260132a0c59178490070a85f7b94f96bbb0c22977cb83781";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sv-SE/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/sv-SE/firefox-115.0b9.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "3eac437f4cff68387f569ec21ff0dd93b89b37e7c8379ea92260eca5c7b9fafc";
+      sha256 = "3423cfbf26cf6f7518a97a13d9e1aaaeac61d02d3e620390365093bc1d0be2c3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/szl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/szl/firefox-115.0b9.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "151a34d816d841f562084ae415c61d2ed66eb2ea56a347baef107104fabb08c0";
+      sha256 = "bbf4e142d570dd877cbafa84680fd71d507d412ace7b6b2bddd70e5d209dc083";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ta/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ta/firefox-115.0b9.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "014a7d5adb807326292a13de4962e6f6aea0933adb04b11b1c6104b07d74d07f";
+      sha256 = "8e92f220d85f7f8fa0608861089dfb2fe746dcfc6302071d05e31d27cf6c1dee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/te/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/te/firefox-115.0b9.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "53fddd1f56e96c6d4925b16d0dd65ca38f38cb0031a0c61bf240792e08caef86";
+      sha256 = "f1e10ae0f6fba48b9a3440edf688a3b7b40688b9616454a6b01c732cf0520884";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/tg/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/tg/firefox-115.0b9.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "2fc96000ab02c184fb22d11bf3c513fab354643bf901acebc3fc2a6095436fe9";
+      sha256 = "54e40ac4c4a69943aba21131fce4701f4fa63959789790ecfcdcd65d8b9018b3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/th/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/th/firefox-115.0b9.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "cf48e41648b12f180d32341242ebdbd01d8bbb3b515c7ba3d80f3eca53169582";
+      sha256 = "f936481ede653c9214aa625f6bc1f723dc7188493f380dbc6561d43ac58bf950";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/tl/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/tl/firefox-115.0b9.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "0ab2d2adcdbb1d444ae2c0d07bc129390d71f6dbf7e3b4df32e08b9c435e4d28";
+      sha256 = "1a67c0707b407d86a1410a148cb81c087199c70197233c8d3b2bc1d9f6384c51";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/tr/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/tr/firefox-115.0b9.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "68c0538ff7ab0ef6d013a9b17550f5794a50c7e593a1445cb49170df57a4497d";
+      sha256 = "91e5b5524934c63f90394a7320d7a726079f72ef9ce75ac0ce3393a13d9bcfd0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/trs/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/trs/firefox-115.0b9.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "8776aa1cafc7979602dc23e6e02c002445ae61ae2dc01cc017e87da3e2784bf1";
+      sha256 = "31b009a17aa3c9439b26d2ade3fbb74256ccb79402c258d9975c79d3ec3023a0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/uk/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/uk/firefox-115.0b9.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "64822eb5673bbf4e5ddbac17f0a67b875791a3c3eb1a10451e45a11341e1581e";
+      sha256 = "8559ba5e0776ae7d2cfd8384d45b76fddcf39fd6364f2d748f6e8e791eca5158";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ur/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/ur/firefox-115.0b9.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "4dda75e77d1ae72160638bdf56fb4b7cc566192d324d391b3d5584d0df1e3c9d";
+      sha256 = "236f401e8dbfa78eb6d87712c1e84c0481d2681cbad0cac25e3e5395c9fc3ac5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/uz/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/uz/firefox-115.0b9.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "670c6308a8a9229cc63b2027e60b328365e8c919bc26ec67951e5fb6ea8224e5";
+      sha256 = "39ae3db99d7bb50bdf5238382fbdf59c40ad748a99bd9bde39c1025e5afcecb0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/vi/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/vi/firefox-115.0b9.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "60d005d6f23dd45447b09c71a9c8a28cac4b0e737c9b7e27807f713a9268e569";
+      sha256 = "4d16eaddc4489c19224feddfa53edbf0736f2447a804316ad25e68bd131ee1d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/xh/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/xh/firefox-115.0b9.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "84928fe9bfd10591698284e99745782cc1ccc91aba38397605655a4012bb26e9";
+      sha256 = "40103ad901ce03622b63b49b59c875d08a8827a9a75b0d3068520dc36a61e4ee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/zh-CN/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/zh-CN/firefox-115.0b9.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "4def26d090635e24922c2c2911f4df8d7845d937e1c1e4e54f72e88b5b4ba4a9";
+      sha256 = "19c65f89c860e42de97f19e543c530113c8fe876bd28af62fafe572d7dc1c33b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/zh-TW/firefox-115.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b9/linux-i686/zh-TW/firefox-115.0b9.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "3223daa71996d8acb8035b1fabba0e36ba807136c0a6129d6a2cb08e4e702673";
+      sha256 = "b49b074f7ae19a0da9a7c9e0cebb4048a7d75e44c695804a78ea3c450e62c5ad";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,1015 +1,1015 @@
 {
-  version = "114.0b7";
+  version = "115.0b7";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ach/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ach/firefox-115.0b7.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "9b33281a91fc816f1d886078c5767a1928885f9ca4687d1058956f846551d2a8";
+      sha256 = "122514763d09bf7579ae4ba6acdb81deb24304c8a1dbbac57cb57f65583ebbc7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/af/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/af/firefox-115.0b7.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "e2dff3c0f83e3fdcfdf82344b658622fecfb5e9291d9297037ec7ed1976d4f19";
+      sha256 = "904b6d2fcafd4bf9964ee9f7821d3a0cddb58d54a0ba551c1ebf29e698b3d6a8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/an/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/an/firefox-115.0b7.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "bc350c5f80a59af753a25ce6c5e9958286ae344cc39c22dff564155843b2c0a0";
+      sha256 = "c0bee1f77504cb5146e20ac8f1be69eb1f411137a824bd361dd2f13b01a5872a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ar/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ar/firefox-115.0b7.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "da29353f797f0590f81a92a7ac09dc77b9f470265fe07c6eadf4bfb4b7253db3";
+      sha256 = "b89cc1ff73a2bb666d388bf94d57b31631f3668aee0b563d47df314c5de37916";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ast/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ast/firefox-115.0b7.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "ebc1e851e3a34bb31adf60f7983205ffcf696011f3285940fddaac7bf943b62b";
+      sha256 = "5dc80a963225af8fecc52f3b54d5d8bd66c47c6d275cc4538e7cc740ab63ae6b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/az/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/az/firefox-115.0b7.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "eff98a45ccc69fd9d229ad0c962a1198bb41a301b20f2020db03436f338da357";
+      sha256 = "c98d4ad6b5ccafd9443d3e83adc914e42958c0055461627eb5bc5d24c3157297";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/be/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/be/firefox-115.0b7.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "d920b215d86d0f013cc74cb564e658049f080e4a850fb9d1be00cb4d4af0bdbe";
+      sha256 = "818a63af8e5c956c11d7d752b39a51d2f44f8f7b80b99a5ac5ab6b1734c00e68";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/bg/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/bg/firefox-115.0b7.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "f989ca3a5fdafb8193063343cf19aff34cc20813f4e1942b85096a76529d1906";
+      sha256 = "9cc2ac8238c8be89bcd58bb1e7318990f25b3f67f0145bfce4ec8f871173e9ba";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/bn/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/bn/firefox-115.0b7.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "f40f8b64e795ba7a285335894c8fa3b8fd0272b1f04af0dfbb15ed1eaa7c5bec";
+      sha256 = "cbccfe6021ba4a5a9d86078b84a775cda721cf06266f430bff6134c94418534f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/br/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/br/firefox-115.0b7.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "3fcba1c8e7f2cc464bced2bef6546c0b0cb553613ee61be82ae1191898cf1afa";
+      sha256 = "2b1d595fbcb04a0f2ff0315b0d9c32513d308c2d39bc693d5ce052d22e9748c9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/bs/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/bs/firefox-115.0b7.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "0dec35e2f5965c695c9cfb10bd6bb7fdf572db434d6c58b97f66f9c926f45f52";
+      sha256 = "8e685061063661d8d9f923de7637eeab76a5e4f3fde92c2c87897df66475d2f3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ca-valencia/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ca-valencia/firefox-115.0b7.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "960e585abbaf0e27548dddfc98cd7272e7b230b10c5c068cf3475f0555037a92";
+      sha256 = "41ffc401beaf6b690c4b8407382dbef4150d7959f927185fd1d66ef12342345b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ca/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ca/firefox-115.0b7.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "97236d1223430f5df91c03f5dad8f4a055e6147e2a95897862ab6edd79732d9e";
+      sha256 = "469deb711f4f3d3f31c30e63bfa2e4e0792a9c69ab06edb887cf461528de6d00";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/cak/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/cak/firefox-115.0b7.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "3c84d9ffa11aa8b87b5789cfa892df4bec060754f32aee9e5f94c56995cee959";
+      sha256 = "190b997583df2b0941abca64cc9ef248829b114aaf7324a7865ab7e87e145870";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/cs/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/cs/firefox-115.0b7.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "db11e14f26979f27f5e829f09d9c23c7a3190acf1e9f29ef9cb6ccd01550e6ba";
+      sha256 = "b440439cf0ba533332b84306c0a65d9a0b544ed0cdb72254513ebed39a2d89be";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/cy/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/cy/firefox-115.0b7.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "10769218e926c8589b67514d8209ad32ba1d4c30f0f7a5b35b2e560c5bd93d9b";
+      sha256 = "29921d84845813b5b0b492569f461ddead2154ee53c16fcbf7d8945992186ea0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/da/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/da/firefox-115.0b7.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "80ca6851fd2f355b2021938660e91c954633045336db8401e6d0f13f96729fb5";
+      sha256 = "808d3a0e00160415934c282a61cf31a261d2e00607cec1ff2e30f3f1099ce869";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/de/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/de/firefox-115.0b7.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "6d9a481f763b0638fc68e20aa1c184619f93b4d25fc13b6e21d8ca8642b201b0";
+      sha256 = "17dac31b776bdfa6628df42db716c577a7d0b13f97f6f5df79a88d9985d92fd2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/dsb/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/dsb/firefox-115.0b7.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "2eaeb5eac2bb6cd7d3f7c308919ecef61438e0b60d39edc6def3e5340ff26fac";
+      sha256 = "065aae1bf40bf141a7bfb3c0424418874b61f6374f138f3b3fd80039984a33d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/el/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/el/firefox-115.0b7.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "8ba613daa3b4b60255ba2430f44cdeca485e3231c87db514c3307e9204080ad7";
+      sha256 = "dd0e120d769ae13ed8dc977426376dc9e7e6c61e308d2649de0547357511ed94";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/en-CA/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/en-CA/firefox-115.0b7.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "629cd3807a8db59aee8d780cd70d78b685a2030d85c4fff03ee2e86e8fd8ba6e";
+      sha256 = "8a74bb56574c143e6c98c2e64e9d414963cabe09fdb17af04bf1c4d35cd6606b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/en-GB/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/en-GB/firefox-115.0b7.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "f992fdbc0d8b6e9dd3614490e0f14ed2d6f9a5021055b5942df14249e076ceac";
+      sha256 = "69de0e17e5959683eaae357884d467c16203ca0cb84b03a76080feb7f86e0020";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/en-US/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/en-US/firefox-115.0b7.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "231ea47bde630c377c58a20c57a4ac3a6745891e0667bff8ce21d5f30ca60876";
+      sha256 = "e402244a4ae93ee272e3d39d15d891ab17d6e77101506201aa664335c110b685";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/eo/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/eo/firefox-115.0b7.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "21c725756f3b25d8a113999ff20a4137462647025be33c8924c4849513802042";
+      sha256 = "85b2b3d035084dbb04dea0c9397ad42d1fa8d2c7516ddba2ef9e4ce9f5bf4cc3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/es-AR/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/es-AR/firefox-115.0b7.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "5e284b176114ec673b3a718a1bb085df3438293912c2c400549594e36e8a18c5";
+      sha256 = "ece4ab12d660a629dba5149f3b34afca81047178a9ded433f1cf50ddfeb17132";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/es-CL/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/es-CL/firefox-115.0b7.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "764687d9509480951e5cb4cadb3271e43a0676002c6a65511bf8a1801648057d";
+      sha256 = "f70665d28a7bfa257830c6e54317cd617ae2088a9610ea5838303e7e433cbc05";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/es-ES/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/es-ES/firefox-115.0b7.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "b9491a73589d990d7d2e375b7992eac3517b8354ff5073d44beb2d02563882c6";
+      sha256 = "a268ebe720b8f8a1ac375b035dfb3372dc6f2bb5e040583fcfba77748f61b5c6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/es-MX/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/es-MX/firefox-115.0b7.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "0f3a23e7dfc5e029f2bb79608ca272f60e0637ea92aed5b39743ae0fcd705b58";
+      sha256 = "d510da5318fadc8731ac469a00c0991aa21281bd8b024f139f3a19c711b81509";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/et/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/et/firefox-115.0b7.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "45a4ae8166f5cbb1beb07a17d3a2649d7256fb635785ef22962ab918f1827f08";
+      sha256 = "127f2fffd7397cd08f248d1b33ad3255d1c637cb1508bef94383efc1c4b91566";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/eu/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/eu/firefox-115.0b7.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "4f411e661e0c624524c3d79558a386bf7a1586102e5f847ab931cd133a6116b4";
+      sha256 = "2ed7466c942a91aa975d9133d2153c13ddd32facaf030b6c5ba5da46c1df1290";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/fa/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fa/firefox-115.0b7.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "fc3de73eec19197755de7c3a19da95fd83c12f7cbd5ed19e9bdf84bf05e304db";
+      sha256 = "b3f69b8bd137f76e0a6e81673791ab6f702f55fc677b145c4bdaa1cbdb76b7b2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ff/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ff/firefox-115.0b7.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "9cef3186134e05bde04beb6400d6b0b97a94f7d01179560cde169d0e09100d35";
+      sha256 = "de2aea7b91ff3c6901b988df82a232dc3758b0991762474f19d148a416f3593a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/fi/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fi/firefox-115.0b7.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "e6f50067d6b661eae474af88e42670e2a52d657e5cbc5b3f76365e3cbe1bada7";
+      sha256 = "cf7921ea0984f20dabbf05e06c0b8fc48ddaab8f26f2bc075f10ce01748bcea6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/fr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fr/firefox-115.0b7.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "7ca8737381f4adf43ba8274ea2661efc4fe40f7c79e5483c8fc0e1b59cbccda2";
+      sha256 = "fe4c4b5bcc6966a11f31312f8f7fba69428afd7b176a738c4dba9b8928cd2609";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/fur/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fur/firefox-115.0b7.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "4cf9582a48fc541a4e0fbc5061738b1626e9e79fe0c3348fbd61b6190042dd1a";
+      sha256 = "527d85a087e83f9d41297c0dfc3416764a3171e6206338b4ef02005ec0832197";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/fy-NL/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/fy-NL/firefox-115.0b7.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "973035af6859cc3c42eafe49f52c41d9f1c211ef4f926a88d84f928f10bfa820";
+      sha256 = "f1ae19d25063c41eb657148cefeb03e1747d8402537feb65328b1c23b4ce01e0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ga-IE/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ga-IE/firefox-115.0b7.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "22be1de9302453b6487f5c953c50fe4777edad6d1725e964b537e07cedaf4bbf";
+      sha256 = "09799ddd69e9a2bff1b48a0aac9cff07b456980b2dd2cc8a51fedf3a614762c5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/gd/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/gd/firefox-115.0b7.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "6a393d01866d2b31ccb84cceaf3f9ce4d105d8c1faaf9469a1e859aa6590c093";
+      sha256 = "d0d6322d0d36c1575da178d24473ab58bdaef487abd93fb632890c5c8f690898";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/gl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/gl/firefox-115.0b7.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "70179b824798c65bd89d1760bc1cdae283fb78f735e6935bd32036b43108e570";
+      sha256 = "d2cf62ddb2e9869daaec8fca514a9f3e8a2d612f5ace1a666f185937a9e51ad8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/gn/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/gn/firefox-115.0b7.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "51a9bca4c05c9237ece4241d8c1cec5ac45521fc38e5664db5d9cc8847d609bc";
+      sha256 = "35015ccaa1b57e4ab115104854fd9e48a2028f0f5cba6d149c6b055d336aba24";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/gu-IN/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/gu-IN/firefox-115.0b7.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "5e4cacfb47b7cc1c71efc845153682d4759a94700de088ec7a7129a23c60d371";
+      sha256 = "3f52af5b750787b6481c6aea6dac60d5400d1cdd4f8568d67a7199cda4c08998";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/he/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/he/firefox-115.0b7.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "adc718fdabde347d6e73ac722362cd3f08b1710b8255f6505a12688122685d67";
+      sha256 = "ef047afbacd6813fd90d4f2e2fb6a95a0044b98a68d768194f78f890da773c1c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/hi-IN/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hi-IN/firefox-115.0b7.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "c3726cbd241596763158475b676e77a8bbbf50c2bce3b68d7535110684811c1b";
+      sha256 = "300d14c88bfba6844c465a74f9e01c0f1abbfe0e9d3a4ba3e7d54c4db361e63c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/hr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hr/firefox-115.0b7.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "876ded953d0d94659b47abe5d243c6a43d7616edbc5964b53a3699614f5f2f4a";
+      sha256 = "ded7ce7143b232f8f73152ab2b6a7322ba668045d6ea8765331ddd77c04318ea";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/hsb/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hsb/firefox-115.0b7.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "2f7b625946f1b13f5c46081fffa114c696a57bf057f7ece180c256eac1abfdf1";
+      sha256 = "7ae5b81c5f3b434ec4335d8ad8b7f87aadbc6684fd8ac80cbb23ea940d34afaf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/hu/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hu/firefox-115.0b7.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "bfca7ae0c55fc473f5f5e11b98373fa01f2d5485e0435df55576685efe2f8d76";
+      sha256 = "4e2055f60081dc47f441c5dbde77a05625de8052e583d38f21f431b8d8338570";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/hy-AM/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/hy-AM/firefox-115.0b7.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "3fe692ae4c3909964865c0cb5af514e95551b6b8065e158317005d327b1e4c9e";
+      sha256 = "af041f39f9c6e9f01f57f68521d4487c3bc7866834f7087cb68b8b7e77bf5308";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ia/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ia/firefox-115.0b7.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "a50f70b9caafee6a3e19a6394c5b795b2fd5fcc46ae8f58ef397ff3ba1bc58ba";
+      sha256 = "6f106b9e05b13365d2b706c549e1e2c06cdcec6d169ca2af36a677fcd94d3e18";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/id/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/id/firefox-115.0b7.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "5e4e85fe23d3f4780f013e59479d10072caeb0838b7fad6652ad91f0ee5486ab";
+      sha256 = "7351554145c01f6eb58e386afdda62d62143c0beb4c06068fdccd8de561ad188";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/is/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/is/firefox-115.0b7.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "da032757085c7dd5caeea275b1092524e53313257e701f18df8eb246b927cb02";
+      sha256 = "1fdf7e0c5ce813d24f39b477a09d5516d3b04f735258e019fb48a642fc3995a9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/it/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/it/firefox-115.0b7.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "e6fdf936501f98a3cacaff9e891fe77b090062fb232223c6251d5563d9dc2a2c";
+      sha256 = "bbe16791acaa2286975e881a9e216e640939d6aa6e8fd6a5860d5639a800a6f1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ja/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ja/firefox-115.0b7.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "0ae2e8ef345d200103a1f4cb16a16a14dd66633781e872f2c2e5153bac3449ef";
+      sha256 = "8d07b5d24b7cf634e171ae373ac1427d94936536d4891cf4913229716f24c8a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ka/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ka/firefox-115.0b7.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "092fe84add9f47b26c342c1d2474e7ae58d1840d1704be137a030836ab1e4827";
+      sha256 = "c4fb2eb926da09fe89231e904b7c70e918a4fccdf46741b22322341a8ad477c5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/kab/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/kab/firefox-115.0b7.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "a686a72888b8245b17dad75f267750d56295a3027eec2750677b568aacc64dd5";
+      sha256 = "d1e09821b1505f9883a5f9fc5afb4469a32fa11b20522675308cfdd095737096";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/kk/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/kk/firefox-115.0b7.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "c01c39ab011aee483efcb4e879af973bf44d22f61ce4d82de9a7624e0ca03cbe";
+      sha256 = "4ad0d7cfc930419421393cfc52198922a6412ff856986c0ceb781bab5bf3e71d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/km/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/km/firefox-115.0b7.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "f9b5eca3693876fc7845d77666f4964b9138806ff0de91c6297d7306cddd4482";
+      sha256 = "575b8d6d63b1cb466bd9a125301412e34a5c1b117c9658594b98d0bca4031fa3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/kn/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/kn/firefox-115.0b7.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "0cef752b0f6254c68a8e9fa7a593a59a3dd2ed862fb13655efb62f8bf24521cc";
+      sha256 = "8e9129886c22f96285d80ef88a4dd06fac84f7cd729c9129d3df90cd89234cdf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ko/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ko/firefox-115.0b7.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "a8161a09e91b1b613192c4c1ea9944f63384813ef5a34dd4ad91b827fb3d6de9";
+      sha256 = "fff40d603d8032410a41182cd18b87319f30293499cc44e8dec72191c4341652";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/lij/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/lij/firefox-115.0b7.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "33c6fad6549e35cf3d725fbba9d09bc283907993941b279bc0d95b1184dbdb05";
+      sha256 = "7c991cefdd82ced1175fd5a2b6cde335ca3498124d0d25485c48a75d518b90fe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/lt/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/lt/firefox-115.0b7.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "2093d1a67e245c80ad4b06eef615245fc82e51292770bf996e0794c7771bb08b";
+      sha256 = "f11932255c50c7e8ec2346bcaf6066d7f6622be0470d49245a342fea13e0cafa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/lv/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/lv/firefox-115.0b7.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "8120990eae0313e70ebd5f293ae02fcaaf6190ee1f372baf3e507c2aa1a77359";
+      sha256 = "354361e574a71f9a38bf662f476fea8f2e1f0cffffe8f0407a0af841b5d17a33";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/mk/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/mk/firefox-115.0b7.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "9043a5e8a9995027abf9f0bd3e734eb227c865fe28a924529e47a614d5032b0f";
+      sha256 = "bed4a99caac6a736f8ac7926611390d6ed5f3a41803210d9eb0f821588f1c0c7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/mr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/mr/firefox-115.0b7.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "e3360db4c94dc96027d7a0e82f1cf2eb283de8793492eae51ac547c990bd8024";
+      sha256 = "2aebefb7f785db786314b999791b9ce1d51a724dff6a869cfc9d79b1c7bcaa0c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ms/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ms/firefox-115.0b7.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "daa37a1b892ac99f3fef658c222012a333c9eb3089fc3b2e14e07d4a436a4230";
+      sha256 = "3198469f7df6cd7e995dc8d4ffc67b67456fbaf18b3cf6e98bec886f185ba908";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/my/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/my/firefox-115.0b7.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "aef0f6e601c2e7bc10068dd193cb0aa0564eabe22e5b779ac6ff99ea5cbb8935";
+      sha256 = "65acb1cb85e1605ef34d4d6c3c8f7ab9f7869a2674457bfcacf414850e8bfac7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/nb-NO/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/nb-NO/firefox-115.0b7.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "f99a3dfe2eec7254ff2c54472b033dc450cb71d986974eec41151b5ba544c92f";
+      sha256 = "cf1e6001d8b0a4868fc3a65a6c478aebd3a9fbe93270e5fc63d339163381ebff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ne-NP/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ne-NP/firefox-115.0b7.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "8ece8d0d6e906b2c97b36e29dbc52b42603db868924e053e29bca709bc2a1af1";
+      sha256 = "d70be6b3d6ed56d4c69cdb0cc13388c99e9b3ba3b1c911dc5faee9e2837b823d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/nl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/nl/firefox-115.0b7.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "4824c38ebedf502bb10814ee25b4767a465f22f1e437777b8402e097852c9002";
+      sha256 = "946314bb95a600d0e14565cde387493224a4832d68e5773729194e86ac445899";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/nn-NO/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/nn-NO/firefox-115.0b7.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "c1bf14d325f9e75e9ad74ebc5ff974b228ea5bfd7d454e68e2784925bff91fbd";
+      sha256 = "4db45b58ccac4e8677fb0c714d5426f87545738678aa15bc180713b3241da4a4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/oc/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/oc/firefox-115.0b7.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "b18b491d76ffe8b5ba81803f1580a1ffd2c534788a704788506777e912e4552c";
+      sha256 = "e292675fc6de21e9cb9d500c8ed5607708eb712491496ed7fb4e9ebe94829d09";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/pa-IN/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/pa-IN/firefox-115.0b7.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "6c25ea1011390478d4e4ab11d812ee3ecfc88ceb19344628845d985a382becc9";
+      sha256 = "a32bd566a2716398721061f39e0bf091c1ffee6d0c21e0078d341cecd104ce9e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/pl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/pl/firefox-115.0b7.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "4ec3609769b398b4badddfd4fcdba491af4bb099890f95580db1b05a51fd270e";
+      sha256 = "94b292f2ae66fac9edd774ea61200fa6cf40e5052b1a8e32f74503b82d2fbe94";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/pt-BR/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/pt-BR/firefox-115.0b7.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "fccbcc5bcff9299836b8006c20437bd72a85361950c7a8003b53210143fc3443";
+      sha256 = "644ae31a6d0e45b250d08a4754d5a51646d3419c9815e520b32260368ffa01d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/pt-PT/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/pt-PT/firefox-115.0b7.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "f39e3d1d4be3ec52f5a4f0c6735e23e38f3337586168f7599f37aa9c84be3136";
+      sha256 = "2ea948ac5e9c0ac096f1493f19d199de475010dd18153adec5eb0504de6fb36f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/rm/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/rm/firefox-115.0b7.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "e1c7589ae117230ef46b1ea0e1270cd2d0036bda2e53dd4618e481d34d9a0702";
+      sha256 = "c6e7478d5df741621f864f1faa981d15862a6dd0678cfefe166226da271b6105";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ro/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ro/firefox-115.0b7.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "f1e6eaf4584bbb746e9c806134df37b3031d810db908a8316bd15db7cabf3829";
+      sha256 = "0f83dd8852fd1c66f482854ac3c44744ec2ad601179e001e9709bff43037d532";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ru/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ru/firefox-115.0b7.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "abd3abc05651e2792983ff3c8ae6c34998b9043a310ce263ff17060ea9691dc6";
+      sha256 = "5d8b83c9f05251dfd9c190b8acedc44ff9f6d5980984ade0bc5fc11bf7544d32";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/sc/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sc/firefox-115.0b7.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "5df4f3d33daa9c53b9db924d479d8b5023d293c9807d8be3e6074e1586ae0e71";
+      sha256 = "966a9dfb0e95fdb587cdfdce973084f8b010bb02ca680ccf51f5a37afeaa0980";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/sco/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sco/firefox-115.0b7.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "87ddd7c8f966a907191b7f72dc23a0f882dc4313a921810efe969eb6d2fa22bc";
+      sha256 = "e7d1875db9080579d23eff236ea27df5376beee8102ab73bc083e02bed6074d1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/si/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/si/firefox-115.0b7.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "2030fa748ee56bd716c33416b5f3e6e35504c8cd5daafd21878590b2af4ee7e2";
+      sha256 = "ef542ddb73a903aa602ad49560c4db55967ecee82c4523c2a53c9d79ec0d7df1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/sk/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sk/firefox-115.0b7.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "7fa111b0675fb3483a99de43450b2551f0c97f3440ec03d59fa0e35c5f97d1fd";
+      sha256 = "c2535ff13c6fadeb58eb8311fc4d508e68c1da15f6269a08b0a1d7c8872f43d5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/sl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sl/firefox-115.0b7.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "bbb7d9e7d4ef7db3f18ef4cac094ac382f0d096c39365bb115ddf89fba5ef386";
+      sha256 = "c2aaa30acc6ba35e6b982c352182fde7e9c13e38acdbd403bc098a717c0e12e6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/son/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/son/firefox-115.0b7.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "83cac4d9c0012fb708a9283311c1cfb207fb07b0db3f08d5b6e1d1f5ef915376";
+      sha256 = "a6e5340f68eabcf22013bcb0a13ee23158b70f8b89e18b6c6d023cf3bc3ae266";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/sq/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sq/firefox-115.0b7.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a4a493f0a981381dfbed72fd6f09e14746d3e3ecf338b4d530beac4bc5cac45a";
+      sha256 = "5b28edd11ae13beb02c233d8801d264f783d83fe0bc92b5a4c39c00054d998ff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/sr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sr/firefox-115.0b7.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "40b680911e07e319952bcd3a0764fcfd9920e0f5b75317bc14c6a05cc3bed2ce";
+      sha256 = "1337a560e49651b79027d03c660eb3c156d89bda9796513ed559bb875c317a7a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/sv-SE/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/sv-SE/firefox-115.0b7.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "6967bb32ef76134a14669c542496076058473bbe71fddb58c33a47e1419b1913";
+      sha256 = "c2eca0314f7281713359c855bf859b627c89bbb9ffb7fb2fdb0766a970b846a7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/szl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/szl/firefox-115.0b7.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "8ee39abf7e84e25061b15b748f7222b527615c5d6f1df1b5baf1473ba7a6bd9f";
+      sha256 = "2328a0fd772949705858256985c75b519a8fa79773a30fc996a8747b62ca7511";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ta/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ta/firefox-115.0b7.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "322523104c1f58400cf82c6040f882a27fd05c1078f6ce63cd07757f7f726e62";
+      sha256 = "8d5da66309669987c08b33ca2c2c25aadc0b8ddfa21cb27936ec2839a16868a0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/te/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/te/firefox-115.0b7.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "9fe2af668a2fa6235e021ab187b5a0228a86f63b2478587a1c7148d6ff78665e";
+      sha256 = "3dfe3f18d1f74b7820c08d897f89347b04c6d32d13050a5e8f3c981c430649b7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/tg/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/tg/firefox-115.0b7.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "453258cb630cdd37e67aaa8368df3b27473b6971c714ae822c5666ef5fc57a97";
+      sha256 = "ff6608ba3d74afa9c2ff71cd59e7811e34d7d459f436916f56ef6e83fcb8a0da";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/th/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/th/firefox-115.0b7.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "a3e348bdcada026458410039ca564c818e8106142b7f5c62f3b357663decb9a7";
+      sha256 = "69d87203c7efb4b3ccc89e5c75b245e1e2ce4d3c2487b92dd8bafb5f590d4753";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/tl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/tl/firefox-115.0b7.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "122e71cb477f3f8dcb3546f514914d08ce92805a26b491c17a1d006ae07aaa5d";
+      sha256 = "9c5d9b3e7da4314a19c521ada717e3c79f93767878efabcc7d16a70e35eb0227";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/tr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/tr/firefox-115.0b7.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "df5b7fbbdb77455dc4c7fb6ed98e8ab373dd2cdb3a1f99b553672ea44f8db63c";
+      sha256 = "31e16254eaf7f989339d53e1628a4e7fbd3f5aff643dc00d20e81a660ae5dc84";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/trs/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/trs/firefox-115.0b7.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "12ab329441603d070ace74e6c25d87a6f6fc999ada15544bfb528361218d4a62";
+      sha256 = "2fc1065103cd904a80e19025cbd2371916649e970731d45007354b8da0790c5f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/uk/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/uk/firefox-115.0b7.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "590c3c5f0bf1a7e4eeb1703bce36b0f52fcc1240c642ac41ebc22081ece805f2";
+      sha256 = "10e5e8200aebd70002da84b225c7b1addfcbb27d7d2ea873c46abee5521419ed";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/ur/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/ur/firefox-115.0b7.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "fe84c0a0510cd1a198b0c35cbcb1439adb2fa5ff03733e640b91fc6bd5e5920f";
+      sha256 = "8a6172109767166b030555bca6ed3d33f7529f1b4f13f1df3eb15fd8b872b30c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/uz/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/uz/firefox-115.0b7.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "14207b01b2e091fb03b373f2ed6d6503b136812610b82e218e70413b2930ba30";
+      sha256 = "331fe36d19f99fc6dcad54603e33fc22f70b637db503e428dcb8be814a931bbe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/vi/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/vi/firefox-115.0b7.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "d3fb81887aa079bd26dc6f077a7ecb759792a8f1971aee9c2d934ce7b544d4a0";
+      sha256 = "d5f218abefb0fbbf4e20a6dd3343d5e039be48eb142e922779159b6080f8b2cd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/xh/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/xh/firefox-115.0b7.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a6b062da22fef3333f159a4a486cc1d249f6ddaf3578de6ee96942b284b7c52e";
+      sha256 = "b9f2e4441e95995bf10ca64c1c4d525260260f1ad7b3b4242f42cbf23683c176";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/zh-CN/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/zh-CN/firefox-115.0b7.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "b409f723c3bcfe4d4d797499b1efc1baa95c44d00e9a85a5b03dd2518034c76b";
+      sha256 = "61c974be7866df1e9943584aeef0308f35b01220af52a9075036b8cb6089b831";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-x86_64/zh-TW/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-x86_64/zh-TW/firefox-115.0b7.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "f91a51817e74f93d1ed807dafda66b901480a3ae77f4ff4056cc4f62e2a76432";
+      sha256 = "83c29f71d3c4cc70ecc143a1de9c6c6d4a75c2867ee2522025d0db80b8885b46";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ach/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ach/firefox-115.0b7.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "d8bc1eaca9be464328bfba4e1e0c1df8add6e8eafef29f256e33de9d7be171f1";
+      sha256 = "766f80671cbe04fbfc67e624a956ce29f954ceaee5d0ddf4241932848780da79";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/af/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/af/firefox-115.0b7.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "b3b6ad6feb642f3ba16deb6ce9b0ee747602d5b39f44aa86ced3ea184e47044e";
+      sha256 = "75d1bb061978aab04f10949cf8c2137ceead5bb8665666bc7dd32579e8fd9801";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/an/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/an/firefox-115.0b7.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "d438c92fa9505c894ca9e0751c256eb40402c71cc4819593f1023cc94cf05c4a";
+      sha256 = "a3f0cc844a02473ce3ebb664ce7a900b356c3ac90ec3661300d73d55e94bae0e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ar/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ar/firefox-115.0b7.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "81bad47e88b00ab3a6e0ff8df201c6f5bc5c07634fab6cff4e07f719bc3f86a2";
+      sha256 = "bfcca8582181c95e368b56b3f6c6081fea3713ac8bd299040e5f1ecd0d8dff66";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ast/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ast/firefox-115.0b7.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "33e8d05acd6914ebe498a0f90c6bfc98e6acf29131cb3f877883e3e307c0505c";
+      sha256 = "75b5af037d45ddff395b3860b23544a26af6c368859020791682df02adc8b6e4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/az/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/az/firefox-115.0b7.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "f3c8fe5d0e498e4f4b903a708e2d3c35e311798f2f5447bb04e3f1d1404ee1f5";
+      sha256 = "0c4affed92a86027df30734650ed288285ad4069078fb9ac62b53dac2ed4258f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/be/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/be/firefox-115.0b7.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "6d1a029f652f36bfa7067240b0e329eeb8416d3d61f9c059fc5763a5c3753fcd";
+      sha256 = "97153254ad6ca81111f3ae19eb8de9bb4de72bf4537b24aa9e3dd01e94f439f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/bg/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/bg/firefox-115.0b7.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "a71ecd0c86849a8b1d1ce86562a68ecffeddfda9ff10bfcdaf360061fc93cace";
+      sha256 = "6afa075d73580afac23de00c40eb2a3b0bd24c8f2cd621229f4d59feb975248a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/bn/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/bn/firefox-115.0b7.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "59fad81435f07ea8ff2078e4dfad914c16a1d5225acabcaa1ba6713b13a6e701";
+      sha256 = "e266ead9a8510954e0f7c4f9ad46847cdaf1cd5387b3146e86ce1a452fe1517b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/br/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/br/firefox-115.0b7.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "fce568edd724aea9f04ddd04d522f5025d3c88dfa6e6986fcd88d35420ab886e";
+      sha256 = "ea2dfd9c080db569f7b47b3d2dcb30344a075b3bc84160bf494119dff36d22e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/bs/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/bs/firefox-115.0b7.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "8367f07b7b8422e25375d35635f8eff94b4f25def4229ec8ce7013e655fa1d53";
+      sha256 = "d8e107e4c66fc31a525487e127a313fc747bb425ed4e4a241aa20302ac6fcb4d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ca-valencia/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ca-valencia/firefox-115.0b7.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "235f8ebfad6af55bf3007d2e0b237a98702f72e8e5e6aa97d9bfb8f61e691be5";
+      sha256 = "78479255d3b60f9891173e0e4923f925540864bf62b194bf223fd6b9395739b9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ca/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ca/firefox-115.0b7.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "24b7fe321d45a197d7cac78b954fcaf671335b4d16f80dc503c7585136ecd38e";
+      sha256 = "d0471c522d73edc1710de9e9d209bdc61c292cf9f1a0811b07deb586ea585f0d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/cak/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/cak/firefox-115.0b7.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "3ce46f849efd763c195fc688d824de774d77ff7a3356d49e3736a24bab003093";
+      sha256 = "1776b0ada0643e6854ff815079cc73b1a0c6e6b05329f75b7d641ae090d1eb9d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/cs/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/cs/firefox-115.0b7.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "55b643ec61e20ce03a57d736acc955a8696ccefe35e7633f1a47a014dc955e8c";
+      sha256 = "2606c6a8da7d0b64e4f531f70a01b29c93c6d04caaa3214f79457635b3d9c45c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/cy/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/cy/firefox-115.0b7.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "ba98d309b57484ca9e59b92b4161b6bb0e15ec7c527689ea80a9a719608b467a";
+      sha256 = "09bc95a8b4059ae1c64d20b3f3588588f8e92f4f8aa09e2ead2c5fa1a42b3a1c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/da/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/da/firefox-115.0b7.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "15c4ba7e2ebe99e5c221ed3aebff5093a3a64567b71cf4f17d129a7f71ba4014";
+      sha256 = "3e4c76dfdf3b345144894efcfd6cada1ca0a0c73375049eaa2665bac22eb2011";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/de/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/de/firefox-115.0b7.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "362c4291cee10321d940be52d77e3e5607adbca3b6aec0ed1b8f2c4eac6fe76f";
+      sha256 = "ca36dd0eb8a9ec4ff4498f6d3bce316ccece46464762a8acc2ccab5cdb546caf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/dsb/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/dsb/firefox-115.0b7.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "e002674afdb8317a129f964dc58373c40a786a37d8d3462b2f9ca0930d816643";
+      sha256 = "698749896235b4c4ec620594cf323e33b8c46f4b79d7c0a475b1212ec670ca9b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/el/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/el/firefox-115.0b7.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "ee5361423e276bc1afbc4367bf7740141a485eaa6caa138712573a5e0eaa50b3";
+      sha256 = "a9be42f9abe53862543febe9749146ba9dc7d6cf9b193ea112c8e2b69d36b1c3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/en-CA/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/en-CA/firefox-115.0b7.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "bf9a443933c8d103e95223c90c64473ad81ae1cb05850e6b7ef88a72f8c2db48";
+      sha256 = "353a82f2ff7d2379c48502bf78325326f7315f8a36d729c4b9ca9b9024784345";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/en-GB/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/en-GB/firefox-115.0b7.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "fb3dd0ee1a469a9182f489ef1ff615f85a64a6666554687e247ee0616d23ac94";
+      sha256 = "00c7893222755ed929e62a6af53a3533fef9061f7e540ebd91408e490b611e07";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/en-US/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/en-US/firefox-115.0b7.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "455df67e25652fd59c80bc81e903be8a2b1343c3336f28ba6d961cfb72869456";
+      sha256 = "66867368b6703d0d98cad37f2d79ff4d8d1e957a5574e692e8fa68f443dd2802";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/eo/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/eo/firefox-115.0b7.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "e6b8609f7518370a721d86895f00b8264294f4ff4fd09c337b92cff983687322";
+      sha256 = "b72c950fe71929acc6f026cd24ad035958912baee7e137dab1b5764330ba59f9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/es-AR/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/es-AR/firefox-115.0b7.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "700fb01bf07d3596a04689ac049ccea78ec2d7ab83b8d85d3be0ea528af21f7a";
+      sha256 = "d7292b6702b9197176e8698bafa483a773d17b795d1cb9f3631d2355f32d8860";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/es-CL/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/es-CL/firefox-115.0b7.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "6c55fa992913ad7a399ae8c7c077127ae1fbfdf651654366b82e8f9ac0f2e242";
+      sha256 = "60d87b67c78bd83d778114fe3c9ab541c62de2941bf45cd73b86dec3c456a7a8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/es-ES/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/es-ES/firefox-115.0b7.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "001e7ead5f92688ddf4799ebe579b4d6a0b4882c1db4ace70b5b312dc17e4818";
+      sha256 = "511193c69fb2505c9e3eab11ffb297fd977374b2363afb48fa532c9672766959";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/es-MX/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/es-MX/firefox-115.0b7.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "d599a4fa7a7abd63bfb58108752f1f861cb9727de2e978ad83d50bf0967c4fd1";
+      sha256 = "4cc7c4dc8ddb20d518caff66a0c7610fb579e02ceee68a671e71a0e8e58ebaa6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/et/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/et/firefox-115.0b7.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "1a28febf5232273ab54b835c2722b0d809707a2745b0c6cf52c2d15a3a30c752";
+      sha256 = "60ad867801e303318e64a8683972800517b589ffe28c50cbeb7b783e55857e0e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/eu/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/eu/firefox-115.0b7.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "30f17d474cdd4abc01ae41fd0f76d43f05052667c91aded1be83ee6d9952e4f0";
+      sha256 = "842e0720f6c8d1007424360e18c1efa0ffcc7f4859f0786b60c9bc0869ceeeb7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/fa/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fa/firefox-115.0b7.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "7028fb550cf164d0e85825be014f15573be2d9c62d062bf43e99f59f69514d9b";
+      sha256 = "9a08eb4457b763d9b0ee80d457e78db0fbfd72ed2c8cd82fa1257db8bb80eadb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ff/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ff/firefox-115.0b7.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "31ba5610f9a82b49ae283c00f30aa76d4d8c8144b7225cf005f035b6b37b781d";
+      sha256 = "de3b2516f729a8adb44cc48cd7e10f3ccf3dd2732c62b3762003656e68a81e3b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/fi/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fi/firefox-115.0b7.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "08ec00531c65adb3f6b3d55fdd96bb040409e1ddd4142b7177dad35251bfa6df";
+      sha256 = "85a474f3b862339dde6326c08649c0b725a53cf435bd321895803df256263000";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/fr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fr/firefox-115.0b7.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "1e5c05f503b5fc2bb5b0aecf883522b2d2f486f293af3099361644620446916d";
+      sha256 = "e65a5b55d56590a33f11965b9216241164e73f4420ef98b8c10b054c13031171";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/fur/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fur/firefox-115.0b7.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "25cce1819b0ce7eca2eb6401824bcd9619635a7bed8d699226b54fa8a9493883";
+      sha256 = "ad6de2291db9c70b3300aea38d900cbef498a883e2501c18b2059cd6c62b7a4f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/fy-NL/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/fy-NL/firefox-115.0b7.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "c0e2cf9cb5da9730a6c02017f8e4d486f1d263b00d840e87c365003f6b9e55ac";
+      sha256 = "237b65fb160ac3c1bcc1322cef20f61a4805bbd479ce6fc6bcef3223d24de876";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ga-IE/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ga-IE/firefox-115.0b7.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "82858ebbdde27e66179e3383f7b5fc86919a44940a537427eec153de7bc3f5f3";
+      sha256 = "e826759c8a9a3e598e752731040ca13592a50c756fa7901307af2d2872f8af52";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/gd/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/gd/firefox-115.0b7.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "0b0bd0eb73d06d39c0302cdfdbbb3d5f0b96f1be746c0a075cf43f63458a4e0e";
+      sha256 = "7faaaa95ba7327c6d6af322f08f92c87b4e4d53236a26530fa27a58bc5cf10a3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/gl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/gl/firefox-115.0b7.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "8cde4d089ce8d6aca0e4f2f754afc74da5e3a709bb10c0201cef7e7919be6b8a";
+      sha256 = "332a5004f455c7acb473d54a888471725383342f1a655e37a7edb87cb622a32b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/gn/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/gn/firefox-115.0b7.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "41bd1642013cee275ef5f2b8c25bb62bf6db2272b1d7d1de39f1442957ff4ebd";
+      sha256 = "c418d37b8c3330aca72cc9e77ed157a734d2b97d575e518d9253a8ae5ccaa5be";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/gu-IN/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/gu-IN/firefox-115.0b7.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "74bc63bcb36d2c3ba74e81918d384922138478ef1ef7a7894ec4cf9fe15d1b88";
+      sha256 = "aa39556e59573ead2ff607d59aa4568d727b32bd8a0ba412bde30ca002b6f04e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/he/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/he/firefox-115.0b7.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "c82b49371a3b01df6a884cec9cbcfa5f30c21162cd4942dc4a230c64877e1cc8";
+      sha256 = "b5e0e651b673d0b48959125bd82933bb2b2d459e640691b8a947097f8e85caf6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/hi-IN/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hi-IN/firefox-115.0b7.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "383c03a4b59694947ec192ef11b766b34455ffe4a5cf29cef459faff504c4e2a";
+      sha256 = "fc50dae40101df14d9e3c5fac8e517e40114c9c2655ec7d382364a0200fec2c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/hr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hr/firefox-115.0b7.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "8b0f5c8cda799db3ef574d76da5cee62db9f0d429947cde040cf784d91a0aff3";
+      sha256 = "f5d5d31a2d6a5106f0f1bd1f92bff2fc4f884cffff1a4d01cd56c704a2406fb6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/hsb/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hsb/firefox-115.0b7.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "0afff99390971da52638d986a4fa5b06387836060e53519f0cb081fedf79eb90";
+      sha256 = "9a4b66696d56b4fb00de5da9d1adb95c63615b5c95844ed775d022d2b3cdf2ad";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/hu/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hu/firefox-115.0b7.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "9cdc7201e9c79f829fad977c778712cfa945d972d0d6daab5ad1c2e1984d116a";
+      sha256 = "18c1a825605311c284a39dd98be577eabd084edf6a2763675a41eb11005b61c3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/hy-AM/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/hy-AM/firefox-115.0b7.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "cf412b78b4f78043522fcc3ecc72d89a2588ad2b97741de0de0922550f4d604d";
+      sha256 = "ddd868aba059b01235abc51bc7845b2e8e2661501376d1a7f9e057805610c6af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ia/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ia/firefox-115.0b7.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "8cee564d4c37c79aaa8ca588f3a713233c549155888067d3c945e6530faca1c3";
+      sha256 = "1ece208c87df53b1eea98a86f81d283d4c65f39da7e33100dfa45ef54e4fb17e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/id/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/id/firefox-115.0b7.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "7443c62fda6187a8776b2b6bcd91d5eb96a4514df4a0f6a088c2bcbe45c98561";
+      sha256 = "cbbf691bd10e1c51885e090708896521d1b530454b7fcdda643ea789e800b533";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/is/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/is/firefox-115.0b7.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "876d597b27d2cf06bb6a93d3372622604fbb07a3020241d3dd864a1c5cfee80e";
+      sha256 = "15ce697b391e285b40a2915e866097886ac8878af9940e9f16bb12d9feb33188";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/it/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/it/firefox-115.0b7.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "95ab36a17b732e58a0614e6fa667e8a841e9b29cbfee556ea6873217db1a0f28";
+      sha256 = "a1f4c30734bcc8885e0ad1f6b1207b11a49281990ce8fa0ec417a325247ac701";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ja/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ja/firefox-115.0b7.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "415916e610f791753a0f51dd82bad79747c15519b5245221323197ced944fe6c";
+      sha256 = "dc325041fd7844628201436a6c51cb48e573d19d37cac1a5828b8e13543b6212";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ka/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ka/firefox-115.0b7.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "3f92ecce5f4e0a86053ec46e4a237853449b2f443e6ea80a289babec49835622";
+      sha256 = "501a166313bde6e858f4573a1ce04d694dfdc49b31e871021365de27158a4c30";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/kab/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/kab/firefox-115.0b7.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "9656969a798f060f3bb8e452f1d77b4d894874323880c0c8e9bd471441edc0b8";
+      sha256 = "aa8de7d888f12946f204f9b6c0e564d837ec6c4bf41ce9c75b5b2d7162f641cb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/kk/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/kk/firefox-115.0b7.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "98d4c46bda75d101fa5d48d32a9fc11b0882ac3dc41854e4f1208f14daedeb2c";
+      sha256 = "618f63b1f9bd340d2df30f58bf69a2851031034c32f45640f228e701cecabd1c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/km/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/km/firefox-115.0b7.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "fbfa3ebc5b7a4fc2ef6d2b5601f6e0c249445233101c09b97081a70d4ff1dca4";
+      sha256 = "7fc94e906558352871b41f72a700e1ac4b583abc422796b5477f9250c4c44791";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/kn/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/kn/firefox-115.0b7.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "3abbeab39f731a999e1361770bf178d4bbfc4a05a439f1916166144585961536";
+      sha256 = "87a410b6ae3966cf84a8e1002d84567cf761b5fcd667aae2e5664be68d9afd27";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ko/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ko/firefox-115.0b7.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "6c9bcc420a3f53504c5f21f5333af9ac0050de5f9f384aa7ea8d037fef73060f";
+      sha256 = "a299aa07f8ef801a3d9fb9e77b488b967b34cc5e8cdf935a22aaa9716474edef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/lij/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/lij/firefox-115.0b7.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "7235e014a6cad6806268075632ffbbad337a94871f6a3cb7e5a0163ef03aa577";
+      sha256 = "3915c22d264c36f7e9cbb7d99174ec0bddde12c7174a87c140b0b61f3eb22b79";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/lt/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/lt/firefox-115.0b7.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "693b99db17996aeb031771c567b1ce6aca695b112a81c4dc416fa6d17feb93f8";
+      sha256 = "17ee70412c6ae1cb2866dea9ddedb96b1295e3a82c20a7428bfd53f6227fb10e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/lv/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/lv/firefox-115.0b7.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "8f9bb22016f9fe00e02c58095ff3806f803f7b20227d03b5dca1d7190a024972";
+      sha256 = "fa2c43b4785aa2955d6edb5aceedc74424a5532b5bd1dd72c69a5487afd9ce77";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/mk/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/mk/firefox-115.0b7.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "97d857564f9687f81061c430ecff2eb76c130f3b02ac83eaa66a7ff1b73757e2";
+      sha256 = "7d05fbb0e6427b0f6b7ec7891aa1c43b8453eb9e0ca16769e11153216f5d4d24";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/mr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/mr/firefox-115.0b7.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "e472502a2b2a7490ccdbd1320d05355dcb8919facfd96c9c51faeb7882dfd702";
+      sha256 = "be9ec1ef87c1fc0a8846b5c2d13ab9418251b0124602dbace17fe2adb9837054";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ms/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ms/firefox-115.0b7.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "4ea6c014885a911fe282da8727d6869d991ff8dd7bd345a006bfcd9e7235fc8e";
+      sha256 = "91b5cd6538e769d540bdbdeea13228ef1e203327228dca131b03a54748bfc00b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/my/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/my/firefox-115.0b7.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "f0ab10301421c7c08f43e2a811a0fedbd2a77d254fcf29e63f426217c21745cd";
+      sha256 = "2f333838aad3aef86ee3f7c1c7ef3b864eb961599558bfa5c90b042fd704918f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/nb-NO/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/nb-NO/firefox-115.0b7.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "5fb3a1a20cc359652e65e893eb00e1590c406a0f1d0bc2bf2917ee4a10b4dbc9";
+      sha256 = "20ec4989f7dbf8e815c304d69cbc5b589fa2d598e128798b9088c5bd9c47ad00";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ne-NP/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ne-NP/firefox-115.0b7.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "225af0dde54b5c1ef76bb035b183b03702b6d44d4d6a66a9a4a18ab6c35ae032";
+      sha256 = "ab4b6dd5d5c80f2e9396dae33820aa752469abd63f8a49f640a70433028abd5a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/nl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/nl/firefox-115.0b7.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "df2c75c7ca3c41cd3de58727c848c819288b969622fde689871a09c7e2986c24";
+      sha256 = "88a9fc8dbab36defb43100a0b9a4c0251050d0511507911f883afb86f34a3f9c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/nn-NO/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/nn-NO/firefox-115.0b7.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "5eda349aa44fb8004d075d8b35cca349c55f7ae301b92f20914e55897234912a";
+      sha256 = "cae591940e48901b8d04440a040587d290de0f001590dca011b3a37d0b083ae9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/oc/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/oc/firefox-115.0b7.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "7bc2c97f641294ce456e5581855111e8ca77519bb9e49cce8c114b80aca6c2c9";
+      sha256 = "5ca57dd54a4026d13175ab6b0bb670f1141c4444e82594b364f98718cdab15a9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/pa-IN/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/pa-IN/firefox-115.0b7.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "de74c6847ab099680c54eb4a3758488650ea9dc42597ad121af23651fb038629";
+      sha256 = "5e8d395fddc21c0539fd8c7a32daf3a2ccf814f46356ba71e75afb3598f3351d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/pl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/pl/firefox-115.0b7.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "3d2f4a7d141c6fe0b0c9cf62737a00af99ea70a2347ee0d214a7bb9cfdf2f03a";
+      sha256 = "da98f688a22e7a8bdb7beb09414ffab345490a2c53cc39efa597ab0e1a83db33";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/pt-BR/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/pt-BR/firefox-115.0b7.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "7e5fcde9c70edeb4c860fcdb9769e114166bec9f18012d98438ceca01868adc0";
+      sha256 = "79e21f7fe4e6482e6601f72ba5497eecb0cd3e0e46bf9065ae7174102d1f8cc8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/pt-PT/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/pt-PT/firefox-115.0b7.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "9f8f62905f2460b3dabcebf9b4bc6cbceb4a5897cabfcb70a251adfe3e3238b8";
+      sha256 = "108f6cedee686bcd812bba13ecaea0ee15e43721c2869b70e65989bf4d95e408";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/rm/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/rm/firefox-115.0b7.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "9a11df8533a5aa5efa82862ab5811c4cbf95004a10e0591b67fb1eb5b7404ef7";
+      sha256 = "104b098afc8b72520c563a9bb8e7498fc567ef7ce78a837f747874d9df13b1b9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ro/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ro/firefox-115.0b7.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "8ad3ad808ee3a45d647c259931507a4204ca4a5dcc60f47514bcd87df3e93507";
+      sha256 = "d30e3778196be42250b4676dfaac46fcff90c15ee0789660a55f6527ed91b953";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ru/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ru/firefox-115.0b7.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f48f0a80684d34c591df12c1cf2e49051c3043332d3624fb1ae9f2820e6b08f6";
+      sha256 = "58c96bd756e3ad2c26e638915025b08e695015e37cbaff2e9f3155c5b4dec016";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/sc/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sc/firefox-115.0b7.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "80751a05ab918b9d3cacc73b42112e0b51e9a215d977b22e1e1ca3aa57eb0de4";
+      sha256 = "d55b42a82a2aff14ee2991dfa10d3b9f4807b6886d71d3e9b1c364693a2fa1d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/sco/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sco/firefox-115.0b7.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "5216cf73506c74b19a027fee90d171a783ce2e5fded8657eb0fdcd46b0866291";
+      sha256 = "4b7cccd707f614ca67b7a75b58c0a968ac3d449074f58e62d530c0461951cba3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/si/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/si/firefox-115.0b7.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "952fb86ec3cb28f7fb0bf5c1e3deced6cfb77dc5636de17e3fb0b092f973e59d";
+      sha256 = "a8243c2ac65eaae4559e4d1230f67fdccf2620d4db1f47b99a72d6a426768d51";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/sk/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sk/firefox-115.0b7.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "d37fe92f0e6032e39bf450140874531a23bb6a3574ec783fc1ce83f6745d9164";
+      sha256 = "4389010fca2b09bc8776a3d6b8490d1f6aa6fc19ce8fab6a65a5261f8526424b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/sl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sl/firefox-115.0b7.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "9df7d668e8faecb02a9c3232b676a9b4e51d55df5d5b2d14762981e313835970";
+      sha256 = "10aae36750f15e0695b1b2180a9fd87d21af2ac98ec32e1503bda7e41d8fc5c7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/son/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/son/firefox-115.0b7.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "748b7a802b20ca481f49c3470a0d92ef3d8ded2d066c536439bca7567a8123b5";
+      sha256 = "5ab5c15d581093ff28d2fbb2ec12e2ede5183595b8483a3c45f246c749ba1218";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/sq/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sq/firefox-115.0b7.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "ddbacff458f1cf73a2a4167a445f54f12de73efa09f975d4354a677a9b0f33a8";
+      sha256 = "6d5fc4466f878d8a27add0c9f8a2f1b19e48333ae677b49009bd5bcff8932d10";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/sr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sr/firefox-115.0b7.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "2b981c6260c70710cd4908286b7498a15ab6956a97ef97d81e54457e52a391f7";
+      sha256 = "c8c2ccc4d0d30313e0b4f4a884c472fb89fa3a358aeef84fcc96a8d44d6e2bfe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/sv-SE/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/sv-SE/firefox-115.0b7.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "e501eed76140f53343dd9f96f794e07226c069e483bb873f70b4abf8a27d59c1";
+      sha256 = "3eac437f4cff68387f569ec21ff0dd93b89b37e7c8379ea92260eca5c7b9fafc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/szl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/szl/firefox-115.0b7.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "ccef0033ed07ad13699d1dfe978bce3f56c607404f0a9d962ae45a69c6b147eb";
+      sha256 = "151a34d816d841f562084ae415c61d2ed66eb2ea56a347baef107104fabb08c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ta/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ta/firefox-115.0b7.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "772fa17f6b4ead368a7cb4ba4a296223b2271b81697818cff1c8f1ab7dc304d4";
+      sha256 = "014a7d5adb807326292a13de4962e6f6aea0933adb04b11b1c6104b07d74d07f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/te/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/te/firefox-115.0b7.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "546adcf58879174ebf7825767d13873ba8d0cd0d44837d6e3353d7dabe54b6c0";
+      sha256 = "53fddd1f56e96c6d4925b16d0dd65ca38f38cb0031a0c61bf240792e08caef86";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/tg/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/tg/firefox-115.0b7.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "8346375636a40a3569189a5e2adcc5779d6b7fb6bc252407ac1d202081860029";
+      sha256 = "2fc96000ab02c184fb22d11bf3c513fab354643bf901acebc3fc2a6095436fe9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/th/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/th/firefox-115.0b7.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "ed9760d9867517146a90210e2be65017f195bbf2583437e4861258acb4fdeab0";
+      sha256 = "cf48e41648b12f180d32341242ebdbd01d8bbb3b515c7ba3d80f3eca53169582";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/tl/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/tl/firefox-115.0b7.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "1b36bb97fad5e1d1683f753d4b74ad82dcdaffc9f10cfada3948ad54a59e99c6";
+      sha256 = "0ab2d2adcdbb1d444ae2c0d07bc129390d71f6dbf7e3b4df32e08b9c435e4d28";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/tr/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/tr/firefox-115.0b7.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "7abeaba0da79b5a8ca9398eda13f85b63af15f4abf4e5f2fa7f4014aeba3933a";
+      sha256 = "68c0538ff7ab0ef6d013a9b17550f5794a50c7e593a1445cb49170df57a4497d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/trs/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/trs/firefox-115.0b7.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "f8ff73280f73bfa21238993f1aab04b20fdbedb3d5b40520b7de31d5a82c818c";
+      sha256 = "8776aa1cafc7979602dc23e6e02c002445ae61ae2dc01cc017e87da3e2784bf1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/uk/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/uk/firefox-115.0b7.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "4a0af8c646f688406e1a7429d45358b9c81f8f4523f72a41fc121c550eb77ce1";
+      sha256 = "64822eb5673bbf4e5ddbac17f0a67b875791a3c3eb1a10451e45a11341e1581e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/ur/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/ur/firefox-115.0b7.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "69091a344b0785a1876b51d626d149459e07d7b6cf8414ca9a9a8cd7fe5a45e0";
+      sha256 = "4dda75e77d1ae72160638bdf56fb4b7cc566192d324d391b3d5584d0df1e3c9d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/uz/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/uz/firefox-115.0b7.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "df76e8a0e62d11e37bbb6b8a5f4d39c5c603ee17cd9d37a5c7ae1c3836d4e68b";
+      sha256 = "670c6308a8a9229cc63b2027e60b328365e8c919bc26ec67951e5fb6ea8224e5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/vi/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/vi/firefox-115.0b7.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "93e856a8b374066052d0526579069e0aab6fc6ecaae16b092485f75b06fa722b";
+      sha256 = "60d005d6f23dd45447b09c71a9c8a28cac4b0e737c9b7e27807f713a9268e569";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/xh/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/xh/firefox-115.0b7.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "d2f347a987005d0b85fd582fd1e3d1db95772d0a7432a5fb44eabbe4a0118223";
+      sha256 = "84928fe9bfd10591698284e99745782cc1ccc91aba38397605655a4012bb26e9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/zh-CN/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/zh-CN/firefox-115.0b7.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "86448a435e1db96efeacbc6316b9686c8856a20dd2116f8642b4458703be485c";
+      sha256 = "4def26d090635e24922c2c2911f4df8d7845d937e1c1e4e54f72e88b5b4ba4a9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/114.0b7/linux-i686/zh-TW/firefox-114.0b7.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/115.0b7/linux-i686/zh-TW/firefox-115.0b7.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "1528cfd1bfe241dfeb28852d2caa113b75cbb4d6540c3ebbdd4c375a7db93fef";
+      sha256 = "3223daa71996d8acb8035b1fabba0e36ba807136c0a6129d6a2cb08e4e702673";
     }
     ];
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
