### PR TITLE
python3.pkgs.cmake: init stub at 3.26.4

### DIFF
--- a/pkgs/development/python-modules/cmake/default.nix
+++ b/pkgs/development/python-modules/cmake/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, flit-core
+, cmake
+}:
+
+buildPythonPackage rec {
+  pname = "cmake";
+  inherit (cmake) version;
+  format = "pyproject";
+
+  src = ./stub;
+
+  postUnpack = ''
+    substituteInPlace "$sourceRoot/pyproject.toml" \
+      --subst-var version
+
+    substituteInPlace "$sourceRoot/cmake/__init__.py" \
+      --subst-var-by CMAKE_BIN_DIR "${cmake}/bin"
+  '';
+
+  inherit (cmake) setupHooks;
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  pythonImportsCheck = [
+    "cmake"
+  ];
+
+  meta = with lib; {
+    description = "CMake is an open-source, cross-platform family of tools designed to build, test and package software";
+    longDescription = ''
+      This is a stub of the cmake package on PyPI that uses the cmake program
+      provided by nixpkgs instead of downloading cmake from the web.
+    '';
+    homepage = "https://github.com/scikit-build/cmake-python-distributions";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tjni ];
+  };
+}

--- a/pkgs/development/python-modules/cmake/stub/cmake/__init__.py
+++ b/pkgs/development/python-modules/cmake/stub/cmake/__init__.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+import sys
+
+CMAKE_BIN_DIR = '@CMAKE_BIN_DIR@'
+
+def _program(name, args):
+    return subprocess.call([os.path.join(CMAKE_BIN_DIR, name)] + args, close_fds=False)
+
+def cmake():
+    raise SystemExit(_program('cmake', sys.argv[1:]))
+
+def cpack():
+    raise SystemExit(_program('cpack', sys.argv[1:]))
+
+def ctest():
+    raise SystemExit(_program('ctest', sys.argv[1:]))

--- a/pkgs/development/python-modules/cmake/stub/pyproject.toml
+++ b/pkgs/development/python-modules/cmake/stub/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["flit_core"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "cmake"
+version = "@version@"
+description = "CMake is an open-source, cross-platform family oftools designed to build, test and package software"
+
+[project.scripts]
+cmake = "cmake:cmake"
+cpack = "cmake:cpack"
+ctest = "cmake:ctest"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11361,7 +11361,9 @@ self: super: with self; {
 
   scikit-build = callPackage ../development/python-modules/scikit-build { };
 
-  scikit-build-core = callPackage ../development/python-modules/scikit-build-core { };
+  scikit-build-core = callPackage ../development/python-modules/scikit-build-core {
+    inherit (pkgs) cmake;
+  };
 
   scikit-fmm = callPackage ../development/python-modules/scikit-fmm { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2033,6 +2033,8 @@ self: super: with self; {
 
   cmaes = callPackage ../development/python-modules/cmaes { };
 
+  cmake = callPackage ../development/python-modules/cmake { inherit (pkgs) cmake; };
+
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
 
   cmd2 = callPackage ../development/python-modules/cmd2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -899,7 +899,9 @@ self: super: with self; {
 
   awkward = callPackage ../development/python-modules/awkward { };
 
-  awkward-cpp = callPackage ../development/python-modules/awkward-cpp { };
+  awkward-cpp = callPackage ../development/python-modules/awkward-cpp {
+    inherit (pkgs) cmake;
+  };
 
   aws-adfs = callPackage ../development/python-modules/aws-adfs { };
 


### PR DESCRIPTION
## Description of changes

I would like this to be as transparent as possible for Python packages, so I'm shadowing the top-level cmake attribute by using the same name as the PyPI package that this replaces.

As in https://github.com/NixOS/nixpkgs/pull/246963, a goal is to help with the rollout of https://github.com/NixOS/nixpkgs/pull/245509 by letting packages that depend on this in their builds to pass dependency validation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
