### PR TITLE
gtk-layer-shell: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/libraries/gtk-layer-shell/default.nix
+++ b/pkgs/development/libraries/gtk-layer-shell/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -15,9 +14,9 @@
 , vala
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gtk-layer-shell";
-  version = "0.8.0";
+  version = "0.8.1";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "devdoc"; # for demo
@@ -25,24 +24,9 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "wmww";
     repo = "gtk-layer-shell";
-    rev = "v${version}";
-    sha256 = "sha256-Z7jPYLKgkwMNXu80aaZ2vNj57LbN+X2XqlTTq6l0wTE=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-WW5sdOAJUKbSLWUpI9BK7O63/Uli+Tu9Tj9ccCOREPM=";
   };
-
-  patches = [
-    # https://github.com/wmww/gtk-layer-shell/pull/146
-    # Mark wayland-scanner as a build-time dependency
-    (fetchpatch {
-      url = "https://github.com/wmww/gtk-layer-shell/commit/6fd16352e5b35fefc91aa44e73671addaaa95dfc.patch";
-      hash = "sha256-U/mxmcRcZnsF0fvWW0axo6ajqW40NuOzNIAzoLCboRM=";
-    })
-    # https://github.com/wmww/gtk-layer-shell/pull/147
-    # Remove redundant dependency check for gtk-doc
-    (fetchpatch {
-      url = "https://github.com/wmww/gtk-layer-shell/commit/124ccc2772d5ecbb40b54872c22e594c74bd39bc.patch";
-      hash = "sha256-WfrWe9UJCp1RvVJhURAxGw4jzqPjoaP6182jVdoEAQs=";
-    })
-  ];
 
   strictDeps = true;
 
@@ -74,8 +58,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A library to create panels and other desktop components for Wayland using the Layer Shell protocol";
+    homepage = "https://github.com/wmww/gtk-layer-shell";
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ eonpatapon ];
+    maintainers = with maintainers; [ eonpatapon donovanglover ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Release: https://github.com/wmww/gtk-layer-shell/releases/tag/v0.8.1
Changes: https://github.com/wmww/gtk-layer-shell/compare/v0.8.0...v0.8.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

```
28 packages built:
avizo eww-wayland greetd.gtkgreet gtk-layer-shell gtk-layer-shell.dev gtk-layer-shell.devdoc gtklock nwg-bar nwg-dock nwg-dock-hyprland nwg-drawer nwg-launchers nwg-menu nwg-panel nwg-panel.dist nwg-wrapper nwg-wrapper.dist sfwbar sirula swaynotificationcenter swayosd swaysettings waybar wayfire-with-plugins wayfirePlugins.wayfire-plugins-extra wayfirePlugins.wcm wayfirePlugins.wf-shell wlogout
```