### PR TITLE
onlyoffice-documentserver: added aarch64-linux support

### DIFF
--- a/pkgs/servers/onlyoffice-documentserver/default.nix
+++ b/pkgs/servers/onlyoffice-documentserver/default.nix
@@ -12,14 +12,27 @@
 }:
 
 let
+  version = "7.4.0";
+  tag = lib.concatStringsSep "." (lib.take 3 (lib.splitVersion version));
+  dist = {
+    x86_64-linux = rec {
+      archSuffix = "amd64";
+      url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${tag}/onlyoffice-documentserver_${archSuffix}.deb";
+      hash = "sha256-FL09EXxQlUZuJMMHYu9tSOH8ARPgzoqAKmQYV6225PU=";
+    };
+    aarch64-linux = rec {
+      archSuffix = "arm64";
+      url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${tag}/onlyoffice-documentserver_${archSuffix}.deb";
+      hash = "sha256-JHDdwLAfrH+hKF0c1UqcjwxTdeYFjWVEjzjG8HTcqaA=";
+    };
+  };
   # var/www/onlyoffice/documentserver/server/DocService/docservice
-  onlyoffice-documentserver = stdenv.mkDerivation rec {
+  onlyoffice-documentserver = stdenv.mkDerivation {
     pname = "onlyoffice-documentserver";
-    version = "7.4.0";
-
+    inherit version;
     src = fetchurl {
-      url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${lib.concatStringsSep "." (lib.take 3 (lib.splitVersion version))}/onlyoffice-documentserver_amd64.deb";
-      sha256 = "sha256-FL09EXxQlUZuJMMHYu9tSOH8ARPgzoqAKmQYV6225PU=";
+      inherit (dist.${stdenv.hostPlatform.system} or
+      (throw "Unsupported system: ${stdenv.hostPlatform.system}")) url hash;
     };
 
     preferLocalBuild = true;
@@ -143,7 +156,7 @@ let
       '';
       homepage = "ONLYOFFICE Document Server is an online office suite comprising viewers and editors";
       license = licenses.agpl3;
-      platforms = [ "x86_64-linux" ];
+      platforms = [ "x86_64-linux" "aarch64-linux" ];
       sourceProvenance = [ sourceTypes.binaryNativeCode ];
       maintainers = with maintainers; [ SuperSandro2000 ];
     };

--- a/pkgs/servers/onlyoffice-documentserver/default.nix
+++ b/pkgs/servers/onlyoffice-documentserver/default.nix
@@ -12,18 +12,18 @@
 }:
 
 let
-  version = "7.4.0";
+  version = "7.4.1";
   tag = lib.concatStringsSep "." (lib.take 3 (lib.splitVersion version));
   dist = {
     x86_64-linux = rec {
       archSuffix = "amd64";
       url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${tag}/onlyoffice-documentserver_${archSuffix}.deb";
-      hash = "sha256-FL09EXxQlUZuJMMHYu9tSOH8ARPgzoqAKmQYV6225PU=";
+      hash = "sha256-60S8M1Y9BxuMxXGxEaxW82Va5lSnZZPfQnPq2ivTXdU=";
     };
     aarch64-linux = rec {
       archSuffix = "arm64";
       url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${tag}/onlyoffice-documentserver_${archSuffix}.deb";
-      hash = "sha256-JHDdwLAfrH+hKF0c1UqcjwxTdeYFjWVEjzjG8HTcqaA=";
+      hash = "sha256-z2Mp9q+KLpQLG3tVUZaD3jMYoRAXoq7s5wUhNnckTDg=";
     };
   };
   # var/www/onlyoffice/documentserver/server/DocService/docservice

--- a/pkgs/servers/onlyoffice-documentserver/default.nix
+++ b/pkgs/servers/onlyoffice-documentserver/default.nix
@@ -12,27 +12,27 @@
 }:
 
 let
-  version = "7.4.1";
-  tag = lib.concatStringsSep "." (lib.take 3 (lib.splitVersion version));
-  dist = {
-    x86_64-linux = rec {
-      archSuffix = "amd64";
-      url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${tag}/onlyoffice-documentserver_${archSuffix}.deb";
-      hash = "sha256-60S8M1Y9BxuMxXGxEaxW82Va5lSnZZPfQnPq2ivTXdU=";
+  lookup = {
+    x86_64-linux = {
+      fileSuffix = "amd64.deb";
+      fileHash = "sha256-60S8M1Y9BxuMxXGxEaxW82Va5lSnZZPfQnPq2ivTXdU=";
     };
-    aarch64-linux = rec {
-      archSuffix = "arm64";
-      url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${tag}/onlyoffice-documentserver_${archSuffix}.deb";
-      hash = "sha256-z2Mp9q+KLpQLG3tVUZaD3jMYoRAXoq7s5wUhNnckTDg=";
+    aarch64-linux = {
+      fileSuffix = "arm64.deb";
+      fileHash = "sha256-z2Mp9q+KLpQLG3tVUZaD3jMYoRAXoq7s5wUhNnckTDg=";
     };
   };
   # var/www/onlyoffice/documentserver/server/DocService/docservice
-  onlyoffice-documentserver = stdenv.mkDerivation {
+  onlyoffice-documentserver = stdenv.mkDerivation rec {
     pname = "onlyoffice-documentserver";
-    inherit version;
-    src = fetchurl {
-      inherit (dist.${stdenv.hostPlatform.system} or
-      (throw "Unsupported system: ${stdenv.hostPlatform.system}")) url hash;
+    version = "7.4.1";
+    src = let
+      inherit (lookup.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}")) fileSuffix fileHash;
+      tag = lib.concatStringsSep "." (lib.take 3 (lib.splitVersion version));
+      url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${tag}/onlyoffice-documentserver_${fileSuffix}";
+      hash = "${fileHash}";
+    in fetchurl {
+      inherit url hash;
     };
 
     preferLocalBuild = true;


### PR DESCRIPTION
## Description of changes

Added aarch64-linux platform support

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
