### PR TITLE
gnome: check for package exclusions by name for default program modules

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -12,7 +12,7 @@ let
     extraGSettingsOverrides = cfg.extraGSettingsOverrides;
   };
 
-  notExcluded = pkg: (!(lib.elem pkg config.environment.cinnamon.excludePackages));
+  notExcluded = pkg: (!(lib.elem (lib.getName pkg) (map lib.getName config.environment.cinnamon.excludePackages)));
 in
 
 {

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -59,7 +59,7 @@ let
     enableGnomePanel = true;
   } ++ cfg.flashback.customSessions;
 
-  notExcluded = pkg: mkDefault (!(lib.elem pkg config.environment.gnome.excludePackages));
+  notExcluded = pkg: mkDefault (!(lib.elem (lib.getName pkg) (map lib.getName config.environment.gnome.excludePackages)));
 
 in
 


### PR DESCRIPTION
## Description of changes

The GNOME module has an option `environment.gnome.excludePackages`. This defines the set of optional packages to skip that would otherwise be included. The logic used to evaluate this option compares each package's name to the optional packages, which means overridden packages with the same name will still match, and more importantly, it doesn't evaluate the full package and therefore doesn't break if the package fails to evaluate.

This same option is used to conditonally enable various programs/services (e.g. `programs.geary.enable` is set unless `pkgs.gnome.geary` is excluded). Unfortunately the logic here is just a direct value comparison (`lib.elem pkg config.environment.gnome.excludePackages`). This means I can have a configuration where a given package is excluded from `environment.systemPackages` and yet the corresponding programs/services module is still enabled. More importantly, this means a broken package in the exclusions list will be fully evaluated and will break evaluation of my configuration. This can lead to a weird situation where my `config.system.build.toplevel` does not depend on a given package and yet evaluation breaks on that package.

This issue can be easily reproducing by adding `agpl3Plus` to your blocklisted licenses, as GNOME pulls in `orca`, which transiently pulls in `mbrola`, which is agpl3Plus. In this setup, trying to exclude `orca` still breaks on evaluating `mbrola` due to the blocklisted license.

The fix in this PR is to change the programs/services enabling logic to also compare by name only. This makes the logic the same as the other uses of `environment.gnome.excludePackages` and fixes evaluation when an excluded package is not available.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I did not build, but I did run `nix flake check --no-build` on my flake that was failing evaluation and now it passes. I also inspected the resulting config values to ensure that e.g. setting `environment.gnome.excludePackages = [ pkgs.gnome.geary ]` correctly disabled the `programs.geary.enable` option.
