### PR TITLE
python2.pkgs.backports-functools-lru-cache: init at 1.6.6

### DIFF
--- a/pkgs/development/python2-modules/backports-functools-lru-cache/default.nix
+++ b/pkgs/development/python2-modules/backports-functools-lru-cache/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "backports-functools-lru-cache";
+  version = "1.6.6";
+  format = "pyproject";
+
+  src = fetchPypi {
+    pname = "backports.functools_lru_cache";
+    inherit version;
+    hash = "sha256-e3DnAbpNtYwO2GcanTORsKu5vRvCTU6Qw0gPS6r8wtw=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  # circular dependency:
+  # backports-functools-lru-cache -> pytest -> wc-width -> backports-functools-lru-cache
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "backports.functools_lru_cache"
+  ];
+
+  meta = {
+    description = "Backport of functools.lru_cache";
+    homepage = "https://github.com/jaraco/backports.functools_lru_cache";
+    license = lib.licenses.mit;
+  };
+}
+

--- a/pkgs/development/python2-modules/wcwidth/default.nix
+++ b/pkgs/development/python2-modules/wcwidth/default.nix
@@ -1,0 +1,10 @@
+{ backports-functools-lru-cache
+, wcwidth
+}:
+
+wcwidth.overridePythonAttrs(oldAttrs: {
+  propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [
+    backports-functools-lru-cache
+  ];
+})
+

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -7,6 +7,8 @@ self: super:
 with self; with super; {
   attrs = callPackage ../development/python2-modules/attrs { };
 
+  backports-functools-lru-cache = callPackage ../development/python2-modules/backports-functools-lru-cache { };
+
   bootstrapped-pip = toPythonModule (callPackage ../development/python2-modules/bootstrapped-pip { });
 
   cffi = callPackage ../development/python2-modules/cffi { inherit cffi; };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -83,6 +83,10 @@ with self; with super; {
     doCheck = false;  # circular dependency with pytest
   });
 
+  wcwidth = callPackage ../development/python2-modules/wcwidth {
+    inherit wcwidth;
+  };
+
   wheel = callPackage ../development/python2-modules/wheel { };
 
   zeek = disabled super.zeek;


### PR DESCRIPTION
## Description of changes

This is a minimal restoration of this package to python2-modules to resolve https://github.com/NixOS/nixpkgs/issues/246631.

I'm supportive of the effort to update FAH, but I also see that the GIMP plugin issue seems unresolvable without someone putting concentrated effort into it upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
