### PR TITLE
whitesur-kde: init at unstable-2023-08-15

### DIFF
--- a/pkgs/data/themes/whitesur-kde/default.nix
+++ b/pkgs/data/themes/whitesur-kde/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gitUpdater
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "whitesur-kde";
+  version = "unstable-2023-08-15";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = finalAttrs.pname;
+    rev = "d50bc20b2b78705bb9856204066affb763fa8a35";
+    hash = "sha256-oG6QT4VQpBznM+gvzdiY4CldOwdHcBeHlbvlc52eFuU=";
+  };
+
+  postPatch = ''
+    patchShebangs install.sh
+
+    substituteInPlace install.sh \
+      --replace '$HOME/.config' $out/share \
+      --replace '$HOME/.local' $out \
+      --replace '"$HOME"/.Xresources' $out/doc/.Xresources
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/doc
+
+    name= ./install.sh
+
+    mkdir -p $out/share/sddm/themes
+    cp -a sddm/WhiteSur $out/share/sddm/themes/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "A MacOS big sur like theme for KDE Plasma desktop";
+    homepage = "https://github.com/vinceliuice/WhiteSur-kde";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29898,6 +29898,8 @@ with pkgs;
 
   whitesur-icon-theme = callPackage ../data/icons/whitesur-icon-theme { };
 
+  whitesur-kde = callPackage ../data/themes/whitesur-kde { };
+
   wireless-regdb = callPackage ../data/misc/wireless-regdb { };
 
   work-sans  = callPackage ../data/fonts/work-sans { };


### PR DESCRIPTION
## Description of changes

Add [WhiteSur-kde](https://github.com/vinceliuice/WhiteSur-kde), a MacOS big sur like theme for KDE Plasma desktop.

Fixes https://github.com/NixOS/nixpkgs/issues/246707

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
