### PR TITLE
dt-schema, python3.pkgs.dtschema: handle jsonschema incompatibility

### DIFF
--- a/pkgs/development/python-modules/dtschema/default.nix
+++ b/pkgs/development/python-modules/dtschema/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , buildPythonPackage
 , fetchFromGitHub
 , jsonschema
@@ -54,6 +55,14 @@ buildPythonPackage rec {
     changelog = "https://github.com/devicetree-org/dt-schema/releases/tag/v${version}";
     license = with licenses; [ bsd2 /* or */ gpl2Only ];
     maintainers = with maintainers; [ sorki ];
+
+    broken = (
+      # Library not loaded: @rpath/libfdt.1.dylib
+      stdenv.isDarwin ||
+
+      # see https://github.com/devicetree-org/dt-schema/issues/108
+      versionAtLeast jsonschema.version "4.18"
+    );
   };
 }
 

--- a/pkgs/development/tools/dt-schema/default.nix
+++ b/pkgs/development/tools/dt-schema/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, python3
+}:
+
+let python = python3.override {
+  packageOverrides = self: super: {
+    # see https://github.com/devicetree-org/dt-schema/issues/108
+    jsonschema = super.jsonschema.overridePythonAttrs (old: rec {
+      version = "4.17.3";
+      disabled = self.pythonOlder "3.7";
+
+      src = old.src.override {
+        inherit version;
+        hash = "sha256-D4ZEN6uLYHa6ZwdFPvj5imoNUSqA6T+KvbZ29zfstg0=";
+      };
+
+      propagatedBuildInputs = with self; ([
+        attrs
+        pyrsistent
+      ] ++ lib.optionals (pythonOlder "3.8") [
+        importlib-metadata
+        typing-extensions
+      ] ++ lib.optionals (pythonOlder "3.9") [
+        importlib-resources
+        pkgutil-resolve-name
+      ]);
+    });
+  };
+}; in python.pkgs.toPythonApplication python.pkgs.dtschema
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7396,7 +7396,7 @@ with pkgs;
 
   dtc = callPackage ../development/compilers/dtc { };
 
-  dt-schema = with python3Packages; toPythonApplication dtschema;
+  dt-schema = callPackage ../development/tools/dt-schema { };
 
   dub = callPackage ../development/tools/build-managers/dub { };
 


### PR DESCRIPTION
## Description of changes

1. dt-schema is an application, so it can pin jsonschema to 4.17
2. mark python3.pkgs.dtschema broken with jsonschema > 4.17
3. mark python3.pkgs.dtschema broken on Darwin

Some context about each of these points:

1. Per discussion in https://github.com/devicetree-org/dt-schema/issues/108, dt-schema will need more time before it can support jsonschema 4.18.
2. The package even on master is broken on Darwin right now.

This is currently broken on staging-next (https://github.com/NixOS/nixpkgs/pull/245935).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
