### PR TITLE
agdaPackages._1lab: init at unstable-2023-03-07

### DIFF
--- a/pkgs/development/libraries/agda/1lab/default.nix
+++ b/pkgs/development/libraries/agda/1lab/default.nix
@@ -1,0 +1,32 @@
+{ lib, mkDerivation, fetchFromGitHub }:
+
+mkDerivation rec {
+  pname = "1lab";
+  version = "unstable-2023-03-07";
+
+  src = fetchFromGitHub {
+    owner = "plt-amy";
+    repo = pname;
+    # Last commit that compiles with Agda 2.6.3
+    rev = "c6ee57a2da327def241324b4775ec2c67cdab2af";
+    hash = "sha256-zDqFaDZxAdFxYM6l2zc7ZTi4XwMThw1AQwHfvhOxzdg=";
+  };
+
+  # We don't need anything in support; avoid installing LICENSE.agda
+  postPatch = ''
+    rm -rf support
+  '';
+
+  libraryName = "cubical-1lab";
+  libraryFile = "1lab.agda-lib";
+  everythingFile = "src/index.lagda.md";
+
+  meta = with lib; {
+    description =
+      "A formalised, cross-linked reference resource for mathematics done in Homotopy Type Theory ";
+    homepage = src.meta.homepage;
+    license = licenses.agpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ncfavier ];
+  };
+}

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -33,5 +33,7 @@ let
     generic = callPackage ../development/libraries/agda/generic { };
 
     agdarsec = callPackage ../development/libraries/agda/agdarsec { };
+
+    _1lab = callPackage ../development/libraries/agda/1lab { };
   };
 in mkAgdaPackages Agda


### PR DESCRIPTION
https://github.com/plt-amy/1lab: A formalised, cross-linked reference resource for mathematics done in Homotopy Type Theory

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
