### PR TITLE
rtkit: reduce logging

### DIFF
--- a/pkgs/os-specific/linux/rtkit/default.nix
+++ b/pkgs/os-specific/linux/rtkit/default.nix
@@ -16,13 +16,21 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://github.com/heftig/rtkit/commit/7d62095b94f8df3891c984a1535026d2658bb177.patch";
+      name = "meson-actual-use-systemd_systemunitdir.patch";
+      url = "https://github.com/heftig/rtkit/pull/19/commits/7d62095b94f8df3891c984a1535026d2658bb177.patch";
       sha256 = "17acv549zqcgh7sgprfagbf6drqsr0zdwvf1dsqda7wlqc2h9zn7";
     })
 
     (fetchpatch {
-      url = "https://github.com/heftig/rtkit/commit/98f70edd8f534c371cb4308b9720739c5178918d.patch";
+      name = "meson-fix-librt-find_library-check.patch";
+      url = "https://github.com/heftig/rtkit/pull/18/commits/98f70edd8f534c371cb4308b9720739c5178918d.patch";
       sha256 = "18mnjjsdjfr184nkzi01xyphpdngi31ry4bmkv9ysjxf9wilv4nl";
+    })
+
+    (fetchpatch {
+      name = "rtkit-daemon-dont-log-debug-messages-by-default.patch";
+      url = "https://github.com/heftig/rtkit/pull/33/commits/ad649ee491ed1a41537774ad11564a208e598a09.patch";
+      sha256 = "sha256-p+MdJVMv58rFd1uc1UFKtq83RquDSFZ3M6YfaBU12UU=";
     })
   ];
 


### PR DESCRIPTION
Pull in a patch from a cleaner upstream PR to reduce logging.

Slightly update the URLs used to download the existing patches to make it easier to find the relevant PRs.

Re: NixOS/nixpkgs#180102, heftig/rtkit#22

https://github.com/heftig/rtkit/pull/33

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
