### PR TITLE
elinks: use gentoo patch to fix perl 5.38.0 support

### DIFF
--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -4,7 +4,16 @@
 , # Incompatible licenses, LGPLv3 - GPLv2
   enableGuile        ? false,                                         guile ? null
 , enablePython       ? false,                                         python ? null
-, enablePerl         ? (!stdenv.isDarwin) && (stdenv.hostPlatform == stdenv.buildPlatform), perl ? null
+# Original enablePerl value was:
+# (!stdenv.isDarwin) && (stdenv.hostPlatform == stdenv.buildPlatform)
+# Since perl 5.38.0, we experience this issue:
+# https://github.com/rkd77/elinks/issues/256
+#
+# Using perl536 doesn't make the build fail, but we prefer not depend on perl
+# when we are not aware of the features that this dependency enables -
+# upstream's manual mentions the word `perl` only once.
+, enablePerl         ? false
+, perl ? null
 # re-add javascript support when upstream supports modern spidermonkey
 }:
 

--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -4,16 +4,8 @@
 , # Incompatible licenses, LGPLv3 - GPLv2
   enableGuile        ? false,                                         guile ? null
 , enablePython       ? false,                                         python ? null
-# Original enablePerl value was:
-# (!stdenv.isDarwin) && (stdenv.hostPlatform == stdenv.buildPlatform)
-# Since perl 5.38.0, we experience this issue:
-# https://github.com/rkd77/elinks/issues/256
-#
-# Using perl536 doesn't make the build fail, but we prefer not depend on perl
-# when we are not aware of the features that this dependency enables -
-# upstream's manual mentions the word `perl` only once.
-, enablePerl         ? false
-, perl ? null
+, enablePerl         ? (!stdenv.isDarwin) && (stdenv.hostPlatform == stdenv.buildPlatform), perl ? null
+, fetchpatch
 # re-add javascript support when upstream supports modern spidermonkey
 }:
 
@@ -30,6 +22,15 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-u6QGhfi+uWeIzSUFuYHAH3Xu0Fky0yw2h4NOKgYFLsM=";
   };
+
+  patches = [
+    # Fix build bug with perl 5.38.0. Backport of https://github.com/rkd77/elinks/pull/243 by gentoo:
+    # https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=dfefaa456bd69bc14e3a1c2c6c1b0cc19c6b0869
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/www-client/elinks/files/elinks-0.16.1.1-perl-5.38.patch?id=dfefaa456bd69bc14e3a1c2c6c1b0cc19c6b0869";
+      hash = "sha256-bHP9bc/l7VEw7oXlkSUQhhuq8rT2QTahh9SM7ZJgK5w=";
+    })
+  ];
 
   buildInputs = [
     ncurses libX11 bzip2 zlib brotli zstd xz


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
