### PR TITLE
teavpn2: init at unstable-2023-07-25

### DIFF
--- a/pkgs/tools/networking/teavpn2/default.nix
+++ b/pkgs/tools/networking/teavpn2/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, substituteAll
+, iproute2
+}:
+stdenv.mkDerivation {
+  pname = "teavpn2";
+  version = "unstable-2023-07-25";
+
+  src = fetchFromGitHub {
+    owner = "TeaInside";
+    repo = "teavpn2";
+    rev = "b21898d001a2e7b821e045162dd18f13561cb04b";
+    hash = "sha256-0/eHK2/+pn6NfawL1xLJv4jDBFvLwELSXNWLUvff1gs=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./nix.patch;
+      inherit iproute2;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 0755 teavpn2 $out/bin/teavpn2
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An open source VPN Software";
+    homepage = "https://github.com/TeaInside/teavpn2";
+    license = licenses.gpl2Plus;
+    mainProgram = "teavpn2";
+    maintainers = with maintainers; [ ludovicopiero ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/teavpn2/nix.patch
+++ b/pkgs/tools/networking/teavpn2/nix.patch
@@ -1,0 +1,14 @@
+diff --git a/src/teavpn2/net/linux/iface.c b/src/teavpn2/net/linux/iface.c
+index a77c1c8..e59c901 100644
+--- a/src/teavpn2/net/linux/iface.c
++++ b/src/teavpn2/net/linux/iface.c
+@@ -327,7 +327,8 @@ static __cold __always_inline const char *find_ip_cmd(void)
+ 		"/usr/sbin/ip",
+ 		"/usr/local/bin/ip",
+ 		"/usr/local/sbin/ip",
+-		"/data/data/com.termux/files/usr/bin/ip"
++		"/data/data/com.termux/files/usr/bin/ip",
++		"@iproute2@/bin/ip"
+ 	};
+ 
+ 	for (size_t i = 0; i < (sizeof(ip_bin) / sizeof(*ip_bin)); i++) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13443,6 +13443,8 @@ with pkgs;
 
   tea = callPackage ../tools/misc/tea { };
 
+  teavpn2 = callPackage ../tools/networking/teavpn2 { };
+
   inherit (nodePackages) teck-programmer;
 
   ted = callPackage ../tools/typesetting/ted { };


### PR DESCRIPTION
## Description of changes

https://github.com/TeaInside/teavpn2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
