### PR TITLE
Add ms-python.black-formatter, ms-python.isort vscode extensions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2412,6 +2412,22 @@ let
         };
       };
 
+      ms-python.black-formatter = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "black-formatter";
+          publisher = "ms-python";
+          version = "2023.4.1";
+          sha256 = "sha256-IJaLke0WF1rlKTiuwJHAXDQB1SS39AoQhc4iyqqlTyY=";
+        };
+        meta = with lib; {
+          description = "Formatter extension for Visual Studio Code using black";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter";
+          homepage = "https://github.com/microsoft/vscode-black-formatter";
+          license = licenses.mit;
+          maintainers = with maintainers; [ sikmir ];
+        };
+      };
+
       ms-python.python = callPackage ./ms-python.python { };
 
       ms-python.vscode-pylance = buildVscodeMarketplaceExtension {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2428,6 +2428,22 @@ let
         };
       };
 
+      ms-python.isort = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "isort";
+          publisher = "ms-python";
+          version = "2023.10.1";
+          sha256 = "sha256-NRsS+mp0pIhGZiqxAMXNZ7SwLno9Q8pj+RS1WB92HzU=";
+        };
+        meta = with lib; {
+          description = "Import sorting extension for Visual Studio Code using isort";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-python.isort";
+          homepage = "https://github.com/microsoft/vscode-isort";
+          license = licenses.mit;
+          maintainers = with maintainers; [ sikmir ];
+        };
+      };
+
       ms-python.python = callPackage ./ms-python.python { };
 
       ms-python.vscode-pylance = buildVscodeMarketplaceExtension {


### PR DESCRIPTION
## Description of changes
* https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter
* https://marketplace.visualstudio.com/items?itemName=ms-python.isort

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
