### PR TITLE
pagefind: init at 1.0.3

### DIFF
--- a/pkgs/applications/misc/pagefind/default.nix
+++ b/pkgs/applications/misc/pagefind/default.nix
@@ -1,0 +1,110 @@
+{ lib
+, callPackage
+, rustPlatform
+, fetchFromGitHub
+, fetchNpmDeps
+, npmHooks
+, binaryen
+, gzip
+, nodejs
+, rustc-wasm32
+, wasm-bindgen-cli
+, wasm-pack
+}:
+
+let
+
+  wasm-bindgen-84 = wasm-bindgen-cli.override {
+    version = "0.2.84";
+    hash = "sha256-0rK+Yx4/Jy44Fw5VwJ3tG243ZsyOIBBehYU54XP/JGk=";
+    cargoHash = "sha256-vcpxcRlW1OKoD64owFF6mkxSqmNrvY+y3Ckn5UwEQ50=";
+  };
+
+in
+
+rustPlatform.buildRustPackage rec {
+  pname = "pagefind";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "cloudcannon";
+    repo = "pagefind";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-vQbLaZug3gySMIbMdNqU7XcL4GZ7XqZ3ZkwdDBC5T9o=";
+  };
+
+  cargoHash = "sha256-ubuzO/67HguWPqd3y/IapO07L2pg2Q4vo1yTpEthdoU=";
+
+  env.npmDeps_web_js = fetchNpmDeps {
+    name = "npm-deps-web-js";
+    src = "${src}/pagefind_web_js";
+    hash = "sha256-pGE4lUFZ4dA++8kBklcMBoaN/1Z92dfOzQKhukbuEyc=";
+  };
+  env.npmDeps_ui_default = fetchNpmDeps {
+    name = "npm-deps-ui-default";
+    src = "${src}/pagefind_ui/default";
+    hash = "sha256-voCs49JneWYE1W9U7aB6G13ypH6JqathVDeF58V57U8=";
+  };
+  env.npmDeps_ui_modular = fetchNpmDeps {
+    name = "npm-deps-ui-modular";
+    src = "${src}/pagefind_ui/modular";
+    hash = "sha256-O0RqZUsRFtByxMQdwNGNcN38Rh+sDqqNo9YlBcrnsF4=";
+  };
+
+  postPatch = ''
+    # Tricky way to run npmConfigHook multiple times
+    (
+      local postPatchHooks=() # written to by npmConfigHook
+      source ${npmHooks.npmConfigHook}/nix-support/setup-hook
+      npmRoot=pagefind_web_js     npmDeps=$npmDeps_web_js     npmConfigHook
+      npmRoot=pagefind_ui/default npmDeps=$npmDeps_ui_default npmConfigHook
+      npmRoot=pagefind_ui/modular npmDeps=$npmDeps_ui_modular npmConfigHook
+    )
+  '';
+
+  nativeBuildInputs = [
+    binaryen
+    gzip
+    nodejs
+    rustc-wasm32
+    rustc-wasm32.llvmPackages.lld
+    wasm-bindgen-84
+    wasm-pack
+  ];
+
+  # build wasm and js assets
+  # based on "test-and-build" in https://github.com/CloudCannon/pagefind/blob/main/.github/workflows/release.yml
+  preBuild = ''
+    export HOME=$(mktemp -d)
+    (
+      cd pagefind_web_js
+      npm run build-coupled
+    )
+
+    (
+      cd pagefind_web
+      export RUSTFLAGS="-C linker=lld"
+      bash ./local_build.sh
+    )
+
+    (
+      cd pagefind_ui/default
+      npm run build
+    )
+
+    (
+      cd pagefind_ui/modular
+      npm run build
+    )
+  '';
+
+  buildFeatures = [ "extended" ];
+
+  meta = with lib; {
+    description = "Generate low-bandwidth search index for your static website";
+    homepage = "https://pagefind.app/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pbsds ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/ldap/lldap/default.nix
+++ b/pkgs/servers/ldap/lldap/default.nix
@@ -7,6 +7,7 @@
 , nixosTests
 , rustPlatform
 , rustc
+, rustc-wasm32
 , stdenv
 , wasm-bindgen-cli
 , wasm-pack
@@ -14,23 +15,6 @@
 }:
 
 let
-
-  # replace with upstream wasm rustc, after resolution of
-  # https://github.com/NixOS/nixpkgs/issues/89426
-  rustc-wasm = (rustc.override {
-    stdenv = stdenv.override {
-      targetPlatform = stdenv.targetPlatform // {
-        parsed = {
-          cpu.name = "wasm32";
-          vendor.name = "unknown";
-          kernel.name = "unknown";
-          abi.name = "unknown";
-        };
-      };
-    };
-  }).overrideAttrs (attrs: {
-    configureFlags = attrs.configureFlags ++ ["--set=build.docs=false"];
-  });
 
   wasm-bindgen-84 = wasm-bindgen-cli.override {
     version = "0.2.84";
@@ -71,7 +55,7 @@ let
     pname = commonDerivationAttrs.pname + "-frontend";
 
     nativeBuildInputs = [
-      wasm-pack wasm-bindgen-84 binaryen which rustc-wasm rustc-wasm.llvmPackages.lld
+      wasm-pack wasm-bindgen-84 binaryen which rustc-wasm32 rustc-wasm32.llvmPackages.lld
     ];
 
     buildPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16864,6 +16864,22 @@ with pkgs;
 
   inherit (rustPackages) cargo cargo-auditable cargo-auditable-cargo-wrapper clippy rustc rustPlatform;
 
+  # https://github.com/NixOS/nixpkgs/issues/89426
+  rustc-wasm32 = (rustc.override {
+    stdenv = stdenv.override {
+      targetPlatform = stdenv.targetPlatform // {
+        parsed = {
+          cpu.name = "wasm32";
+          vendor.name = "unknown";
+          kernel.name = "unknown";
+          abi.name = "unknown";
+        };
+      };
+    };
+  }).overrideAttrs (old: {
+    configureFlags = old.configureFlags ++ ["--set=build.docs=false"];
+  });
+
   makeRustPlatform = callPackage ../development/compilers/rust/make-rust-platform.nix { };
 
   buildRustCrate = callPackage ../build-support/rust/build-rust-crate { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11534,6 +11534,8 @@ with pkgs;
 
   PageEdit = libsForQt5.callPackage ../applications/office/PageEdit { };
 
+  pagefind = libsForQt5.callPackage ../applications/misc/pagefind { };
+
   paging-calculator  = callPackage ../development/tools/paging-calculator { };
 
   pagmo2 = callPackage ../development/libraries/pagmo2 { };


### PR DESCRIPTION
## Description of changes

This PR packages [pagefind](https://pagefind.app/) by @cloudcannon ([pagefind source](https://github.com/cloudcannon/pagefind)), which can generate a low-bandwidth search index for nearly any static website. I've tested [the use case documented here](https://pagefind.app/docs/ui-usage/) on a huge HTML soup, and it worked wonders.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
