### PR TITLE
rizin: 0.5.2 -> 0.6.0

### DIFF
--- a/pkgs/development/tools/analysis/rizin/cutter.nix
+++ b/pkgs/development/tools/analysis/rizin/cutter.nix
@@ -4,6 +4,7 @@
 # Qt
 , qtbase, qtsvg, qtwebengine, qttools
 # buildInputs
+, graphviz
 , rizin
 , python3
 , wrapQtAppsHook
@@ -11,24 +12,25 @@
 
 mkDerivation rec {
   pname = "cutter";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "rizinorg";
     repo = "cutter";
     rev = "v${version}";
-    hash = "sha256-rzMLPkL382webds7cnfanHy9BsV+8ARkl6aES5ckmO4=";
+    hash = "sha256-oQ3sLIGKMEw3k27aSFcrJqo0TgGkkBNdzl6GSoOIYak=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake qmake pkg-config python3 wrapQtAppsHook ];
   propagatedBuildInputs = [ python3.pkgs.pyside2 ];
-  buildInputs = [ qtbase qttools qtsvg qtwebengine rizin python3 ];
+  buildInputs = [ graphviz qtbase qttools qtsvg qtwebengine rizin python3 ];
 
   cmakeFlags = [
     "-DCUTTER_USE_BUNDLED_RIZIN=OFF"
     "-DCUTTER_ENABLE_PYTHON=ON"
     "-DCUTTER_ENABLE_PYTHON_BINDINGS=ON"
+    "-DCUTTER_ENABLE_GRAPHVIZ=ON"
   ];
 
   preBuild = ''

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -8,11 +8,12 @@
 , perl
 , zlib
 , openssl
-, libuv
 , file
+, libmspack
 , libzip
 , lz4
 , xxHash
+, xz
 , meson
 , python3
 , cmake
@@ -23,11 +24,11 @@
 
 stdenv.mkDerivation rec {
   pname = "rizin";
-  version = "0.5.2";
+  version = "0.6.0";
 
   src = fetchurl {
     url = "https://github.com/rizinorg/rizin/releases/download/v${version}/rizin-src-v${version}.tar.xz";
-    hash = "sha256-cauA/DyKycgKEAANg4EoryigXTGg7hg5AMLFxuNQ7KM=";
+    hash = "sha256-apJJBu/fVHrFBGJ2f1rdU5AkNuekhi0sDiTKkbd2FQg=";
   };
 
   mesonFlags = [
@@ -35,9 +36,11 @@ stdenv.mkDerivation rec {
     "-Duse_sys_magic=enabled"
     "-Duse_sys_libzip=enabled"
     "-Duse_sys_zlib=enabled"
-    "-Duse_sys_xxhash=enabled"
     "-Duse_sys_lz4=enabled"
+    "-Duse_sys_lzma=enabled"
+    "-Duse_sys_xxhash=enabled"
     "-Duse_sys_openssl=enabled"
+    "-Duse_sys_libmspack=enabled"
     "-Duse_sys_tree_sitter=enabled"
   ];
 
@@ -77,9 +80,10 @@ stdenv.mkDerivation rec {
     zlib
     lz4
     openssl
-    libuv
+    libmspack
     tree-sitter
     xxHash
+    xz
   ];
 
   postPatch = ''


### PR DESCRIPTION
If you want, you can also check out my other PR that adds [Rizin/Cutter plugin support to nixpkgs](https://github.com/NixOS/nixpkgs/pull/220885/) (not yet rebased for Rizin 0.6)

## Description of changes

Update Rizin to 0.6.0, update Cutter along with it. Change some build settings that I think are a good idea to change.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
