### PR TITLE
qtwebengine: link to pulseaudio

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -170,6 +170,7 @@ let
         extraPrefix = "src/3rdparty/";
         hash = "sha256-s4GsGMJTBNWw2gTJuIEP3tqT82AmTsR2mbj59m2p6rM=";
       })
+      ./qtwebengine-link-pulseaudio.patch
     ] ++ lib.optionals stdenv.isDarwin [
       ./qtwebengine-darwin-no-platform-check.patch
       ./qtwebengine-mac-dont-set-dsymutil-path.patch

--- a/pkgs/development/libraries/qt-5/5.15/qtwebengine-link-pulseaudio.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtwebengine-link-pulseaudio.patch
@@ -1,0 +1,8 @@
+--- a/src/core/config/common.pri
++++ b/src/core/config/common.pri
+@@ -47,3 +47,5 @@
+
+ !qtConfig(webengine-nodejs10): gn_args += use_rollup=false
+ gn_args += enable_ipc_logging=false
++
++gn_args += link_pulseaudio=true

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -9,6 +9,7 @@
 , zlib, minizip, libjpeg, libpng, libtiff, libwebp, libopus
 , jsoncpp, protobuf, libvpx, srtp, snappy, nss, libevent
 , alsa-lib
+, pulseaudio
 , libcap
 , pciutils
 , systemd
@@ -145,6 +146,7 @@ qtModule {
 
     # Audio formats
     alsa-lib
+    pulseaudio
 
     # Text rendering
     fontconfig freetype

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -135,6 +135,7 @@ qtModule {
     # environment variable, since NixOS relies on it working.
     # See https://github.com/NixOS/nixpkgs/issues/226484 for more context.
     ../patches/qtwebengine-xkb-includes.patch
+    ../patches/qtwebengine-link-pulseaudio.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/qt-6/patches/qtwebengine-link-pulseaudio.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtwebengine-link-pulseaudio.patch
@@ -1,0 +1,10 @@
+--- a/src/core/CMakeLists.txt
++++ b/src/core/CMakeLists.txt
+@@ -341,6 +341,7 @@
+             devtools_fast_bundle=false
+             devtools_skip_typecheck=false
+             enable_jxl_decoder=false # temporarily because libjxl causes internal compiler error on armv7
++            link_pulseaudio=true
+         )
+
+         extend_gn_list(gnArgArg


### PR DESCRIPTION
Nix builds of QTWebEngine doesn't support sound output via Pulse, only through ALSA, unless sandboxing is disabled and LD_LIBRARY_PATH contains a reference to the Pulse libraries.

## Description of changes

By default, Chromium won't link to PulseAudio, but dlopens it in run-time. It is tricky to make this work because of the nontrivial sandbox configuration. Nix builds of Chromium already [link against Pulse directly](https://github.com/NixOS/nixpkgs/blob/5029a01733c7b6bdfe086c39237316566cfe57d2/pkgs/applications/networking/browsers/chromium/common.nix#L397), so it makes sense to copy this behavior in QTWebEngine.

## Things done

I've checked that Qutebrowser has proper PulseAudio support after building with an earlier version of this patch. As building Chromium takes forever, I am yet to test this latest revision.
Possibly resolves #197728

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
