### PR TITLE
ocamlPackages.camlp5: 7.14 → 8.00.05

### DIFF
--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -1,31 +1,57 @@
-{ lib, stdenv, fetchFromGitHub, ocaml, perl }:
+{ lib, stdenv, fetchFromGitHub, ocaml, findlib, perl, makeWrapper
+, rresult, bos, ocaml_pcre, re, camlp-streams
+}:
 
 if lib.versionOlder ocaml.version "4.02"
-|| lib.versionOlder "4.13" ocaml.version
 then throw "camlp5 is not available for OCaml ${ocaml.version}"
 else
 
-stdenv.mkDerivation rec {
+let params =
+  if lib.versionAtLeast ocaml.version "4.12"
+  then rec {
+    version = "8.00.05";
 
-  pname = "camlp5";
-  version = "7.14";
+    src = fetchFromGitHub {
+      owner = "camlp5";
+      repo = "camlp5";
+      rev = version;
+      hash = "sha256-Havr3RB6iUP7QzV+LUGwMHtGzmRdS5RqYsqJ0N5w6gE=";
+    };
 
-  src = fetchFromGitHub {
-    owner = "camlp5";
-    repo = "camlp5";
-    rev = "rel${builtins.replaceStrings [ "." ] [ "" ] version}";
-    sha256 = "1dd68bisbpqn5lq2pslm582hxglcxnbkgfkwhdz67z4w9d5nvr7w";
-  };
+    nativeBuildInputs = [ makeWrapper ocaml findlib perl ];
+    buildInputs = [ bos ocaml_pcre re rresult ];
+    propagatedBuildInputs = [ camlp-streams ];
+
+    postFixup = ''
+      for p in camlp5 camlp5o camlp5r camlp5sch mkcamlp5 ocpp5
+      do
+        wrapProgram $out/bin/$p \
+        --suffix CAML_LD_LIBRARY_PATH : ${ocaml_pcre}/lib/ocaml/${ocaml.version}/site-lib/stublibs
+      done
+    '';
+  } else rec {
+    version = "7.14";
+    src = fetchFromGitHub {
+      owner = "camlp5";
+      repo = "camlp5";
+      rev = "rel${builtins.replaceStrings [ "." ] [ "" ] version}";
+      sha256 = "1dd68bisbpqn5lq2pslm582hxglcxnbkgfkwhdz67z4w9d5nvr7w";
+    };
+    nativeBuildInputs = [ ocaml perl ];
+  }
+; in
+
+stdenv.mkDerivation (params // {
+
+  pname = "ocaml${ocaml.version}-camlp5";
 
   strictDeps = true;
-
-  nativeBuildInputs = [ ocaml perl ];
 
   prefixKey = "-prefix ";
 
   preConfigure = ''
     configureFlagsArray=(--strict --libdir $out/lib/ocaml/${ocaml.version}/site-lib)
-    patchShebangs ./config/find_stuffversion.pl
+    patchShebangs ./config/find_stuffversion.pl etc/META.pl
   '';
 
   buildFlags = [ "world.opt" ];
@@ -45,4 +71,4 @@ stdenv.mkDerivation rec {
       maggesi vbgl
     ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39129,7 +39129,7 @@ with pkgs;
 
   hol = callPackage ../applications/science/logic/hol { };
 
-  inherit (ocaml-ng.ocamlPackages_4_12) hol_light;
+  inherit (ocamlPackages) hol_light;
 
   hologram = callPackage ../tools/security/hologram { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10088,7 +10088,7 @@ with pkgs;
   lact = callPackage ../tools/system/lact { };
 
   ledit = callPackage ../tools/misc/ledit {
-    inherit (ocaml-ng.ocamlPackages_4_12) ocaml camlp5;
+    inherit (ocaml-ng.ocamlPackages_4_11) ocaml camlp5;
   };
 
   ledmon = callPackage ../tools/system/ledmon { };


### PR DESCRIPTION
## Description of changes

There are major (incompatible) changes in `camlp5` between versions 7 and 8. Apparently, most of `nixpkgs` is ready.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
