### PR TITLE
source-sans: 3.046 -> 3.052

### DIFF
--- a/pkgs/data/fonts/source-sans/default.nix
+++ b/pkgs/data/fonts/source-sans/default.nix
@@ -2,11 +2,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "source-sans";
-  version = "3.046";
+  version = "3.052";
 
   src = fetchzip {
     url = "https://github.com/adobe-fonts/source-sans/archive/${version}R.zip";
-    hash = "sha256-nBLEK+T5n1CdZK2zvCWIhF2MxPmiAwL9l55a55yHtgU=";
+    hash = "sha256-yzbYy/ZS1GGlgJW+ARVWF4tjFqmMq7x+YqSQnojtQBs=";
   };
 
   installPhase = ''
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
 
     install -Dm444 OTF/*.otf -t $out/share/fonts/opentype
     install -Dm444 TTF/*.ttf -t $out/share/fonts/truetype
-    install -Dm444 VAR/*.otf -t $out/share/fonts/variable
+    install -Dm444 VF/*.otf -t $out/share/fonts/variable
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Fonts version 3.052 (OTF, TTF, VF, WOFF, WOFF2)](https://github.com/adobe-fonts/source-sans/releases/tag/3.052R)
Source Sans 3, version 3.052 created 2023/03/30
Adds Medium weight requested by user. (GitHub issue https://github.com/adobe-fonts/source-sans/issues/253)
Updates the design of several glyphs to arrive at more compact vertical metrics.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
