### PR TITLE
mbedtls: 3.4.0 -> 3.4.1, mbedtls_2: 2.28.3 -> 2.28.4

### DIFF
--- a/pkgs/development/libraries/mbedtls/2.nix
+++ b/pkgs/development/libraries/mbedtls/2.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "2.28.3";
-  hash = "sha256-w5bJErCNRZLE8rHcuZlK3bOqel97gPPMKH2cPGUR6Zw=";
+  version = "2.28.4";
+  hash = "sha256-88Lnj9NgS5PWg2hydvb9cwi6s6BG3UMvkUH2Ny1jmtE=";
 }

--- a/pkgs/development/libraries/mbedtls/3.nix
+++ b/pkgs/development/libraries/mbedtls/3.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "3.4.0";
-  hash = "sha256-1YA4hp/VEjph5k0qJqhhH4nBbTP3Qu2pl7WpuvPkVfg=";
+  version = "3.4.1";
+  hash = "sha256-NIjyRcVbg6lT6+RlTz5Jt6V9T85mvta5grOSLIAK9Ts=";
 }

--- a/pkgs/development/libraries/mbedtls/generic.nix
+++ b/pkgs/development/libraries/mbedtls/generic.nix
@@ -42,6 +42,12 @@ stdenv.mkDerivation rec {
     "-DGEN_FILES=off"
   ];
 
+  doCheck = true;
+
+  # Parallel checking causes test failures
+  # https://github.com/Mbed-TLS/mbedtls/issues/4980
+  enableParallelChecking = false;
+
   meta = with lib; {
     homepage = "https://www.trustedfirmware.org/projects/mbed-tls/";
     changelog = "https://github.com/Mbed-TLS/mbedtls/blob/${pname}-${version}/ChangeLog";


### PR DESCRIPTION
## Description of changes

https://github.com/Mbed-TLS/mbedtls/blob/v3.4.1/ChangeLog

https://github.com/Mbed-TLS/mbedtls/blob/v2.28.4/ChangeLog

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>obs-studio-plugins.obs-hyperion</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>obs-studio-plugins.obs-ndi</li>
  </ul>
</details>
<details>
  <summary>190 packages built:</summary>
  <ul>
    <li>bctoolbox</li>
    <li>belcard</li>
    <li>belle-sip</li>
    <li>belr</li>
    <li>bzrtp</li>
    <li>dillo</li>
    <li>dillong</li>
    <li>dislocker</li>
    <li>dolphin-emu</li>
    <li>dolphin-emu-primehack</li>
    <li>gauche</li>
    <li>gaucheBootstrap</li>
    <li>hashlink</li>
    <li>haxe</li>
    <li>haxePackages.format</li>
    <li>haxePackages.heaps</li>
    <li>haxePackages.hlopenal</li>
    <li>haxePackages.hlsdl</li>
    <li>haxePackages.hxcpp</li>
    <li>haxePackages.hxcs</li>
    <li>haxePackages.hxjava</li>
    <li>haxePackages.hxnodejs_4</li>
    <li>haxe_4_0</li>
    <li>haxe_4_1</li>
    <li>hiawatha</li>
    <li>hyperion-ng</li>
    <li>imhex</li>
    <li>kodiPackages.libretro-2048</li>
    <li>kodiPackages.libretro-fuse</li>
    <li>kodiPackages.libretro-genplus</li>
    <li>kodiPackages.libretro-mgba</li>
    <li>kodiPackages.libretro-snes9x</li>
    <li>liblinphone</li>
    <li>libosmoabis</li>
    <li>libretro.atari800</li>
    <li>libretro.beetle-gba</li>
    <li>libretro.beetle-lynx</li>
    <li>libretro.beetle-ngp</li>
    <li>libretro.beetle-pce-fast</li>
    <li>libretro.beetle-pcfx</li>
    <li>libretro.beetle-psx</li>
    <li>libretro.beetle-psx-hw</li>
    <li>libretro.beetle-saturn</li>
    <li>libretro.beetle-snes</li>
    <li>libretro.beetle-supafaust</li>
    <li>libretro.beetle-supergrafx</li>
    <li>libretro.beetle-vb</li>
    <li>libretro.beetle-wswan</li>
    <li>libretro.blastem</li>
    <li>libretro.bluemsx</li>
    <li>libretro.bsnes</li>
    <li>libretro.bsnes-hd</li>
    <li>libretro.bsnes-mercury</li>
    <li>libretro.bsnes-mercury-balanced</li>
    <li>libretro.bsnes-mercury-performance</li>
    <li>libretro.citra</li>
    <li>libretro.desmume</li>
    <li>libretro.desmume2015</li>
    <li>libretro.dolphin</li>
    <li>libretro.dosbox</li>
    <li>libretro.dosbox-pure</li>
    <li>libretro.eightyone</li>
    <li>libretro.fbalpha2012</li>
    <li>libretro.fbneo</li>
    <li>libretro.fceumm</li>
    <li>libretro.flycast</li>
    <li>libretro.fmsx</li>
    <li>libretro.freeintv</li>
    <li>libretro.fuse</li>
    <li>libretro.gambatte</li>
    <li>libretro.genesis-plus-gx</li>
    <li>libretro.gpsp</li>
    <li>libretro.gw</li>
    <li>libretro.handy</li>
    <li>libretro.hatari</li>
    <li>libretro.mame</li>
    <li>libretro.mame2000</li>
    <li>libretro.mame2003</li>
    <li>libretro.mame2003-plus</li>
    <li>libretro.mame2010</li>
    <li>libretro.mame2015</li>
    <li>libretro.mame2016</li>
    <li>libretro.melonds</li>
    <li>libretro.mesen</li>
    <li>libretro.mesen-s</li>
    <li>libretro.meteor</li>
    <li>libretro.mgba</li>
    <li>libretro.mupen64plus</li>
    <li>libretro.neocd</li>
    <li>libretro.nestopia</li>
    <li>libretro.np2kai</li>
    <li>libretro.nxengine</li>
    <li>libretro.o2em</li>
    <li>libretro.opera</li>
    <li>libretro.parallel-n64</li>
    <li>libretro.pcsx-rearmed</li>
    <li>libretro.pcsx2</li>
    <li>libretro.picodrive</li>
    <li>libretro.play</li>
    <li>libretro.ppsspp</li>
    <li>libretro.prboom</li>
    <li>libretro.prosystem</li>
    <li>libretro.puae</li>
    <li>libretro.quicknes</li>
    <li>libretro.sameboy</li>
    <li>libretro.scummvm</li>
    <li>libretro.smsplus-gx</li>
    <li>libretro.snes9x</li>
    <li>libretro.snes9x2002</li>
    <li>libretro.snes9x2005</li>
    <li>libretro.snes9x2005-plus</li>
    <li>libretro.snes9x2010</li>
    <li>libretro.stella</li>
    <li>libretro.stella2014</li>
    <li>libretro.swanstation</li>
    <li>libretro.tgbdual</li>
    <li>libretro.thepowdertoy</li>
    <li>libretro.tic80</li>
    <li>libretro.twenty-fortyeight</li>
    <li>libretro.vba-m</li>
    <li>libretro.vba-next</li>
    <li>libretro.vecx</li>
    <li>libretro.virtualjaguar</li>
    <li>libretro.yabause</li>
    <li>librist</li>
    <li>libubox-mbedtls</li>
    <li>lime</li>
    <li>linphone</li>
    <li>lutris</li>
    <li>lutris-free</li>
    <li>mbedtls</li>
    <li>mbedtls_2</li>
    <li>mediastreamer</li>
    <li>mediastreamer-openh264</li>
    <li>msilbc</li>
    <li>nanomq</li>
    <li>neko</li>
    <li>nng</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.advanced-scene-switcher</li>
    <li>obs-studio-plugins.droidcam-obs</li>
    <li>obs-studio-plugins.input-overlay</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-3d-effect</li>
    <li>obs-studio-plugins.obs-backgroundremoval</li>
    <li>obs-studio-plugins.obs-command-source</li>
    <li>obs-studio-plugins.obs-gradient-source</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-livesplit-one</li>
    <li>obs-studio-plugins.obs-move-transition</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-mute-filter</li>
    <li>obs-studio-plugins.obs-nvfbc</li>
    <li>obs-studio-plugins.obs-pipewire-audio-capture</li>
    <li>obs-studio-plugins.obs-rgb-levels-filter</li>
    <li>obs-studio-plugins.obs-scale-to-sound</li>
    <li>obs-studio-plugins.obs-shaderfilter</li>
    <li>obs-studio-plugins.obs-source-clone</li>
    <li>obs-studio-plugins.obs-source-record</li>
    <li>obs-studio-plugins.obs-source-switcher</li>
    <li>obs-studio-plugins.obs-teleport</li>
    <li>obs-studio-plugins.obs-text-pthread</li>
    <li>obs-studio-plugins.obs-transition-table</li>
    <li>obs-studio-plugins.obs-tuna</li>
    <li>obs-studio-plugins.obs-vaapi</li>
    <li>obs-studio-plugins.obs-vertical-canvas</li>
    <li>obs-studio-plugins.obs-vintage-filter</li>
    <li>obs-studio-plugins.obs-vkcapture</li>
    <li>obs-studio-plugins.obs-websocket</li>
    <li>obs-studio-plugins.waveform</li>
    <li>obs-studio-plugins.wlrobs</li>
    <li>openrgb</li>
    <li>openrgb-with-all-plugins</li>
    <li>ortp</li>
    <li>osmo-bsc</li>
    <li>osmo-bts</li>
    <li>osmo-hlr</li>
    <li>osmo-hnbgw</li>
    <li>osmo-hnodeb</li>
    <li>osmo-mgw</li>
    <li>osmo-msc</li>
    <li>osmo-sgsn</li>
    <li>retroarch</li>
    <li>retroarchBare</li>
    <li>retroarchFull</li>
    <li>shadowsocks-libev</li>
    <li>srsran</li>
    <li>trx</li>
    <li>ustream-ssl-mbedtls</li>
    <li>yojimbo</li>
  </ul>
</details>