### PR TITLE
lib.systems.examples: use four component triples for embedded 

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -124,22 +124,22 @@ rec {
   riscv32 = riscv "32";
 
   riscv64-embedded = {
-    config = "riscv64-none-elf";
+    config = "riscv64-unknown-none-elf";
     libc = "newlib";
   };
 
   riscv32-embedded = {
-    config = "riscv32-none-elf";
+    config = "riscv32-unknown-none-elf";
     libc = "newlib";
   };
 
   mips64-embedded = {
-    config = "mips64-none-elf";
+    config = "mips64-unknown-none-elf";
     libc = "newlib";
   };
 
   mips-embedded = {
-    config = "mips-none-elf";
+    config = "mips-unknown-none-elf";
     libc = "newlib";
   };
 
@@ -153,7 +153,7 @@ rec {
   };
 
   rx-embedded = {
-    config = "rx-none-elf";
+    config = "rx-unknown-none-elf";
     libc = "newlib";
   };
 
@@ -189,11 +189,11 @@ rec {
   };
 
   arm-embedded = {
-    config = "arm-none-eabi";
+    config = "arm-unknown-none-eabi";
     libc = "newlib";
   };
   armhf-embedded = {
-    config = "arm-none-eabihf";
+    config = "arm-unknown-none-eabihf";
     libc = "newlib";
     # GCC8+ does not build without this
     # (https://www.mail-archive.com/gcc-bugs@gcc.gnu.org/msg552339.html):
@@ -204,22 +204,22 @@ rec {
   };
 
   aarch64-embedded = {
-    config = "aarch64-none-elf";
+    config = "aarch64-unknown-none-elf";
     libc = "newlib";
   };
 
   aarch64be-embedded = {
-    config = "aarch64_be-none-elf";
+    config = "aarch64_be-unknown-none-elf";
     libc = "newlib";
   };
 
   ppc-embedded = {
-    config = "powerpc-none-eabi";
+    config = "powerpc-unknown-none-eabi";
     libc = "newlib";
   };
 
   ppcle-embedded = {
-    config = "powerpcle-none-eabi";
+    config = "powerpcle-unknown-none-eabi";
     libc = "newlib";
   };
 

--- a/pkgs/applications/virtualization/spike/default.nix
+++ b/pkgs/applications/virtualization/spike/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       runHook preInstallCheck
 
       echo -e "#include<stdio.h>\nint main() {printf(\"Hello, world\");return 0;}" > hello.c
-      ${riscvPkgs.stdenv.cc}/bin/riscv64-none-elf-gcc -o hello hello.c
+      ${riscvPkgs.stdenv.cc}/bin/${riscvPkgs.stdenv.cc.targetPrefix}cc -o hello hello.c
       $out/bin/spike -m64 ${riscvPkgs.riscv-pk}/bin/pk hello | grep -Fq "Hello, world"
 
       runHook postInstallCheck

--- a/pkgs/development/tools/fusee-launcher/default.nix
+++ b/pkgs/development/tools/fusee-launcher/default.nix
@@ -6,6 +6,10 @@
 , makeWrapper
 } :
 
+let
+  gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
+in
+
 stdenv.mkDerivation {
   pname = "fusee-launcher";
   version = "unstable-2018-07-14";
@@ -16,6 +20,10 @@ stdenv.mkDerivation {
     rev = "265e8f3e1987751ec41db6f1946d132b296aba43";
     sha256 = "1pqkgw5bk0xcz9x7pc1f0r0b9nsc8jnnvcs1315d8ml8mx23fshm";
   };
+
+  makeFlags = [
+    "CROSS_COMPILE=${gcc-arm-embedded.targetPrefix}"
+  ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share
@@ -28,7 +36,7 @@ stdenv.mkDerivation {
       --prefix PYTHONPATH : "$PYTHONPATH:$(toPythonPath $out)"
   '';
 
-  nativeBuildInputs = [ pkgsCross.arm-embedded.buildPackages.gcc makeWrapper python3Packages.wrapPython ];
+  nativeBuildInputs = [ gcc-arm-embedded makeWrapper python3Packages.wrapPython ];
   buildInputs = [ python3 python3Packages.pyusb ];
   pythonPath = with python3Packages; [ pyusb ];
 

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -53,6 +53,7 @@ let
 
     makeFlags = [
       "HOSTCC=$(CC_FOR_BUILD)"
+      "M0_CROSS_COMPILE=${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}"
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
       # binutils 2.39 regression
       # `warning: /build/source/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions`

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -52,6 +52,7 @@ let
     buildInputs = [ openssl ];
 
     makeFlags = [
+      "HOSTCC=$(CC_FOR_BUILD)"
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
       # binutils 2.39 regression
       # `warning: /build/source/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions`

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -80,7 +80,7 @@ in lib.init bootStages ++ [
              (hostPlatform.isLinux && !buildPlatform.isLinux)
              [ buildPackages.patchelf ]
         ++ lib.optional
-             (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode;
+             (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode || p.isNone;
                in f hostPlatform && !(f buildPlatform) )
              buildPackages.updateAutotoolsGnuConfigScriptsHook
         ;


### PR DESCRIPTION
## Description of changes

Should solve #165836 by using triples that are interpreted the same by nixpkgs and the current gnu-config version.
Depends on/includes changes from #247325.

Tested `stdenv` build for:

* [x] riscv32
* [x] riscv64
* [x] misp64
* [x] mips
* [x] rx
* [x] arm eabi
* [x]  arm eabihf
* [x] aarch64_be
* [x] powerpc
* [x] powerpcle


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
