### PR TITLE
prismlauncher: add support for darwin

### DIFF
--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -1,8 +1,10 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , cmark
+, Cocoa
 , ninja
 , jdk17
 , zlib
@@ -13,7 +15,8 @@
 , ghc_filesystem
 , gamemode
 , msaClientID ? null
-, gamemodeSupport ? true
+, gamemodeSupport ? stdenv.isLinux
+,
 }:
 let
   libnbtplusplus = fetchFromGitHub {
@@ -23,7 +26,11 @@ let
     sha256 = "sha256-TvVOjkUobYJD9itQYueELJX3wmecvEdCbJ0FinW2mL4=";
   };
 in
-stdenv.mkDerivation rec {
+
+assert lib.assertMsg (stdenv.isLinux || !gamemodeSupport) "gamemodeSupport is only available on Linux";
+
+stdenv.mkDerivation
+rec {
   pname = "prismlauncher-unwrapped";
   version = "7.2";
 
@@ -34,23 +41,53 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-RArg60S91YKp1Mt97a5JNfBEOf2cmuX4pK3VAx2WfqM=";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules cmake jdk17 ninja ];
-  buildInputs = [
-    qtbase
-    zlib
-    quazip
-    ghc_filesystem
-    tomlplusplus
-    cmark
-  ] ++ lib.optional gamemodeSupport gamemode;
+  patches = lib.optionals stdenv.isDarwin [
+    # https://github.com/PrismLauncher/PrismLauncher/pull/1452
+    # These patches allow us to disable the Sparkle updater and cmake bundling
+    # TODO: remove these when updating to 8.0
+    (fetchpatch {
+      name = "disable-sparkle-when-url-is-empty.patch";
+      url = "https://github.com/PrismLauncher/PrismLauncher/commit/48e50401968a72846350c6fbd76cc957b64a6b5a.patch";
+      hash = "sha256-IFxp6Sj87ogQcMooV4Ql5/4B+C7oTzEk+4tlMud2OLo=";
+    })
+    (fetchpatch {
+      name = "make-install_bundle-cached.patch";
+      url = "https://github.com/PrismLauncher/PrismLauncher/commit/a8498b0dab94d0ab6c9e5cf395e5003db541b749.patch";
+      hash = "sha256-ji5GGUnzVut9xFXkynqf9aVR9FO/zsqIbt3P9dexJ2I=";
+    })
+    (fetchpatch {
+      name = "dont-include-sparkle-when-not-enabled.patch";
+      url = "https://github.com/PrismLauncher/PrismLauncher/commit/51bfda937d47837ed426150ed6f43a60b4ca0ce1.patch";
+      hash = "sha256-7hMgANOg4zRIf3F2AfLXGR3dAEBqVmKm/J5SH0G5oCk=";
+    })
+    (fetchpatch {
+      name = "introduce-internal-updater-variable.patch";
+      url = "https://github.com/PrismLauncher/PrismLauncher/commit/b1aa9e584624a0732dd55fc6c459524a8abfe6ba.patch";
+      hash = "sha256-mm++EfnBxz7NVtKLMb889mMq8F/OdQmzob8OmlvNlRA=";
+    })
+  ];
 
-  hardeningEnable = [ "pie" ];
+  nativeBuildInputs = [ extra-cmake-modules cmake jdk17 ninja ];
+  buildInputs =
+    [
+      qtbase
+      zlib
+      quazip
+      ghc_filesystem
+      tomlplusplus
+      cmark
+    ]
+    ++ lib.optional gamemodeSupport gamemode
+    ++ lib.optionals stdenv.isDarwin [ Cocoa ];
+
+  hardeningEnable = lib.optionals stdenv.isLinux [ "pie" ];
 
   cmakeFlags = [
     # downstream branding
     "-DLauncher_BUILD_PLATFORM=nixpkgs"
   ] ++ lib.optionals (msaClientID != null) [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
-    ++ lib.optionals (lib.versionOlder qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=5" ];
+  ++ lib.optionals (lib.versionOlder qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=5" ]
+  ++ lib.optionals stdenv.isDarwin [ "-DINSTALL_BUNDLE=nodeps" "-DMACOSX_SPARKLE_UPDATE_FEED_URL=''" ];
 
   postUnpack = ''
     rm -rf source/libraries/libnbtplusplus
@@ -67,7 +104,7 @@ stdenv.mkDerivation rec {
       their own mods, texture packs, saves, etc) and helps you manage them and
       their associated options with a simple interface.
     '';
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     changelog = "https://github.com/PrismLauncher/PrismLauncher/releases/tag/${version}";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ minion3665 Scrumplex getchoo ];

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -16,7 +16,7 @@
 , gamemode
 
 , msaClientID ? null
-, gamemodeSupport ? true
+, gamemodeSupport ? stdenv.isLinux
 , jdks ? [ jdk17 jdk8 ]
 , additionalLibs ? [ ]
 }:
@@ -38,7 +38,7 @@ symlinkJoin {
     qtbase
     qtsvg
   ]
-  ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland;
+  ++ lib.optional (lib.versionAtLeast qtbase.version "6" && stdenv.isLinux) qtwayland;
 
   postBuild = ''
     wrapQtAppsHook
@@ -64,9 +64,9 @@ symlinkJoin {
       ++ additionalLibs;
 
     in
-    [
+    [ "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}" ]
+    ++ lib.optionals stdenv.isLinux [
       "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${lib.makeLibraryPath libs}"
-      "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
       # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
       "--prefix PATH : ${lib.makeBinPath [xorg.xrandr]}"
     ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37747,11 +37747,15 @@ with pkgs;
 
   principia = callPackage ../games/principia { };
 
-  prismlauncher-qt5-unwrapped = libsForQt5.callPackage ../games/prismlauncher { };
+  prismlauncher-qt5-unwrapped = libsForQt5.callPackage ../games/prismlauncher {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   prismlauncher-qt5 = libsForQt5.callPackage ../games/prismlauncher/wrapper.nix { prismlauncher-unwrapped = prismlauncher-qt5-unwrapped; };
 
-  prismlauncher-unwrapped = qt6Packages.callPackage ../games/prismlauncher { };
+  prismlauncher-unwrapped = qt6Packages.callPackage ../games/prismlauncher {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   prismlauncher = qt6Packages.callPackage ../games/prismlauncher/wrapper.nix { };
 


### PR DESCRIPTION
## Description of changes

as the title says, this adds support for darwin in the prismlauncher package. it uses a patch currently in the `develop` branch upstream that allows for disabling the built in updater and post install bundling - both of which were the main blockers for this support until now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
