### PR TITLE
sway-contrib: switch source to new separate repo

### DIFF
--- a/pkgs/applications/window-managers/sway/contrib.nix
+++ b/pkgs/applications/window-managers/sway/contrib.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-
+, fetchFromGitHub
 , coreutils
 , makeWrapper
 , sway-unwrapped
@@ -14,13 +14,27 @@
 , python3Packages
 }:
 
+let
+  version = "unstable-2023-06-30";
+  src = fetchFromGitHub {
+    owner = "OctopusET";
+    repo = "sway-contrib";
+    rev = "7e138bfc112872b79ac9fd766bc57c0f125b96d4";
+    hash = "sha256-u4sw1NeAhl4FJCG2YOeY45SHoN7tw6cSJwEL5iqr0uQ=";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/OctopusET/sway-contrib";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+in
 {
 
 grimshot = stdenv.mkDerivation rec {
-  pname = "grimshot";
-  version = sway-unwrapped.version;
+  inherit version src;
 
-  src = sway-unwrapped.src;
+  pname = "grimshot";
 
   dontBuild = true;
   dontConfigure = true;
@@ -31,9 +45,9 @@ grimshot = stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [ bash ];
   installPhase = ''
-    installManPage contrib/grimshot.1
+    installManPage grimshot.1
 
-    install -Dm 0755 contrib/grimshot $out/bin/grimshot
+    install -Dm 0755 grimshot $out/bin/grimshot
     wrapProgram $out/bin/grimshot --set PATH \
       "${lib.makeBinPath [
         sway-unwrapped
@@ -58,21 +72,17 @@ grimshot = stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A helper for screenshots within sway";
-    homepage = "https://github.com/swaywm/sway/tree/master/contrib";
-    license = licenses.mit;
-    platforms = platforms.all;
-    maintainers = sway-unwrapped.meta.maintainers ++ (with maintainers; [ evils ]);
+    maintainers = with maintainers; [ evils ];
   };
 };
 
 
 inactive-windows-transparency = python3Packages.buildPythonApplication rec {
+  inherit version src;
+
   # long name is long
   lname = "inactive-windows-transparency";
   pname = "sway-${lname}";
-  version = sway-unwrapped.version;
-
-  src = sway-unwrapped.src;
 
   format = "other";
   dontBuild = true;
@@ -81,12 +91,15 @@ inactive-windows-transparency = python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = [ python3Packages.i3ipc ];
 
   installPhase = ''
-    install -Dm 0755 $src/contrib/${lname}.py $out/bin/${lname}.py
+    install -Dm 0755 $src/${lname}.py $out/bin/${lname}.py
   '';
 
-  meta = sway-unwrapped.meta // {
+  meta = with lib; {
     description = "It makes inactive sway windows transparent";
-    homepage    = "https://github.com/swaywm/sway/tree/${sway-unwrapped.version}/contrib";
+    mainProgram = "${lname}.py";
+    maintainers = with maintainers; [
+      evils # packaged this as a side-effect of grimshot but doesn't use it
+    ];
   };
 };
 


### PR DESCRIPTION
## Description of changes

sway-contrib switched from being a subdirectory of the sway source to its own repo

closes #247231

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).