### PR TITLE
capstone_5: init at 5.0

### DIFF
--- a/pkgs/development/libraries/capstone/4.nix
+++ b/pkgs/development/libraries/capstone/4.nix
@@ -2,27 +2,19 @@
 , stdenv
 , cmake
 , fetchFromGitHub
-, fetchpatch
 , fixDarwinDylibNames
 }:
 
 stdenv.mkDerivation rec {
   pname = "capstone";
-  version = "5.0";
+  version = "4.0.2";
 
   src = fetchFromGitHub {
     owner = "capstone-engine";
     repo = "capstone";
     rev = version;
-    sha256 = "sha256-+CdGp05TCnxPeNG69BFaQEkjcn3Zb7SSyHlnHEWlei0=";
+    sha256 = "sha256-XMwQ7UaPC8YYu4yxsE4bbR3leYPfBHu5iixSLz05r3g=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/capstone-engine/capstone/commit/b0d1725379a65b31fb5f637f81f1c12a1a2e840c.patch";
-      sha256 = "sha256-65xPXKv0apL5TFGiUnS/lcKX3mz7Yne1W/kLX252fCU=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4439,7 +4439,9 @@ with pkgs;
 
   candle = libsForQt5.callPackage ../applications/misc/candle { };
 
-  capstone = callPackage ../development/libraries/capstone { };
+  capstone = callPackage ../development/libraries/capstone/4.nix { };
+
+  capstone_5 = callPackage ../development/libraries/capstone { };
 
   keystone = callPackage ../development/libraries/keystone { };
 


### PR DESCRIPTION
## Description of changes

[Capstone](https://github.com/capstone-engine/capstone/) has been on version 4.0.2 since 2020. This PR conservatively keeps Capstone 4 as the default, while allowing maintainers to switch the packages they know need Capstone 5 to the new version (which just released). When more developers switch to it (although I don't know whether/how the ABI changed), this can be made the default.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
