### PR TITLE
nerdfonts: Add missing fonts

### DIFF
--- a/pkgs/data/fonts/nerdfonts/shas.nix
+++ b/pkgs/data/fonts/nerdfonts/shas.nix
@@ -13,6 +13,7 @@
   "DaddyTimeMono" = "1w5n170l63hfxh1xclw3jpf8amj60br6py4yx12yhqanp2zg0shj";
   "DejaVuSansMono" = "1j22f5jnpmyli686r67c4c07g07ac78aq9wg8hy1vwblxfzdvq9f";
   "DroidSansMono" = "13r1sglgwf05swnbn0mha2gpdqammzlg0p6h7c33af1vr7n8cnca";
+  "EnvyCodeR" = "1y03cb0kq548nm8qh4jh8yw2zpx6ahl0y8561c429p5f16707qxl";
   "FantasqueSansMono" = "1k0p6gvas6mgwq0bbvpwbn3mm6yaaapgjqgk30fvpq9zvn4a26bf";
   "FiraCode" = "14vbb3w6il32kd8my75vvv786azm7sxmdpba9np0qjx4rs8xdhbn";
   "FiraMono" = "1iiz5cnhrb67793ww6pj5y5x9s1a5nlk9kqwbv92kxmbqakarlcb";
@@ -27,6 +28,7 @@
   "Inconsolata" = "02rar6g3zbbpxxxz37v7d5qzafn59bhp04iv3wk16kqxy0havgx5";
   "InconsolataGo" = "0nx6j3v2fvhdw3ygmz65zwlj6zwrkpmf59wfxirpzkcqqsdh4zwl";
   "InconsolataLGC" = "00s2051fz3k6jnsfmnlqnd2cghr9sj2pddi5gpid1i5x006rig7a";
+  "IntelOneMono" = "02cynzrpn93b1kmi21p60lhdai6rppmm3m1f872kvf08damc1660";
   "Iosevka" = "1byrmfbsqi06fsy958364jy694dnm7a7pcjsv64w6mwfsi5vjn1r";
   "IosevkaTerm" = "1k65jfa0c7c6pvns7vfcxcfc3i1qcr6wg16qafbp9zggabbvl7aa";
   "JetBrainsMono" = "0mbzvfl36a6mgb2dnjf8n3kkm28sz0xhv7s5lww141wpgj5jb4a9";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
