### PR TITLE
texlive: use standard mktexlsr instead of mktexlsr.pl

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -30,11 +30,12 @@ let
     # remove fake derivations (without 'outPath') to avoid undesired build dependencies
     paths = lib.catAttrs "outPath" pkgList.nonbin;
 
-    nativeBuildInputs = [ (lib.last tl.texlive-scripts.pkgs) ];
+    # mktexlsr
+    nativeBuildInputs = [ (lib.last tl."texlive.infra".pkgs) ];
 
     postBuild = # generate ls-R database
     ''
-      mktexlsr --sort "$out"
+      mktexlsr "$out"
     '';
   }).overrideAttrs (_: { allowSubstitutes = true; });
 
@@ -88,7 +89,8 @@ in (buildEnv {
   nativeBuildInputs = [
     makeWrapper
     libfaketime
-    (lib.last tl.texlive-scripts.pkgs) # fmtutil, mktexlsr, updmap
+    (lib.last tl."texlive.infra".pkgs) # mktexlsr
+    (lib.last tl.texlive-scripts.pkgs) # fmtutil, updmap
     (lib.last tl.texlive-scripts-extra.pkgs) # texlinks
     perl
   ];
@@ -222,8 +224,8 @@ in (buildEnv {
       "$TEXMFDIST"/tex/generic/config/language.dat.lua > "$TEXMFSYSVAR"/tex/generic/config/language.dat.lua
     [[ -e "$TEXMFDIST"/web2c/fmtutil.cnf ]] && sed -E -f '${fmtutilSed}' "$TEXMFDIST"/web2c/fmtutil.cnf > "$TEXMFCNF"/fmtutil.cnf
 
-    # make new files visible to kpathsea
-    mktexlsr --sort "$TEXMFSYSVAR"
+    # create $TEXMFSYSCONFIG database, make new $TEXMFSYSVAR files visible to kpathsea
+    mktexlsr "$TEXMFSYSCONFIG" "$TEXMFSYSVAR"
   '') +
     # generate format links (reads fmtutil.cnf to know which ones) *after* the wrappers have been generated
   ''
@@ -260,7 +262,7 @@ in (buildEnv {
     # sort entries to improve reproducibility
     [[ -f "$TEXMFSYSCONFIG"/web2c/updmap.cfg ]] && sort -o "$TEXMFSYSCONFIG"/web2c/updmap.cfg "$TEXMFSYSCONFIG"/web2c/updmap.cfg
 
-    mktexlsr --sort "$TEXMFSYSCONFIG" "$TEXMFSYSVAR" # to make sure (of what?)
+    mktexlsr "$TEXMFSYSCONFIG" "$TEXMFSYSVAR" # to make sure (of what?)
   '' +
     # remove *-sys scripts since /nix/store is readonly
   ''


### PR DESCRIPTION
## Description of changes
Return to the standard `mktexlsr` distributed by TeX Live, instead of the perl version `mktexlsr.pl`. Very little difference in practice, except that `mktexlsr` always sort its output and it matches the content of `man mktexlsr`.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - `tests.texlive.binaries`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
