### PR TITLE
nixos/dae: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13476,6 +13476,12 @@
     githubId = 38314551;
     name = "Peter Okelmann";
   };
+  pokon548 = {
+    email = "nix@bukn.uk";
+    github = "pokon548";
+    githubId = 65808665;
+    name = "Bu Kun";
+  };
   polarmutex = {
     email = "brian@brianryall.xyz";
     github = "polarmutex";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -863,6 +863,7 @@
   ./services/networking/coturn.nix
   ./services/networking/create_ap.nix
   ./services/networking/croc.nix
+  ./services/networking/dae.nix
   ./services/networking/dante.nix
   ./services/networking/dhcpcd.nix
   ./services/networking/dnscache.nix

--- a/nixos/modules/services/networking/dae.nix
+++ b/nixos/modules/services/networking/dae.nix
@@ -1,0 +1,41 @@
+{ config, pkgs, lib, ... }:
+let
+  cfg = config.services.dae;
+in
+{
+  meta.maintainers = with lib.maintainers; [ pokon548 ];
+
+  options = {
+    services.dae = {
+      enable = lib.options.mkEnableOption (lib.mdDoc "the dae service");
+      package = lib.mkPackageOptionMD pkgs "dae" { };
+    };
+  };
+
+  config = lib.mkIf config.services.dae.enable {
+    networking.firewall.allowedTCPPorts = [ 12345 ];
+    networking.firewall.allowedUDPPorts = [ 12345 ];
+
+    systemd.services.dae = {
+      unitConfig = {
+        Description = "dae Service";
+        Documentation = "https://github.com/daeuniverse/dae";
+        After = [ "network.target" "systemd-sysctl.service" ];
+        Wants = [ "network.target" ];
+      };
+
+      serviceConfig = {
+        User = "root";
+        ExecStartPre = "${lib.getExe cfg.package} validate -c /etc/dae/config.dae";
+        ExecStart = "${lib.getExe cfg.package} run --disable-timestamp -c /etc/dae/config.dae";
+        ExecReload = "${lib.getExe cfg.package} reload $MAINPID";
+        LimitNPROC = 512;
+        LimitNOFILE = 1048576;
+        Restart = "on-abnormal";
+        Type = "notify";
+      };
+
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/pkgs/tools/networking/dae/default.nix
+++ b/pkgs/tools/networking/dae/default.nix
@@ -58,7 +58,8 @@ buildGoModule rec {
     description = "A Linux high-performance transparent proxy solution based on eBPF";
     homepage = "https://github.com/daeuniverse/dae";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ oluceps ];
+    maintainers = with maintainers; [ oluceps pokon548 ];
     platforms = platforms.linux;
+    mainProgram = "dae";
   };
 }


### PR DESCRIPTION
## Description of changes
This pull request introduce ```services.dae``` option for existing package ```dae```. For example:
```
services.dae.enable = true;
```

As I am actively using ```dae```, I will continue to maintain this module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
