### PR TITLE
termusic: 0.7.10 -> 0.7.11

### DIFF
--- a/pkgs/applications/audio/termusic/default.nix
+++ b/pkgs/applications/audio/termusic/default.nix
@@ -47,7 +47,6 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.IOKit
     darwin.apple_sdk.frameworks.MediaPlayer
     darwin.apple_sdk.frameworks.Security
-    darwin.apple_sdk.frameworks.SystemConfiguration
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
   ];

--- a/pkgs/applications/audio/termusic/default.nix
+++ b/pkgs/applications/audio/termusic/default.nix
@@ -1,13 +1,14 @@
-{ lib
-, stdenv
-, rustPlatform
-, fetchFromGitHub
-, protobuf
+{
+  alsa-lib
+, darwin
 , dbus
+, fetchFromGitHub
+, lib
 , openssl
 , pkg-config
-, alsa-lib
-, darwin
+, protobuf
+, rustPlatform
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -37,10 +38,10 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.AudioUnit
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Terminal Music Player TUI written in Rust";
     homepage = "https://github.com/tramhao/termusic";
-    license = with licenses; [ gpl3Only ];
-    maintainers = with maintainers; [ devhell ];
+    license = with lib.licenses; [ gpl3Only ];
+    maintainers = with lib.maintainers; [ devhell ];
   };
 }

--- a/pkgs/applications/audio/termusic/default.nix
+++ b/pkgs/applications/audio/termusic/default.nix
@@ -1,8 +1,10 @@
 { lib
 , stdenv
 , rustPlatform
-, fetchCrate
-, fetchpatch
+, fetchFromGitHub
+, protobuf
+, dbus
+, openssl
 , pkg-config
 , alsa-lib
 , darwin
@@ -10,22 +12,27 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "termusic";
-  version = "0.7.10";
+  version = "0.7.11";
 
-  src = fetchCrate {
-    inherit pname version;
-    hash = "sha256-m0hi5u4BcRcEDEpg1BoWXc25dfhD6+OJtqSZfSdV0HM=";
+  src = fetchFromGitHub {
+    owner = "tramhao";
+    repo = "termusic";
+    rev = "v${version}";
+    hash = "sha256-ykOBXM/WF+zasAt+6mgY2aSFCpGaYcqk+YI7YLM3MWs=";
   };
 
-  cargoHash = "sha256-A83gLsaPm6t4nm7DJfcp9z1huDU/Sfy9gunP8pzBiCA=";
+  cargoHash = "sha256-BrOpU0RFdlRXQIMjfHfs/XYIdBCYKFSA+5by/rGzC8Y=";
 
   nativeBuildInputs = [
     pkg-config
+    protobuf
     rustPlatform.bindgenHook
   ];
 
   buildInputs = lib.optionals stdenv.isLinux [
     alsa-lib
+    dbus
+    openssl
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.AudioUnit
   ];

--- a/pkgs/applications/audio/termusic/default.nix
+++ b/pkgs/applications/audio/termusic/default.nix
@@ -12,6 +12,7 @@
 , rustPlatform
 , sqlite
 , stdenv
+, SystemConfiguration
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -47,6 +48,7 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.IOKit
     darwin.apple_sdk.frameworks.MediaPlayer
     darwin.apple_sdk.frameworks.Security
+    SystemConfiguration
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
   ];

--- a/pkgs/applications/audio/termusic/default.nix
+++ b/pkgs/applications/audio/termusic/default.nix
@@ -45,6 +45,7 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.CoreGraphics
     darwin.apple_sdk.frameworks.Foundation
     darwin.apple_sdk.frameworks.IOKit
+    darwin.apple_sdk.frameworks.MediaPlayer
     darwin.apple_sdk.frameworks.Security
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib

--- a/pkgs/applications/audio/termusic/default.nix
+++ b/pkgs/applications/audio/termusic/default.nix
@@ -3,11 +3,14 @@
 , darwin
 , dbus
 , fetchFromGitHub
+, glib
+, gst_all_1
 , lib
 , openssl
 , pkg-config
 , protobuf
 , rustPlatform
+, sqlite
 , stdenv
 }:
 
@@ -30,12 +33,21 @@ rustPlatform.buildRustPackage rec {
     rustPlatform.bindgenHook
   ];
 
-  buildInputs = lib.optionals stdenv.isLinux [
-    alsa-lib
+  buildInputs = [
     dbus
+    glib
+    gst_all_1.gstreamer
     openssl
+    sqlite
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.AudioUnit
+    darwin.apple_sdk.frameworks.AppKit
+    darwin.apple_sdk.frameworks.CoreAudio
+    darwin.apple_sdk.frameworks.CoreGraphics
+    darwin.apple_sdk.frameworks.Foundation
+    darwin.apple_sdk.frameworks.IOKit
+    darwin.apple_sdk.frameworks.Security
+  ] ++ lib.optionals stdenv.isLinux [
+    alsa-lib
   ];
 
   meta = {

--- a/pkgs/applications/audio/termusic/default.nix
+++ b/pkgs/applications/audio/termusic/default.nix
@@ -12,7 +12,6 @@
 , rustPlatform
 , sqlite
 , stdenv
-, SystemConfiguration
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -48,7 +47,7 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.IOKit
     darwin.apple_sdk.frameworks.MediaPlayer
     darwin.apple_sdk.frameworks.Security
-    SystemConfiguration
+    darwin.apple_sdk.frameworks.SystemConfiguration
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
   ];

--- a/pkgs/applications/audio/termusic/default.nix
+++ b/pkgs/applications/audio/termusic/default.nix
@@ -1,15 +1,21 @@
 {
   alsa-lib
-, darwin
+, AppKit
+, CoreAudio
+, CoreGraphics
 , dbus
+, Foundation
 , fetchFromGitHub
 , glib
 , gst_all_1
+, IOKit
 , lib
+, MediaPlayer
 , openssl
 , pkg-config
 , protobuf
 , rustPlatform
+, Security
 , sqlite
 , stdenv
 }:
@@ -40,13 +46,13 @@ rustPlatform.buildRustPackage rec {
     openssl
     sqlite
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.AppKit
-    darwin.apple_sdk.frameworks.CoreAudio
-    darwin.apple_sdk.frameworks.CoreGraphics
-    darwin.apple_sdk.frameworks.Foundation
-    darwin.apple_sdk.frameworks.IOKit
-    darwin.apple_sdk.frameworks.MediaPlayer
-    darwin.apple_sdk.frameworks.Security
+    AppKit
+    CoreAudio
+    CoreGraphics
+    Foundation
+    IOKit
+    MediaPlayer
+    Security
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1938,7 +1938,7 @@ with pkgs;
 
   tere = callPackage ../tools/misc/tere { };
 
-  termusic = callPackage ../applications/audio/termusic { };
+  termusic = darwin.apple_sdk_11_0.callPackage ../applications/audio/termusic { };
 
   tfk8s = callPackage ../tools/misc/tfk8s { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1938,7 +1938,9 @@ with pkgs;
 
   tere = callPackage ../tools/misc/tere { };
 
-  termusic = darwin.apple_sdk_11_0.callPackage ../applications/audio/termusic { };
+  termusic = darwin.apple_sdk_11_0.callPackage ../applications/audio/termusic {
+    inherit (darwin.apple_sdk_11_0.frameworks) AppKit CoreAudio CoreGraphics Foundation IOKit MediaPlayer Security;
+  };
 
   tfk8s = callPackage ../tools/misc/tfk8s { };
 


### PR DESCRIPTION
## Description of changes

[Change log](https://github.com/tramhao/termusic/blob/v0.7.11/CHANGELOG.md#v0711)
Most notable change is that the actual player is split of into a `termusi-server` that is able to run in the background and comes as its own binary and the tui/launcher `termusic` binary.
This split made it necessary to switch the `fetcher` to pull directly the tarball from github, as on crates.io those are two distinct and independent crates.

The one thing where I am not sure is, if `darwin` would need the openssl dep explicitly as well.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
