### PR TITLE
python310Packages.cookiecutter: 2.1.1 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/cookiecutter/default.nix
+++ b/pkgs/development/python-modules/cookiecutter/default.nix
@@ -1,23 +1,32 @@
 { lib, buildPythonPackage, fetchPypi, isPyPy
-, pytest, pytest-cov, pytest-mock, freezegun
+, pytest, pytest-cov, pytest-mock, freezegun, safety, pre-commit
 , jinja2, future, binaryornot, click, jinja2-time, requests
 , python-slugify
 , pyyaml
+, arrow
+, rich
 }:
 
 buildPythonPackage rec {
   pname = "cookiecutter";
-  version = "2.1.1";
+  version = "2.3.0";
 
   # not sure why this is broken
   disabled = isPyPy;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-85gr6NnFPawSYYZAE/3sf4Ov0uQu3m9t0GnF4UnFQNU=";
+    hash = "sha256-lCp5SYF0f21/Q51uSdOdyRqaZBKDYUFgyTxHTHLCliE=";
   };
 
-  nativeCheckInputs = [ pytest pytest-cov pytest-mock freezegun ];
+  nativeCheckInputs = [
+    pytest
+    pytest-cov
+    pytest-mock
+    freezegun
+    safety
+    pre-commit
+  ];
   propagatedBuildInputs = [
     binaryornot
     jinja2
@@ -26,6 +35,8 @@ buildPythonPackage rec {
     jinja2-time
     python-slugify
     requests
+    arrow
+    rich
   ];
 
   # requires network access for cloning git repos


### PR DESCRIPTION
## Description of changes

- https://github.com/cookiecutter/cookiecutter/releases/tag/2.3.0
- https://github.com/cookiecutter/cookiecutter/releases/tag/2.2.3
- https://github.com/cookiecutter/cookiecutter/releases/tag/2.2.1 which is mistakenly ([I guess?](https://github.com/cookiecutter/cookiecutter/compare/2.2.0...2.2.1)) released as 2.2.0)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
