### PR TITLE
doc: Document disabling cargo phases in Rust builds

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -397,8 +397,12 @@ In this scenario, the `checkPhase` will be ran in `debug` mode as well.
 
 Some packages may use custom scripts for building/installing, e.g. with a `Makefile`.
 In these cases, it's recommended to override the `buildPhase`/`installPhase`/`checkPhase`.
-
 Otherwise, some steps may fail because of the modified directory structure of `target/`.
+
+If you want to run targets from a `Makefile`, instead of overriding the phases,
+you can set `dontCargoBuild`/`dontCargoInstall`/`dontCargoCheck` to `true` to
+use the [default phases from `stdenv`](#sec-stdenv-phases), which execute make
+targets and can be controlled by various variables in the derivation.
 
 ### Building a crate with an absent or out-of-date Cargo.lock file {#building-a-crate-with-an-absent-or-out-of-date-cargo.lock-file}
 

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -399,7 +399,7 @@ Some packages may use custom scripts for building/installing, e.g. with a `Makef
 In these cases, it's recommended to override the `buildPhase`/`installPhase`/`checkPhase`.
 Otherwise, some steps may fail because of the modified directory structure of `target/`.
 
-If you want to run targets from a `Makefile`, instead of overriding the phases,
+If you want to run hooks from other build systems, instead of overriding the phases,
 you can set `dontCargoBuild`/`dontCargoInstall`/`dontCargoCheck` to `true` to
 use the [default phases from `stdenv`](#sec-stdenv-phases), which execute make
 targets and can be controlled by various variables in the derivation.

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -399,10 +399,9 @@ Some packages may use custom scripts for building/installing, e.g. with a `Makef
 In these cases, it's recommended to override the `buildPhase`/`installPhase`/`checkPhase`.
 Otherwise, some steps may fail because of the modified directory structure of `target/`.
 
-If you want to run hooks from other build systems, instead of overriding the phases,
+If you have to use build system other than cargo, instead of overriding the phases,
 you can set `dontCargoBuild`/`dontCargoInstall`/`dontCargoCheck` to `true` to
-use the [default phases from `stdenv`](#sec-stdenv-phases), which execute make
-targets and can be controlled by various variables in the derivation.
+use the [default phases from `stdenv`](#sec-stdenv-phases).
 
 ### Building a crate with an absent or out-of-date Cargo.lock file {#building-a-crate-with-an-absent-or-out-of-date-cargo.lock-file}
 


### PR DESCRIPTION
## Description of changes

Since 042adf08d1c ("cargo/hooks: allow hooks to be disabled"), it is possible to disable the default cargo hooks. This allows to switch back to the default phases from stdenv. This can be useful to package projects that rely on Makefiles. I encountered this by chance when creating #245862, so let's document it for future contributors. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
