### PR TITLE
lib/options: strip superfluous trailing dots from enable options

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -32,6 +32,7 @@ let
   inherit (lib.strings)
     concatMapStrings
     concatStringsSep
+    removeSuffix
     ;
   inherit (lib.types)
     mkOptionType
@@ -100,7 +101,7 @@ rec {
     name: mkOption {
     default = false;
     example = true;
-    description = "Whether to enable ${name}.";
+    description = "Whether to enable ${removeSuffix "." (removeSuffix "\n" name)}.";
     type = lib.types.bool;
   };
 


### PR DESCRIPTION
## Description of changes

This gets rid of trailing double dots in `man configuration.nix`.
 
## Things done

Built the man pages with this change and looked at the [diff](https://github.com/NixOS/nixpkgs/files/12250463/no-double-dots.txt).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Alternatives to consider

* Fix all occurrences of this in tree and add checks to OfBorg to prevent people from adding trailing dots.
    (could also be done on top of this pr in addition or as a way forward)
* Do nothing and keep fixing every new occurrence 