### PR TITLE
python3.pkgs.atomman: 1.4.6 -> unstable-2023-07-28

### DIFF
--- a/pkgs/development/python-modules/atomman/default.nix
+++ b/pkgs/development/python-modules/atomman/default.nix
@@ -11,20 +11,19 @@
 , phonopy
 , potentials
 , pymatgen
-, pytest
 , pytestCheckHook
 , pythonOlder
-, pythonAtLeast
 , requests
 , scipy
 , setuptools
 , toolz
+, wheel
 , xmltodict
 , pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
-  version = "1.4.6";
+  version = "unstable-2023-07-28";
   pname = "atomman";
   format = "pyproject";
 
@@ -33,12 +32,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "usnistgov";
     repo = "atomman";
-    rev = "v${version}";
-    hash = "sha256-tcsxtFbBdMC6+ixzqhnR+5UNwcQmnPQSvuyNA2IYelI=";
+    rev = "b8af21a9285959d38ee26173081db1b4488401bc";
+    hash = "sha256-WfB+OY61IPprT6OCVHl8VA60p7lLVkRGuyYX+nm7bbA=";
   };
 
   nativeBuildInputs = [
     setuptools
+    wheel
     pythonRelaxDepsHook
   ];
 
@@ -70,7 +70,6 @@ buildPythonPackage rec {
     ase
     phonopy
     pymatgen
-    pytest
     pytestCheckHook
   ];
 


### PR DESCRIPTION
## Description of changes

This picks up some changes that are needed for tests to be compatible with Pandas 2. There are a good chunk of commits since our current version, and the releases are a little haphazard (e.g. there is a v1.4.10 on PyPI but not tagged in Git), so I felt it was easier to take in all of the changes / fixes up to the latest version rather than work out what's going on.

Targeting staging-next for now because it fixes the failing build there (https://github.com/NixOS/nixpkgs/pull/245935).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
