### PR TITLE
libgnt: 2.14.1 -> 2.14.3

### DIFF
--- a/pkgs/development/libraries/libgnt/default.nix
+++ b/pkgs/development/libraries/libgnt/default.nix
@@ -2,20 +2,24 @@
 , gtk-doc, docbook-xsl-nons
 , glib, ncurses, libxml2
 , buildDocs ? true
+, mesonEmulatorHook
 }:
 stdenv.mkDerivation rec {
   pname = "libgnt";
-  version = "2.14.1";
+  version = "2.14.3";
 
   outputs = [ "out" "dev" ] ++ lib.optional buildDocs "devdoc";
 
   src = fetchurl {
     url = "mirror://sourceforge/pidgin/${pname}-${version}.tar.xz";
-    sha256 = "1n2bxg0ignn53c08cp69pj4sdg53kwlqn23rincyjmpr327fdhsy";
+    hash = "sha256-V/VFf3KZnQuxoTmjfydG7BtaAsCU8nEKM52LzqQjYSM=";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config ]
-    ++ lib.optionals buildDocs [ gtk-doc docbook-xsl-nons ];
+  nativeBuildInputs = [ glib meson ninja pkg-config ]
+    ++ lib.optionals buildDocs [ gtk-doc docbook-xsl-nons ]
+    ++ lib.optionals (buildDocs && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      mesonEmulatorHook
+    ];
 
   buildInputs = [ glib ncurses libxml2 ];
 
@@ -23,9 +27,11 @@ stdenv.mkDerivation rec {
     substituteInPlace meson.build --replace \
       "ncurses_sys_prefix = '/usr'" \
       "ncurses_sys_prefix = '${lib.getDev ncurses}'"
-  '' + lib.optionalString (!buildDocs) ''
-    sed "/^subdir('doc')$/d" -i meson.build
   '';
+  mesonFlags = [
+    (lib.mesonBool "doc" buildDocs)
+    (lib.mesonBool "python2" false)
+  ];
 
   meta = with lib; {
     description = "An ncurses toolkit for creating text-mode graphical user interfaces";


### PR DESCRIPTION
## Description of changes

[changelog](https://keep.imfreedom.org/libgnt/libgnt/file/v2.14.3/ChangeLog)

tested by using `chatty` for a day. the main user of this library is `pidgin` though, so might be better if a pidgin user could test it more directly.

upstream exposes proper meson_options for building docs, so use that. this enables cross compilation via `pkgsCross.aarch64-multiplatform.libgnt` :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
