### PR TITLE
add mpiCheckPhaseHook

### DIFF
--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -17,6 +17,7 @@ installShellFiles.section.md
 libiconv.section.md
 libxml2.section.md
 meson.section.md
+mpi-check-hook.section.md
 ninja.section.md
 patch-rc-path-hooks.section.md
 perl.section.md

--- a/doc/hooks/mpi-check-hook.section.md
+++ b/doc/hooks/mpi-check-hook.section.md
@@ -1,0 +1,24 @@
+#  mpiCheckPhaseHook {#setup-hook-mpi-check}
+
+
+This hook can be used to setup a check phase that
+requires running a MPI application. It detects the
+used present MPI implementaion type and exports
+the neceesary environment variables to use
+`mpirun` and `mpiexec` in a Nix sandbox.
+
+
+Example:
+
+```nix
+  { mpiCheckPhaseHook, mpi, ... }:
+
+  ...
+
+  nativeCheckInputs = [
+    openssh
+    mpiCheckPhaseHook
+  ];
+```
+
+

--- a/pkgs/applications/science/chemistry/cp2k/default.nix
+++ b/pkgs/applications/science/chemistry/cp2k/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, python3, gfortran, blas, lapack
+{ lib, stdenv, fetchFromGitHub, mpiCheckPhaseHook, python3, gfortran, blas, lapack
 , fftw, libint, libvori, libxc, mpi, gsl, scalapack, openssh, makeWrapper
 , libxsmm, spglib, which, pkg-config, plumed, zlib
 , enableElpa ? false
@@ -88,14 +88,18 @@ in stdenv.mkDerivation rec {
     EOF
   '';
 
+  nativeCheckInputs = [
+    mpiCheckPhaseHook
+    openssh
+  ];
+
   checkPhase = ''
-    export OMP_NUM_THREADS=1
+    runHook preCheck
 
-    export HYDRA_IFACE=lo  # Fix to make mpich run in a sandbox
-    export OMPI_MCA_rmaps_base_oversubscribe=1
     export CP2K_DATA_DIR=data
-
     mpirun -np 2 exe/${arch}/libcp2k_unittest.${cp2kVersion}
+
+    runHook postCheck
   '';
 
   installPhase = ''

--- a/pkgs/applications/science/chemistry/nwchem/default.nix
+++ b/pkgs/applications/science/chemistry/nwchem/default.nix
@@ -3,6 +3,7 @@
 , pkgs
 , fetchFromGitHub
 , fetchurl
+, mpiCheckPhaseHook
 , which
 , openssh
 , gcc
@@ -190,16 +191,15 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   doInstallCheck = true;
+  nativeCheckInputs = [ mpiCheckPhaseHook ];
   installCheckPhase = ''
-    export OMP_NUM_THREADS=1
-
-    # Fix to make mpich run in a sandbox
-    export HYDRA_IFACE=lo
-    export OMPI_MCA_rmaps_base_oversubscribe=1
+    runHook preInstallCheck
 
     # run a simple water test
     mpirun -np 2 $out/bin/nwchem $out/share/nwchem/QA/tests/h2o/h2o.nw > h2o.out
     grep "Total SCF energy" h2o.out  | grep 76.010538
+
+    runHook postInstallCheck
   '';
 
   passthru = { inherit mpi; };

--- a/pkgs/build-support/setup-hooks/mpi-check-hook/default.nix
+++ b/pkgs/build-support/setup-hooks/mpi-check-hook/default.nix
@@ -1,0 +1,5 @@
+{ callPackage, makeSetupHook }:
+
+makeSetupHook {
+  name = "mpi-checkPhase-hook";
+} ./mpi-check-hook.sh

--- a/pkgs/build-support/setup-hooks/mpi-check-hook/mpi-check-hook.sh
+++ b/pkgs/build-support/setup-hooks/mpi-check-hook/mpi-check-hook.sh
@@ -1,0 +1,54 @@
+preCheckHooks+=('setupMpiCheck')
+preInstallCheckHooks+=('setupMpiCheck')
+
+
+setupMpiCheck() {
+  # Find out which MPI implementation we are using
+  # and set safe defaults that are guaranteed to run
+  # on any build machine
+
+  mpiType="NONE"
+
+  # OpenMPI signature
+  if command ompi_info &> /dev/null; then
+    mpiType="openmpi"
+  fi
+
+  # MPICH based implementations
+  if command mpichversion &> /dev/null; then
+    if [ "$mpiType" != "NONE" ]; then
+      echo "WARNING: found OpenMPI and MPICH/MVAPICH executables"
+    fi
+
+    version=$(mpichversion)
+    if [[ "$version" == *"MPICH"* ]]; then
+      mpiType="MPICH"
+    fi
+    if [[ "$version" == *"MVAPICH"* ]]; then
+      mpiType="MVAPICH"
+    fi
+  fi
+
+  echo "Found MPI implementation: $mpiType"
+
+  case $mpiType in
+    openmpi)
+      # make sure the test starts even if we have less than the requested amount of cores
+      export OMPI_MCA_rmaps_base_oversubscribe=1
+      # Disable CPU pinning
+      export OMPI_MCA_hwloc_base_binding_policy=none
+      ;;
+    MPICH)
+      # Fix to make mpich run in a sandbox
+      export HYDRA_IFACE=lo
+      ;;
+    MVAPICH)
+      # Disable CPU pinning
+      export MV2_ENABLE_AFFINITY=0
+      ;;
+  esac
+
+  # Limit number of OpenMP threads. Default is "all cores".
+  export OMP_NUM_THREADS=1
+}
+

--- a/pkgs/development/libraries/elpa/default.nix
+++ b/pkgs/development/libraries/elpa/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, autoreconfHook, gfortran, perl
-, mpi, blas, lapack, scalapack, openssh
+{ lib, stdenv, fetchurl, autoreconfHook, mpiCheckPhaseHook
+, gfortran, perl, mpi, blas, lapack, scalapack, openssh
 # CPU optimizations
 , avxSupport ? stdenv.hostPlatform.avxSupport
 , avx2Support ? stdenv.hostPlatform.avx2Support
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile.am --replace '#!/bin/bash' '#!${stdenv.shell}'
   '';
 
-  nativeBuildInputs = [ autoreconfHook perl openssh ];
+  nativeBuildInputs = [ autoreconfHook perl ];
 
   buildInputs = [ mpi blas lapack scalapack ]
     ++ lib.optional enableCuda cudatoolkit;
@@ -76,14 +76,9 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  nativeCheckInputs = [ mpiCheckPhaseHook openssh ];
   preCheck = ''
     #patchShebangs ./
-
-    # make sure the test starts even if we have less than 4 cores
-    export OMPI_MCA_rmaps_base_oversubscribe=1
-
-    # Fix to make mpich run in a sandbox
-    export HYDRA_IFACE=lo
 
     # Run dual threaded
     export OMP_NUM_THREADS=2

--- a/pkgs/development/libraries/science/math/dbcsr/default.nix
+++ b/pkgs/development/libraries/science/math/dbcsr/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , cmake
+, mpiCheckPhaseHook
 , pkg-config
 , fypp
 , gfortran
@@ -64,13 +65,12 @@ stdenv.mkDerivation rec {
     "-DUSE_MPI=ON"
   ];
 
-  checkInputs = [ openssh ];
+  checkInputs = [
+    openssh
+    mpiCheckPhaseHook
+  ];
 
   doCheck = true;
-  preCheck = ''
-    export HYDRA_IFACE=lo  # Fix to make mpich run in a sandbox
-    export OMPI_MCA_rmaps_base_oversubscribe=1
-  '';
 
   meta = with lib; {
     description = "Distributed Block Compressed Sparse Row matrix library";

--- a/pkgs/development/libraries/science/math/p4est-sc/default.nix
+++ b/pkgs/development/libraries/science/math/p4est-sc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, mpiCheckPhaseHook
 , autoreconfHook, pkg-config
 , p4est-sc-debugEnable ? true, p4est-sc-mpiSupport ? true
 , mpi, openssh, zlib
@@ -47,10 +47,10 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
   makeFlags = [ "V=0" ];
 
-  preCheck = ''
-    export OMPI_MCA_rmaps_base_oversubscribe=1
-    export HYDRA_IFACE=lo
-  '';
+  nativeCheckInputs = lib.optionals mpiSupport [
+    mpiCheckPhaseHook
+    openssh
+  ];
 
   # disallow Darwin checks due to prototype incompatibility of qsort_r
   # to be fixed in a future version of the source code

--- a/pkgs/development/libraries/science/math/p4est/default.nix
+++ b/pkgs/development/libraries/science/math/p4est/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
     ++ lib.optional withMetis "--with-metis"
   ;
 
-  inherit (p4est-sc) makeFlags dontDisableStatic enableParallelBuilding preCheck doCheck;
+  inherit (p4est-sc) makeFlags dontDisableStatic enableParallelBuilding doCheck;
 
   meta = {
     branch = "prev3-develop";

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, openssh
-, mpi, blas, lapack
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake
+, openssh, mpiCheckPhaseHook, mpi, blas, lapack
 } :
 
 assert blas.isILP64 == lapack.isILP64;
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake ];
-  nativeCheckInputs = [ openssh ];
+  nativeCheckInputs = [ openssh mpiCheckPhaseHook ];
   buildInputs = [ blas lapack ];
   propagatedBuildInputs = [ mpi ];
   hardeningDisable = lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [ "stackprotector" ];
@@ -60,17 +60,6 @@ stdenv.mkDerivation rec {
   # Increase individual test timeout from 1500s to 10000s because hydra's builds
   # sometimes fail due to this
   checkFlagsArray = [ "ARGS=--timeout 10000" ];
-
-  preCheck = ''
-    # make sure the test starts even if we have less than 4 cores
-    export OMPI_MCA_rmaps_base_oversubscribe=1
-
-    # Fix to make mpich run in a sandbox
-    export HYDRA_IFACE=lo
-
-    # Run single threaded
-    export OMP_NUM_THREADS=1
-  '';
 
   meta = with lib; {
     homepage = "http://www.netlib.org/scalapack/";

--- a/pkgs/development/python-modules/meep/default.nix
+++ b/pkgs/development/python-modules/meep/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , autoreconfHook
 , pkg-config
+, mpiCheckPhaseHook
 , gfortran
 , mpi
 , blas
@@ -108,15 +109,11 @@ buildPythonPackage rec {
   errors can be caught.
   */
   doCheck = true;
+  nativeCheckInputs = [ mpiCheckPhaseHook openssh ];
   checkPhase = ''
-    export PATH=$PATH:${openssh}/bin
+    runHook preCheck
+
     export PYTHONPATH="$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
-
-    export OMP_NUM_THREADS=1
-
-    # Fix to make mpich run in a sandbox
-    export HYDRA_IFACE=lo
-    export OMPI_MCA_rmaps_base_oversubscribe=1
 
     # Generate a python test script
     cat > test.py << EOF
@@ -139,6 +136,8 @@ buildPythonPackage rec {
     EOF
 
     ${mpi}/bin/mpiexec -np 2 python3 test.py
+
+    runHook postCheck
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -1,4 +1,6 @@
-{ lib, fetchPypi, fetchpatch, python, buildPythonPackage, mpi, openssh }:
+{ lib, fetchPypi, fetchpatch, python, buildPythonPackage
+, mpi, mpiCheckPhaseHook, openssh
+}:
 
 buildPythonPackage rec {
   pname = "mpi4py";
@@ -33,10 +35,6 @@ buildPythonPackage rec {
     # sometimes packages specify where files should be installed outside the usual
     # python lib prefix, we override that back so all infrastructure (setup hooks)
     # work as expected
-
-    # Needed to run the tests reliably. See:
-    # https://bitbucket.org/mpi4py/mpi4py/issues/87/multiple-test-errors-with-openmpi-30
-    export OMPI_MCA_rmaps_base_oversubscribe=yes
   '';
 
   setupPyBuildFlags = ["--mpicc=${mpi}/bin/mpicc"];
@@ -45,7 +43,7 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  nativeCheckInputs = [ openssh ];
+  nativeCheckInputs = [ openssh mpiCheckPhaseHook ];
 
   meta = with lib; {
     description = "Python bindings for the Message Passing Interface standard";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12258,6 +12258,7 @@ with pkgs;
   outils = callPackage ../tools/misc/outils { };
 
   mpi = openmpi; # this attribute should used to build MPI applications
+  mpiCheckPhaseHook = callPackage ../build-support/setup-hooks/mpi-check-hook { };
 
   ucc = callPackage ../development/libraries/ucc { };
 


### PR DESCRIPTION
## Description of changes
MPI programs usually expect some kind of bare metal machine to run its tasks. Packages that run a test (i.e. in the checkPhase) have to do so in the sandbox. 
The new hook sets variables to allow it for running in smoothly in a sandbox.
It avoids the boiler plate of setting these variables for each package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
