### PR TITLE
flood: fix mainProgram merge issue

### DIFF
--- a/pkgs/applications/networking/p2p/flood/default.nix
+++ b/pkgs/applications/networking/p2p/flood/default.nix
@@ -21,5 +21,6 @@ buildNpmPackage rec {
     homepage = "https://flood.js.org";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ thiagokokada winter ];
+    mainProgram = "flood";
   };
 }

--- a/pkgs/development/node-packages/main-programs.nix
+++ b/pkgs/development/node-packages/main-programs.nix
@@ -46,7 +46,6 @@
   firebase-tools = "firebase";
   fkill-cli = "fkill";
   fleek-cli = "fleek";
-  flood = "flood";
   git-run = "gr";
   gitmoji-cli = "gitmoji";
   graphql-cli = "graphql";


### PR DESCRIPTION
The package was repackaged using `buildNpmPackage` ([1]). In parallel its `meta.mainProgram` was defined for the old `node-packages.nix` packaging format ([2]).

Both branches were merged almost at the same time, breaking the build.

[1]: https://github.com/NixOS/nixpkgs/pull/245435
[2]: https://github.com/NixOS/nixpkgs/pull/247095
