### PR TITLE
python3.pkgs.ansi2html: dependency cleanup

### DIFF
--- a/pkgs/development/python-modules/ansi2html/default.nix
+++ b/pkgs/development/python-modules/ansi2html/default.nix
@@ -1,22 +1,42 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k, six, mock, pytestCheckHook, setuptools, setuptools-scm }:
+{ lib
+, buildPythonPackage
+, fetchpatch
+, fetchPypi
+, pytestCheckHook
+, setuptools
+, setuptools-scm
+, wheel
+}:
 
 buildPythonPackage rec {
   pname = "ansi2html";
   version = "1.8.0";
   format = "pyproject";
 
-  disabled = !isPy3k;
-
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-OLgqKYSCofomE/D5yb6z23Ko+DLurFjrLke/Ms039tU=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ six setuptools ];
+  patches = [
+    (fetchpatch {
+      name = "update-build-requirements.patch";
+      url = "https://github.com/pycontribs/ansi2html/commit/be9c47dd39e500b2e34e95efde90d0a3b44daaee.patch";
+      hash = "sha256-nvOclsgysg+4sK694ppls0BLfq5MCJJQW3V/Ru30D/k=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+    wheel
+  ];
 
   preCheck = "export PATH=$PATH:$out/bin";
-  nativeCheckInputs = [ mock pytestCheckHook ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "ansi2html" ];
 


### PR DESCRIPTION
## Description of changes

Some dependencies can be removed, and some build dependencies need to be added to prepare for stricter dependency validation.

Extracted from the original version and required by https://github.com/NixOS/nixpkgs/pull/245509.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
