### PR TITLE
nixos-render-docs: fix empty inlines

### DIFF
--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -623,7 +623,7 @@ class HTMLConverter(BaseConverter[ManualHTMLRenderer]):
             elif bt.type == 'footnote_ref' and (id := cast(str, bt.attrs.get('id', ''))):
                 result.append(XrefTarget(id, "???", None, None, target_file))
             elif bt.type == 'inline':
-                assert bt.children
+                assert bt.children is not None
                 result += self._collect_ids(bt.children, target_file, typ, False)
             elif id := cast(str, bt.attrs.get('id', '')):
                 # anchors and examples have no titles we could use, but we'll have to put

--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/md.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/md.py
@@ -458,7 +458,7 @@ def _footnote_ids(md: markdown_it.MarkdownIt) -> None:
                 token.attrs['id'] = f'{token.meta["label"]}.__back.{token.meta["subId"]}'
                 token.meta['target'] = token.meta["label"]
             elif token.type == 'inline':
-                assert token.children
+                assert token.children is not None
                 generate_ids(token.children)
 
     def footnote_ids(state: markdown_it.rules_core.StateCore) -> None:


### PR DESCRIPTION
## Description of changes

`children` only has to be not-None, not also not-[]. empty table cells would can produce an empty inline token and cause these checks to fail, even though the token actually is totally valid.

showed up in
https://github.com/NixOS/nixpkgs/pull/246956#discussion_r1283146120.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
