### PR TITLE
just.setupHook: init

### DIFF
--- a/pkgs/development/tools/just/default.nix
+++ b/pkgs/development/tools/just/default.nix
@@ -72,6 +72,8 @@ rustPlatform.buildRustPackage rec {
       --zsh completions/just.zsh
   '';
 
+  setupHook = ./setup-hook.sh;
+
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {

--- a/pkgs/development/tools/just/setup-hook.sh
+++ b/pkgs/development/tools/just/setup-hook.sh
@@ -1,0 +1,58 @@
+justBuildPhase() {
+    runHook preBuild
+
+    local flagsArray=($justFlags "${justFlagsArray[@]}")
+
+    echoCmd 'build flags' "${flagsArray[@]}"
+    just "${flagsArray[@]}"
+
+    runHook postBuild
+}
+
+justCheckPhase() {
+    runHook preCheck
+
+    if [ -z "${checkTarget:-}" ]; then
+        if just -n test >/dev/null 2>&1; then
+            checkTarget=test
+        fi
+    fi
+
+    if [ -z "${checkTarget:-}" ]; then
+        echo "no test target found in just, doing nothing"
+    else
+        local flagsArray=(
+            $justFlags "${justFlagsArray[@]}"
+            $checkTarget
+        )
+
+        echoCmd 'check flags' "${flagsArray[@]}"
+        just "${flagsArray[@]}"
+    fi
+
+    runHook postCheck
+}
+
+justInstallPhase() {
+    runHook preInstall
+
+    # shellcheck disable=SC2086
+    local flagsArray=($justFlags "${justFlagsArray[@]}" ${installTargets:-install})
+
+    echoCmd 'install flags' "${flagsArray[@]}"
+    just "${flagsArray[@]}"
+
+    runHook postInstall
+}
+
+if [ -z "${dontUseJustBuild-}" -a -z "${buildPhase-}" ]; then
+    buildPhase=justBuildPhase
+fi
+
+if [ -z "${dontUseJustCheck-}" -a -z "${checkPhase-}" ]; then
+    checkPhase=justCheckPhase
+fi
+
+if [ -z "${dontUseJustInstall-}" -a -z "${installPhase-}" ]; then
+    installPhase=justInstallPhase
+fi

--- a/pkgs/tools/networking/dogdns/default.nix
+++ b/pkgs/tools/networking/dogdns/default.nix
@@ -41,6 +41,10 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+  dontUseJustInstall = true;
+
   postPatch = ''
     # update Cargo.lock to work with openssl 3
     ln -sf ${./Cargo.lock} Cargo.lock


### PR DESCRIPTION
## Description of changes

Adapted from the Ninja setup hook.  This will mean that adding just to nativeBuildInputs is enough to have a package be automatically built with it, matching make, bmake, ninja, etc.

Currently, we have two packages in Nixpkgs that use just, dogdns and kabeljau.  kabeljau follows the expected conventions, while dogdns does not.  I expect there to be more packages using just in future, following these conventions, because all of the packages in system76's in-progress COSMIC desktop environment use just, and follow the conventions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
