### PR TITLE
linuxPackages_testing.perf: fix patchShebang

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf/default.nix
+++ b/pkgs/os-specific/linux/kernel/perf/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
   postPatch = ''
     # Linux scripts
     patchShebangs scripts
-
+    patchShebangs tools/perf/check-headers.sh
   '' + lib.optionalString (lib.versionAtLeast kernel.version "6.3") ''
     # perf-specific scripts
     patchShebangs tools/perf/pmu-events


### PR DESCRIPTION
Without the change `perf` build fails as:

    $ nix build --no-link -f. linuxPackages_testing.perf -L

    build flags: SHELL=/nix/store/p6dlr3skfhxpyphipg2bqnj52999banh-bash-5.2-p15/bin/bash prefix=\$\(out\) WERROR=0 ASCIIDOC8=1 O=\$\(buildRoot\) CC=/nix/store/bxic6j2whyg3z4h2x3xjyqgp7fl83bnp-gcc-wrapper-12.3.0/bin/cc HOSTCC=/nix/store/bxic6j2whyg3z4h2x3xjyqgp7fl83bnp-gcc-wrapper-12.3.0/bin/cc HOSTLD=/nix/store/kcp78dk7h5gcs7d4qss7rbz3skxhzdnn-binutils-wrapper-2.40/bin/ld ARCH=x86_64 NO_GTK2=1
      BUILD:   Doing 'make -j16' parallel build
      HOSTCC  fixdep.o
      HOSTLD  fixdep-in.o
      LINK    fixdep
    make[1]: ./check-headers.sh: No such file or directory
    make[1]: *** [Makefile.perf:241: sub-make] Error 127
    make: *** [Makefile:70: all] Error 2

This started happening because upstream linux commit
    https://github.com/torvalds/linux/commit/d6748385098a8333a0e1c7e2d77119c919776728
changed shebang from /bin/sh to /bin/bash.

Let's retroactively switch all `perf` releases to shell interpreter from store.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
