### PR TITLE
airwindows-lv2: 20.0 -> 22.0

### DIFF
--- a/pkgs/applications/audio/airwindows-lv2/default.nix
+++ b/pkgs/applications/audio/airwindows-lv2/default.nix
@@ -1,13 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, lv2 }:
+{ lib, stdenv, fetchFromSourcehut, meson, ninja, pkg-config, lv2 }:
 
 stdenv.mkDerivation rec {
   pname = "airwindows-lv2";
-  version = "20.0";
-  src = fetchFromGitHub {
-    owner = "hannesbraun";
+  version = "22.0";
+  src = fetchFromSourcehut {
+    owner = "~hannes";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-uflvUmUzOtF3BwiLfnd+qhz+ZYyn8AKvODFs599phhU=";
+    sha256 = "sha256-u62wLRrJ45ap981Q8JmMnanc8AWQb1MJHK32PEr10I4=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config ];
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Airwindows plugins (ported to LV2)";
-    homepage = "https://github.com/hannesbraun/airwindows-lv2";
+    homepage = "https://sr.ht/~hannes/airwindows-lv2";
     license = licenses.mit;
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.unix;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This pull request updates the package to version 22.0. The changelog is available here: https://git.sr.ht/~hannes/airwindows-lv2/refs/v22.0

As the project moved to Sourcehut, I updated the source location as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
