### PR TITLE
python3.pkgs.aiohttp: fix tests with setuptools 67.5.0+

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -6,6 +6,7 @@
 , pythonOlder
 # build_requires
 , setuptools
+, wheel
 # install_requires
 , attrs
 , charset-normalizer
@@ -49,6 +50,8 @@ buildPythonPackage rec {
       url = "https://github.com/aio-libs/aiohttp/commit/7dcc235cafe0c4521bbbf92f76aecc82fee33e8b.patch";
       hash = "sha256-ZzhlE50bmA+e2XX2RH1FuWQHZIAa6Dk/hZjxPoX5t4g=";
     })
+    # https://github.com/aio-libs/aiohttp/pull/7454 but does not merge cleanly
+    ./setuptools-67.5.0-compatibility.diff
   ];
 
   postPatch = ''
@@ -57,6 +60,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
+    wheel
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiohttp/setuptools-67.5.0-compatibility.diff
+++ b/pkgs/development/python-modules/aiohttp/setuptools-67.5.0-compatibility.diff
@@ -1,0 +1,27 @@
+diff --git a/setup.cfg b/setup.cfg
+index 6944b7e2..dfa65d69 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -128,6 +128,7 @@ filterwarnings =
+ 	ignore:Creating a LegacyVersion has been deprecated and will be removed in the next major release:DeprecationWarning::
+ 	ignore:module 'sre_constants' is deprecated:DeprecationWarning:pkg_resources._vendor.pyparsing
+ 	ignore:path is deprecated. Use files.. instead. Refer to https.//importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.:DeprecationWarning:certifi.core
++	ignore:pkg_resources is deprecated as an API:DeprecationWarning
+ junit_suite_name = aiohttp_test_suite
+ norecursedirs = dist docs build .tox .eggs
+ minversion = 3.8.2
+diff --git a/tests/test_circular_imports.py b/tests/test_circular_imports.py
+index 22e5ea47..a655fd1d 100644
+--- a/tests/test_circular_imports.py
++++ b/tests/test_circular_imports.py
+@@ -113,6 +113,10 @@ def test_no_warnings(import_path: str) -> None:
+         "-W",
+         "ignore:Creating a LegacyVersion has been deprecated and will "
+         "be removed in the next major release:DeprecationWarning:",
++        # Deprecation warning emitted by setuptools v67.5.0+ triggered by importing
++        # `gunicorn.util`.
++        "-W", "ignore:pkg_resources is deprecated as an API:"
++        "DeprecationWarning",
+         "-c", f"import {import_path!s}",
+         # fmt: on
+     )


### PR DESCRIPTION
## Description of changes

Adds necessary build dependencies and pulls in a patch to fix tests when run against setuptools 67.5.0+.

This can supersede https://github.com/NixOS/nixpkgs/pull/212602.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
