### PR TITLE
dleyna-*: Fix build with meson 1.2

### DIFF
--- a/pkgs/development/libraries/dleyna-connector-dbus/default.nix
+++ b/pkgs/development/libraries/dleyna-connector-dbus/default.nix
@@ -4,6 +4,7 @@
 , ninja
 , pkg-config
 , fetchFromGitHub
+, fetchpatch
 , dleyna-core
 , glib
 }:
@@ -18,6 +19,17 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "WDmymia9MD3BRU6BOCzCIMrz9V0ACRzmEGqjbbuUmlA=";
   };
+
+  patches = [
+    # Fix build with meson 1.2. We use the gentoo patch intead of the
+    # usptream one because the latter only applies on the libsoup_3 based
+    # merged dLeyna project.
+    # https://gitlab.gnome.org/World/dLeyna/-/merge_requests/6
+    (fetchpatch {
+      url = "https://github.com/gentoo/gentoo/raw/4a0982b49a1d94aa785b05d9b7d256c26c499910/net-libs/dleyna-connector-dbus/files/meson-1.2.0.patch";
+      sha256 = "sha256-/p2OaPO5ghWtPotwIir2TtcFF5IDFN9FFuyqPHevuFI=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/development/libraries/dleyna-renderer/default.nix
+++ b/pkgs/development/libraries/dleyna-renderer/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -26,6 +27,17 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-bGasT3XCa7QHV3D7z59TSHoqWksNSIgaO0z9zYfHHuw=";
   };
+
+  patches = [
+    # Fix build with meson 1.2. We use the gentoo patch intead of the
+    # usptream one because the latter only applies on the libsoup_3 based
+    # merged dLeyna project.
+    # https://gitlab.gnome.org/World/dLeyna/-/merge_requests/6
+    (fetchpatch {
+      url = "https://github.com/gentoo/gentoo/raw/2ebe20ff4cda180cc248d31a021107d08ecf39d9/net-libs/dleyna-renderer/files/meson-1.2.0.patch";
+      sha256 = "sha256-/p2OaPO5ghWtPotwIir2TtcFF5IDFN9FFuyqPHevuFI=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/development/libraries/dleyna-server/default.nix
+++ b/pkgs/development/libraries/dleyna-server/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , meson
 , ninja
 , makeWrapper
@@ -24,6 +25,17 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-jlF9Lr/NG+Fsy/bB7aLb7xOLqel8GueJK5luo9rsDME=";
   };
+
+  patches = [
+    # Fix build with meson 1.2. We use the gentoo patch intead of the
+    # usptream one because the latter only applies on the libsoup_3 based
+    # merged dLeyna project.
+    # https://gitlab.gnome.org/World/dLeyna/-/merge_requests/6
+    (fetchpatch {
+      url = "https://github.com/gentoo/gentoo/raw/2e3a1f4f7a1ef0c3e387389142785d98b5834e60/net-misc/dleyna-server/files/meson-1.2.0.patch";
+      sha256 = "sha256-/p2OaPO5ghWtPotwIir2TtcFF5IDFN9FFuyqPHevuFI=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
## Description of changes

meson 1.2 is in staging.

```
ERROR: Unexpected "[provides]" section, did you mean "[provide]"?
```

It is expected that 3 patches have the same sha256 due to how fetchpatch works

For quick testing, you may use https://github.com/NixOS/nixpkgs/compare/master...bobby285271:nixpkgs:test/dleyna which contains a `meson_1_2` package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
