### PR TITLE
gupnp, gupnp_1_6: fix compilation

### DIFF
--- a/pkgs/development/libraries/gupnp/1.6.nix
+++ b/pkgs/development/libraries/gupnp/1.6.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gupnp";
-  version = "1.6.4";
+  version = "1.6.5";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gupnp/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-1sPQNYOET6UqvgAwQxhgB/DIQUX+OwD6slmVvtqb5Vo=";
+    hash = "sha256-Q33/lwFC6EBwh6iYVfcX4g0nydduBbTNUX32IcfYiM0=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gupnp/default.nix
+++ b/pkgs/development/libraries/gupnp/default.nix
@@ -35,9 +35,18 @@ stdenv.mkDerivation rec {
     # Bring .pc file in line with our patched pkg-config.
     ./0001-pkg-config-Declare-header-dependencies-as-public.patch
 
+    # Unbreak build with Meson 1.2.0
+    # https://gitlab.gnome.org/GNOME/gupnp/-/merge_requests/33
+    (fetchpatch2 {
+      name = "meson-1.2-fix.patch";
+      url = "https://gitlab.gnome.org/GNOME/gupnp/-/commit/85c0244cfbf933d3e90d50ab68394c68d86f9ed5.patch";
+      hash = "sha256-poDhkEgDTpgGnTbbZLPwx8Alf0h81vmzJyx3izWmDGw=";
+    })
+
     # Fix build against libxml2 2.11
     # https://gitlab.gnome.org/GNOME/gupnp/-/merge_requests/34
     (fetchpatch2 {
+      name = "libxml2-2.11-fix.patch";
       url = "https://gitlab.gnome.org/GNOME/gupnp/-/commit/bc56f02b0f89e96f2bd74af811903d9931965f58.patch";
       hash = "sha256-KCHlq7Es+WLIWKgIgGVTaHarVQIiZPEi5r6nMAhXTgY=";
     })


### PR DESCRIPTION
meson 1.1.1 -> 1.2.0 had a few breaking changes. upstream [fixed it](https://gitlab.gnome.org/GNOME/gupnp/-/merge_requests/33) on both the main 1.6 and legacy 1.4 branches, but only published a release for `gupnp_1_6`: for the legacy `gupnp` we have to cherry-pick that fix.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
