### PR TITLE
gleam: add update script

### DIFF
--- a/pkgs/development/compilers/gleam/default.nix
+++ b/pkgs/development/compilers/gleam/default.nix
@@ -1,4 +1,14 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, git, pkg-config, openssl, Security, libiconv }:
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, git
+, pkg-config
+, openssl
+, Security
+, libiconv
+, nix-update-script
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "gleam";
@@ -17,6 +27,8 @@ rustPlatform.buildRustPackage rec {
     lib.optionals stdenv.isDarwin [ Security libiconv ];
 
   cargoHash = "sha256-K7MrrnupH1BS8KEIgVdlnGF91J5ND5umgdeLVCg7DbQ=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A statically typed language for the Erlang VM";

--- a/pkgs/development/compilers/gleam/default.nix
+++ b/pkgs/development/compilers/gleam/default.nix
@@ -12,13 +12,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gleam";
-  version = "0.30.2";
+  version = "0.30.5";
 
   src = fetchFromGitHub {
     owner = "gleam-lang";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-XrXN+HZlCPzywFo10/vLHbz/zjglSZnNQKfYvLvx35I=";
+    hash = "sha256-DOQhuSNIyP6K+M9a/uM8Cn6gyzpaH23+n4fux8otPWQ=";
   };
 
   nativeBuildInputs = [ git pkg-config ];
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ] ++
     lib.optionals stdenv.isDarwin [ Security libiconv ];
 
-  cargoHash = "sha256-K7MrrnupH1BS8KEIgVdlnGF91J5ND5umgdeLVCg7DbQ=";
+  cargoHash = "sha256-CkMUconCw94Jvy7FhrOZvBbA8DAi91Ae5GFxGFBcEew=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
## Description of changes

I added an update script and also ran the script and updated gleam from `0.30.2` to `0.30.5`.
*I'm not really good at writing bash but tried my best, waiting for reviews :)*

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

