### PR TITLE
vintagestory: 1.18.6 -> 1.18.7

### DIFF
--- a/pkgs/games/vintagestory/default.nix
+++ b/pkgs/games/vintagestory/default.nix
@@ -22,19 +22,19 @@
 
 stdenv.mkDerivation rec {
   pname = "vintagestory";
-  version = if experimental then "1.18.6" else "1.18.6";
+  version = if experimental then "1.18.8-rc.1" else "1.18.7";
 
   src =
     if experimental
     then
       (fetchurl {
-        url = "https://cdn.vintagestory.at/gamefiles/net7/vs_client_linux-x64_${version}.tar.gz";
-        sha256 = "sha256-h4TyMDFid3eB6oPJix92/tmS0v+Ox6CFSRyn/JRNbxg=";
+        url = "https://cdn.vintagestory.at/gamefiles/unstable/vs_client_linux-x64_${version}.tar.gz";
+        hash = "sha256-FxyAJTiLENTp5QxPKRgsiOhkMXz88CTn3QRvIHtOH+A=";
       })
     else
       (fetchurl {
         url = "https://cdn.vintagestory.at/gamefiles/stable/vs_archive_${version}.tar.gz";
-        sha256 = "sha256-Sa5R/Msg36pKRpZJXXJgM4lcCADJX9x81fMnTD3tjAI=";
+        hash = "sha256-geJoNxBxODXQeTExLdTOaH84asjo2yg2xFm8Pj0IMc0=";
       });
 
 


### PR DESCRIPTION
## Description of changes
Update to 1.18.7
see: https://www.vintagestory.at/blog.html/news/v1187-thatll-buff-it-out-r361/
also updates the experimental version to 1.18.8-rc.1 (this is effectively the same as 1.18.7 but built on dotnet7) see: https://www.vintagestory.at/blog.html/news/v1188-rc1-the-plunge-to-net7-r362/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
