### PR TITLE
LASzip: fix dylib names for darwin and so on

### DIFF
--- a/pkgs/development/libraries/LASzip/default.nix
+++ b/pkgs/development/libraries/LASzip/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, cmake, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   version = "3.4.3";
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+  ] ++ lib.optionals stdenv.isDarwin [
+    fixDarwinDylibNames
   ];
 
   meta = {

--- a/pkgs/development/libraries/LASzip/default.nix
+++ b/pkgs/development/libraries/LASzip/default.nix
@@ -1,14 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fixDarwinDylibNames }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, fixDarwinDylibNames
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "3.4.3";
   pname = "LASzip";
 
   src = fetchFromGitHub {
     owner = "LASzip";
     repo = "LASzip";
-    rev = version;
-    sha256 = "09lcsgxwv0jq50fhsgfhx0npbf1zcwn3hbnq6q78fshqksbxmz7m";
+    rev = finalAttrs.version;
+    hash = "sha256-9fzal54YaocONtguOCxnP7h1LejQPQ0dKFiCzfvTjCY=";
   };
 
   nativeBuildInputs = [
@@ -20,8 +25,9 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Turn quickly bulky LAS files into compact LAZ files without information loss";
     homepage = "https://laszip.org";
+    changelog = "https://github.com/LASzip/LASzip/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.lgpl2;
     maintainers = [ lib.maintainers.michelk ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/laspy/default.nix
+++ b/pkgs/development/python-modules/laspy/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , numpy
 , laszip
+, setuptools
 , pytestCheckHook
 , pythonOlder
 }:
@@ -10,7 +11,7 @@
 buildPythonPackage rec {
   pname = "laspy";
   version = "2.4.1";
-  format = "setuptools";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -19,12 +20,16 @@ buildPythonPackage rec {
     hash = "sha256-E8rsxzJcsiQsslOUmE0hs7X3lsiLy0S8LtLTzxuXKsQ=";
   };
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [
     numpy
     laszip
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 
@@ -36,7 +41,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Interface for reading/modifying/creating .LAS LIDAR files";
     homepage = "https://github.com/laspy/laspy";
-    changelog = "https://github.com/laspy/laspy/blob/2.4.1/CHANGELOG.md";
+    changelog = "https://github.com/laspy/laspy/blob/${version}/CHANGELOG.md";
     license = licenses.bsd2;
     maintainers = with maintainers; [ matthewcroughan ];
   };

--- a/pkgs/development/python-modules/laspy/default.nix
+++ b/pkgs/development/python-modules/laspy/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "laspy";
-  version = "2.4.1";
+  version = "2.5.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-E8rsxzJcsiQsslOUmE0hs7X3lsiLy0S8LtLTzxuXKsQ=";
+    hash = "sha256-uqPJxswVVjbxYRSREfnPwkPb0U9synKclLNWsxxmjy4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/laszip/default.nix
+++ b/pkgs/development/python-modules/laszip/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , scikit-build-core
@@ -10,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "laszip-python";
-  version = "0.2.1";
+  version = "0.2.3";
 
   format = "pyproject";
 
@@ -20,8 +21,10 @@ buildPythonPackage rec {
     owner = "tmontaigu";
     repo = pname;
     rev = version;
-    hash = "sha256-ujKoUm2Btu25T7ZrSGqjRc3NR1qqsQU8OwHQDSx8grY=";
+    hash = "sha256-MiPzL9TDCf1xnCv7apwdfcpkFnBRi4PO/atTQxqL8cw=";
   };
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-std=c++17";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/python-modules/laszip/default.nix
+++ b/pkgs/development/python-modules/laszip/default.nix
@@ -2,13 +2,10 @@
 , buildPythonPackage
 , fetchFromGitHub
 , scikit-build-core
-, distlib
-, pytestCheckHook
-, pyproject-metadata
-, pathspec
 , pybind11
 , cmake
 , LASzip
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -17,31 +14,27 @@ buildPythonPackage rec {
 
   format = "pyproject";
 
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "tmontaigu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ujKoUm2Btu25T7ZrSGqjRc3NR1qqsQU8OwHQDSx8grY=";
+    hash = "sha256-ujKoUm2Btu25T7ZrSGqjRc3NR1qqsQU8OwHQDSx8grY=";
   };
 
   nativeBuildInputs = [
+    cmake
+    pybind11
     scikit-build-core
     scikit-build-core.optional-dependencies.pyproject
-    cmake
   ];
+
+  dontUseCmakeConfigure = true;
 
   buildInputs = [
-    pybind11
     LASzip
   ];
-
-  checkInputs = [
-    pytestCheckHook
-  ];
-
-  preBuild = ''
-    cd ..
-  '';
 
   # There are no tests
   doCheck = false;
@@ -51,6 +44,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Unofficial bindings between Python and LASzip made using pybind11";
     homepage = "https://github.com/tmontaigu/laszip-python";
+    changelog = "https://github.com/tmontaigu/laszip-python/blob/${src.rev}/Changelog.md";
     license = licenses.mit;
     maintainers = with maintainers; [ matthewcroughan ];
   };


### PR DESCRIPTION
## Description of changes

LASzip had a relative dylib name in darwin, so downstream packages like python3Packages.laszip could not find it.
This PR fixes that and also bumps the related package.

- python310Packages.laszip: 0.2.1 -> 0.2.3
- python310Packages.laspy: 2.4.1 -> 2.5.1

I found this build failure in #246143

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
