### PR TITLE
vrrtest: init at 2.1.0

### DIFF
--- a/pkgs/tools/video/vrrtest/default.nix
+++ b/pkgs/tools/video/vrrtest/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, zip
+, love
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vrrtest";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Nixola";
+    repo = "VRRTest";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-esyD+BpdnB8miUrIjV6P8Lho1xztmhLDnKxdQKW8GXc=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ zip ];
+
+  buildPhase = ''
+    runHook preBuild
+    zip -9 -r vrrtest.love .
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 -t $out/share/ vrrtest.love
+    makeWrapper ${love}/bin/love $out/bin/vrrtest \
+      --add-flags $out/share/vrrtest.love
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tool testing variable refresh rates";
+    homepage = "https://github.com/Nixola/VRRTest";
+    license = licenses.zlib;
+    mainProgram = "vrrtest";
+    maintainers = with maintainers; [ justinlime ];
+    inherit (love.meta) platforms;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1962,6 +1962,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  vrrtest = callPackage ../tools/video/vrrtest { };
+
   winbox = callPackage ../tools/admin/winbox {
     wine = wineWowPackages.staging;
   };


### PR DESCRIPTION
## Description of changes

https://github.com/Nixola/VRRTest

init for VRRTest, a simplistic program designed to help you test for screen tearing and the
variable refresh rate functionality on your monitor.

## Things done

Tested on nixos as well as a fresh fedora virtual machine with nix installed under a single user.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
