### PR TITLE
jnethack: init at 3.6.7-0.1

### DIFF
--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -1,62 +1,15 @@
 {
   stdenv,
   lib,
+  callPackage,
   fetchurl,
-  coreutils,
-  ncurses,
-  gzip,
-  flex,
-  bison,
-  less,
-  buildPackages,
   x11Mode ? false,
   qtMode ? false,
-  libXaw,
-  libXext,
-  libXpm,
-  bdftopcf,
-  mkfontdir,
-  pkg-config,
-  qt5,
-  copyDesktopItems,
-  makeDesktopItem,
 }:
 
-let
-  platform =
-    if stdenv.hostPlatform.isUnix then
-      "unix"
-    else
-      throw "Unknown platform for NetHack: ${stdenv.hostPlatform.system}";
-  unixHint =
-    if x11Mode then
-      "linux-x11"
-    else if qtMode then
-      "linux-qt4"
-    else if stdenv.hostPlatform.isLinux then
-      "linux"
-    else if stdenv.hostPlatform.isDarwin then
-      "macosx10.14"
-    # We probably want something different for Darwin
-    else
-      "unix";
-  userDir = "~/.config/nethack";
-  binPath = lib.makeBinPath [
-    coreutils
-    less
-  ];
-
-in
-stdenv.mkDerivation rec {
+callPackage ./generic.nix rec {
+  gameName = "nethack";
   version = "3.6.7";
-  pname =
-    if x11Mode then
-      "nethack-x11"
-    else if qtMode then
-      "nethack-qt"
-    else
-      "nethack";
-
   src = fetchurl {
     url = "https://nethack.org/download/${version}/nethack-${
       lib.replaceStrings [ "." ] [ "" ] version
@@ -64,170 +17,33 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-mM9n323r+WaKYXRaqEwJvKs2Ll0z9blE7FFV1E0qrLI=";
   };
 
-  buildInputs =
-    [ ncurses ]
-    ++ lib.optionals x11Mode [
-      libXaw
-      libXext
-      libXpm
-    ]
-    ++ lib.optionals qtMode [
-      gzip
-      qt5.qtbase.bin
-      qt5.qtmultimedia.bin
-    ];
-
-  nativeBuildInputs =
-    [
-      flex
-      bison
-      copyDesktopItems
-    ]
-    ++ lib.optionals x11Mode [
-      mkfontdir
-      bdftopcf
-    ]
-    ++ lib.optionals qtMode [
-      pkg-config
-      mkfontdir
-      qt5.qtbase.dev
-      qt5.qtmultimedia.dev
-      qt5.wrapQtAppsHook
-      bdftopcf
-    ];
-
-  makeFlags = [ "PREFIX=$(out)" ];
-
-  postPatch = ''
-    sed -e '/^ *cd /d' -i sys/unix/nethack.sh
-    sed \
-      -e 's/^YACC *=.*/YACC = bison -y/' \
-      -e 's/^LEX *=.*/LEX = flex/' \
-      -i sys/unix/Makefile.utl
-    sed \
-      -e 's,^WINQT4LIB =.*,WINQT4LIB = `pkg-config Qt5Gui --libs` \\\
-            `pkg-config Qt5Widgets --libs` \\\
-            `pkg-config Qt5Multimedia --libs`,' \
-      -i sys/unix/Makefile.src
-    sed \
-      -e 's,^CFLAGS=-g,CFLAGS=,' \
-      -e 's,/bin/gzip,${gzip}/bin/gzip,g' \
-      -e 's,^WINTTYLIB=.*,WINTTYLIB=-lncurses,' \
-      -i sys/unix/hints/linux
-    sed \
-      -e 's,^#WANT_WIN_CURSES=1$,WANT_WIN_CURSES=1,' \
-      -e 's,^CC=.*$,CC=${stdenv.cc.targetPrefix}cc,' \
-      -e 's,^HACKDIR=.*$,HACKDIR=\$(PREFIX)/games/lib/\$(GAME)dir,' \
-      -e 's,^SHELLDIR=.*$,SHELLDIR=\$(PREFIX)/games,' \
-      -e 's,^CFLAGS=-g,CFLAGS=,' \
-      -i sys/unix/hints/macosx10.14
-    sed -e '/define CHDIR/d' -i include/config.h
-    ${lib.optionalString qtMode ''
-      sed \
-        -e 's,^QTDIR *=.*,QTDIR=${qt5.qtbase.dev},' \
-        -e 's,CFLAGS.*QtGui.*,CFLAGS += `pkg-config Qt5Gui --cflags`,' \
-        -e 's,CFLAGS+=-DCOMPRESS.*,CFLAGS+=-DCOMPRESS=\\"${gzip}/bin/gzip\\" \\\
-          -DCOMPRESS_EXTENSION=\\".gz\\",' \
-        -e 's,moc-qt4,moc,' \
-        -i sys/unix/hints/linux-qt4
-    ''}
-    ${lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform)
-      # If we're cross-compiling, replace the paths to the data generation tools
-      # with the ones from the build platform's nethack package, since we can't
-      # run the ones we've built here.
-      ''
-        ${buildPackages.perl}/bin/perl -p \
-          -e 's,[a-z./]+/(makedefs|dgn_comp|lev_comp|dlb)(?!\.),${buildPackages.nethack}/libexec/nethack/\1,g' \
-          -i sys/unix/Makefile.*
-      ''
-    }
-    sed -i -e '/rm -f $(MAKEDEFS)/d' sys/unix/Makefile.src
-    # Fix building on darwin where otherwise __has_attribute fails with an empty parameter
-    sed -e 's/define __warn_unused_result__ .*/define __warn_unused_result__ __unused__/' -i include/tradstdc.h
-    sed -e 's/define warn_unused_result .*/define warn_unused_result __unused__/' -i include/tradstdc.h
-  '';
-
-  configurePhase = ''
-    pushd sys/${platform}
-    ${lib.optionalString (platform == "unix") ''
-      sh setup.sh hints/${unixHint}
-    ''}
-    popd
-  '';
-
-  # https://github.com/NixOS/nixpkgs/issues/294751
-  enableParallelBuilding = false;
-
-  preFixup = lib.optionalString qtMode ''
-    wrapQtApp "$out/games/nethack"
-  '';
-
-  postInstall = ''
-    mkdir -p $out/games/lib/nethackuserdir
-    for i in xlogfile logfile perm record save; do
-      mv $out/games/lib/nethackdir/$i $out/games/lib/nethackuserdir
-    done
-
-    mkdir -p $out/bin
-    cat <<EOF >$out/bin/nethack
-    #! ${stdenv.shell} -e
-    PATH=${binPath}:\$PATH
-
-    if [ ! -d ${userDir} ]; then
-      mkdir -p ${userDir}
-      cp -r $out/games/lib/nethackuserdir/* ${userDir}
-      chmod -R +w ${userDir}
-    fi
-
-    RUNDIR=\$(mktemp -d)
-
-    cleanup() {
-      rm -rf \$RUNDIR
-    }
-    trap cleanup EXIT
-
-    cd \$RUNDIR
-    for i in ${userDir}/*; do
-      ln -s \$i \$(basename \$i)
-    done
-    for i in $out/games/lib/nethackdir/*; do
-      ln -s \$i \$(basename \$i)
-    done
-    $out/games/nethack
-    EOF
-    chmod +x $out/bin/nethack
-    ${lib.optionalString x11Mode "mv $out/bin/nethack $out/bin/nethack-x11"}
-    ${lib.optionalString qtMode "mv $out/bin/nethack $out/bin/nethack-qt"}
-    install -Dm 555 util/{makedefs,dgn_comp,lev_comp} -t $out/libexec/nethack/
-    ${lib.optionalString (!(x11Mode || qtMode)) "install -Dm 555 util/dlb -t $out/libexec/nethack/"}
-  '';
+  inherit stdenv x11Mode qtMode;
 
   desktopItems = [
-    (makeDesktopItem {
+    {
       name = "NetHack";
       exec =
         if x11Mode then
-          "nethack-x11"
+          "${gameName}-x11"
         else if qtMode then
-          "nethack-qt"
+          "${gameName}-qt"
         else
-          "nethack";
-      icon = "nethack";
+          gameName;
+      icon = gameName;
       desktopName = "NetHack";
       comment = "NetHack is a single player dungeon exploration game";
       categories = [
         "Game"
         "ActionGame"
       ];
-    })
+    }
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Rogue-like game";
     homepage = "http://nethack.org/";
     license = "nethack";
-    platforms = if x11Mode then platforms.linux else platforms.unix;
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with lib.maintainers; [ abbradar ];
     mainProgram = "nethack";
   };
 }

--- a/pkgs/games/nethack/generic.nix
+++ b/pkgs/games/nethack/generic.nix
@@ -1,0 +1,208 @@
+{
+  stdenv,
+  lib,
+  coreutils,
+  ncurses,
+  gzip,
+  flex,
+  bison,
+  less,
+  buildPackages,
+  x11Mode ? false,
+  qtMode ? false,
+  libXaw,
+  libXext,
+  libXpm,
+  bdftopcf,
+  mkfontdir,
+  pkg-config,
+  qt5,
+  copyDesktopItems,
+  makeDesktopItem,
+  gameName,
+  version,
+  src,
+  meta,
+  desktopItems ? [ ],
+}:
+
+let
+  platform =
+    if stdenv.hostPlatform.isUnix then
+      "unix"
+    else
+      throw "Unknown platform for NetHack: ${stdenv.hostPlatform.system}";
+  unixHint =
+    if x11Mode then
+      "linux-x11"
+    else if qtMode then
+      "linux-qt4"
+    else if stdenv.hostPlatform.isLinux then
+      "linux"
+    else if stdenv.hostPlatform.isDarwin then
+      "macosx10.14"
+    # We probably want something different for Darwin
+    else
+      "unix";
+  userDir = "~/.config/${gameName}";
+  binPath = lib.makeBinPath [
+    coreutils
+    less
+  ];
+
+in
+stdenv.mkDerivation {
+  inherit version src;
+
+  pname =
+    if x11Mode then
+      "${gameName}-x11"
+    else if qtMode then
+      "${gameName}-qt"
+    else
+      gameName;
+
+  buildInputs =
+    [ ncurses ]
+    ++ lib.optionals x11Mode [
+      libXaw
+      libXext
+      libXpm
+    ]
+    ++ lib.optionals qtMode [
+      gzip
+      qt5.qtbase.bin
+      qt5.qtmultimedia.bin
+    ];
+
+  nativeBuildInputs =
+    [
+      flex
+      bison
+      copyDesktopItems
+    ]
+    ++ lib.optionals x11Mode [
+      mkfontdir
+      bdftopcf
+    ]
+    ++ lib.optionals qtMode [
+      pkg-config
+      mkfontdir
+      qt5.qtbase.dev
+      qt5.qtmultimedia.dev
+      qt5.wrapQtAppsHook
+      bdftopcf
+    ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postPatch = ''
+    sed -e '/^ *cd /d' -i sys/unix/nethack.sh
+    sed \
+      -e 's/^YACC *=.*/YACC = bison -y/' \
+      -e 's/^LEX *=.*/LEX = flex/' \
+      -i sys/unix/Makefile.utl
+    sed \
+      -e 's,^WINQT4LIB =.*,WINQT4LIB = `pkg-config Qt5Gui --libs` \\\
+            `pkg-config Qt5Widgets --libs` \\\
+            `pkg-config Qt5Multimedia --libs`,' \
+      -i sys/unix/Makefile.src
+    sed \
+      -e 's,^CFLAGS=-g,CFLAGS=,' \
+      -e 's,/bin/gzip,${gzip}/bin/gzip,g' \
+      -e 's,^WINTTYLIB=.*,WINTTYLIB=-lncurses,' \
+      -i sys/unix/hints/linux
+    sed \
+      -e 's,^#WANT_WIN_CURSES=1$,WANT_WIN_CURSES=1,' \
+      -e 's,^CC=.*$,CC=${stdenv.cc.targetPrefix}cc,' \
+      -e 's,^HACKDIR=.*$,HACKDIR=\$(PREFIX)/games/lib/\$(GAME)dir,' \
+      -e 's,^SHELLDIR=.*$,SHELLDIR=\$(PREFIX)/games,' \
+      -e 's,^CFLAGS=-g,CFLAGS=,' \
+      -i sys/unix/hints/macosx10.14
+    sed -e '/define CHDIR/d' -i include/config.h
+    ${lib.optionalString qtMode ''
+      sed \
+        -e 's,^QTDIR *=.*,QTDIR=${qt5.qtbase.dev},' \
+        -e 's,CFLAGS.*QtGui.*,CFLAGS += `pkg-config Qt5Gui --cflags`,' \
+        -e 's,CFLAGS+=-DCOMPRESS.*,CFLAGS+=-DCOMPRESS=\\"${gzip}/bin/gzip\\" \\\
+          -DCOMPRESS_EXTENSION=\\".gz\\",' \
+        -e 's,moc-qt4,moc,' \
+        -i sys/unix/hints/linux-qt4
+    ''}
+    ${lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform)
+      # If we're cross-compiling, replace the paths to the data generation tools
+      # with the ones from the build platform's nethack package, since we can't
+      # run the ones we've built here.
+      ''
+        ${buildPackages.perl}/bin/perl -p \
+          -e 's,[a-z./]+/(makedefs|dgn_comp|lev_comp|dlb)(?!\.),${buildPackages.${gameName}}/libexec/${gameName}/\1,g' \
+          -i sys/unix/Makefile.*
+      ''
+    }
+    sed -i -e '/rm -f $(MAKEDEFS)/d' sys/unix/Makefile.src
+    # Fix building on darwin where otherwise __has_attribute fails with an empty parameter
+    sed -e 's/define __warn_unused_result__ .*/define __warn_unused_result__ __unused__/' -i include/tradstdc.h
+    sed -e 's/define warn_unused_result .*/define warn_unused_result __unused__/' -i include/tradstdc.h
+  '';
+
+  configurePhase = ''
+    pushd sys/${platform}
+    ${lib.optionalString (platform == "unix") ''
+      sh setup.sh hints/${unixHint}
+    ''}
+    popd
+  '';
+
+  # https://github.com/NixOS/nixpkgs/issues/294751
+  enableParallelBuilding = false;
+
+  preFixup = lib.optionalString qtMode ''
+    wrapQtApp "$out/games/${gameName}"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/games/lib/${gameName}userdir
+    for i in xlogfile logfile perm record save; do
+      mv $out/games/lib/${gameName}dir/$i $out/games/lib/${gameName}userdir
+    done
+
+    mkdir -p $out/bin
+    cat <<EOF >$out/bin/${gameName}
+    #! ${stdenv.shell} -e
+    PATH=${binPath}:\$PATH
+
+    if [ ! -d ${userDir} ]; then
+      mkdir -p ${userDir}
+      cp -r $out/games/lib/${gameName}userdir/* ${userDir}
+      chmod -R +w ${userDir}
+    fi
+
+    RUNDIR=\$(mktemp -d)
+
+    cleanup() {
+      rm -rf \$RUNDIR
+    }
+    trap cleanup EXIT
+
+    cd \$RUNDIR
+    for i in ${userDir}/*; do
+      ln -s \$i \$(basename \$i)
+    done
+    for i in $out/games/lib/${gameName}dir/*; do
+      ln -s \$i \$(basename \$i)
+    done
+    $out/games/${gameName}
+    EOF
+    chmod +x $out/bin/${gameName}
+    ${lib.optionalString x11Mode "mv $out/bin/${gameName} $out/bin/${gameName}-x11"}
+    ${lib.optionalString qtMode "mv $out/bin/${gameName} $out/bin/${gameName}-qt"}
+    install -Dm 555 util/{makedefs,dgn_comp,lev_comp} -t $out/libexec/${gameName}/
+    ${lib.optionalString (!(x11Mode || qtMode)) "install -Dm 555 util/dlb -t $out/libexec/${gameName}/"}
+  '';
+
+  desktopItems = map makeDesktopItem desktopItems;
+
+  meta = meta // {
+    platforms = if x11Mode then lib.platforms.linux else lib.platforms.unix;
+  };
+}

--- a/pkgs/games/nethack/jnethack.nix
+++ b/pkgs/games/nethack/jnethack.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchgit,
+  nkf,
+  callPackage,
+}:
+
+(callPackage ./generic.nix rec {
+  gameName = "jnethack";
+  version = "3.6.7-0.1";
+
+  src = fetchgit {
+    url = "http://scm.osdn.net/gitroot/jnethack/source.git";
+    rev = "3b3a9c4e25df60f9bce2ad09ce368410b4360e85";
+    hash = "sha256-yQZURMjz1FkYptwYgumV3gvab5l2WSJ7eLQcl+EdJGI=";
+  };
+
+  desktopItems = [
+    {
+      name = "JNetHack";
+      exec = gameName;
+      icon = gameName;
+      desktopName = "JNetHack";
+      comment = "JNetHack is a Japanese translation of NetHack";
+      categories = [
+        "Game"
+        "ActionGame"
+      ];
+    }
+  ];
+
+  meta = {
+    description = "Japanese translation of NetHack";
+    homepage = "https://jnethack.osdn.jp";
+    changelog = "https://osdn.net/projects/jnethack/scm/git/source/blobs/${src.rev}/ChangeLog.j";
+    downloadPage = "https://osdn.net/projects/jnethack/latest/releases/release";
+    license = "nethack";
+    mainProgram = "jnethack";
+    maintainers = with lib.maintainers; [ chayleaf ];
+  };
+}).overrideAttrs
+  (old: {
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ nkf ];
+
+    configurePhase = ''
+      find . -type f | xargs -n1 nkf -e --overwrite
+      ${old.configurePhase}
+    '';
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16412,6 +16412,8 @@ with pkgs;
 
   nethack-x11 = callPackage ../games/nethack { x11Mode = true; };
 
+  jnethack = callPackage ../games/nethack/jnethack.nix { };
+
   nile = python3Packages.callPackage ../games/nile { };
 
   npush = callPackage ../games/npush { };


### PR DESCRIPTION
## Description of changes

https://osdn.net/projects/jnethack/ - a Japanese translation of NetHack. GUI support builds, but isn't available, so the options to enable it deliberately aren't exposed (though the user can still override the nethack package).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
