### PR TITLE
cling: tidy/simplify + add experimental libc++ support

### DIFF
--- a/pkgs/development/interpreters/cling/default.nix
+++ b/pkgs/development/interpreters/cling/default.nix
@@ -12,9 +12,12 @@
 , zlib
 
 # *NOT* from LLVM 9!
-# It would be cleanest to use LLVM 9's clang to build this, but it errors.
-# So we use a later version of Clang to compile, but we check out the Cling
-# fork of Clang 9 to build Cling against, as it expects.
+# The compiler used to compile Cling may affect the runtime include and lib
+# directories it expects to be run with. Cling builds against (a fork of) Clang,
+# so we prefer to use Clang as the compiler as well for consistency.
+# It would be cleanest to use LLVM 9's clang, but it errors. So, we use a later
+# version of Clang to compile, but we check out the Cling fork of Clang 9 to
+# build Cling against.
 , clangStdenv
 
 # For runtime C++ standard library

--- a/pkgs/development/interpreters/cling/default.nix
+++ b/pkgs/development/interpreters/cling/default.nix
@@ -8,7 +8,7 @@
 , makeWrapper
 , ncurses
 , python3
-, runCommandNoCC
+, runCommand
 , zlib
 
 # *NOT* from LLVM 9!
@@ -35,7 +35,7 @@ let
   stdenv = clangStdenv;
 
   # The LLVM 9 headers have a couple bugs we need to patch
-  fixedLlvmDev = runCommandNoCC "llvm-dev-${llvmPackages_9.llvm.version}" { buildInputs = [git]; } ''
+  fixedLlvmDev = runCommand "llvm-dev-${llvmPackages_9.llvm.version}" { buildInputs = [git]; } ''
     mkdir $out
     cp -r ${llvmPackages_9.llvm.dev}/include $out
     cd $out
@@ -161,7 +161,7 @@ let
 
 in
 
-runCommandNoCC "cling-${unwrapped.version}" {
+runCommand "cling-${unwrapped.version}" {
   nativeBuildInputs = [ makeWrapper ];
   inherit unwrapped flags;
   inherit (unwrapped) meta;

--- a/pkgs/development/interpreters/cling/default.nix
+++ b/pkgs/development/interpreters/cling/default.nix
@@ -1,22 +1,38 @@
-{ lib
-, stdenv
-, python3
-, libffi
-, git
-, cmake
-, zlib
-, fetchgit
+{ cmake
 , fetchFromGitHub
-, makeWrapper
-, runCommand
+, fetchgit
+, git
+, lib
+, libffi
 , llvmPackages_9
-, glibc
+, makeWrapper
 , ncurses
+, python3
+, runCommandNoCC
+, zlib
+
+# *NOT* from LLVM 9!
+# It would be cleanest to use LLVM 9's clang to build this, but it errors.
+# So we use a later version of Clang to compile, but we check out the Cling
+# fork of Clang 9 to build Cling against, as it expects.
+, clangStdenv
+
+# For runtime C++ standard library
+, gcc-unwrapped
+
+# Build with debug symbols
+, debug ? false
+
+# Build with libc++ (LLVM) rather than stdlibc++ (GCC).
+# This is experimental and not all features work.
+, useLLVMLibcxx ? false
 }:
 
 let
+  stdenv = clangStdenv;
+
   # The LLVM 9 headers have a couple bugs we need to patch
-  fixedLlvmDev = runCommand "llvm-dev-${llvmPackages_9.llvm.version}" { buildInputs = [git]; } ''
+  fixedLlvmDev = runCommandNoCC "llvm-dev-${llvmPackages_9.llvm.version}" { buildInputs = [git]; } ''
     mkdir $out
     cp -r ${llvmPackages_9.llvm.dev}/include $out
     cd $out
@@ -58,7 +74,7 @@ let
     ];
 
     nativeBuildInputs = [ python3 git cmake ];
-    buildInputs = [ libffi zlib ncurses ];
+    buildInputs = [ libffi ncurses zlib ];
 
     strictDeps = true;
 
@@ -69,6 +85,7 @@ let
       "-DLLVM_MAIN_INCLUDE_DIR=${fixedLlvmDev}/include"
       "-DLLVM_TABLEGEN_EXE=${llvmPackages_9.llvm.out}/bin/llvm-tblgen"
       "-DLLVM_TOOLS_BINARY_DIR=${llvmPackages_9.llvm.out}/bin"
+      "-DLLVM_BUILD_TOOLS=Off"
       "-DLLVM_TOOL_CLING_BUILD=ON"
 
       "-DLLVM_TARGETS_TO_BUILD=host;NVPTX"
@@ -78,13 +95,21 @@ let
       # see cling/tools/CMakeLists.txt
       "-DCLING_INCLUDE_TESTS=ON"
       "-DCLANG-TOOLS=OFF"
-      # "--trace-expand"
+    ] ++ lib.optionals debug [
+      "-DCMAKE_BUILD_TYPE=Debug"
+    ] ++ lib.optionals useLLVMLibcxx [
+      "-DLLVM_ENABLE_LIBCXX=ON"
+      "-DLLVM_ENABLE_LIBCXXABI=ON"
     ];
+
+    CPPFLAGS = if useLLVMLibcxx then [ "-stdlib=libc++" ] else [];
 
     postInstall = lib.optionalString (!stdenv.isDarwin) ''
       mkdir -p $out/share/Jupyter
       cp -r /build/clang/tools/cling/tools/Jupyter/kernel $out/share/Jupyter
     '';
+
+    dontStrip = debug;
 
     meta = with lib; {
       description = "The Interactive C++ Interpreter";
@@ -95,44 +120,49 @@ let
     };
   };
 
+  # Runtime flags for the C++ standard library
+  cxxFlags = if useLLVMLibcxx then [
+    "-I" "${lib.getDev llvmPackages_9.libcxx}/include/c++/v1"
+    "-L" "${llvmPackages_9.libcxx}/lib"
+    "-l" "${llvmPackages_9.libcxx}/lib/libc++.so"
+  ] else [
+    "-I" "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}"
+    "-I" "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}/x86_64-unknown-linux-gnu"
+  ];
+
   # The flags passed to the wrapped cling should
   # a) prevent it from searching for system include files and libs, and
-  # b) provide it with the include files and libs it needs (C and C++ standard library)
+  # b) provide it with the include files and libs it needs (C and C++ standard library plus
+  # its own stuff)
 
-  # These are also exposed as cling.flags/cling.compilerIncludeFlags because it's handy to be
-  # able to pass them to tools that wrap Cling, particularly Jupyter kernels such as xeus-cling
-  # and the built-in jupyter-cling-kernel. Both of these use Cling as a library by linking against
-  # libclingJupyter.so, so the makeWrapper approach to wrapping the binary doesn't work.
+  # These are also exposed as cling.flags because it's handy to be able to pass them to tools
+  # that wrap Cling, particularly Jupyter kernels such as xeus-cling and the built-in
+  # jupyter-cling-kernel, which use Cling as a library.
   # Thus, if you're packaging a Jupyter kernel, you either need to pass these flags as extra
   # args to xcpp (for xeus-cling) or put them in the environment variable CLING_OPTS
-  # (for jupyter-cling-kernel)
+  # (for jupyter-cling-kernel).
   flags = [
     "-nostdinc"
     "-nostdinc++"
-    "-isystem" "${lib.getDev stdenv.cc.libc}/include"
-    "-I" "${lib.getDev unwrapped}/include"
-    "-I" "${lib.getLib unwrapped}/lib/clang/9.0.1/include"
-  ];
 
-  # Autodetect the include paths for the compiler used to build Cling, in the same way Cling does at
-  # https://github.com/root-project/cling/blob/v0.7/lib/Interpreter/CIFactory.cpp#L107:L111
-  # Note: it would be nice to just put the compiler in Cling's PATH and let it do this by itself, but
-  # unfortunately passing -nostdinc/-nostdinc++ disables Cling's autodetection logic.
-  compilerIncludeFlags = runCommand "compiler-include-flags.txt" {} ''
-    export LC_ALL=C
-    ${stdenv.cc}/bin/c++ -xc++ -E -v /dev/null 2>&1 | sed -n -e '/^.include/,''${' -e '/^ \/.*++/p' -e '}' > tmp
-    sed -e 's/^/-isystem /' -i tmp
-    tr '\n' ' ' < tmp > $out
-  '';
+    "-isystem" "${lib.getLib unwrapped}/lib/clang/9.0.1/include"
+  ]
+  ++ cxxFlags
+  ++ [
+    # System libc
+    "-isystem" "${lib.getDev stdenv.cc.libc}/include"
+
+    # cling includes
+    "-isystem" "${lib.getDev unwrapped}/include"
+  ];
 
 in
 
-runCommand "cling-${unwrapped.version}" {
+runCommandNoCC "cling-${unwrapped.version}" {
   nativeBuildInputs = [ makeWrapper ];
-  inherit unwrapped flags compilerIncludeFlags;
+  inherit unwrapped flags;
   inherit (unwrapped) meta;
 } ''
   makeWrapper $unwrapped/bin/cling $out/bin/cling \
-    --add-flags "$(cat "$compilerIncludeFlags")" \
     --add-flags "$flags"
 ''


### PR DESCRIPTION
## Description of changes

This PR tidies and improves the Cling derivation as part of my [work to package xeus-cling](https://github.com/NixOS/nixpkgs/pull/244777).

In particular, this removes the weird auto-detection of flags for the C++ standard library, and replaces it with the actual correct ones.

I also added experimental support for LLVM libc++, for users who want to use this entirely without GCC. This is gated behind a flag.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
