### PR TITLE
python3.pkgs.mesonpep517: add build dependencies and fix metadata

### DIFF
--- a/pkgs/development/python-modules/mesonpep517/default.nix
+++ b/pkgs/development/python-modules/mesonpep517/default.nix
@@ -5,6 +5,7 @@
 , ninja
 , setuptools
 , toml
+, wheel
 }:
 
 # TODO: offer meson as a Python package so we have dist-info folder.
@@ -19,18 +20,20 @@ buildPythonPackage rec {
     hash = "sha256-Fyo7JfLqHJqbahEjVDt/0xJxOfVLqLn3xNJ4lSB7KIw=";
   };
 
+  # Applies the following merge request, which doesn't apply cleanly:
+  # https://gitlab.com/thiblahute/mesonpep517/-/merge_requests/25
+  #
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'backend-path = "."' 'backend-path = ["."]'
+  '';
+
   nativeBuildInputs = [
     setuptools
+    wheel
   ];
 
   propagatedBuildInputs = [ toml ];
-
-  # postPatch = ''
-  #   # Meson tries to detect ninja as well, so we should patch meson as well.
-  #   substituteInPlace mesonpep517/buildapi.py \
-  #     --replace "'meson'" "'${meson}/bin/meson'" \
-  #     --replace "'ninja'" "'${ninja}/bin/ninja'"
-  # '';
 
   propagatedNativeBuildInputs = [ meson ninja ];
 


### PR DESCRIPTION
## Description of changes

Extracted from https://github.com/NixOS/nixpkgs/pull/245509. When we use [build](https://pypa-build.readthedocs.io/en/latest/) to build packages instead of pip:

1. We'd like to add wheel as an explicit build dependency.
2. We need to fix invalid pyproject.toml because there is stronger validation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
