### PR TITLE
hostmux: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5488,6 +5488,13 @@
       }
     ];
   };
+  fernsehmuell = {
+    email = "fernsehmuel@googlemail.com";
+    matrix = "@fernsehmuell:matrix.org";
+    github = "fernsehmuell";
+    githubId = 5198058;
+    name = "Udo Sauer";
+  };
   ffinkdevs = {
     email = "fink@h0st.space";
     github = "ffinkdevs";

--- a/pkgs/tools/misc/hostmux/default.nix
+++ b/pkgs/tools/misc/hostmux/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, installShellFiles
+, openssh
+, tmux
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hostmux";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "hukl";
+    repo = "hostmux";
+    rev = finalAttrs.version;
+    hash = "sha256-odN7QFsU3MsWW8VabVjZH+8+AUFOUio8eF9ORv9iPEA=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  buildInputs = [
+    openssh
+    tmux
+  ];
+
+  postPatch = ''
+    substituteInPlace hostmux \
+      --replace "SSH_CMD=ssh" "SSH_CMD=${openssh}/bin/ssh" \
+      --replace "tmux -2" "${tmux}/bin/tmux -2" \
+      --replace "tmux s" "${tmux}/bin/tmux s"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 hostmux $out/bin/hostmux
+    installManPage man/hostmux.1
+    installShellCompletion --zsh zsh-completion/_hostmux
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Small wrapper script for tmux to easily connect to a series of hosts via ssh and open a split pane for each of the hosts";
+    homepage = "https://github.com/hukl/hostmux";
+    license = lib.licenses.mit;
+    mainProgram = "hostmux";
+    maintainers = with lib.maintainers; [ fernsehmuell ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1782,6 +1782,8 @@ with pkgs;
 
   hexdiff = callPackage ../tools/misc/hexdiff { };
 
+  hostmux = callPackage ../tools/misc/hostmux { };
+
   httm = darwin.apple_sdk_11_0.callPackage ../tools/filesystems/httm { };
 
   inherit (callPackage ../tools/networking/ivpn/default.nix {}) ivpn ivpn-service;


### PR DESCRIPTION
## Description of changes
Small wrapper script for tmux to easily connect to a series of hosts via ssh and open a split pane for each of the hosts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
