### PR TITLE
fetch*: cleanup and improve metrics of `fetchzip`, fix a bug in `fetchRepoProject`

### DIFF
--- a/pkgs/build-support/fetchrepoproject/default.nix
+++ b/pkgs/build-support/fetchrepoproject/default.nix
@@ -60,7 +60,7 @@ in stdenvNoCC.mkDerivation {
     ${optionalString (local_manifests != []) ''
       mkdir .repo/local_manifests
       for local_manifest in ${concatMapStringsSep " " toString local_manifests}; do
-        cp $local_manifest .repo/local_manifests/$(stripHash $local_manifest; echo $strippedName)
+        cp $local_manifest .repo/local_manifests/$(stripHash $local_manifest)
       done
     ''}
 


### PR DESCRIPTION
It's a build-wise noop that massively improves nixpkgs metrics and fixes a bug introduced in bef6bef0d2ce2ef7cfaa3e9f1eac2cdc793560c4

`fetchzip` is a very hot function so making it more efficient makes things massively better:

Metrics diff for `nix-env -f . -qaP --argstr system "x86_64-linux" --drv-path` on nix 2.15:

````
-0.08% envs.bytes | 10073544800 -> 10065745672
-0.12% envs.elements | 497902132 -> 497298629
-0.05% envs.number | 380645484 -> 380459790
-1.12% gc.heapSize | 10574036992 -> 10456596480
-0.12% gc.totalBytes | 42307787504 -> 42256723648
-0.07% list.bytes | 1070270408 -> 1069527800
-0.07% list.elements | 133783801 -> 133690975
-0.11% nrAvoided | 408522173 -> 408060497
-0.04% nrFunctionCalls | 340646371 -> 340507104
0.07% nrLookups | 271271613 -> 271455668
-0.13% nrOpUpdateValuesCopied | 275856430 -> 275498155
-0.32% nrOpUpdates | 14691711 -> 14645298
-0.00% nrPrimOpCalls | 188724715 -> 188724689
-0.04% nrThunks | 464283766 -> 464098009
-0.08% sets.bytes | 8799927280 -> 8792730448
-0.08% sets.elements | 476306506 -> 475949530
-0.13% sets.number | 73688949 -> 73596123
-0.00% symbols.bytes | 2474550 -> 2474539
-0.00% symbols.number | 167889 -> 167888
-0.03% values.bytes | 13257964272 -> 13253506104
-0.03% values.number | 552415178 -> 552229421
```
