### PR TITLE
streamdeck-ui: 2.0.6 -> 3.0.1

### DIFF
--- a/nixos/modules/programs/streamdeck-ui.nix
+++ b/nixos/modules/programs/streamdeck-ui.nix
@@ -24,7 +24,7 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = with pkgs; [
       cfg.package
-      (mkIf cfg.autoStart (makeAutostartItem { name = "streamdeck-ui"; package = cfg.package; }))
+      (mkIf cfg.autoStart (makeAutostartItem { name = "streamdeck-ui-noui"; package = cfg.package; }))
     ];
 
     services.udev.packages = [ cfg.package ];

--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -15,8 +15,8 @@ python3Packages.buildPythonApplication rec {
   version = "2.0.6";
 
   src = fetchFromGitHub {
-    repo = pname;
-    owner = "timothycrosley";
+    repo = "streamdeck-linux-gui";
+    owner = "streamdeck-linux-gui";
     rev = "v${version}";
     sha256 = "sha256-5dk+5oefg5R68kv038gsZ2p5ixmpj/vBLBp/V7Sdos8=";
   };
@@ -100,7 +100,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Linux compatible UI for the Elgato Stream Deck";
-    homepage = "https://timothycrosley.github.io/streamdeck-ui/";
+    homepage = "https://streamdeck-linux-gui.github.io/streamdeck-linux-gui/";
     license = licenses.mit;
     maintainers = with maintainers; [ majiir ];
   };

--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -1,37 +1,27 @@
 { lib
 , python3Packages
 , fetchFromGitHub
-, fetchpatch
 , copyDesktopItems
-, wrapQtAppsHook
 , writeText
 , makeDesktopItem
 , xvfb-run
-, qt5
+, qt6
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "streamdeck-ui";
-  version = "2.0.6";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     repo = "streamdeck-linux-gui";
     owner = "streamdeck-linux-gui";
     rev = "v${version}";
-    sha256 = "sha256-5dk+5oefg5R68kv038gsZ2p5ixmpj/vBLBp/V7Sdos8=";
+    sha256 = "sha256-nLtWExxufxT5nRiEYLGNeMhFhvlGzYKA+crA74Yt4ck=";
   };
 
   patches = [
-    (fetchpatch {
-      name = "use-poetry-core.patch";
-      url = "https://github.com/timothycrosley/streamdeck-ui/commit/e271656c1f47b1619d1b942e2ebb01ab2d6a68a9.patch";
-      hash = "sha256-wqYwX6eSqMnW6OG7wSprD62Dz818ayFduVrqW9E/ays=";
-    })
-    (fetchpatch {
-      name = "update-python-xlib-0.33.patch";
-      url = "https://github.com/timothycrosley/streamdeck-ui/commit/07d7fdd33085b413dd26b02d8a02820edad2d568.patch";
-      hash = "sha256-PylTrbfB8RJ0+kbgJlRdcvfdahGoob8LabwhuFNsUpY=";
-    })
+    # nixpkgs has a newer pillow version
+    ./update-pillow.patch
   ];
 
   desktopItems = [ (makeDesktopItem {
@@ -70,7 +60,7 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [
     python3Packages.poetry-core
     copyDesktopItems
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   propagatedBuildInputs = with python3Packages; [
@@ -79,11 +69,11 @@ python3Packages.buildPythonApplication rec {
     cairosvg
     pillow
     pynput
-    pyside2
+    pyside6
     streamdeck
     xlib
   ] ++ lib.optionals stdenv.isLinux [
-    qt5.qtwayland
+    qt6.qtwayland
   ];
 
   nativeCheckInputs = [
@@ -93,13 +83,10 @@ python3Packages.buildPythonApplication rec {
   ];
 
   # Ignored tests are not in a running or passing state.
-  # Fixes have been merged upstream but not yet released.
   # Revisit these ignored tests on each update.
   checkPhase = ''
     xvfb-run pytest tests \
-      --ignore=tests/test_api.py \
-      --ignore=tests/test_filter.py \
-      --ignore=tests/test_stream_deck_monitor.py
+      --ignore=tests/test_api.py
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -24,15 +24,23 @@ python3Packages.buildPythonApplication rec {
     ./update-pillow.patch
   ];
 
-  desktopItems = [ (makeDesktopItem {
-    name = "streamdeck-ui";
-    desktopName = "Stream Deck UI";
-    icon = "streamdeck-ui";
-    exec = "streamdeck --no-ui";
-    comment = "UI for the Elgato Stream Deck";
-    categories = [ "Utility" ];
-    noDisplay = true;
-  }) ];
+  desktopItems = let
+    common = {
+      name = "streamdeck-ui";
+      desktopName = "Stream Deck UI";
+      icon = "streamdeck-ui";
+      exec = "streamdeck";
+      comment = "UI for the Elgato Stream Deck";
+      categories = [ "Utility" ];
+    };
+  in builtins.map makeDesktopItem [
+    common
+    (common // {
+      name = "${common.name}-noui";
+      exec = "${common.exec} --no-ui";
+      noDisplay = true;
+    })
+  ];
 
   postInstall =
     let

--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -51,6 +51,10 @@ python3Packages.buildPythonApplication rec {
       '';
     in
       ''
+        mkdir -p $out/lib/systemd/user
+        substitute scripts/streamdeck.service $out/lib/systemd/user/streamdeck.service \
+          --replace '<path to streamdeck>' $out/bin/streamdeck
+
         mkdir -p "$out/etc/udev/rules.d"
         cp ${writeText "70-streamdeck.rules" udevRules} $out/etc/udev/rules.d/70-streamdeck.rules
 

--- a/pkgs/applications/misc/streamdeck-ui/update-pillow.patch
+++ b/pkgs/applications/misc/streamdeck-ui/update-pillow.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 0aff29e..4371616 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -14,7 +14,7 @@ packages = [
+ [tool.poetry.dependencies]
+ python = ">=3.8,<3.12"
+ streamdeck = "^0.9.3"
+-pillow = "^9.4.0"
++pillow = "^10.0.0"
+ pynput = "^1.7.6"
+ pyside6 = "^6.4.2"
+ CairoSVG = "^2.5.2"

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -9,6 +9,7 @@
 , libglvnd
 , darwin
 , buildPackages
+, python3
 
   # options
 , developerBuild ? false
@@ -24,7 +25,7 @@ let
   addPackages = self: with self;
     let
       callPackage = self.newScope ({
-        inherit qtModule srcs;
+        inherit qtModule srcs python3;
         stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
       });
     in

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , cmake
 , ninja
-, qt6
 , python
 , moveBuildTree
 , shiboken6
@@ -34,7 +33,7 @@ stdenv.mkDerivation rec {
     moveBuildTree
   ];
 
-  buildInputs = with qt6; [
+  buildInputs = with python.pkgs.qt6; [
     # required
     qtbase
   ] ++ lib.optionals stdenv.isLinux [

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation rec {
   buildInputs = with python.pkgs.qt6; [
     # required
     qtbase
+    python.pkgs.ninja
+    python.pkgs.packaging
+    python.pkgs.setuptools
   ] ++ lib.optionals stdenv.isLinux [
     # optional
     qt3d
@@ -67,6 +70,12 @@ stdenv.mkDerivation rec {
   ];
 
   dontWrapQtApps = true;
+
+  postInstall = ''
+    cd ../../..
+    ${python.pythonForBuild.interpreter} setup.py egg_info --build-type=pyside6
+    cp -r PySide6.egg-info $out/${python.sitePackages}/
+  '';
 
   meta = with lib; {
     description = "Python bindings for Qt";

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -35,6 +35,9 @@ llvmPackages.stdenv.mkDerivation rec {
     llvmPackages.llvm
     llvmPackages.libclang
     python.pkgs.qt6.qtbase
+    python.pkgs.ninja
+    python.pkgs.packaging
+    python.pkgs.setuptools
   ];
 
   cmakeFlags = [
@@ -51,6 +54,12 @@ llvmPackages.stdenv.mkDerivation rec {
     install_name_tool -change {@rpath,$out/lib}/libshiboken6.abi3.6.5.dylib $out/${python.sitePackages}/shiboken6/Shiboken.abi3.so
   '' + lib.optionalString stdenv.isLinux ''
     patchelf $out/${python.sitePackages}/shiboken6/Shiboken.abi3.so --shrink-rpath --allowed-rpath-prefixes ${builtins.storeDir}
+  '';
+
+  postInstall = ''
+    cd ../../..
+    ${python.pythonForBuild.interpreter} setup.py egg_info --build-type=shiboken6
+    cp -r shiboken6.egg-info $out/${python.sitePackages}/
   '';
 
   dontWrapQtApps = true;

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -2,7 +2,6 @@
 , fetchurl
 , llvmPackages
 , python
-, qt6
 , cmake
 , autoPatchelfHook
 , stdenv
@@ -35,7 +34,7 @@ llvmPackages.stdenv.mkDerivation rec {
   buildInputs = [
     llvmPackages.llvm
     llvmPackages.libclang
-    qt6.qtbase
+    python.pkgs.qt6.qtbase
   ];
 
   cmakeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32835,7 +32835,7 @@ with pkgs;
 
   srain = callPackage ../applications/networking/irc/srain { };
 
-  streamdeck-ui = libsForQt5.callPackage ../applications/misc/streamdeck-ui { };
+  streamdeck-ui = callPackage ../applications/misc/streamdeck-ui { };
 
   super-productivity = callPackage ../applications/office/super-productivity { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9894,7 +9894,7 @@ self: super: with self; {
   });
 
   pyside6 = toPythonModule (callPackage ../development/python-modules/pyside6 {
-    inherit (pkgs) cmake ninja qt6;
+    inherit (pkgs) cmake ninja;
   });
 
   pyside = callPackage ../development/python-modules/pyside {
@@ -10912,6 +10912,10 @@ self: super: with self; {
 
   qt5reactor = callPackage ../development/python-modules/qt5reactor { };
 
+  qt6 = pkgs.qt6.override {
+    python3 = self.python;
+  };
+
   qtawesome = callPackage ../development/python-modules/qtawesome { };
 
   qtconsole = callPackage ../development/python-modules/qtconsole { };
@@ -11735,7 +11739,7 @@ self: super: with self; {
   });
 
   shiboken6 = toPythonModule (callPackage ../development/python-modules/shiboken6 {
-    inherit (pkgs) cmake llvmPackages qt6;
+    inherit (pkgs) cmake llvmPackages;
   });
 
   shippai = callPackage ../development/python-modules/shippai { };


### PR DESCRIPTION
## Description of changes

- Added a `pythonPackages.qt6` override so that qt6 modules using are built with the correct `python` version when a Python module (e.g. `pyside6`) is built with a different Python package (e.g. `python311`).
- Added `egg_info` to `pyside6` and `shiboken6`. This is required for `streamdeck-ui` to find its `pyside6` dependency. See https://github.com/NixOS/nixpkgs/issues/167452 for background on a similar problem in `pyside2`.
- Updated upstream repository to the actively maintained fork. See: https://github.com/timothycrosley/streamdeck-ui/issues/357#issuecomment-1654606072
- Added systemd user service to the package.
- Updated version `2.0.6` -> `3.0.1`.
- Split the desktop item into one that launches normally and one with the `--no-ui` flag. The `programs.streamdeck-ui.autoLaunch` flag will launch the `--no-ui` item for consistency with current behavior. The default (visible) desktop item no longer needs `--no-ui` because the application properly handles multiple instances being launched as of version `2.0.14`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
