### PR TITLE
jetbrains: autocommit updates

### DIFF
--- a/pkgs/applications/editors/jetbrains/plugins/update_plugins.py
+++ b/pkgs/applications/editors/jetbrains/plugins/update_plugins.py
@@ -383,8 +383,7 @@ def main():
     # Commit the result
     commitMessage = "jetbrains.plugins: update"
     print("#### Committing changes... ####")
-    run(['git', 'add', PLUGINS_FILE], check=True)
-    run(['git', 'commit', '--file=-'], input=commitMessage.encode(), check=True)
+    run(['git', 'commit', f'-m{commitMessage}', '--', f'{PLUGINS_FILE}'], check=True)
 
 
 if __name__ == '__main__':

--- a/pkgs/applications/editors/jetbrains/plugins/update_plugins.py
+++ b/pkgs/applications/editors/jetbrains/plugins/update_plugins.py
@@ -380,6 +380,12 @@ def main():
 
     write_result(result)
 
+    # Commit the result
+    commitMessage = "jetbrains.plugins: update"
+    print("#### Committing changes... ####")
+    run(['git', 'add', PLUGINS_FILE], check=True)
+    run(['git', 'commit', '--file=-'], input=commitMessage.encode(), check=True)
+
 
 if __name__ == '__main__':
     main()

--- a/pkgs/applications/editors/jetbrains/update_ides.py
+++ b/pkgs/applications/editors/jetbrains/update_ides.py
@@ -122,8 +122,7 @@ for name in toVersions.keys():
 
 # Commit the result
 logging.info("#### Committing changes... ####")
-subprocess.run(['git', 'add', versions_file_path], check=True)
-subprocess.run(['git', 'commit', '--file=-'], input=commitMessage.encode(), check=True)
+subprocess.run(['git', 'commit', f'-m{commitMessage}', '--', f'{versions_file_path}'], check=True)
 
 logging.info("#### Updating plugins ####")
 plugin_script = current_path.joinpath("plugins/update_plugins.py").resolve()

--- a/pkgs/applications/editors/jetbrains/update_ides.py
+++ b/pkgs/applications/editors/jetbrains/update_ides.py
@@ -12,6 +12,8 @@ from packaging import version
 updates_url = "https://www.jetbrains.com/updates/updates.xml"
 current_path = pathlib.Path(__file__).parent
 versions_file_path = current_path.joinpath("versions.json").resolve()
+fromVersions = {}
+toVersions = {}
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -74,6 +76,8 @@ def update_product(name, product):
             download_url = product["url-template"].format(version=version_or_build_number, versionMajorMinor=version_number)
             product["url"] = download_url
             if "sha256" not in product or product.get("build_number") != new_build_number:
+                fromVersions[name] = product["version"]
+                toVersions[name] = new_version
                 logging.info("Found a newer version %s with build number %s.", new_version, new_build_number)
                 product["version"] = new_version
                 product["build_number"] = new_build_number
@@ -101,6 +105,27 @@ with open(versions_file_path, "w") as versions_file:
     json.dump(versions, versions_file, indent=2)
     versions_file.write("\n")
 
+if len(toVersions) == 0:
+    # No Updates found
+    sys.exit(0)
+
+if len(toVersions) == 1:
+    commitMessage = ""
+else:
+    lowestVersion = min(fromVersions.values())
+    highestVersion = max(toVersions.values())
+    commitMessage = f"jetbrains: {lowestVersion} -> {highestVersion}"
+    commitMessage += "\n\n"
+
+for name in toVersions.keys():
+    commitMessage += f"jetbrains.{name}: {fromVersions[name]} -> {toVersions[name]}\n"
+
+# Commit the result
+logging.info("#### Committing changes... ####")
+subprocess.run(['git', 'add', versions_file_path], check=True)
+subprocess.run(['git', 'commit', '--file=-'], input=commitMessage.encode(), check=True)
+
 logging.info("#### Updating plugins ####")
 plugin_script = current_path.joinpath("plugins/update_plugins.py").resolve()
 subprocess.call(plugin_script)
+


### PR DESCRIPTION
## Description of changes

With this PR, when the jetbrains IDEs are being updated, the update script will automatically commit the changes. This has the advantage of consistent commit messages.

If there is just a single Product update, the commit message looks like this:
```
jetbrains.phpstorm: 2023.1.4 -> 2023.2
```

If there are multiple Product updates, the commit message looks like this:
```
jetbrains: 2023.1.4 -> 2023.2

jetbrains.phpstorm: 2023.1.4 -> 2023.2
jetbrains.rider: 2023.1.4 -> 2023.2
```

The `plugins.json` file is committed separatly as
```
jetbrains.plugin: update
```
This was suggested [here](https://github.com/NixOS/nixpkgs/pull/242493#issuecomment-1630814556).

//cc @Janik-Haag 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
