### PR TITLE
Init Blackmagic Decklink driver at 12.5

### DIFF
--- a/nixos/modules/hardware/decklink.nix
+++ b/nixos/modules/hardware/decklink.nix
@@ -1,0 +1,16 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.decklink;
+  kernelPackages = config.boot.kernelPackages;
+in
+{
+  options.hardware.decklink.enable = lib.mkEnableOption "hardware support for the Blackmagic Design Decklink audio/video interfaces";
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelModules = [ "blackmagic" "blackmagic-io" "snd_blackmagic-io" ];
+    boot.extraModulePackages = [ kernelPackages.decklink ];
+    systemd.packages = [ pkgs.blackmagic-desktop-video ];
+    systemd.services.DesktopVideoHelper.wantedBy = [ "multi-user.target" ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -55,6 +55,7 @@
   ./hardware/cpu/amd-sev.nix
   ./hardware/cpu/intel-microcode.nix
   ./hardware/cpu/intel-sgx.nix
+  ./hardware/decklink.nix
   ./hardware/device-tree.nix
   ./hardware/digitalbitbox.nix
   ./hardware/flipperzero.nix

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -46,6 +46,8 @@
 , nlohmann_json
 , websocketpp
 , asio
+, decklinkSupport ? false
+, blackmagic-desktop-video
 }:
 
 let
@@ -134,9 +136,17 @@ stdenv.mkDerivation rec {
   ];
 
   dontWrapGApps = true;
-  preFixup = ''
+  preFixup = let
+    wrapperLibraries = [
+      xorg.libX11
+      libvlc
+      libGL
+    ] ++ optionals decklinkSupport [
+      blackmagic-desktop-video
+    ];
+  in ''
     qtWrapperArgs+=(
-      --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath [ xorg.libX11 libvlc libGL ]}"
+      --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath wrapperLibraries}"
       ''${gappsWrapperArgs[@]}
     )
   '';

--- a/pkgs/os-specific/linux/decklink/default.nix
+++ b/pkgs/os-specific/linux/decklink/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, lib, requireFile, fetchpatch, kernel }:
+{ stdenv
+, lib
+, blackmagic-desktop-video
+, kernel
+}:
 
 stdenv.mkDerivation rec {
   pname = "decklink";
-  version = "12.2a12";
 
-  src = requireFile {
-    name = "Blackmagic_Desktop_Video_Linux_${lib.versions.majorMinor version}.tar.gz";
-    url = "https://www.blackmagicdesign.com/support/download/33abc1034cd54cf99101f9acd2edd93d/Linux";
-    sha256 = "62954a18b60d9040aa4a959dff30ac9c260218ef78d6a63cbb243788f7abc05f";
-  };
+  # the download is a horrible curl mess. we reuse it between the kernel module
+  # and desktop service, since the version of the two have to match anyways.
+  # See pkgs/tools/video/blackmagic-desktop-video/default.nix for more.
+  inherit (blackmagic-desktop-video) src version;
 
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   INSTALL_MOD_PATH = placeholder "out";

--- a/pkgs/os-specific/linux/decklink/default.nix
+++ b/pkgs/os-specific/linux/decklink/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, lib, requireFile, fetchpatch, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "decklink";
+  version = "12.0a14";
+
+  src = requireFile {
+    name = "Blackmagic_Desktop_Video_Linux_${lib.versions.majorMinor version}.tar.gz";
+    url = "https://www.blackmagicdesign.com/support/download/76b2edbed5884e1dbbfea104071f1643/Linux";
+    sha256 = "e5a586ee705513cf5e6b024e1ec68621ab91d50b370981023e0bff73a19169c2";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "01-fix-get_user_pages.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/01-fix-get_user_pages.patch?h=decklink&id=212ec426d96db3de0fedad803238d0604cc4df76";
+      sha256 = "193199d59kmwdajhyw9k98636lbxrxwnxwlbhhijp1qms6y1qn2j";
+    })
+    (fetchpatch {
+      name = "02-fix-have_unlocked_ioctl.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/02-fix-have_unlocked_ioctl.patch?h=decklink&id=212ec426d96db3de0fedad803238d0604cc4df76";
+      sha256 = "0yf3bwry28zr1yfnx6wyh650d8kac4q70x95kz4p7sr6r7ajwzdm";
+    })
+  ];
+
+  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  INSTALL_MOD_PATH = placeholder "out";
+
+  nativeBuildInputs =  kernel.moduleBuildDependencies;
+
+  postUnpack = ''
+    tar xf Blackmagic_Desktop_Video_Linux_${lib.versions.majorMinor version}/other/${stdenv.hostPlatform.uname.processor}/desktopvideo-${version}-${stdenv.hostPlatform.uname.processor}.tar.gz
+    moduleRoot=$NIX_BUILD_TOP/desktopvideo-${version}-${stdenv.hostPlatform.uname.processor}/usr/src
+  '';
+
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -C $moduleRoot/blackmagic-${version} -j$NIX_BUILD_CORES
+    make -C $moduleRoot/blackmagic-io-${version} -j$NIX_BUILD_CORES
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    make -C $KERNELDIR M=$moduleRoot/blackmagic-${version} modules_install
+    make -C $KERNELDIR M=$moduleRoot/blackmagic-io-${version} modules_install
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.blackmagicdesign.com/support/family/capture-and-playback";
+    maintainers = [ maintainers.hexchen ];
+    license = licenses.unfree;
+    description = "Kernel module for the Blackmagic Design Decklink cards";
+    sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/decklink/default.nix
+++ b/pkgs/os-specific/linux/decklink/default.nix
@@ -2,26 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "decklink";
-  version = "12.0a14";
+  version = "12.2a12";
 
   src = requireFile {
     name = "Blackmagic_Desktop_Video_Linux_${lib.versions.majorMinor version}.tar.gz";
-    url = "https://www.blackmagicdesign.com/support/download/76b2edbed5884e1dbbfea104071f1643/Linux";
-    sha256 = "e5a586ee705513cf5e6b024e1ec68621ab91d50b370981023e0bff73a19169c2";
+    url = "https://www.blackmagicdesign.com/support/download/33abc1034cd54cf99101f9acd2edd93d/Linux";
+    sha256 = "62954a18b60d9040aa4a959dff30ac9c260218ef78d6a63cbb243788f7abc05f";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "01-fix-get_user_pages.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/01-fix-get_user_pages.patch?h=decklink&id=212ec426d96db3de0fedad803238d0604cc4df76";
-      sha256 = "193199d59kmwdajhyw9k98636lbxrxwnxwlbhhijp1qms6y1qn2j";
-    })
-    (fetchpatch {
-      name = "02-fix-have_unlocked_ioctl.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/02-fix-have_unlocked_ioctl.patch?h=decklink&id=212ec426d96db3de0fedad803238d0604cc4df76";
-      sha256 = "0yf3bwry28zr1yfnx6wyh650d8kac4q70x95kz4p7sr6r7ajwzdm";
-    })
-  ];
 
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   INSTALL_MOD_PATH = placeholder "out";

--- a/pkgs/tools/video/blackmagic-desktop-video/default.nix
+++ b/pkgs/tools/video/blackmagic-desktop-video/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, requireFile, lib,
+  libcxx, libcxxabi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "blackmagic-desktop-video";
+  version = "12.0a14";
+
+  buildInputs = [
+    libcxx libcxxabi
+  ];
+
+  src = requireFile {
+    name = "Blackmagic_Desktop_Video_Linux_${lib.versions.majorMinor version}.tar.gz";
+    url = "https://www.blackmagicdesign.com/support/download/76b2edbed5884e1dbbfea104071f1643/Linux";
+    sha256 = "e5a586ee705513cf5e6b024e1ec68621ab91d50b370981023e0bff73a19169c2";
+  };
+
+  postUnpack = ''
+    tar xf Blackmagic_Desktop_Video_Linux_${lib.versions.majorMinor version}/other/${stdenv.hostPlatform.uname.processor}/desktopvideo-${version}-${stdenv.hostPlatform.uname.processor}.tar.gz
+    unpacked=$NIX_BUILD_TOP/desktopvideo-${version}-${stdenv.hostPlatform.uname.processor}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/doc,lib/systemd/system}
+    cp -r $unpacked/usr/share/doc/desktopvideo $out/share/doc
+    cp $unpacked/usr/lib/*.so $out/lib
+    cp $unpacked/usr/lib/systemd/system/DesktopVideoHelper.service $out/lib/systemd/system
+    ln -s ${libcxx}/lib/* ${libcxxabi}/lib/* $out/lib
+    cp $unpacked/usr/lib/blackmagic/DesktopVideo/libgcc_s.so.1 $out/lib/
+    cp $unpacked/usr/lib/blackmagic/DesktopVideo/DesktopVideoHelper $out/bin/
+
+    substituteInPlace $out/lib/systemd/system/DesktopVideoHelper.service --replace "/usr/lib/blackmagic/DesktopVideo/DesktopVideoHelper" "$out/bin/DesktopVideoHelper"
+
+    runHook postInstall
+  '';
+
+
+  postFixup = ''
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+      --set-rpath "$out/lib:${lib.makeLibraryPath [ libcxx libcxxabi ]}" \
+      $out/bin/DesktopVideoHelper
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.blackmagicdesign.com/support/family/capture-and-playback";
+    maintainers = [ maintainers.hexchen ];
+    license = licenses.unfree;
+    description = "Supporting applications for Blackmagic Decklink. Doesn't include the desktop applications, only the helper required to make the driver work";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/video/blackmagic-desktop-video/default.nix
+++ b/pkgs/tools/video/blackmagic-desktop-video/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "blackmagic-desktop-video";
-  version = "12.0a14";
+  version = "12.2a12";
 
   buildInputs = [
     libcxx libcxxabi
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
 
   src = requireFile {
     name = "Blackmagic_Desktop_Video_Linux_${lib.versions.majorMinor version}.tar.gz";
-    url = "https://www.blackmagicdesign.com/support/download/76b2edbed5884e1dbbfea104071f1643/Linux";
-    sha256 = "e5a586ee705513cf5e6b024e1ec68621ab91d50b370981023e0bff73a19169c2";
+    url = "https://www.blackmagicdesign.com/support/download/33abc1034cd54cf99101f9acd2edd93d/Linux";
+    sha256 = "62954a18b60d9040aa4a959dff30ac9c260218ef78d6a63cbb243788f7abc05f";
   };
 
   postUnpack = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3511,6 +3511,8 @@ with pkgs;
 
   bkyml = callPackage ../tools/misc/bkyml { };
 
+  blackmagic-desktop-video = callPackage ../tools/video/blackmagic-desktop-video { };
+
   blockbench-electron = callPackage ../applications/graphics/blockbench-electron { };
 
   blocksat-cli = with python3Packages; toPythonApplication blocksat-cli;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -339,6 +339,8 @@ in {
 
     dddvb = callPackage ../os-specific/linux/dddvb { };
 
+    decklink = callPackage ../os-specific/linux/decklink { };
+
     digimend = callPackage ../os-specific/linux/digimend { };
 
     dpdk-kmods = callPackage ../os-specific/linux/dpdk-kmods { };


### PR DESCRIPTION
## Description of changes

This is a driver for the Decklink (and UltraStudio) Series of capture cards from Blackmagic Design. https://www.blackmagicdesign.com/products/decklink

There was already an attempt by myself to upstream my module, but it kinda died down because I did not have access to a decklink card for an extended period (this has now changed). See https://github.com/NixOS/nixpkgs/pull/102512 for that.

I have built on top of the old driver, cleaned some things up, and updated it to the current version. I kept the old commit history and made changes in an update commit to get it working on current nixpkgs.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
