### PR TITLE
viking: enable on darwin

### DIFF
--- a/pkgs/applications/misc/viking/default.nix
+++ b/pkgs/applications/misc/viking/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchurl
+{ lib, stdenv, fetchurl, fetchpatch
+, desktopToDarwinBundle
 , docbook_xml_dtd_45, docbook_xsl, intltool, itstool, libxslt, pkg-config, wrapGAppsHook, yelp-tools
 , curl, gdk-pixbuf, gtk3, json-glib, libxml2
 , gpsbabel
@@ -9,7 +10,7 @@
 , withMBTiles ? true, sqlite
 , withMd5Hash ? true, nettle
 , withOAuth ? true, liboauth
-, withRealtimeGPSTracking ? true, gpsd
+, withRealtimeGPSTracking ? (!stdenv.isDarwin), gpsd
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +22,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-lFXIlfmLwT3iS9ayNM0PHV7NwbBotMvG62ZE9hJuRaw=";
   };
 
-  nativeBuildInputs = [ docbook_xml_dtd_45 docbook_xsl intltool itstool libxslt pkg-config wrapGAppsHook yelp-tools ];
+  patches = [
+    # Fix check_md5_hash.sh on macOS
+    (fetchpatch {
+      url = "https://github.com/viking-gps/viking/pull/184/commits/b0e110a3cfefea0f1874669525eb3a220dd29f9f.patch";
+      hash = "sha256-HdkcZMV570SXOQMIZZAti2HT0gIdF/EwQCVXBaOwpqs=";
+    })
+  ];
+
+  nativeBuildInputs = [ docbook_xml_dtd_45 docbook_xsl intltool itstool libxslt pkg-config wrapGAppsHook yelp-tools ]
+    ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
 
   buildInputs = [ curl gdk-pixbuf gtk3 json-glib libxml2 ]
     ++ lib.optional withGeoClue geoclue2
@@ -66,6 +76,6 @@ stdenv.mkDerivation rec {
     homepage = "https://sourceforge.net/projects/viking/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ pSub sikmir ];
-    platforms = with platforms; linux;
+    platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
## Description of changes
Enable on darwin.

https://github.com/viking-gps/viking/pull/184

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
