### PR TITLE
maigret: support pytest >= 7.3.0

### DIFF
--- a/pkgs/tools/security/maigret/default.nix
+++ b/pkgs/tools/security/maigret/default.nix
@@ -1,12 +1,14 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , python3
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maigret";
   version = "0.4.4";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "soxoj";
@@ -15,7 +17,17 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-Z8SnA7Z5+oKW0AOaNf+c/zR30lrPFmXaxxKkbnDXNNs=";
   };
 
+  patches = [
+    # https://github.com/soxoj/maigret/pull/1117
+    (fetchpatch {
+      name = "pytest-7.3-compatibility.patch";
+      url = "https://github.com/soxoj/maigret/commit/ecb33de9e6eec12b6b45a1152199177f32c85be2.patch";
+      hash = "sha256-nFx3j1Q37YLtYhb0QS34UgZFgAc5Z/RVgbO9o1n1ONE=";
+    })
+  ];
+
   nativeBuildInputs = [ python3.pkgs.pythonRelaxDepsHook ];
+
   propagatedBuildInputs = with python3.pkgs; [
     aiodns
     aiohttp
@@ -56,6 +68,8 @@ python3.pkgs.buildPythonApplication rec {
     xmind
     yarl
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   nativeCheckInputs = with python3.pkgs; [
     pytest-httpserver


### PR DESCRIPTION
## Description of changes

Since pytest is updated, maigret needs a patch for its tests to continue working. Currently broken in staging-next (https://github.com/NixOS/nixpkgs/pull/245935).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
