### PR TITLE
sparrow: 1.7.7 -> 1.7.8

### DIFF
--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -21,11 +21,11 @@
 
 let
   pname = "sparrow";
-  version = "1.7.7";
+  version = "1.7.8";
 
   src = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-x86_64.tar.gz";
-    sha256 = "07mgh6xjj8i4d2pvwldl2y586y4fw9ir0rzxr97bh379fdcfqfxa";
+    sha256 = "0nazqxffmai74x47dbkwryvx1pjm8k85rcfz5nr19h7fa1bj8rkc";
   };
 
   launcher = writeScript "sparrow" ''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR updates the sparrow bitcoin wallet from 1.7.7 to 1.7.8. The most notable change is the addition of the zbar library for scanning QR codes. Upstream has vendored the zbar java implementation and the compiled JNI code (libzbar.so). You can get a sense of the changes by reviewing this commit: https://github.com/sparrowwallet/sparrow/commit/96fd824a3eedd6a2f625229727fc85d3af554b20#diff-f6db1486e34268ed1c1a630b66f4991da9a6d09e30a3ecdc3cac56a42aa3d3a4

Note that OpenIMAJGrabber is still referenced in the upstream code, so I didn't remove it from our Nix package. Here are the release notes: https://github.com/sparrowwallet/sparrow/releases/tag/1.7.8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
