### PR TITLE
foomatic-db: unstable 2023-06-30 -> 2023-08-02

### DIFF
--- a/pkgs/misc/cups/drivers/foomatic-db/default.nix
+++ b/pkgs/misc/cups/drivers/foomatic-db/default.nix
@@ -13,15 +13,15 @@
 
 stdenv.mkDerivation rec {
   pname = "foomatic-db";
-  version = "unstable-2023-06-30";
+  version = "unstable-2023-08-02";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,
     # but it gets deleted quickly and would provoke 404 errors
     owner = "OpenPrinting";
     repo = "foomatic-db";
-    rev = "5b916154bcc37d9881f71110b3d5a7e624a67c95";
-    hash = "sha256-mbIVtrmLT8saZga6rIMY55xCQWadV9BSlZR4669wNCs=";
+    rev = "a6e32fa657f3598dc87c650a9fa9cfa38dda6a60";
+    hash = "sha256-lEnog9Klxny6oEm/l2HDlI0DY5aIdPjHhWCBex2vp9Y=";
   };
 
   buildInputs = [ cups cups-filters ghostscript gnused perl ];


### PR DESCRIPTION
## Description of changes

Effectively a tiny change: [The new commit there](https://github.com/OpenPrinting/foomatic-db/commit/a6e32fa657f3598dc87c650a9fa9cfa38dda6a60) just switches the driver of the `NRG` printer `IM C2510`.  I cannot test this as I don't have that printer, but I expect it to be fine.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>foomatic-db</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
  </ul>
</details>
