### PR TITLE
commit-and-tag-version: init at 11.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3906,6 +3906,11 @@
     githubId = 14032;
     name = "Daniel Brockman";
   };
+  DCsunset = {
+    github = "DCsunset";
+    githubId = 23468812;
+    name = "DCsunset";
+  };
   ddelabru = {
     email = "ddelabru@redhat.com";
     github = "ddelabru";

--- a/pkgs/development/tools/commit-and-tag-version/default.nix
+++ b/pkgs/development/tools/commit-and-tag-version/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+}:
+
+buildNpmPackage rec {
+  pname = "commit-and-tag-version";
+  version = "11.2.2";
+
+  src = fetchFromGitHub {
+    owner = "absolute-version";
+    repo = "commit-and-tag-version";
+    rev = "v${version}";
+    hash = "sha256-1oX0zijmGj+dQO+18bU/Oi4NVOf8Z652Sj2LJS8CxxY=";
+  };
+
+  npmDepsHash = "sha256-JNJATd8P98YKS5rHhmZgpewm8PPyZLKUtXSWZR6gLOY=";
+
+  dontNpmBuild = true;
+
+  meta = with lib; {
+    description = "A utility for versioning using semver and CHANGELOG generation powered by Conventional Commits";
+    homepage = "https://github.com/absolute-version/commit-and-tag-version";
+    license = licenses.isc;
+    maintainers = with maintainers; [ DCsunset ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -491,6 +491,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security CoreServices;
   };
 
+  commit-and-tag-version = callPackage ../development/tools/commit-and-tag-version { };
+
   conftest = callPackage ../development/tools/conftest { };
 
   coldsnap = callPackage ../tools/admin/coldsnap {


### PR DESCRIPTION
## Description of changes

Add a new package: https://github.com/absolute-version/commit-and-tag-version

Commit-and-tag-version is a utility for versioning using [semver](https://semver.org/) and CHANGELOG generation powered by [Conventional Commits](https://conventionalcommits.org/).
It supersedes [standard-version](https://github.com/conventional-changelog/standard-version) which is now deprecated.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
