### PR TITLE
nixos/nixosSystem: Remove deprecated arguments, deprecate pkgs argument, and add errors to specialArgs

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -57,6 +57,9 @@ let
   };
 
   withWarnings = x:
+    lib.throwIf (specialArgs?config) "Setting specialArgs.config is a very bad idea"
+    lib.throwIf (specialArgs?modulesPath) "Setting modulesPath is a very bad idea"
+    lib.warnIf (specialArgs?pkgs) "Setting specialArgs.pkgs is potentially dangerous. Please use nixpkgs.pkgs instead"
     lib.warnIf (evalConfigArgs?pkgs) "Passing pkgs to lib.nixosSystem is deprecated. Please set nixpkgs.pkgs instead."
     x;
 

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -13,8 +13,7 @@ evalConfigArgs@
   #     however, removing or changing this default is too much
   #     of a breaking change. To set it modularly, pass `null`.
   system ? builtins.currentSystem
-, # !!! is this argument needed any more? The pkgs argument can
-  # be set modularly anyway.
+, # !!! Deprecated as of 23.11
   pkgs ? null
 , # !!! what do we gain by making this configurable?
   #     we can add modules that are included in specialisations, regardless
@@ -33,9 +32,6 @@ evalConfigArgs@
 , extraModules ? let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
                  in lib.optional (e != "") (import e)
 }:
-
-let pkgs_ = pkgs;
-in
 
 let
   inherit (lib) optional;
@@ -58,13 +54,14 @@ let
         nixpkgs.system = lib.mkDefault system;
       })
       ++
-      (optional (pkgs_ != null) {
-        _module.args.pkgs = lib.mkForce pkgs_;
+      (optional (pkgs != null) {
+        _module.args.pkgs = lib.mkForce pkgs;
       })
     );
   };
 
   withWarnings = x:
+    lib.warnIf (evalConfigArgs?pkgs) "Passing pkgs to lib.nixosSystem is deprecated. Please set nixpkgs.pkgs instead."
     lib.warnIf (evalConfigArgs?extraArgs) "The extraArgs argument to eval-config.nix is deprecated. Please set config._module.args instead."
     lib.warnIf (evalConfigArgs?check) "The check argument to eval-config.nix is deprecated. Please set config._module.check instead."
     x;


### PR DESCRIPTION
## Description of changes
passing `pkgs` to `specialArgs` and `lib.nixosSystem` is a common anti-pattern that new users fall into which causes unexpected behavior and complete ignorance to the `nixpkgs.` option set

Since [readOnlyPkgs](https://github.com/NixOS/nixpkgs/commit/e5db80ae487b59b4e9f950d68983ffb0575e26c6) has merged there's a easy immutable way to set `pkgs`

I think it's time to do away with alternative handling methods of `pkgs`

opinions are appreciated, thanks
