### PR TITLE
apache-jena-fuseki.tests: use non-alias runCommand

### DIFF
--- a/pkgs/servers/nosql/apache-jena/fuseki-test.nix
+++ b/pkgs/servers/nosql/apache-jena/fuseki-test.nix
@@ -1,5 +1,5 @@
-{ lib, runCommandNoCC, apache-jena-fuseki, curl }:
-runCommandNoCC "fuseki-test-${apache-jena-fuseki.name}"
+{ lib, runCommand, apache-jena-fuseki, curl }:
+runCommand "fuseki-test-${apache-jena-fuseki.name}"
 { nativeBuildInputs = [ curl apache-jena-fuseki ]; } ''
   export FUSEKI_BASE="$PWD/fuseki-base"
   mkdir -p "$FUSEKI_BASE/db"


### PR DESCRIPTION
## Description of changes

Turns out the unambiguously named version is an alias…

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- N/A Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- N/A Tested basic functionality of all binary files (usually in `./result/bin/`)
