### PR TITLE
python3Packages.cocotb: 1.7.2 -> 1.8.0

### DIFF
--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -1,19 +1,9 @@
-{ lib
-, stdenv
-, buildPythonPackage
-, fetchFromGitHub
-, setuptools
-, setuptools-scm
-, cocotb-bus
-, find-libpython
-, pytestCheckHook
-, swig
-, verilog
-}:
+{ lib, stdenv, buildPythonPackage, fetchFromGitHub, setuptools, setuptools-scm
+, cocotb-bus, find-libpython, pytestCheckHook, swig, verilog }:
 
 buildPythonPackage rec {
   pname = "cocotb";
-  version = "1.7.2";
+  version = "1.8.0";
 
   # pypi source doesn't include tests
   src = fetchFromGitHub {
@@ -25,7 +15,8 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  buildInputs = [ setuptools find-libpython ];
+  buildInputs = [ setuptools ];
+  propagatedBuildInputs = [ find-libpython ];
 
   postPatch = ''
     patchShebangs bin/*.py
@@ -60,7 +51,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "cocotb" ];
 
   meta = with lib; {
-    description = "Coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python";
+    description =
+      "Coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python";
     homepage = "https://github.com/cocotb/cocotb";
     license = licenses.bsd3;
     maintainers = with maintainers; [ matthuszagh ];

--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -1,5 +1,16 @@
-{ lib, stdenv, buildPythonPackage, fetchFromGitHub, setuptools, setuptools-scm
-, cocotb-bus, find-libpython, pytestCheckHook, swig, verilog }:
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, setuptools-scm
+, cocotb-bus
+, find-libpython
+, pytestCheckHook
+, swig
+, verilog
+, ghdl
+}:
 
 buildPythonPackage rec {
   pname = "cocotb";
@@ -10,7 +21,7 @@ buildPythonPackage rec {
     owner = "cocotb";
     repo = "cocotb";
     rev = "refs/tags/v${version}";
-    hash = "sha256-gLOYwljqnYkGsdbny7+f93QgroLBaLLnDBRpoCe8uEg=";
+    hash = "sha256-k3VizQ9iyDawfDCeE3Zup/KkyD54tFBLdQvRKsbKDLY=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];
@@ -42,7 +53,7 @@ buildPythonPackage rec {
     ./0001-Patch-LDCXXSHARED-for-macOS-along-with-LDSHARED.patch
   ];
 
-  nativeCheckInputs = [ cocotb-bus pytestCheckHook swig verilog ];
+  nativeCheckInputs = [ cocotb-bus pytestCheckHook swig verilog ghdl ];
   preCheck = ''
     export PATH=$out/bin:$PATH
     mv cocotb cocotb.hidden
@@ -51,10 +62,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "cocotb" ];
 
   meta = with lib; {
-    description =
-      "Coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python";
+    changelog = "https://github.com/cocotb/cocotb/releases/tag/v${version}";
+    description = "Coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python";
     homepage = "https://github.com/cocotb/cocotb";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ matthuszagh ];
+    maintainers = with maintainers; [ matthuszagh jleightcap ];
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upate cocotb to https://github.com/cocotb/cocotb/releases/tag/v1.8.0.
Includes small change to testing dependencies, and fixes a runtime dependency error:

```
       > building
       > build flags: SHELL=/nix/store/p6dlr3skfhxpyphipg2bqnj52999banh-bash-5.2-p15/bin/bash
       > Traceback (most recent call last):
       >   File "/nix/store/4c09svm5ipspmkg3l0igsydq20c0gvib-python3.10-cocotb-1.7.2/bin/.cocotb-config-wrapped", line 6, in <module>
       >     from cocotb.config import main
       >   File "/nix/store/4c09svm5ipspmkg3l0igsydq20c0gvib-python3.10-cocotb-1.7.2/lib/python3.10/site-packages/cocotb/config.py", line 47, in <module>
       >     import find_libpython
       > ModuleNotFoundError: No module named 'find_libpython'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
