### PR TITLE
libgpiod: fix Python bindings

### DIFF
--- a/pkgs/development/libraries/libgpiod/default.nix
+++ b/pkgs/development/libraries/libgpiod/default.nix
@@ -1,6 +1,5 @@
-{ lib, stdenv, fetchurl, autoreconfHook, autoconf-archive, pkg-config, kmod
-, enable-tools ? true
-, enablePython ? false, python3, ncurses }:
+{ lib, stdenv, fetchurl, autoreconfHook, autoconf-archive, pkg-config
+, enable-tools ? true }:
 
 stdenv.mkDerivation rec {
   pname = "libgpiod";
@@ -11,7 +10,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-tu2lU1YWCo5zkG49SOlZ74EpZ4fXZJdbEPJX6WYGaOk=";
   };
 
-  buildInputs = [ kmod ] ++ lib.optionals enablePython [ python3 ncurses ];
   nativeBuildInputs = [
     autoconf-archive
     pkg-config
@@ -21,8 +19,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-tools=${if enable-tools then "yes" else "no"}"
     "--enable-bindings-cxx"
-    "--prefix=${placeholder "out"}"
-  ] ++ lib.optional enablePython "--enable-bindings-python";
+  ];
 
   meta = with lib; {
     description = "C library and tools for interacting with the linux GPIO character device";
@@ -32,7 +29,10 @@ stdenv.mkDerivation rec {
       data structures behind a straightforward API.
     '';
     homepage = "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/";
-    license = licenses.lgpl2;
+    license = with licenses; [
+      lgpl21Plus # libgpiod
+      lgpl3Plus # C++ bindings
+    ] ++ lib.optional enable-tools gpl2Plus;
     maintainers = [ maintainers.expipiplus1 ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/python-modules/libgpiod/default.nix
+++ b/pkgs/development/python-modules/libgpiod/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, libgpiod
+}:
+buildPythonPackage {
+  inherit (libgpiod) pname version src;
+  format = "setuptools";
+
+  buildInputs = [ libgpiod ];
+
+  preConfigure = ''
+    cd bindings/python
+  '';
+
+  # Requires libgpiod built with --enable-tests
+  doCheck = false;
+  pythonImportsCheck = [ "gpiod" ];
+
+  meta = with lib; {
+    description = "Python bindings for libgpiod";
+    homepage = "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5846,10 +5846,9 @@ self: super: with self; {
     pythonSupport = true;
   });
 
-  libgpiod = toPythonModule (pkgs.libgpiod.override {
-    enablePython = true;
-    python3 = python;
-  });
+  libgpiod = callPackage ../development/python-modules/libgpiod {
+    inherit (pkgs) libgpiod;
+  };
 
   libgpuarray = callPackage ../development/python-modules/libgpuarray {
     clblas = pkgs.clblas.override { inherit (self) boost; };


### PR DESCRIPTION
## Description of changes

libgpiod's Python bindings no longer worked after the upgrade to 2.0.1 in #246018. The build system installs an egg, which doesn't work in nixpkgs. To fix this, I adopted the same approach I took in #204884. This PR builds the Python bindings as a separate package, using the normal nixpkgs Python infrastructure. Besides fixing the bindings, this has the added benefit of avoiding the need to build a redundant copy of libgpiod as part of the Python bindings package.

Lastly, I cleaned up the libgpiod package a bit, removing an unused dependency on kmod and an unnecessary configure flag. I also added the full list of licenses that apply to the package.

cc @adminy @expipiplus1 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
