### PR TITLE
nixos: add "systemd" udev TAG to `/dev/{kvm,sev}`

### DIFF
--- a/nixos/modules/hardware/cpu/amd-sev.nix
+++ b/nixos/modules/hardware/cpu/amd-sev.nix
@@ -45,7 +45,7 @@ in
       };
 
       services.udev.extraRules = with cfg; ''
-        KERNEL=="sev", OWNER="${user}", GROUP="${group}", MODE="${mode}"
+        KERNEL=="sev", OWNER="${user}", GROUP="${group}", MODE="${mode}", TAG+="systemd"
       '';
     };
   }

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -30,7 +30,7 @@ let
 
   nixosRules = ''
     # Miscellaneous devices.
-    KERNEL=="kvm",                  MODE="0666"
+    KERNEL=="kvm", MODE="0666", TAG+="systemd"
 
     # Needed for gpm.
     SUBSYSTEM=="input", KERNEL=="mice", TAG+="systemd"


### PR DESCRIPTION
## Description of changes

Add the "systemd" udev TAG to the KVM and AMD SEV devices to allow adding dependencies on the devices in systemd units.

See systemd.device(5) for details:

> systemd will dynamically create device units for all kernel devices that are marked with the "systemd" udev tag. [...] To tag a udev device, use "TAG+="systemd"" in the udev rules file, see udev(7) for details.

#### Example

```nix
{
  systemd.services."test-example" = {
    after = [ "dev-kvm.device" ];
  };
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
