### PR TITLE
Update hyprwm packages and nixos/hyprland

### DIFF
--- a/nixos/modules/programs/hyprland.nix
+++ b/nixos/modules/programs/hyprland.nix
@@ -32,11 +32,10 @@ in
       readOnly = true;
       default = cfg.package.override {
         enableXWayland = cfg.xwayland.enable;
-        hidpiXWayland = cfg.xwayland.hidpi;
-        nvidiaPatches = cfg.nvidiaPatches;
+        enableNvidiaPatches = cfg.enableNvidiaPatches;
       };
       defaultText = literalExpression
-        "`wayland.windowManager.hyprland.package` with applied configuration";
+        "`programs.hyprland.package` with applied configuration";
       description = mdDoc ''
         The Hyprland package after applying configuration.
       '';
@@ -44,17 +43,9 @@ in
 
     portalPackage = mkPackageOptionMD pkgs "xdg-desktop-portal-hyprland" { };
 
-    xwayland = {
-      enable = mkEnableOption (mdDoc "XWayland") // { default = true; };
-      hidpi = mkEnableOption null // {
-        description = mdDoc ''
-          Enable HiDPI XWayland, based on [XWayland MR 733](https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/733).
-          See <https://wiki.hyprland.org/Nix/Options-Overrides/#xwayland-hidpi> for more info.
-        '';
-      };
-    };
+    xwayland.enable = mkEnableOption (mdDoc "XWayland") // { default = true; };
 
-    nvidiaPatches = mkEnableOption (mdDoc "patching wlroots for better Nvidia support");
+    enableNvidiaPatches = mkEnableOption (mdDoc "patching wlroots for better Nvidia support");
   };
 
   config = mkIf cfg.enable {
@@ -77,4 +68,15 @@ in
       extraPortals = [ finalPortalPackage ];
     };
   };
+
+  imports = with lib; [
+    (mkRemovedOptionModule
+      [ "programs" "hyprland" "xwayland" "hidpi" ]
+      "XWayland patches are deprecated. Refer to https://wiki.hyprland.org/Configuring/XWayland"
+    )
+    (mkRenamedOptionModule
+      [ "programs" "hyprland" "nvidiaPatches" ]
+      [ "programs" "hyprland" "enableNvidiaPatches" ]
+    )
+  ];
 }

--- a/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
@@ -52,7 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
     # make meson use the provided dependencies instead of the git submodules
     "${finalAttrs.src}/nix/patches/meson-build.patch"
     # look into $XDG_DESKTOP_PORTAL_DIR instead of /usr; runtime checks for conflicting portals
-    "${finalAttrs.src}/nix/patches/portals.patch"
+    # NOTE: revert back to the patch inside SRC on the next version bump
+    # "${finalAttrs.src}/nix/patches/portals.patch"
+    ./portals.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
@@ -2,8 +2,10 @@
 , stdenv
 , fetchFromGitHub
 , pkg-config
+, makeWrapper
 , meson
 , ninja
+, binutils
 , cairo
 , git
 , hyprland-protocols
@@ -24,34 +26,33 @@
 , xcbutilwm
 , xwayland
 , debug ? false
+, enableNvidiaPatches ? false
 , enableXWayland ? true
-, hidpiXWayland ? false
 , legacyRenderer ? false
-, nvidiaPatches ? false
 , withSystemd ? true
+, wrapRuntimeDeps ? true
+  # deprecated flags
+, nvidiaPatches ? false
+, hidpiXWayland ? false
 }:
-let
-  assertXWayland = lib.assertMsg (hidpiXWayland -> enableXWayland) ''
-    Hyprland: cannot have hidpiXWayland when enableXWayland is false.
-  '';
-in
-assert assertXWayland;
+assert lib.assertMsg (!nvidiaPatches) "The option `nvidiaPatches` has been renamed `enableNvidiaPatches`";
+assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been removed. Please refer https://wiki.hyprland.org/Configuring/XWayland";
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprland" + lib.optionalString debug "-debug";
-  version = "0.27.0";
+  version = "unstable-2023-08-08";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = finalAttrs.pname;
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-mEKF6Wcx+wSF/eos/91A7LxhFLDYhSnQnLpwZF13ntg=";
+    rev = "8e04a80e60983f5def26bdcaea701040fea9a7ae";
+    hash = "sha256-5/vEdU3SzAdeIyPykjks/Zxkvh9luPTIei6oa77OY2Q=";
   };
 
   patches = [
     # make meson use the provided dependencies instead of the git submodules
-    "${finalAttrs.src}/nix/meson-build.patch"
+    "${finalAttrs.src}/nix/patches/meson-build.patch"
     # look into $XDG_DESKTOP_PORTAL_DIR instead of /usr; runtime checks for conflicting portals
-    "${finalAttrs.src}/nix/portals.patch"
+    "${finalAttrs.src}/nix/patches/portals.patch"
   ];
 
   postPatch = ''
@@ -64,6 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     jq
+    makeWrapper
     meson
     ninja
     pkg-config
@@ -90,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
       wayland-protocols
       pango
       pciutils
-      (wlroots.override { inherit enableXWayland hidpiXWayland nvidiaPatches; })
+      (wlroots.override { inherit enableNvidiaPatches; })
     ]
     ++ lib.optionals enableXWayland [ libxcb xcbutilwm xwayland ]
     ++ lib.optionals withSystemd [ systemd ];
@@ -105,6 +107,14 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.optional legacyRenderer "-DLEGACY_RENDERER:STRING=true")
     (lib.optional withSystemd "-Dsystemd=enabled")
   ];
+
+  postInstall = ''
+    ln -s ${wlroots}/include/wlr $dev/include/hyprland/wlroots
+    ${lib.optionalString wrapRuntimeDeps ''
+      wrapProgram $out/bin/Hyprland \
+        --suffix PATH : ${lib.makeBinPath [binutils pciutils]}
+    ''}
+  '';
 
   passthru.providedSessions = [ "hyprland" ];
 

--- a/pkgs/applications/window-managers/hyprwm/hyprland/portals.patch
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/portals.patch
@@ -1,0 +1,28 @@
+diff --git a/src/Compositor.cpp b/src/Compositor.cpp
+index 1d978aed..56665389 100644
+--- a/src/Compositor.cpp
++++ b/src/Compositor.cpp
+@@ -2365,17 +2365,16 @@ void CCompositor::performUserChecks() {
+ 
+     static auto* const    PSUPPRESSPORTAL = &g_pConfigManager->getConfigValuePtr("misc:suppress_portal_warnings")->intValue;
+ 
+-    if (!*PSUPPRESSPORTAL) {
+-        if (std::ranges::any_of(BAD_PORTALS, [&](const std::string& portal) { return std::filesystem::exists("/usr/share/xdg-desktop-portal/portals/" + portal + ".portal"); })) {
++    static auto* const    PORTALDIRENV = getenv("XDG_DESKTOP_PORTAL_DIR");
++
++    static auto const     PORTALDIR = PORTALDIRENV != NULL ? std::string(PORTALDIRENV) : "";
++
++    if (!*PSUPPRESSPORTAL && PORTALDIR != "") {
++        if (std::ranges::any_of(BAD_PORTALS, [&](const std::string& portal) { return std::filesystem::exists(PORTALDIR + "/" + portal + ".portal"); })) {
+             // bad portal detected
+             g_pHyprNotificationOverlay->addNotification("You have one or more incompatible xdg-desktop-portal impls installed. Please remove incompatible ones to avoid issues.",
+                                                         CColor(0), 15000, ICON_ERROR);
+         }
+-
+-        if (std::filesystem::exists("/usr/share/xdg-desktop-portal/portals/hyprland.portal") && std::filesystem::exists("/usr/share/xdg-desktop-portal/portals/wlr.portal")) {
+-            g_pHyprNotificationOverlay->addNotification("You have xdg-desktop-portal-hyprland and -wlr installed simultaneously. Please uninstall one to avoid issues.", CColor(0),
+-                                                        15000, ICON_ERROR);
+-        }
+     }
+ }
+ 

--- a/pkgs/applications/window-managers/hyprwm/hyprland/wlroots.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/wlroots.nix
@@ -1,15 +1,11 @@
 { fetchFromGitLab
 , hyprland
 , wlroots
-, xwayland
-, fetchpatch
 , lib
 , libdisplay-info
 , libliftoff
 , hwdata
-, hidpiXWayland ? true
-, enableXWayland ? true
-, nvidiaPatches ? false
+, enableNvidiaPatches ? false
 }:
 let
   libdisplay-info-new = libdisplay-info.overrideAttrs (old: {
@@ -38,10 +34,7 @@ let
     ];
   });
 in
-assert (lib.assertMsg (hidpiXWayland -> enableXWayland) ''
-  wlroots-hyprland: cannot have hidpiXWayland when enableXWayland is false.
-'');
-(wlroots.overrideAttrs
+wlroots.overrideAttrs
   (old: {
     version = "0.17.0-dev";
 
@@ -49,65 +42,31 @@ assert (lib.assertMsg (hidpiXWayland -> enableXWayland) ''
       domain = "gitlab.freedesktop.org";
       owner = "wlroots";
       repo = "wlroots";
-      rev = "7e7633abf09b362d0bad9e3fc650fd692369291d";
-      hash = "sha256-KovjVFwcuoUO0eu/UiWrnD3+m/K+SHSAVIz4xF9K1XA=";
+      rev = "e8d545a9770a2473db32e0a0bfa757b05d2af4f3";
+      hash = "sha256-gv5kjss6REeQG0BmvK2gTx7jHLRdCnP25po6It6I6N8=";
     };
 
     pname =
       old.pname
       + "-hyprland"
-      + (
-        if hidpiXWayland
-        then "-hidpi"
-        else ""
-      )
-      + (
-        if nvidiaPatches
-        then "-nvidia"
-        else ""
-      );
+      + lib.optionalString enableNvidiaPatches "-nvidia";
 
     patches =
       (old.patches or [ ])
-      ++ (lib.optionals (enableXWayland && hidpiXWayland) [
-        "${hyprland.src}/nix/wlroots-hidpi.patch"
-        (fetchpatch {
-          url = "https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/18595000f3a21502fd60bf213122859cc348f9af.diff";
-          sha256 = "sha256-jvfkAMh3gzkfuoRhB4E9T5X1Hu62wgUjj4tZkJm0mrI=";
-          revert = true;
-        })
-      ])
-      ++ (lib.optionals nvidiaPatches [
-        (fetchpatch {
-          url = "https://aur.archlinux.org/cgit/aur.git/plain/0001-nvidia-format-workaround.patch?h=hyprland-nvidia-screenshare-git&id=2830d3017d7cdd240379b4cc7e5dd6a49cf3399a";
-          sha256 = "A9f1p5EW++mGCaNq8w7ZJfeWmvTfUm4iO+1KDcnqYX8=";
-        })
+      ++ (lib.optionals enableNvidiaPatches [
+        "${hyprland.src}/nix/patches/nvidia.patch"
       ]);
 
     postPatch =
       (old.postPatch or "")
       + (
-        if nvidiaPatches
-        then ''
-          substituteInPlace render/gles2/renderer.c --replace "glFlush();" "glFinish();"
-        ''
-        else ""
+        lib.optionalString enableNvidiaPatches
+          ''substituteInPlace render/gles2/renderer.c --replace "glFlush();" "glFinish();"''
       );
 
-    buildInputs =
-      old.buildInputs
-      ++ [
-        hwdata
-        libdisplay-info-new
-        libliftoff-new
-      ];
-  })).override {
-  xwayland = xwayland.overrideAttrs (old: {
-    patches =
-      (old.patches or [ ])
-      ++ (lib.optionals hidpiXWayland [
-        "${hyprland.src}/nix/xwayland-vsync.patch"
-        "${hyprland.src}/nix/xwayland-hidpi.patch"
-      ]);
-  });
-}
+    buildInputs = old.buildInputs ++ [
+      hwdata
+      libdisplay-info-new
+      libliftoff-new
+    ];
+  })

--- a/pkgs/applications/window-managers/hyprwm/hyprpaper/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprpaper/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, file
 , libjpeg
 , mesa
 , pango
@@ -13,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprpaper";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
-    hash = "sha256-/ehJbAtSJS86NlqHVOeR2ViBKlImKH4guFVPacTmCr8=";
+    hash = "sha256-V5ulB9CkGh1ghiC4BKvRdoYKZzpaiOKzAOUmJIFkgM0=";
   };
 
   nativeBuildInputs = [
@@ -29,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    file
     libjpeg
     mesa
     pango

--- a/pkgs/applications/window-managers/hyprwm/xdg-desktop-portal-hyprland/source.nix
+++ b/pkgs/applications/window-managers/hyprwm/xdg-desktop-portal-hyprland/source.nix
@@ -3,7 +3,7 @@
 , wayland
 }:
 let
-  version = "0.4.0";
+  version = "0.5.0";
 in
 {
   inherit version;
@@ -12,7 +12,7 @@ in
     owner = "hyprwm";
     repo = "xdg-desktop-portal-hyprland";
     rev = "v${version}";
-    hash = "sha256-r+XMyOoRXq+hlfjayb+fyi9kq2JK48TrwuNIAXqlj7U=";
+    hash = "sha256-C5AO0KnyAFJaCkOn+5nJfWm0kyiPn/Awh0lKTjhgr7Y=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

This release brings a few changes, such as improved performance and better blur.
On the technical side, we're dropping HiDPI XWayland patches support, opting to use the builtin `xwayland:force_zero_scaling` option instead. It is described in more detail in https://wiki.hyprland.org/Configuring/XWayland.
Reference PRs for this change:
- hyprwm/Hyprland#2870
- hyprwm/hyprland-wiki#282

Change list:
- hyprland: 0.27.0 -> unstable-2023-08-08 (due to screenshare fixes after release)
- hyprland: remove wlr/hyprland portal checks since they do not conflict anymore
- nixos/hyprland: remove xwayland.hidpi
- xdg-desktop-portal-hyprland: 0.4.0 -> 0.5.0
- hyprpaper: 0.3.0 -> 0.4.0

Fixes https://github.com/NixOS/nixpkgs/issues/247952.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
