### PR TITLE
nwg-look: init at v0.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10591,7 +10591,7 @@
     }];
   };
   max-amb = {
-    email = "maxpeterambaum@gmail.com";
+    email = "max_a@e.email";
     github = "max-amb";
     githubId = 137820334;
     name = "Max Ambaum";

--- a/pkgs/applications/misc/nwg-look/default.nix
+++ b/pkgs/applications/misc/nwg-look/default.nix
@@ -31,7 +31,7 @@ buildGoModule rec {
   patches = [ ./fix-paths.patch ];
 
   postPatch = ''
-    sed -i 's|@out@|'"''${out}"'|g' main.go tools.go
+    substituteInPlace main.go tools.go --replace '@out@' $out
   '';
 
   ldflags = [ "-s" "-w" ];

--- a/pkgs/applications/misc/nwg-look/default.nix
+++ b/pkgs/applications/misc/nwg-look/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, substituteAll
+, buildGoModule
+, go
+, glib
+, pkg-config
+, cairo
+, gtk3
+, xcur2png
+, libX11
+, zlib
+}:
+
+buildGoModule rec {
+  pname = "nwg-look";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "nwg-piotr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-wUI58qYkVYgES87HQ4octciDlOJ10oJldbUkFgxRUd4=";
+  };
+
+  vendorHash = "sha256-dev+TV6FITd29EfknwHDNI0gLao7gsC95Mg+3qQs93E=";
+
+  # Replace /usr/ directories with the packages output location
+  # This means it references the correct path
+  patches = [ ./fix-paths.patch ];
+
+  postPatch = ''
+    sed -i 's|@out@|'"''${out}"'|g' main.go tools.go
+  '';
+
+  ldflags = [ "-s" "-w" ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    xcur2png
+    libX11.dev
+    zlib
+    gtk3
+  ];
+
+  CGO_ENABLED = 1;
+
+  postInstall = ''
+    mkdir -p $out/share
+    mkdir -p $out/share/nwg-look/langs
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/pixmaps
+    cp stuff/main.glade $out/share/nwg-look/
+    cp langs/* $out/share/nwg-look/langs
+    cp stuff/nwg-look.desktop $out/share/applications
+    cp stuff/nwg-look.svg $out/share/pixmaps
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/nwg-piotr/nwg-look";
+    description = "Nwg-look is a GTK3 settings editor, designed to work properly in wlroots-based Wayland environment.";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ max-amb ];
+    mainProgram = "nwg-look";
+  };
+}

--- a/pkgs/applications/misc/nwg-look/default.nix
+++ b/pkgs/applications/misc/nwg-look/default.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
     owner = "nwg-piotr";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-wUI58qYkVYgES87HQ4octciDlOJ10oJldbUkFgxRUd4=";
+    hash = "sha256-wUI58qYkVYgES87HQ4octciDlOJ10oJldbUkFgxRUd4=";
   };
 
   vendorHash = "sha256-dev+TV6FITd29EfknwHDNI0gLao7gsC95Mg+3qQs93E=";

--- a/pkgs/applications/misc/nwg-look/fix-paths.patch
+++ b/pkgs/applications/misc/nwg-look/fix-paths.patch
@@ -1,0 +1,35 @@
+diff --git a/main.go b/main.go
+index 23c4756..c52e9c3 100644
+--- a/main.go
++++ b/main.go
+@@ -335,7 +335,7 @@ func main() {
+
+ 	gtkSettings, _ = gtk.SettingsGetDefault()
+
+-	builder, _ := gtk.BuilderNewFromFile("/usr/share/nwg-look/main.glade")
++	builder, _ := gtk.BuilderNewFromFile("@out@/share/nwg-look/main.glade")
+ 	win, _ := getWindow(builder, "window")
+
+ 	win.Connect("destroy", func() {
+diff --git a/tools.go b/tools.go
+index e6e7665..59d6f35 100644
+--- a/tools.go
++++ b/tools.go
+@@ -1034,7 +1034,7 @@ func getDataDirs() []string {
+ 	if os.Getenv("XDG_DATA_DIRS") != "" {
+ 		xdgDataDirs = os.Getenv("XDG_DATA_DIRS")
+ 	} else {
+-		xdgDataDirs = "/usr/local/share/:/usr/share/"
++		xdgDataDirs = "@out@/local/share/:@out@/share/"
+ 	}
+
+ 	for _, d := range strings.Split(xdgDataDirs, ":") {
+@@ -1280,7 +1280,7 @@ func detectLang() string {
+ }
+
+ func loadVocabulary(lang string) map[string]string {
+-	langsDir := "/usr/share/nwg-look/langs/"
++	langsDir := "@out@/share/nwg-look/langs/"
+ 	enUSFile := filepath.Join(langsDir, "en_US.json")
+ 	if pathExists(enUSFile) {
+ 		log.Infof(">>> Loading basic lang from '%s'", enUSFile)

--- a/pkgs/applications/misc/nwg-look/go.mod
+++ b/pkgs/applications/misc/nwg-look/go.mod
@@ -1,0 +1,10 @@
+module github.com/nwg-piotr/nwg-look
+
+go 1.20
+
+require (
+	github.com/gotk3/gotk3 v0.6.2
+	github.com/sirupsen/logrus v1.9.3
+)
+
+require golang.org/x/sys v0.6.0 // indirect

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33711,6 +33711,8 @@ with pkgs;
 
   nwg-launchers = callPackage ../applications/misc/nwg-launchers { };
 
+  nwg-look = callPackage ../applications/misc/nwg-look { };
+
   nwg-menu = callPackage ../applications/misc/nwg-menu { };
 
   nwg-panel = callPackage ../applications/misc/nwg-panel { };


### PR DESCRIPTION
## Description of changes
https://github.com/nwg-piotr/nwg-look
## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

fixes #246315