### PR TITLE
enpass: fix update_script.py

### DIFF
--- a/pkgs/tools/security/enpass/update_script.py
+++ b/pkgs/tools/security/enpass/update_script.py
@@ -1,95 +1,74 @@
-from __future__ import print_function
-
-
-import argparse
-import bz2
-import email
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3 python3.pkgs.packaging python3.pkgs.requests
+import gzip
 import json
 import logging
+import pathlib
+import re
+import subprocess
+import sys
 
-from itertools import product
-from operator import itemgetter
+from packaging import version
+import requests
 
-import attr
-import pkg_resources
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
-from pathlib2 import Path
-from requests import Session
-from six.moves.urllib_parse import urljoin
+current_path = pathlib.Path(__file__).parent
+DATA_JSON = current_path.joinpath("data.json").resolve()
+logging.debug(f"Path to version file: {DATA_JSON}")
+last_new_version = None
 
+with open(DATA_JSON, "r") as versions_file:
+    versions = json.load(versions_file)
 
-@attr.s
-class ReleaseElement(object):
-    sha256 = attr.ib(repr=False)
-    size = attr.ib(convert=int)
-    path = attr.ib()
+def find_latest_version(arch):
+    CHECK_URL = f'https://apt.enpass.io/dists/stable/main/binary-{arch}/Packages.gz'
+    packages = gzip.decompress(requests.get(CHECK_URL).content).decode()
 
-log = logging.getLogger('enpass.updater')
+    # Loop every package to find the newest one!
+    version_selector = re.compile("Version: (?P<version>.+)")
+    path_selector = re.compile("Filename: (?P<path>.+)")
+    hash_selector = re.compile("SHA256: (?P<sha256>.+)")
+    last_version = version.parse("0")
+    for package in packages.split("\n\n"):
+        matches = version_selector.search(package)
+        matched_version = matches.group('version') if matches and matches.group('version') else "0"
+        parsed_version = version.parse(matched_version)
+        if parsed_version > last_version:
+            path = path_selector.search(package).group('path')
+            sha256 = hash_selector.search(package).group('sha256')
+            last_version = parsed_version
+            return {"path": path, "sha256": sha256, "version": matched_version}
 
+for arch in versions.keys():
+    current_version = versions[arch]['version']
+    logging.info(f"Current Version for {arch} is {current_version}")
+    new_version = find_latest_version(arch)
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--repo')
-parser.add_argument('--target', type=Path)
+    if not new_version or new_version['version'] == current_version:
+        continue
 
-
-session = Session()
-
-
-def parse_bz2_msg(msg):
-    msg = bz2.decompress(msg)
-    if '\n\n' in msg:
-        parts = msg.split('\n\n')
-        return list(map(email.message_from_string, parts))
-    return email.message_from_string(msg)
-
-
-def fetch_meta(repo, name, parse=email.message_from_string, split=False):
-    url = urljoin(repo, 'dists/stable', name)
-    response = session.get("{repo}/dists/stable/{name}".format(**locals()))
-    return parse(response.content)
-
-
-def fetch_filehashes(repo, path):
-    meta = fetch_meta(repo, path, parse=parse_bz2_msg)
-    for item in meta:
-        yield {
-            'version': pkg_resources.parse_version(str(item['Version'])),
-            'path': item['Filename'],
-            'sha256': item['sha256'],
-        }
-
-
-def fetch_archs(repo):
-    m = fetch_meta(repo, 'Release')
-
-    architectures = m['Architectures'].split()
-    elements = [ReleaseElement(*x.split()) for x in m['SHA256'].splitlines()]
-    elements = [x for x in elements if x.path.endswith('bz2')]
-
-    for arch, elem in product(architectures, elements):
-        if arch in elem.path:
-            yield arch, max(fetch_filehashes(repo, elem.path),
-                            key=itemgetter('version'))
+    last_current_version = current_version
+    last_new_version = new_version
+    logging.info(f"Update found ({arch}): enpass: {current_version} -> {new_version['version']}")
+    versions[arch]['path'] = new_version['path']
+    versions[arch]['sha256'] = new_version['sha256']
+    versions[arch]['version'] = new_version['version']
 
 
-class OurVersionEncoder(json.JSONEncoder):
-    def default(self, obj):
-        # the other way around to avoid issues with
-        # newer setuptools having strict/legacy versions
-        if not isinstance(obj, (dict, str)):
-            return str(obj)
-        return json.JSONEncoder.default(self, obj)
+if not last_new_version:
+    logging.info('#### No update found ####')
+    sys.exit(0)
 
+# write new versions back
+with open(DATA_JSON, "w") as versions_file:
+    json.dump(versions, versions_file, indent=2)
+    versions_file.write("\n")
 
-def main(repo, target):
-    logging.basicConfig(level=logging.DEBUG)
-    with target.open(mode='wb') as fp:
-        json.dump(
-            dict(fetch_archs(repo)), fp,
-            cls=OurVersionEncoder,
-            indent=2,
-            sort_keys=True)
+# Commit the result:
+logging.info("Committing changes...")
+commit_message = f"enpass: {last_current_version} -> {last_new_version['version']}"
+subprocess.run(['git', 'add', DATA_JSON], check=True)
+subprocess.run(['git', 'commit', '--file=-'], input=commit_message.encode(), check=True)
 
-
-opts = parser.parse_args()
-main(opts.repo, opts.target)
+logging.info("Done.")


### PR DESCRIPTION
## Description of changes

The `update_script.py` did not work on my machine and probably used an outdated url to check.
With this PR the script now queries the official APT repo and fetches the latest version from there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
