### PR TITLE
python3.pkgs.oldest-supported-numpy: init at 2023.8.3

### DIFF
--- a/pkgs/development/python-modules/oldest-supported-numpy/default.nix
+++ b/pkgs/development/python-modules/oldest-supported-numpy/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "oldest-supported-numpy";
+  version = "2023.8.3";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-yJp+wzsihagnI3crGPDBo+CqbVO4Xhxulj/o/NitxU0=";
+  };
+
+  # The purpose of oldest-supported-numpy is to build a project against the
+  # oldest version of numpy for a given Python distribution in order to build
+  # a binary that is compatible with the largest possible versons of numpy.
+  # We only build against one version of numpy in nixpkgs, so instead we only
+  # want to make sure that we have a version above the minimum.
+  #
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace 'numpy==' 'numpy>='
+  '';
+
+  nativeBuildInputs = [
+    numpy
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Meta-package providing the oldest supported Numpy for a given Python version and platform";
+    homepage = "https://github.com/scipy/oldest-supported-numpy";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ tjni ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7291,6 +7291,8 @@ self: super: with self; {
 
   okta = callPackage ../development/python-modules/okta { };
 
+  oldest-supported-numpy = callPackage ../development/python-modules/oldest-supported-numpy { };
+
   olefile = callPackage ../development/python-modules/olefile { };
 
   oletools = callPackage ../development/python-modules/oletools { };


### PR DESCRIPTION
## Description of changes

The main purpose of this package is to be used as a dependency in projects that depend upon it without having to patch their build dependency requirements.

In my opinion, adding this dependency is easier to follow, review, and understand than patching a pyproject.toml file. Feedback and other opinions welcome for discussion.

Related to https://github.com/NixOS/nixpkgs/pull/245509.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
