### PR TITLE
jextract: install with bundle binaries

### DIFF
--- a/pkgs/development/tools/java/jextract/default.nix
+++ b/pkgs/development/tools/java/jextract/default.nix
@@ -77,17 +77,14 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    install -D --mode=0444 --target-directory="$out/share/java" \
-      ./build/libs/org.openjdk.jextract-unspecified.jar
+    mkdir -p $out/opt/
+    cp -r ./build/jextract $out/opt/jextract
 
     runHook postInstall
   '';
 
   postFixup = ''
-    makeWrapper "${jdk20}/bin/java" "$out/bin/jextract" \
-      --add-flags "--enable-preview" \
-      --add-flags "--class-path $out/share/java/org.openjdk.jextract-unspecified.jar" \
-      --add-flags "org.openjdk.jextract.JextractTool"
+    makeWrapper "$out/opt/jextract/bin/jextract" "$out/bin/jextract"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Fix error

```
Exception in thread "main" java.lang.UnsatisfiedLinkError: /usr/lib/libclang.so.15.0.7: libLLVM-15.so: cannot open shared object file: No such file or directory
        at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
        at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(NativeLibraries.java:331)
        at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:197)
        at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:139)
        at java.base/jdk.internal.loader.NativeLibraries.findFromPaths(NativeLibraries.java:259)
        at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:251)
        at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2437)
        at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:880)
        at java.base/java.lang.System.loadLibrary(System.java:2051)
        at org.openjdk.jextract.clang.libclang.RuntimeHelper.<clinit>(RuntimeHelper.java:65)
        at org.openjdk.jextract.clang.libclang.constants$0.<clinit>(constants$0.java:46)
        at org.openjdk.jextract.clang.libclang.Index_h.clang_createIndex$MH(Index_h.java:210)
        at org.openjdk.jextract.clang.libclang.Index_h.clang_createIndex(Index_h.java:218)
        at org.openjdk.jextract.clang.LibClang.createIndex(LibClang.java:69)
        at org.openjdk.jextract.impl.Parser.parse(Parser.java:52)
        at org.openjdk.jextract.JextractTool.parse(JextractTool.java:116)
        at org.openjdk.jextract.JextractTool.run(JextractTool.java:466)
        at org.openjdk.jextract.JextractTool.main(JextractTool.java:174)
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
