### PR TITLE
openmolcas: enable dmrg and nevpt2 support

### DIFF
--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -1,19 +1,47 @@
-{ lib, stdenv, fetchFromGitLab, cmake, gfortran, perl
-, blas-ilp64, hdf5-cpp, python3, texlive
-, armadillo, libxc, makeWrapper
-# Note that the CASPT2 module is broken with MPI
-# See https://gitlab.com/Molcas/OpenMolcas/-/issues/169
+{ lib
+, stdenv
+, fetchFromGitLab
+, fetchFromGitHub
+, cmake
+, gfortran
+, perl
+, blas-ilp64
+, hdf5-cpp
+, python3
+, texlive
+, armadillo
+, libxc
+, makeWrapper
+, gsl
+, boost175
+, autoPatchelfHook
+  # Note that the CASPT2 module is broken with MPI
+  # See https://gitlab.com/Molcas/OpenMolcas/-/issues/169
 , enableMpi ? false
-, mpi, globalarrays
-} :
+, mpi
+, globalarrays
+}:
 
 assert blas-ilp64.isILP64;
 assert lib.elem blas-ilp64.passthru.implementation [ "openblas" "mkl" ];
 
 let
-  python = python3.withPackages (ps : with ps; [ six pyparsing numpy h5py ]);
+  python = python3.withPackages (ps: with ps; [ six pyparsing numpy h5py ]);
+  qcmaquisSrc = fetchFromGitHub {
+    owner = "qcscine";
+    repo = "qcmaquis";
+    rev = "release-3.1.1"; # Must match tag in cmake/custom/qcmaquis.cmake
+    hash = "sha256-diLDWj/Om6EHrVp+Hd24jsN6R9vV2vRl0y9gqyRWhkI=";
+  };
+  nevtp2Src = fetchFromGitHub {
+    owner = "qcscine";
+    repo = "nevpt2";
+    rev = "e1484fd"; # Must match tag in cmake/custom/nevpt2.cmake
+    hash = "sha256-Vl+FhwhJBbD/7U2CwsYE9BClSQYLJ8DKXV9EXxQUmz0=";
+  };
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   pname = "openmolcas";
   version = "23.06";
 
@@ -28,12 +56,22 @@ in stdenv.mkDerivation {
   patches = [
     # Required to handle openblas multiple outputs
     ./openblasPath.patch
+
+    # Required for a local QCMaquis build
+    ./qcmaquis.patch
   ];
 
   postPatch = ''
     # Using env fails in the sandbox
     substituteInPlace Tools/pymolcas/export.py --replace \
       "/usr/bin/env','python3" "python3"
+
+    # Pointing CMake to local QCMaquis and NEVPT2 archives
+    substituteInPlace cmake/custom/qcmaquis.cmake \
+      --subst-var-by "qcmaquis_src_url" "file://${qcmaquisSrc}"
+
+    substituteInPlace cmake/custom/nevpt2.cmake \
+      --subst-var-by "nevpt2_src_url" "file://${nevtp2Src}"
   '';
 
   nativeBuildInputs = [
@@ -42,6 +80,7 @@ in stdenv.mkDerivation {
     cmake
     texlive.combined.scheme-minimal
     makeWrapper
+    autoPatchelfHook
   ];
 
   buildInputs = [
@@ -50,6 +89,8 @@ in stdenv.mkDerivation {
     python
     armadillo
     libxc
+    gsl.dev
+    boost175
   ] ++ lib.optionals enableMpi [
     mpi
     globalarrays
@@ -64,10 +105,15 @@ in stdenv.mkDerivation {
     "-DHDF5=ON"
     "-DFDE=ON"
     "-DEXTERNAL_LIBXC=${libxc}"
+    "-DDMRG=ON"
+    "-DNEVPT2=ON"
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ] ++ lib.optionals (blas-ilp64.passthru.implementation == "openblas") [
-    "-DOPENBLASROOT=${blas-ilp64.passthru.provider.dev}" "-DLINALG=OpenBLAS"
+    "-DOPENBLASROOT=${blas-ilp64.passthru.provider.dev}"
+    "-DLINALG=OpenBLAS"
   ] ++ lib.optionals (blas-ilp64.passthru.implementation == "mkl") [
-    "-DMKLROOT=${blas-ilp64.passthru.provider}" "-DLINALG=MKL"
+    "-DMKLROOT=${blas-ilp64.passthru.provider}"
+    "-DLINALG=MKL"
   ] ++ lib.optionals enableMpi [
     "-DGA=ON"
     "-DMPI=ON"
@@ -89,6 +135,10 @@ in stdenv.mkDerivation {
     rm -r $out/Tools
   '';
 
+  # DMRG executables contain references to /build, however, they are properly
+  # removed by autopatchelf
+  noAuditTmpdir = true;
+
   postFixup = ''
     # Wrong store path in shebang (no Python pkgs), force re-patching
     sed -i "1s:/.*:/usr/bin/env python:" $out/bin/pymolcas
@@ -101,7 +151,7 @@ in stdenv.mkDerivation {
     description = "Advanced quantum chemistry software package";
     homepage = "https://gitlab.com/Molcas/OpenMolcas";
     maintainers = [ maintainers.markuskowa ];
-    license = licenses.lgpl21Only;
+    license = with licenses; [ lgpl21Only bsd3 ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "pymolcas";
   };

--- a/pkgs/applications/science/chemistry/openmolcas/qcmaquis.patch
+++ b/pkgs/applications/science/chemistry/openmolcas/qcmaquis.patch
@@ -1,0 +1,46 @@
+diff --git a/cmake/custom/nevpt2.cmake b/cmake/custom/nevpt2.cmake
+index 789739ec8..6c86a7b8c 100644
+--- a/cmake/custom/nevpt2.cmake
++++ b/cmake/custom/nevpt2.cmake
+@@ -67,6 +67,7 @@ list(APPEND NEVPT2CMakeArgs
+   "-DMOLCAS_BUILD_DIR=${PROJECT_BINARY_DIR}"
+   "-DCMAKE_Fortran_MODULE_DIRECTORY=${mod_dir}"
+   "-DDMRG_INCLUDE=${HDF5_QCM_INCLUDE}"
++  "-DCMAKE_SKIP_BUILD_RPATH=ON"
+   )
+ 
+ if(HDF5_ROOT)
+@@ -118,9 +119,7 @@ endif ()
+ 
+ ExternalProject_Add(${EP_PROJECT}
+                     PREFIX ${CUSTOM_NEVPT2_LOCATION}
+-                    GIT_REPOSITORY ${reference_git_repo}
+-                    GIT_TAG ${reference_git_commit}
+-                    UPDATE_DISCONNECTED ${EP_SkipUpdate}
++                    URL @nevpt2_src_url@
+                     CMAKE_ARGS "${NEVPT2CMakeArgs}"
+                     INSTALL_DIR "${PROJECT_BINARY_DIR}/qcmaquis"
+                    )
+diff --git a/cmake/custom/qcmaquis.cmake b/cmake/custom/qcmaquis.cmake
+index 176d02761..e160b7bc8 100644
+--- a/cmake/custom/qcmaquis.cmake
++++ b/cmake/custom/qcmaquis.cmake
+@@ -78,6 +78,7 @@ list(APPEND QCMaquisCMakeArgs
+   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+   -DCMAKE_CXX_FLAGS=${QCM_CMake_CXX_FLAGS}
+   -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
++  -DCMAKE_SKIP_BUILD_RPATH=ON
+   )
+ if(HDF5_ROOT)
+   list(APPEND QCMaquisCMakeArgs
+@@ -278,9 +279,7 @@ set (CMAKE_DISABLE_SOURCE_CHANGES OFF)
+ 
+     ExternalProject_Add(${EP_PROJECT}
+         PREFIX ${extprojpath}
+-        GIT_REPOSITORY ${reference_git_repo}
+-        GIT_TAG ${reference_git_commit}
+-        UPDATE_DISCONNECTED ${EP_SkipUpdate}
++        URL @qcmaquis_src_url@
+ 
+         SOURCE_SUBDIR dmrg
+         CMAKE_ARGS ${EP_CMAKE_ARGS}


### PR DESCRIPTION
## Description of changes

This adds support for DMRG CASSCF and DMRG NEVPT2 calculations via QCMaquis to OpenMolcas.
I've confirmed that the input example at https://molcas.gitlab.io/OpenMolcas/sphinx/users.guide/programs/dmrgscf.html#input-files actually works! :partying_face: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).