### PR TITLE
flips: unstable-2021-10-28 -> unstable-2023-03-15

### DIFF
--- a/pkgs/tools/compression/flips/default.nix
+++ b/pkgs/tools/compression/flips/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "flips";
-  version = "unstable-2021-10-28";
+  version = "unstable-2023-03-15";
 
   src = fetchFromGitHub {
     owner = "Alcaro";
     repo = "Flips";
-    rev = "3a8733e74c9bdbb6b89da2b45913a0be3d0e1866";
-    sha256 = "1jik580mz2spik5mgh60h93ryaj5x8dffncnr1lwija0v803xld7";
+    rev = "fdd5c6e34285beef5b9be759c9b91390df486c66";
+    hash = "sha256-uuHgpt7aWqiMTUILm5tAEGGeZrls3g/DdylYQgsfpTw=";
   };
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook ];

--- a/pkgs/tools/compression/flips/use-system-libdivsufsort.patch
+++ b/pkgs/tools/compression/flips/use-system-libdivsufsort.patch
@@ -1,12 +1,12 @@
 diff --git a/Makefile b/Makefile
-index c9d8b6d..9d66b0b 100644
+index b3d5aeb..a5acc08 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -79,9 +79,7 @@ endif
+@@ -83,9 +83,7 @@ endif
+ 
  MOREFLAGS := $(CFLAGS_$(TARGET))
  
- 
--DIVSUF := libdivsufsort-2.0.1
+-DIVSUF := $(SRCDIR)/libdivsufsort-2.0.1
 -SOURCES += $(DIVSUF)/lib/divsufsort.c $(DIVSUF)/lib/sssort.c $(DIVSUF)/lib/trsort.c
 -MOREFLAGS += -I$(DIVSUF)/include -DHAVE_CONFIG_H -D__STDC_FORMAT_MACROS
 +MOREFLAGS += -ldivsufsort


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Minor update that fixes some small bugs. Floating IPS is in maintenance mode.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
