### PR TITLE
srt-to-vtt-cl: fix macOS builds

### DIFF
--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, substituteAll }:
+{ lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "srt-to-vtt-cl";
@@ -12,14 +12,13 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-validation.patch;
-    })
+    ./fix-validation.patch
+    ./simplify-macOS-builds.patch
   ];
 
   installPhase = ''
     mkdir -p $out/bin
-    cp bin/$(uname -s)/$(uname -m)/srt-vtt $out/bin
+    cp bin/srt-vtt $out/bin
   '';
 
   meta = with lib; {
@@ -27,6 +26,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ ericdallo ];
     homepage = "https://github.com/nwoltman/srt-to-vtt-cl";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/simplify-macOS-builds.patch
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/simplify-macOS-builds.patch
@@ -1,0 +1,31 @@
+From be08356f421825d3d2dd7ab687f86d9981a31f9a Mon Sep 17 00:00:00 2001
+From: "Travis A. Everett" <travis.a.everett@gmail.com>
+Date: Thu, 3 Aug 2023 20:15:40 -0500
+Subject: [PATCH] simplify macOS builds
+
+---
+ Makefile | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 6dfd829..19c3ae3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -8,13 +8,7 @@ CXXFLAGS = -std=c++11 -O2 -MMD -I ./deps
+ OBJECTS := src/text_encoding_detect.o src/Utils.o src/Converter.o src/main.o
+ DEPENDS := $(OBJECTS:.o=.d)
+ EXEC = srt-vtt
+-UNAME_S := $(shell uname -s)
+-ifeq ($(UNAME_S), Darwin)
+-	BIN_DIR = bin/Mac-OSX
+-else
+-	UNAME_M := $(shell uname -m)
+-	BIN_DIR = bin/$(UNAME_S)/$(UNAME_M)
+-endif
++BIN_DIR = bin
+ EXEC_PATH = $(BIN_DIR)/$(EXEC)
+ 
+ .PHONY: test
+-- 
+2.39.0
+


### PR DESCRIPTION
The upstream Makefile is using logic to build into different dirs depending on uname output. Trivial to get macOS builds working if we just don't do that.

I've also stripped out a use of substituteAll that was having no effect (the variables it replaced were removed during review of the initial PR.)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>srt-to-vtt-cl</li>
  </ul>
</details>

Result of `nixpkgs-review pr 247058` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>srt-to-vtt-cl</li>
  </ul>
</details>

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
