### PR TITLE
fm: init at unstable-2023-07-25

### DIFF
--- a/pkgs/applications/file-managers/fm/default.nix
+++ b/pkgs/applications/file-managers/fm/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, wrapGAppsHook4
+, libadwaita
+, libpanel
+, gtksourceview5
+, poppler
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "fm";
+  version = "unstable-2023-07-25";
+
+  src = fetchFromGitHub {
+    owner = "euclio";
+    repo = "fm";
+    rev = "a0830b5483a48a8b1e40982f20c28dcb5bfe4a6e";
+    hash = "sha256-uso7j+bf6PF5wiTzSJymSxNNfzqXVcJygkfGdzQl4xA=";
+  };
+
+  cargoHash = "sha256-3IxpnDYbfLI1VAMgqIE4eSkiT9Z6HcC3K6MH6uqD9Ic=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+    libpanel
+    gtksourceview5
+    poppler
+  ];
+
+  meta = with lib; {
+    description = "Small, general purpose file manager built with GTK4";
+    homepage = "https://github.com/euclio/fm";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aleksana ];
+    mainProgram = "fm";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1740,6 +1740,8 @@ with pkgs;
 
   fabs = callPackage ../tools/backup/fabs { };
 
+  fm = callPackage ../applications/file-managers/fm { };
+
   fm-tune = callPackage ../applications/radio/fm-tune { };
 
   fwbuilder = libsForQt5.callPackage ../tools/security/fwbuilder { };


### PR DESCRIPTION
## Description of changes

![image](https://github.com/NixOS/nixpkgs/assets/42209822/85425b72-53ed-490b-baf2-84d07cd499ef)

It is said to support darwin build but I've not tested.

> The application is known to run successfully on MacOS. Other platforms are untested, but if you can get the system dependencies to build, fm should work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
