### PR TITLE
Revert "lib.getExe: Do not make assumptions about the main program"

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -144,9 +144,5 @@ rec {
        => "/nix/store/am9ml4f4ywvivxnkiaqwr0hyxka1xjsf-mustache-go-1.3.0/bin/mustache"
   */
   getExe = x:
-    "${lib.getBin x}/bin/${x.meta.mainProgram or (
-      # This could be turned into an error when 23.05 is at end of life
-      lib.warn "getExe: Package ${lib.strings.escapeNixIdentifier x.meta.name or x.pname or x.name} does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, specify the full path to the program, such as \"\${lib.getBin foo}/bin/bar\"."
-      lib.getName x
-    )}";
+    "${lib.getBin x}/bin/${x.meta.mainProgram or (lib.getName x)}";
 }


### PR DESCRIPTION
A possible resolution to https://github.com/NixOS/nixpkgs/pull/247115