### PR TITLE
python3.pkgs.aplpy: dependency cleanup

### DIFF
--- a/pkgs/development/python-modules/aplpy/default.nix
+++ b/pkgs/development/python-modules/aplpy/default.nix
@@ -1,8 +1,6 @@
 { lib
 , astropy
-, astropy-helpers
 , buildPythonPackage
-, cython
 , fetchpatch
 , fetchPypi
 , matplotlib
@@ -15,7 +13,10 @@
 , pythonOlder
 , reproject
 , scikit-image
+, setuptools
+, setuptools-scm
 , shapely
+, wheel
 }:
 
 buildPythonPackage rec {
@@ -32,12 +33,13 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    astropy-helpers
+    setuptools
+    setuptools-scm
+    wheel
   ];
 
   propagatedBuildInputs = [
     astropy
-    cython
     matplotlib
     numpy
     pillow

--- a/pkgs/development/python-modules/pyregion/default.nix
+++ b/pkgs/development/python-modules/pyregion/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage rec {
     pyparsing
     numpy
     astropy
+    cython
   ];
 
   # Upstream patches needed for the tests to pass


### PR DESCRIPTION
## Description of changes

A few dependencies could be cleaned up. The build dependencies that are added are in preparation for https://github.com/NixOS/nixpkgs/pull/245509.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
