### PR TITLE
yambar: fix strictDeps compilation

### DIFF
--- a/pkgs/applications/misc/yambar/default.nix
+++ b/pkgs/applications/misc/yambar/default.nix
@@ -44,12 +44,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" "man" ];
 
+  depsBuildBuild = [ pkg-config ];
+
   nativeBuildInputs = [
     bison
     flex
     meson
     ninja
     pkg-config
+    scdoc
     wayland-scanner
   ];
 
@@ -62,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     pipewire
     pixman
     pulseaudio
-    scdoc
     tllist
     udev
   ] ++ lib.optionals (waylandSupport) [


### PR DESCRIPTION
Yambar uses meson as build system. Its `dependency` function uses pkg-config as default method for finding the required dependencies.

However, as seen in their code[^1], scdoc is searched with `native` set to true. According to Meson specs[^2], it directs the search to the _build_ machine instead of the _host_ one. This parameter is usually needed only when finding a tool to be used during compilation.

Because of this, `pkg-config` needs to be included at `depsBuildBuild`.

Why? Magic! Sorry, I am not so proficient in cross-compilation issues yet.

[^1] https://codeberg.org/dnkl/yambar/src/commit/78f7b60e1308d9f6c879b5cbae2dadba4fa88762/doc/meson.build#L3 [^2] https://mesonbuild.com/Reference-manual_functions.html#dependency_native

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
