### PR TITLE
gifski: fix tests by running them in debug mode

### DIFF
--- a/pkgs/tools/graphics/gifski/default.nix
+++ b/pkgs/tools/graphics/gifski/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     owner = "ImageOptim";
     repo = "gifski";
     rev = version;
-    sha256 = "sha256-sPsq/hntNqOdPJcoob1jrDUrLLiBEnfRoDANyFUjOuM=";
+    hash = "sha256-sPsq/hntNqOdPJcoob1jrDUrLLiBEnfRoDANyFUjOuM=";
   };
 
   cargoLock = {
@@ -35,8 +35,15 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = [ "video" ];
 
-  # error: the crate `gifski` is compiled with the panic strategy `abort` which is incompatible with this crate's strategy of `unwind`
-  doCheck = !stdenv.isDarwin;
+  # When the default checkType of release is used, we get the following error:
+  #
+  #   error: the crate `gifski` is compiled with the panic strategy `abort` which
+  #   is incompatible with this crate's strategy of `unwind`
+  #
+  # It looks like https://github.com/rust-lang/cargo/issues/6313, which does not
+  # outline a solution.
+  #
+  checkType = "debug";
 
   # error: linker `/usr/bin/x86_64-linux-gnu-gcc` not found
   postPatch = ''
@@ -49,5 +56,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/ImageOptim/gifski/releases/tag/${src.rev}";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ figsoda marsam ];
+    mainProgram = "gifski";
   };
 }


### PR DESCRIPTION
## Description of changes

It looks like we're running into https://github.com/rust-lang/cargo/issues/6313, and I don't have a better workaround.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
