### PR TITLE
guile: canonicalize site dirs

### DIFF
--- a/pkgs/applications/misc/haunt/default.nix
+++ b/pkgs/applications/misc/haunt/default.nix
@@ -49,15 +49,11 @@ stdenv.mkDerivation rec {
   # Test suite is non-determinisitic in later versions
   doCheck = false;
 
-  postInstall =
-    let
-      guileVersion = lib.versions.majorMinor guile.version;
-    in
-    ''
-      wrapProgram $out/bin/haunt \
-        --prefix GUILE_LOAD_PATH : "$out/share/guile/site/${guileVersion}:$GUILE_LOAD_PATH" \
-        --prefix GUILE_LOAD_COMPILED_PATH : "$out/lib/guile/${guileVersion}/site-ccache:$GUILE_LOAD_COMPILED_PATH"
-    '';
+  postInstall = ''
+    wrapProgram $out/bin/haunt \
+      --prefix GUILE_LOAD_PATH : "$out/${guile.siteDir}:$GUILE_LOAD_PATH" \
+      --prefix GUILE_LOAD_COMPILED_PATH : "$out/${guile.siteCcacheDir}:$GUILE_LOAD_COMPILED_PATH"
+  '';
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/development/guile-modules/guile-gnutls/default.nix
+++ b/pkgs/development/guile-modules/guile-gnutls/default.nix
@@ -27,9 +27,9 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--with-guile-site-dir=${builtins.placeholder "out"}/share/guile/site"
-    "--with-guile-site-ccache-dir=${builtins.placeholder "out"}/share/guile/site"
-    "--with-guile-extension-dir=${builtins.placeholder "out"}/share/guile/extensions"
+    "--with-guile-site-dir=${builtins.placeholder "out"}/${guile.siteDir}"
+    "--with-guile-site-ccache-dir=${builtins.placeholder "out"}/${guile.siteCcacheDir}"
+    "--with-guile-extension-dir=${builtins.placeholder "out"}/lib/guile/${guile.effectiveVersion}/extensions"
   ];
 
   meta = with lib; {

--- a/pkgs/development/guile-modules/guile-ncurses/default.nix
+++ b/pkgs/development/guile-modules/guile-ncurses/default.nix
@@ -29,16 +29,12 @@ stdenv.mkDerivation rec {
     "--with-gnu-filesystem-hierarchy"
   ];
 
-  postFixup =
-    let
-      guileVersion = lib.versions.majorMinor guile.version;
-    in
-    ''
-      for f in $out/share/guile/site/ncurses/**.scm; do \
-        substituteInPlace $f \
-          --replace "libguile-ncurses" "$out/lib/guile/${guileVersion}/libguile-ncurses"; \
-      done
-    '';
+  postFixup = ''
+    for f in $out/${guile.siteDir}/ncurses/**.scm; do \
+      substituteInPlace $f \
+        --replace "libguile-ncurses" "$out/lib/guile/${guile.effectiveVersion}/libguile-ncurses"; \
+    done
+  '';
 
   # XXX: 1 of 65 tests failed.
   doCheck = false;

--- a/pkgs/development/guile-modules/guile-reader/default.nix
+++ b/pkgs/development/guile-modules/guile-reader/default.nix
@@ -27,9 +27,9 @@ stdenv.mkDerivation rec {
     libffi
   ];
 
-  GUILE_SITE="${guile-lib}/share/guile/site";
+  env.GUILE_SITE = "${guile-lib}/${guile.siteDir}";
 
-  configureFlags = [ "--with-guilemoduledir=$(out)/share/guile/site" ];
+  configureFlags = [ "--with-guilemoduledir=$(out)/${guile.siteDir}" ];
 
   meta = with lib; {
     homepage = "https://www.nongnu.org/guile-reader/";

--- a/pkgs/development/guile-modules/guile-ssh/default.nix
+++ b/pkgs/development/guile-modules/guile-ssh/default.nix
@@ -20,10 +20,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-P29U88QrCjoyl/wdTPZbiMoykd/v6ul6CW/IJn9UAyw=";
   };
 
-  configureFlags = [ "--with-guilesitedir=\${out}/share/guile/site" ];
+  configureFlags = [ "--with-guilesitedir=\${out}/${guile.siteDir}" ];
 
   postFixup = ''
-    for f in $out/share/guile/site/ssh/**.scm; do \
+    for f in $out/${guile.siteDir}/ssh/**.scm; do \
       substituteInPlace $f \
         --replace "libguile-ssh" "$out/lib/libguile-ssh"; \
     done

--- a/pkgs/development/guile-modules/guile-xcb/default.nix
+++ b/pkgs/development/guile-modules/guile-xcb/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--with-guile-site-dir=$out/share/guile/site"
-    "--with-guile-site-ccache-dir=$out/share/guile/site"
+    "--with-guile-site-dir=$(out)/${guile.siteDir}"
+    "--with-guile-site-ccache-dir=$(out)/${guile.siteCcacheDir}"
   ];
 
   makeFlags = [

--- a/pkgs/development/interpreters/guile/1.8.nix
+++ b/pkgs/development/interpreters/guile/1.8.nix
@@ -86,6 +86,12 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook-1.8.sh;
 
+  passthru = {
+    effectiveVersion = lib.versions.majorMinor version;
+    siteCcacheDir = "lib/guile/site-ccache";
+    siteDir = "share/guile/site";
+  };
+
   meta = with lib; {
     homepage = "https://www.gnu.org/software/guile/";
     description = "Embeddable Scheme implementation";

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -133,6 +133,12 @@ builder rec {
 
   setupHook = ./setup-hook-2.0.sh;
 
+  passthru = rec {
+    effectiveVersion = lib.versions.majorMinor version;
+    siteCcacheDir = "lib/guile/${effectiveVersion}/site-ccache";
+    siteDir = "share/guile/site/${effectiveVersion}";
+  };
+
   meta = with lib; {
     homepage = "https://www.gnu.org/software/guile/";
     description = "Embeddable Scheme implementation";

--- a/pkgs/development/interpreters/guile/2.2.nix
+++ b/pkgs/development/interpreters/guile/2.2.nix
@@ -124,6 +124,12 @@ builder rec {
 
   setupHook = ./setup-hook-2.2.sh;
 
+  passthru = rec {
+    effectiveVersion = lib.versions.majorMinor version;
+    siteCcacheDir = "lib/guile/${effectiveVersion}/site-ccache";
+    siteDir = "share/guile/site/${effectiveVersion}";
+  };
+
   meta = with lib; {
     homepage = "https://www.gnu.org/software/guile/";
     description = "Embeddable Scheme implementation";

--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -127,7 +127,11 @@ builder rec {
 
   setupHook = ./setup-hook-3.0.sh;
 
-  passthru = {
+  passthru = rec {
+    effectiveVersion = lib.versions.majorMinor version;
+    siteCcacheDir = "lib/guile/${effectiveVersion}/site-ccache";
+    siteDir = "share/guile/site/${effectiveVersion}";
+
     updateScript = writeScript "update-guile-3" ''
       #!/usr/bin/env nix-shell
       #!nix-shell -i bash -p curl pcre common-updater-scripts

--- a/pkgs/development/libraries/libfive/default.nix
+++ b/pkgs/development/libraries/libfive/default.nix
@@ -9,7 +9,7 @@
 , zlib
 , libpng
 , boost
-, guile_3_0
+, guile
 , stdenv
 }:
 
@@ -25,12 +25,12 @@ mkDerivation {
   };
 
   nativeBuildInputs = [ wrapQtAppsHook cmake ninja pkg-config ];
-  buildInputs = [ eigen zlib libpng boost guile_3_0 ];
+  buildInputs = [ eigen zlib libpng boost guile ];
 
   preConfigure = ''
     substituteInPlace studio/src/guile/interpreter.cpp \
       --replace "qputenv(\"GUILE_LOAD_COMPILED_PATH\", \"libfive/bind/guile\");" \
-                "qputenv(\"GUILE_LOAD_COMPILED_PATH\", \"libfive/bind/guile:$out/lib/guile/3.0/ccache\");"
+                "qputenv(\"GUILE_LOAD_COMPILED_PATH\", \"libfive/bind/guile:$out/${guile.siteCcacheDir}\");"
 
     substituteInPlace libfive/bind/guile/CMakeLists.txt \
       --replace "LIBFIVE_FRAMEWORK_DIR=$<TARGET_FILE_DIR:libfive>" \
@@ -42,7 +42,7 @@ mkDerivation {
   '';
 
   cmakeFlags = [
-    "-DGUILE_CCACHE_DIR=${placeholder "out"}/lib/guile/3.0/ccache"
+    "-DGUILE_CCACHE_DIR=${placeholder "out"}/${guile.siteCcacheDir}"
   ];
 
   postInstall = if stdenv.isDarwin then ''

--- a/pkgs/development/libraries/libmatheval/default.nix
+++ b/pkgs/development/libraries/libmatheval/default.nix
@@ -1,8 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, guile, flex, fetchpatch }:
 
-let
-  guileVersion = lib.versions.majorMinor guile.version;
-in
 stdenv.mkDerivation rec {
   version = "1.1.11";
   pname = "libmatheval";
@@ -32,8 +29,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev guile}/include/guile/${guileVersion}";
-  env.NIX_LDFLAGS = "-L${guile}/lib -lguile-${guileVersion}";
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev guile}/include/guile/${guile.effectiveVersion}";
+  env.NIX_LDFLAGS = "-L${guile}/lib -lguile-${guile.effectiveVersion}";
 
   meta = {
     description = "A library to parse and evaluate symbolic expressions input as text";

--- a/pkgs/development/tools/guile/guile-hall/default.nix
+++ b/pkgs/development/tools/guile/guile-hall/default.nix
@@ -20,15 +20,11 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postInstall =
-    let
-      guileVersion = lib.versions.majorMinor guile.version;
-    in
-    ''
-      wrapProgram $out/bin/hall \
-        --prefix GUILE_LOAD_PATH : "$out/share/guile/site/${guileVersion}:$GUILE_LOAD_PATH" \
-        --prefix GUILE_LOAD_COMPILED_PATH : "$out/lib/guile/${guileVersion}/site-ccache:$GUILE_LOAD_COMPILED_PATH"
-    '';
+  postInstall = ''
+    wrapProgram $out/bin/hall \
+      --prefix GUILE_LOAD_PATH : "$out/${guile.siteDir}:$GUILE_LOAD_PATH" \
+      --prefix GUILE_LOAD_COMPILED_PATH : "$out/${guile.siteCcacheDir}:$GUILE_LOAD_COMPILED_PATH"
+  '';
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/tools/networking/junkie/default.nix
+++ b/pkgs/tools/networking/junkie/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpcap guile_2_2 openssl ];
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   configureFlags = [
-    "GUILELIBDIR=\${out}/share/guile/site"
-    "GUILECACHEDIR=\${out}/lib/guile/ccache"
+    "GUILELIBDIR=\${out}/${guile_2_2.siteDir}"
+    "GUILECACHEDIR=\${out}/${guile_2_2.siteCcacheDir}"
   ];
 
   meta = {

--- a/pkgs/tools/typesetting/skribilo/default.nix
+++ b/pkgs/tools/typesetting/skribilo/default.nix
@@ -46,15 +46,11 @@ in stdenv.mkDerivation (finalAttrs: {
   ++ optional enablePloticus ploticus
   ++ optional enableTex tex;
 
-  postInstall =
-    let
-      guileVersion = lib.versions.majorMinor guile.version;
-    in
-    ''
-      wrapProgram $out/bin/skribilo \
-        --prefix GUILE_LOAD_PATH : "$out/share/guile/site/${guileVersion}:$GUILE_LOAD_PATH" \
-        --prefix GUILE_LOAD_COMPILED_PATH : "$out/lib/guile/${guileVersion}/site-ccache:$GUILE_LOAD_COMPILED_PATH"
-    '';
+  postInstall = ''
+    wrapProgram $out/bin/skribilo \
+      --prefix GUILE_LOAD_PATH : "$out/${guile.siteDir}:$GUILE_LOAD_PATH" \
+      --prefix GUILE_LOAD_COMPILED_PATH : "$out/${guile.siteCcacheDir}:$GUILE_LOAD_COMPILED_PATH"
+  '';
 
   meta = {
     homepage = "https://www.nongnu.org/skribilo/";


### PR DESCRIPTION
## Description of changes

This PR implements https://discourse.nixos.org/t/guile-module-packaging-guidelines/5909.

Specifically, all existing packages are updated to follow `guile.siteCcacheDir` and `guile.siteDir` instead of random folders. The definitions of the variables are straightforward, see:

```bash
$ guile -c '(display (effective-version))'
3.0
$ guile -c '(display (%site-ccache-dir))'
/nix/store/cfv98rrdxr6hljpb6zgy88n6lifbv28j-guile-3.0.9/lib/guile/3.0/site-ccache
$ guile -c '(display (%site-dir))'
/nix/store/cfv98rrdxr6hljpb6zgy88n6lifbv28j-guile-3.0.9/share/guile/site/3.0
```

```bash
$ nix eval -f . 'guile.effectiveVersion'
"3.0"
$ nix eval -f . 'guile.siteCcacheDir'
"lib/guile/3.0/site-ccache"
$ nix eval -f . 'guile.siteDir'
"share/guile/site/3.0"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
