### PR TITLE
tidgi: init at 0.9.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10628,6 +10628,12 @@
     github = "kkoniuszy";
     githubId = 120419423;
   };
+  klchen0112 = {
+    name = "klchen0112";
+    email = "klchen0112@gmail.com";
+    github = "klchen0112";
+    githubId = 32459567;
+  };
   klden = {
     name = "Kenzyme Le";
     email = "kl@kenzymele.com";

--- a/pkgs/by-name/ti/tidgi/package.nix
+++ b/pkgs/by-name/ti/tidgi/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  unzip,
+}:
+stdenv.mkDerivation rec {
+  pname = "tidgi";
+  version = "0.9.6";
+
+  src =
+    if stdenv.isAarch64
+    then
+      fetchurl
+      {
+        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${version}/TidGi-darwin-arm64-${version}.zip";
+        sha256 = "sha256-1Z9lxZZWrUVQEhBO/Kt2AS/uNs2XfihdL0iGrguPQ5g=";
+      }
+    else
+      fetchurl
+      {
+        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${version}/TidGi-darwin-x64-${version}.zip";
+        sha256 = "sha256-5jHW/QrgzsGQfX4LvsRebdOJPzYTvhtC5mczxp2wPI8=";
+      };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [unzip];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -r *.app "$out/Applications"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/tag/v${version}";
+    description = "Customizable personal knowledge-base and blogging platform with git as backup manager";
+    homepage = "https://github.com/tiddly-gittly/TidGi-Desktop";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [klchen0112];
+    platforms = ["aarch64-darwin" "x86_64-darwin"];
+    sourceProvenance = with lib.sourceTypes; [binaryNativeCode];
+  };
+}


### PR DESCRIPTION
## Description of changes
[TidGi](https://github.com/tiddly-gittly/TidGi-Desktop) is a cross-platform Note Taking & GTD & Fragment Knowledge Management desktop app powered by [nodejs-TiddlyWiki](https://github.com/Jermolene/TiddlyWiki5#installing-tiddlywiki-on-nodejs), it ship with a lot of tiddlywiki plugins from the [TiddlyWiki community](https://groups.google.com/forum/#!forum/tiddlywiki).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
