### PR TITLE
gif-for-cli: support pillow 10

### DIFF
--- a/pkgs/tools/misc/gif-for-cli/default.nix
+++ b/pkgs/tools/misc/gif-for-cli/default.nix
@@ -1,19 +1,49 @@
-{ lib, fetchFromGitHub, python3Packages, ffmpeg, zlib, libjpeg }:
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, python3Packages
+, ffmpeg
+, zlib
+, libjpeg
+}:
 
 python3Packages.buildPythonApplication {
   pname = "gif-for-cli";
   version = "1.1.2";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "gif-for-cli";
     rev = "31f8aa2d617d6d6e941154f60e287c38dd9a74d5";
-    sha256 = "Bl5o492BUAn1KsscnlMIXCzJuy7xWUsdnxIKZKaRM3M=";
+    hash = "sha256-Bl5o492BUAn1KsscnlMIXCzJuy7xWUsdnxIKZKaRM3M=";
   };
 
-  nativeCheckInputs = [ python3Packages.coverage ];
-  buildInputs = [ zlib libjpeg ];
-  propagatedBuildInputs = with python3Packages; [ ffmpeg pillow requests x256 ];
+  patches = [
+    # https://github.com/google/gif-for-cli/pull/36
+    (fetchpatch {
+      name = "pillow-10-compatibility.patch";
+      url = "https://github.com/google/gif-for-cli/commit/49b13ec981e197cbc10f920b7b25a97c4cc6a61c.patch";
+      hash = "sha256-B8wfkdhSUY++St6DzgaJ1xF1mZKvi8oxLXbo63yemDM=";
+    })
+  ];
+
+  # coverage is not needed to build and test this package
+  postPatch = ''
+    sed -i '/coverage>=/d' setup.py
+  '';
+
+  buildInputs = [
+    zlib
+    libjpeg
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    ffmpeg
+    pillow
+    requests
+    x256
+  ];
 
   meta = with lib; {
     description = "Render gifs as ASCII art in your cli";
@@ -22,5 +52,4 @@ python3Packages.buildPythonApplication {
     license = licenses.asl20;
     maintainers = with maintainers; [ Scriptkiddi ];
   };
-
 }


### PR DESCRIPTION
## Description of changes

Plus some minor reformatting and derivation improvements. This is currently broken on staging-next (https://github.com/NixOS/nixpkgs/pull/245935).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
