### PR TITLE
wgnord: Dynamic configuration path

### DIFF
--- a/pkgs/applications/networking/wgnord/default.nix
+++ b/pkgs/applications/networking/wgnord/default.nix
@@ -24,6 +24,7 @@ resholve.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace wgnord \
+      --replace 'conf_dir=/var/lib/wgnord' "conf_dir=$out/share" \
       --replace '$conf_dir/countries.txt' "$out/share/countries.txt" \
       --replace '$conf_dir/countries_iso31662.txt' "$out/share/countries_iso31662.txt"
   '';


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

wgnord looks for the changes in `/var/lib/wgnord` which is not available. So changing it to `$out`
