### PR TITLE
zig_0_9: refactor

### DIFF
--- a/pkgs/development/compilers/zig/0.9.1.nix
+++ b/pkgs/development/compilers/zig/0.9.1.nix
@@ -54,9 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     llvm
   ]);
 
-  preBuild = ''
-    export HOME=$TMPDIR;
-  '';
+  env.ZIG_GLOBAL_CACHE_DIR = "$TMPDIR/zig-cache";
 
   cmakeFlags = [
     # file RPATH_CHANGE could not write new RPATH
@@ -66,12 +64,14 @@ stdenv.mkDerivation (finalAttrs: {
     "-DZIG_TARGET_MCPU=baseline"
   ];
 
-  doCheck = true;
+  doInstallCheck = true;
 
-  checkPhase = ''
-    runHook preCheck
-    ./zig test --cache-dir "$TMPDIR" -I $src/test $src/test/behavior.zig
-    runHook postCheck
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/zig test --cache-dir "$TMPDIR/cache-dir" -I $src/test $src/test/behavior.zig
+
+    runHook postInstallCheck
   '';
 
   meta = {


### PR DESCRIPTION
- set env.ZIG_GLOBAL_CACHE_DIR instead of preBuild
- use installCheckPhase instead of checkPhase

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
