### PR TITLE
ndi: 5.5.2 -> 5.6.0

### DIFF
--- a/pkgs/development/libraries/ndi/version.json
+++ b/pkgs/development/libraries/ndi/version.json
@@ -1,1 +1,1 @@
-{"hash": "sha256:70e04c2e7a629a9854de2727e0f978175b7a4ec6cf4cd9799a22390862f6fa27", "version": "5.5.2"}
+{"hash": "sha256:fbd15bdabda90cd6b297c3728ee37e20f8aace07899521615ecd2c85efd1f396", "version": "5.6.0"}


### PR DESCRIPTION
## Description of changes
The version that we get to download from NDI is 5.6.0, I cannot find how to download older sdk versions from their website, so this change only updates the SHA and the version so we can install the only available version

## Things done

Im new to Nix and dont really know how to overwrite a file in a derivation to test it properly, I am assuming this is the only change needed but haven't tested anything really

I found the hash by 
- first downloading the SDK from their website (register + got email + clicked link in the email),
- `nix-hash type sha256 path/to/Install_NDI_SDK_v5_Linux.tar.gz`

and I found the specific version by uncompressing the tar file and running the sh file, accepting the license agreement, it created a bunch of files and in there was a version file with this `NDI 2023-07-26 r135585 v5.6.0`

