### PR TITLE
fetchrepoproject: fix a bug

### DIFF
--- a/pkgs/build-support/fetchrepoproject/default.nix
+++ b/pkgs/build-support/fetchrepoproject/default.nix
@@ -60,7 +60,7 @@ in stdenvNoCC.mkDerivation {
     ${optionalString (local_manifests != []) ''
       mkdir .repo/local_manifests
       for local_manifest in ${concatMapStringsSep " " toString local_manifests}; do
-        cp $local_manifest .repo/local_manifests/$(stripHash $local_manifest; echo $strippedName)
+        cp $local_manifest .repo/local_manifests/$(stripHash $local_manifest)
       done
     ''}
 


### PR DESCRIPTION
`stripHash` changed semantics in bef6bef0d2ce2ef7cfaa3e9f1eac2cdc793560c4, this line still uses the previous one.