### PR TITLE
nixos/image: use stable target dir for amended repart definitions

### DIFF
--- a/nixos/modules/image/amend-repart-definitions.py
+++ b/nixos/modules/image/amend-repart-definitions.py
@@ -15,8 +15,6 @@ files using the same mechanism.
 import json
 import sys
 import shutil
-import os
-import tempfile
 from pathlib import Path
 
 
@@ -92,12 +90,13 @@ def main() -> None:
         print("Partition config is empty.")
         sys.exit(1)
 
-    temp = tempfile.mkdtemp()
-    shutil.copytree(repart_definitions, temp, dirs_exist_ok=True)
+    target_dir = Path("amended-repart.d")
+    target_dir.mkdir()
+    shutil.copytree(repart_definitions, target_dir, dirs_exist_ok=True)
 
     for name, config in partition_config.items():
-        definition = Path(f"{temp}/{name}.conf")
-        os.chmod(definition, 0o644)
+        definition = target_dir.joinpath(f"{name}.conf")
+        definition.chmod(0o644)
 
         contents = config.get("contents")
         add_contents_to_definition(definition, contents)
@@ -106,7 +105,7 @@ def main() -> None:
         strip_nix_store_prefix = config.get("stripStorePaths")
         add_closure_to_definition(definition, closure, strip_nix_store_prefix)
 
-    print(temp)
+    print(target_dir.absolute())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of changes

Output the amended repart definitions to a well-known directory in $TMPDIR instead of using a temporary directory with a random directory name.

The output file `repart-output.json` also contains the full path to the repart definition file used to create the partition. As `amend-repart-definitions.py` uses `tempfile.mkdtemp`, this introduces an impurity:

```json
{
        "type" : "root-x86-64",
        "label" : "rootfs",
        "uuid" : "f2fa2e49-e443-45d2-a2e2-c3754cab6363",
        "file" : "/build/tmppjo7kv5o/rootfs.conf",
        "node" : "image.raw2",
        "offset" : 135266304,
        "old_size" : 0,
        "raw_size" : 1651101696,
        "old_padding" : 0,
        "raw_padding" : 0,
        "activity" : "create",
}
```

This commit changes the parent directory of the amended repart definitions to `/build/amended-repart.d/`.

ref: #246603

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
