### PR TITLE
opencv-mobile: init at 4.6.0-16; deepin: use opencv-mobile

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-album/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-album/default.nix
@@ -15,7 +15,7 @@
 , image-editor
 , glibmm
 , freeimage
-, opencv
+, opencv-mobile
 , ffmpeg
 , ffmpegthumbnailer
 }:
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     image-editor
     glibmm
     freeimage
-    opencv
+    opencv-mobile
     ffmpeg
     ffmpegthumbnailer
   ];

--- a/pkgs/desktops/deepin/library/image-editor/default.nix
+++ b/pkgs/desktops/deepin/library/image-editor/default.nix
@@ -7,7 +7,7 @@
 , qttools
 , pkg-config
 , wrapQtAppsHook
-, opencv
+, opencv-mobile
 , freeimage
 , libmediainfo
 , ffmpegthumbnailer
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dtkwidget
-    opencv
+    opencv-mobile
     freeimage
     libmediainfo
     ffmpegthumbnailer

--- a/pkgs/development/libraries/opencv-mobile/default.nix
+++ b/pkgs/development/libraries/opencv-mobile/default.nix
@@ -1,0 +1,62 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+}:
+
+let
+  opencvVer = "4.6.0";
+  patchVer = "16";
+
+  opencvSrc = fetchFromGitHub {
+    owner = "opencv";
+    repo = "opencv";
+    rev = opencvVer;
+    hash = "sha256-zPkMc6xEDZU5TlBH3LAzvB17XgocSPeHVMG/U6kfpxg=";
+  };
+
+  patchSrc = fetchFromGitHub {
+    owner = "nihui";
+    repo = "opencv-mobile";
+    rev = "v${patchVer}";
+    hash = "sha256-ijt3EoezUr9Pnh0FFHL7y1Or/ec63sgKds1p4Ob5Tcc=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "opencv-mobile";
+  version = "${opencvVer}-${patchVer}";
+
+  src = opencvSrc;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  postPatch = ''
+    patch -p1 -i ${patchSrc}/opencv-4.6.0-no-zlib.patch
+    truncate -s 0 cmake/OpenCVFindLibsGrfmt.cmake
+    rm -rf modules/gapi
+    rm -rf modules/highgui
+    cp -r ${patchSrc}/highgui modules/
+    chmod +w modules/highgui
+    patch -p1 -i ${patchSrc}/opencv-4.6.0-no-rtti.patch
+  '';
+
+  preConfigure = ''
+    cmakeFlags="`cat ${patchSrc}/opencv4_cmake_options.txt` $cmakeFlags"
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_opencv_world=OFF"
+  ];
+
+  meta = {
+    description = "The minimal opencv for Android, iOS, ARM Linux, Windows, Linux, MacOS, WebAssembly";
+    homepage = "https://github.com/nihui/opencv-mobile";
+    license = with lib.licenses; [ bsd3 asl20 ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ rewine ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24025,6 +24025,8 @@ with pkgs;
 
   opencv = opencv4;
 
+  opencv-mobile = callPackage ../development/libraries/opencv-mobile { };
+
   imath = callPackage ../development/libraries/imath { };
 
   openexr = openexr_2;


### PR DESCRIPTION
## Description of changes

https://github.com/nihui/opencv-mobile

This project provides the minimal build of opencv library for the Android, iOS and ARM Linux platforms, 

```
# info by nix-tree
/nix/store/n3c5563nzrzd7cim7hjsnvsxxr998ll4-opencv-4.7.0                                                  
NAR Size: 66.2 MiB | Closure Size: 695.23 MiB | Added Size: 695.23 MiB

/nix/store/anyhzy340ah7pb139sbcfld8mw836vaq-opencv-mobile-4.6-16                                          
NAR Size: 33.34 MiB | Closure Size: 334.76 MiB | Added Size: 334.76 MiB
```
For some packages, opencv-mobile can be used to reduce the Closure Size

opencv-mobile v16  support opencv 2.4.13.7, 3.4.18 and 4.6.0,  Currently only 4.6.0 is packaged, older versions can be added if needed





<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
