### PR TITLE
fetchzip: cleanup and improve metrics

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -132,6 +132,13 @@ let
     else throw "fetchurl requires a hash for fixed-output derivation: ${lib.concatStringsSep ", " urls_}";
 in
 
+assert (lib.isList curlOpts) -> lib.warn ''
+    fetchurl for ${toString (builtins.head urls_)}: curlOpts is a list (${lib.generators.toPretty { multiline = false; } curlOpts}), which is not supported anymore.
+    - If you wish to get the same effect as before, for elements with spaces (even if escaped) to expand to multiple curl arguments, use a string argument instead:
+      curlOpts = ${lib.strings.escapeNixString (toString curlOpts)};
+    - If you wish for each list element to be passed as a separate curl argument, allowing arguments to contain spaces, use curlOptsList instead:
+      curlOptsList = [ ${lib.concatMapStringsSep " " lib.strings.escapeNixString curlOpts} ];'' true;
+
 stdenvNoCC.mkDerivation ((
   if (pname != "" && version != "") then
     { inherit pname version; }
@@ -161,12 +168,7 @@ stdenvNoCC.mkDerivation ((
 
   outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
 
-  curlOpts = lib.warnIf (lib.isList curlOpts) ''
-    fetchurl for ${toString (builtins.head urls_)}: curlOpts is a list (${lib.generators.toPretty { multiline = false; } curlOpts}), which is not supported anymore.
-    - If you wish to get the same effect as before, for elements with spaces (even if escaped) to expand to multiple curl arguments, use a string argument instead:
-      curlOpts = ${lib.strings.escapeNixString (toString curlOpts)};
-    - If you wish for each list element to be passed as a separate curl argument, allowing arguments to contain spaces, use curlOptsList instead:
-      curlOptsList = [ ${lib.concatMapStringsSep " " lib.strings.escapeNixString curlOpts} ];'' curlOpts;
+  inherit curlOpts;
   curlOptsList = lib.escapeShellArgs curlOptsList;
   inherit showURLs mirrorsFile postFetch downloadToTemp executable;
 


### PR DESCRIPTION
This cleans up `fetchzip` and `fetchurl` derivations a bit, improving Nixpkgs metrics.

`fetchzip` seems to change semantics with me removing arguments there, but it does not, since all that `pname` logic was ignored by underlying `fetchurl` anyway.