### PR TITLE
dt: init at 1.2.3

### DIFF
--- a/pkgs/tools/text/dt/default.nix
+++ b/pkgs/tools/text/dt/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, testers
+, zigHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dt";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "so-dang-cool";
+    repo = "dt";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-C6sG8iqXs64x2AWCxKGFPyoXC1Fn4p2eSLWwJAQ8CSc=";
+  };
+
+  nativeBuildInputs = [ zigHook ];
+
+  passthru.tests.version = testers.testVersion { package = finalAttrs.dt; };
+
+  meta = {
+    homepage = "https://dt.plumbing";
+    description = "Duct tape for your unix pipes.";
+    longDescription = ''
+       dt is a utility and programming language. The utility is intended for
+       ergonomic in-the-shell execution. The language is straightforward (in
+       the most literal sense) with a minimal syntax that allows for
+       high-level, higher-order programming.
+
+       It's meant to supplement (not replace!) other tools like awk, sed,
+       xargs, and shell built-ins. Something like the Perl one-liners popular
+       yesteryear, but hopefully easier to read and reason through.
+
+       In short, dt is intended to be generally useful, with zero pretense of
+       elegance.
+    '';
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ booniepepper ];
+    mainProgram = "dt";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -595,6 +595,12 @@ with pkgs;
 
   dsq = callPackage ../tools/misc/dsq { };
 
+  dt = callPackage ../tools/text/dt {
+    zigHook = zigHook.override {
+      zig = buildPackages.zig_0_11;
+    };
+  };
+
   dtv-scan-tables = callPackage ../data/misc/dtv-scan-tables { };
 
   dufs = callPackage ../servers/http/dufs {


### PR DESCRIPTION
## Description of changes

An initial package for dt ([Repo](https://github.com/so-dang-cool/dt), [Website](https://dt.plumbing))

I also am the upstream owner

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
