### PR TITLE
python3.pkgs.josepy: fix tests with setuptools 67.5.0+

### DIFF
--- a/pkgs/development/python-modules/josepy/default.nix
+++ b/pkgs/development/python-modules/josepy/default.nix
@@ -1,11 +1,11 @@
 { lib
 , buildPythonPackage
 , cryptography
+, fetchpatch
 , fetchPypi
 , pyopenssl
 , pytestCheckHook
 , pythonOlder
-, setuptools
 }:
 
 buildPythonPackage rec {
@@ -20,10 +20,19 @@ buildPythonPackage rec {
     hash = "sha256-iTHa84+KTIUnSg6LfLJa3f2NHyj5+4++0FPdUa7HXck=";
   };
 
+  patches = [
+    # https://github.com/certbot/josepy/pull/158
+    (fetchpatch {
+      name = "fix-setuptools-deprecation.patch";
+      url = "https://github.com/certbot/josepy/commit/8f1b4b57a29a868a87fd6eee19a67a7ebfc07ea1.patch";
+      hash = "sha256-9d+Bk/G4CJXpnjJU0YkXLsg0G3tPxR8YN2niqriQQkI=";
+      includes = [ "tests/test_util.py" ];
+    })
+  ];
+
   propagatedBuildInputs = [
     pyopenssl
     cryptography
-    setuptools
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description of changes

Extracted from https://github.com/NixOS/nixpkgs/pull/245509. When setuptools is updated to 67.5.0+, a new deprecation warning is emitted that fails the tests. We can pull in a patch that stops using setuptools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
