### PR TITLE
python311Packages.zeep: expose optionals and clean up

### DIFF
--- a/pkgs/development/python-modules/zeep/default.nix
+++ b/pkgs/development/python-modules/zeep/default.nix
@@ -3,10 +3,8 @@
 , aioresponses
 , attrs
 , buildPythonPackage
-, cached-property
 , defusedxml
 , fetchFromGitHub
-, fetchpatch
 , freezegun
 , httpx
 , isodate
@@ -29,6 +27,7 @@
 buildPythonPackage rec {
   pname = "zeep";
   version = "4.2.1";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
@@ -41,9 +40,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     attrs
-    cached-property
     defusedxml
-    httpx
     isodate
     lxml
     platformdirs
@@ -51,7 +48,19 @@ buildPythonPackage rec {
     requests
     requests-file
     requests-toolbelt
-    xmlsec
+  ];
+
+  passthru.optional-dependencies = {
+    async_require = [
+      httpx
+    ];
+    xmlsec_require = [
+      xmlsec
+    ];
+  };
+
+  pythonImportsCheck = [
+    "zeep"
   ];
 
   nativeCheckInputs = [
@@ -64,26 +73,15 @@ buildPythonPackage rec {
     pytest-httpx
     pytestCheckHook
     requests-mock
-  ];
+  ]
+  ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   preCheck = ''
-    export HOME=$(mktemp -d);
+    export HOME=$TMPDIR
   '';
 
-  disabledTests = [
-    # lxml.etree.XMLSyntaxError: Extra content at the end of the document, line 2, column 64
-    "test_mime_content_serialize_text_xml"
-    # Tests are outdated
-    "test_load"
-    "test_load_cache"
-    "test_post"
-  ];
-
-  pythonImportsCheck = [
-    "zeep"
-  ];
-
   meta = with lib; {
+    changelog = "https://github.com/mvantellingen/python-zeep/releases/tag/${version}";
     description = "Python SOAP client";
     homepage = "http://docs.python-zeep.org";
     license = licenses.mit;


### PR DESCRIPTION
Set format, prune disabled tests.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
