### PR TITLE
lomiri.lomiri-ui-extras: init at 0.6.2

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -22,6 +22,7 @@ let
 
     #### QML / QML-related
     lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };
+    lomiri-ui-extras = callPackage ./qml/lomiri-ui-extras { };
     lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
 
     #### Services

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-extras/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-extras/default.nix
@@ -1,0 +1,125 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, cmake
+, cmake-extras
+, cups
+, exiv2
+, lomiri-ui-toolkit
+, pam
+, pkg-config
+, qtbase
+, qtdeclarative
+, xvfb-run
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-ui-extras";
+  version = "0.6.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-ui-extras";
+    rev = finalAttrs.version;
+    hash = "sha256-RZTGTe18ebqKz8kWOpRgFJO2sR97sVbdPQMW/XLHs68=";
+  };
+
+  patches = [
+    # Fix compatibility with Exiv2 0.28.0
+    # Remove when version > 0.6.2
+    (fetchpatch {
+      name = "0001-lomiri-ui-extras-Fix-for-exiv2-0.28.0.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-ui-extras/-/commit/f337ceefa7c4f8f39dc7c75d51df8b86f148891a.patch";
+      hash = "sha256-dm50un46eTeBZsyHJF1npGBqOAF1BopJZ1Uln1PqSOE=";
+    })
+
+    # Remove deprecated qt5_use_modules usage
+    # Remove when version > 0.6.2
+    (fetchpatch {
+      name = "0002-lomiri-ui-extras-Stop-using-qt5_use_modules.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-ui-extras/-/commit/df506e7ebe7107dd0465d7d65727753f07abd122.patch";
+      hash = "sha256-VmOhJaUgjp9BHoYAO780uxI5tE7F0Gtp9gRNe0QCrhs=";
+    })
+
+    # Find qmltestrunner via PATH instead of hardcoded path
+    # https://gitlab.com/ubports/development/core/lomiri-ui-extras/-/merge_requests/84
+    (fetchpatch {
+      name = "0003-lomiri-ui-extras-Dont-insist-on-finding-qmltestrunner-only-at-hardcoded-guess.patch";
+      url = "https://gitlab.com/OPNA2608/lomiri-ui-extras/-/commit/b0c4901818761b516a45b7f0524ac713ddf33cfe.patch";
+      hash = "sha256-oFeaGiYEDr9XHRlCpXX+0ALlVdfb0FmGBFF1RzIXSBE=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace modules/Lomiri/Components/Extras{,/{plugin,PamAuthentication}}/CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+
+    # tst_busy_indicator runs into a codepath in lomiri-ui-toolkit that expects a working GL context
+    sed -i tests/qml/CMakeLists.txt \
+      -e '/declare_qml_test("tst_busy_indicator"/d'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    cups
+    exiv2
+    pam
+    qtbase
+    qtdeclarative
+  ];
+
+  nativeCheckInputs = [
+    qtdeclarative # qmltestrunner
+    xvfb-run
+  ];
+
+  checkInputs = [
+    lomiri-ui-toolkit
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.finalPackage.doCheck}"
+  ];
+
+  # tst_PhotoEditorPhoto and tst_PhotoEditorPhotoImageProvider randomly fail, haven't had time to debug
+  doCheck = false;
+
+  # Parallelism breaks xvfb-run-launched script for QML tests
+  enableParallelChecking = false;
+
+  preCheck = let
+    listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
+  in ''
+    export QT_PLUGIN_PATH=${listToQtVar qtbase.qtPluginPrefix [ qtbase ]}
+    export QML2_IMPORT_PATH=${listToQtVar qtbase.qtQmlPrefix ([ qtdeclarative lomiri-ui-toolkit ] ++ lomiri-ui-toolkit.propagatedBuildInputs)}
+    export XDG_RUNTIME_DIR=$PWD
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Lomiri UI Extra Components";
+    longDescription = ''
+      A collection of UI components that for various reasons can't be included in
+      the main Lomiri UI toolkit - mostly because of the level of quality, lack of
+      documentation and/or lack of automated tests.
+    '';
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-ui-extras";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri UI Extras](https://gitlab.com/ubports/development/core/lomiri-ui-extras), more QML components for Lomiri applications. Required by some Lomiri core applications - gallery, file manager, terminal, web browser.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
