### PR TITLE
texlive: fix tlmgr, tlshell, licenses

### DIFF
--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -234,9 +234,6 @@
 
         # 'Error initialising QuantumRenderer: no suitable pipeline found'
         "tlcockpit"
-
-        # 'tlmgr: config.guess script does not exist, goodbye'
-        "tlshell"
       ] ++ lib.optional stdenv.isDarwin "epspdftk";  # wish shebang is a script, not a binary!
 
       # (1) binaries requiring -v
@@ -271,7 +268,7 @@
         "dt2dv" "dv2dt" "dvi2tty" "dvidvi" "dvispc" "otp2ocp" "outocp" "pmxab"
 
         # GUI scripts that accept no argument or crash without a graphics server; please test manualy
-        "epspdftk" "texdoctk" "xasy"
+        "epspdftk" "texdoctk" "tlshell" "xasy"
 
         # requires Cinderella, not open source and not distributed via Nixpkgs
         "ketcindy"

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -30,11 +30,12 @@ let
     # remove fake derivations (without 'outPath') to avoid undesired build dependencies
     paths = lib.catAttrs "outPath" pkgList.nonbin;
 
-    nativeBuildInputs = [ (lib.last tl.texlive-scripts.pkgs) ];
+    # mktexlsr
+    nativeBuildInputs = [ (lib.last tl."texlive.infra".pkgs) ];
 
     postBuild = # generate ls-R database
     ''
-      mktexlsr --sort "$out"
+      mktexlsr "$out"
     '';
   }).overrideAttrs (_: { allowSubstitutes = true; });
 
@@ -88,7 +89,8 @@ in (buildEnv {
   nativeBuildInputs = [
     makeWrapper
     libfaketime
-    (lib.last tl.texlive-scripts.pkgs) # fmtutil, mktexlsr, updmap
+    (lib.last tl."texlive.infra".pkgs) # mktexlsr
+    (lib.last tl.texlive-scripts.pkgs) # fmtutil, updmap
     (lib.last tl.texlive-scripts-extra.pkgs) # texlinks
     perl
   ];
@@ -222,8 +224,8 @@ in (buildEnv {
       "$TEXMFDIST"/tex/generic/config/language.dat.lua > "$TEXMFSYSVAR"/tex/generic/config/language.dat.lua
     [[ -e "$TEXMFDIST"/web2c/fmtutil.cnf ]] && sed -E -f '${fmtutilSed}' "$TEXMFDIST"/web2c/fmtutil.cnf > "$TEXMFCNF"/fmtutil.cnf
 
-    # make new files visible to kpathsea
-    mktexlsr --sort "$TEXMFSYSVAR"
+    # create $TEXMFSYSCONFIG database, make new $TEXMFSYSVAR files visible to kpathsea
+    mktexlsr "$TEXMFSYSCONFIG" "$TEXMFSYSVAR"
   '') +
     # generate format links (reads fmtutil.cnf to know which ones) *after* the wrappers have been generated
   ''
@@ -260,7 +262,7 @@ in (buildEnv {
     # sort entries to improve reproducibility
     [[ -f "$TEXMFSYSCONFIG"/web2c/updmap.cfg ]] && sort -o "$TEXMFSYSCONFIG"/web2c/updmap.cfg "$TEXMFSYSCONFIG"/web2c/updmap.cfg
 
-    mktexlsr --sort "$TEXMFSYSCONFIG" "$TEXMFSYSVAR" # to make sure (of what?)
+    mktexlsr "$TEXMFSYSCONFIG" "$TEXMFSYSVAR" # to make sure (of what?)
   '' +
     # remove *-sys scripts since /nix/store is readonly
   ''

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -352,6 +352,12 @@ let
         substituteInPlace "$out"/bin/* --replace java "$interpJava"
       '';
 
+      # hardcode revision numbers (since texlive.infra, tlshell are not in either system or user texlive.tlpdb)
+      tlshell.postFixup = ''
+        substituteInPlace "$out"/bin/tlshell \
+          --replace '[dict get $::pkgs texlive.infra localrev]' '${toString overridden."texlive.infra".revision}' \
+          --replace '[dict get $::pkgs tlshell localrev]' '${toString overridden.tlshell.revision}'
+      '';
       #### dependency changes
 
       # it seems to need it to transform fonts

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -652,8 +652,8 @@ in
           scheme-basic = [ free gfl gpl1Only gpl2 gpl2Plus knuth lgpl21 lppl1 lppl13c mit ofl publicDomain ];
           scheme-context = [ bsd2 bsd3 cc-by-sa-40 free gfl gfsl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21
             lppl1 lppl13c mit ofl publicDomain x11 ];
-          scheme-full = [ artistic1 artistic1-cl8 asl20 bsd2 bsd3 bsdOriginal cc-by-10 cc-by-40 cc-by-sa-10 cc-by-sa-20
-            cc-by-sa-30 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl1Plus gpl2 gpl2Plus gpl3 gpl3Plus isc knuth
+          scheme-full = [ artistic1-cl8 asl20 bsd2 bsd3 bsdOriginal cc-by-10 cc-by-40 cc-by-sa-10 cc-by-sa-20
+            cc-by-sa-30 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth
             lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
           scheme-gust = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl2
             gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -113,6 +113,7 @@ let
       ps2eps.extraBuildInputs = [ ghostscript_headless ];
       pst2pdf.extraBuildInputs = [ ghostscript_headless ];
       tex4ht.extraBuildInputs = [ ruby ];
+      "texlive.infra".extraBuildInputs = [ coreutils gnused (lib.last tl.kpathsea.pkgs) ];
       texlive-scripts.extraBuildInputs = [ gnused ];
       texlive-scripts-extra.extraBuildInputs = [ coreutils findutils ghostscript_headless gnused ];
       thumbpdf.extraBuildInputs = [ ghostscript_headless ];
@@ -131,12 +132,8 @@ let
       # so we add it back to binfiles to generate it from mkPkgBin
       mptopdf.binfiles = (orig.mptopdf.binfiles or []) ++ [ "mptopdf" ];
 
-      # mktexlsr distributed by texlive.infra has implicit dependencies (e.g. kpsestat)
-      # the perl one hidden in texlive-scripts is better behaved
-      "texlive.infra".binfiles = lib.remove "mktexlsr" orig."texlive.infra".binfiles;
-
-      # remove man, add mktexlsr
-      texlive-scripts.binfiles = (lib.remove "man" orig.texlive-scripts.binfiles) ++ [ "mktexlsr" ];
+      # remove man
+      texlive-scripts.binfiles = lib.remove "man" orig.texlive-scripts.binfiles;
 
       # upmendex is "TODO" in bin.nix
       uptex.binfiles = lib.remove "upmendex" orig.uptex.binfiles;
@@ -171,7 +168,7 @@ let
 
       texlive-scripts.binlinks = {
         mktexfmt = "fmtutil";
-        texhash = "mktexlsr";
+        texhash = (lib.last tl."texlive.infra".pkgs) + "/bin/mktexlsr";
       };
 
       texlive-scripts-extra.binlinks = {
@@ -341,9 +338,11 @@ let
       '';
 
       # make tlmgr believe it can use kpsewhich to evaluate TEXMFROOT
+      # add runtime dependencies to PATH
       "texlive.infra".postFixup = ''
         substituteInPlace "$out"/bin/tlmgr \
           --replace 'if (-r "$bindir/$kpsewhichname")' 'if (1)'
+        sed -i '2iPATH="${lib.makeBinPath overridden."texlive.infra".extraBuildInputs}''${PATH:+:$PATH}"' "$out"/bin/mktexlsr
       '';
 
       # Patch texlinks.sh back to 2015 version;

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -405,6 +405,9 @@ let
         extraRevision = ".tlpdb${toString tlpdbVersion.revision}";
         extraVersion = "-tlpdb-${toString tlpdbVersion.revision}";
 
+        # add license of tlmgr and TeXLive::* perl packages and of bin.core
+        license = [ "gpl2Plus" ] ++ lib.toList bin.core.meta.license.shortName ++ orig."texlive.infra".license or [ ];
+
         scriptsFolder = "texlive";
         extraBuildInputs = [ coreutils gnused gnupg (lib.last tl.kpathsea.pkgs) (perl.withPackages (ps: with ps; [ Tk ])) ];
 
@@ -654,7 +657,7 @@ in
             lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
           scheme-gust = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl2
             gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
-          scheme-infraonly = [ gpl2 lgpl21 ];
+          scheme-infraonly = [ gpl2 gpl2Plus lgpl21 ];
           scheme-medium = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-20 cc-by-sa-30 cc-by-sa-40 cc0 fdl13Only
             free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a lppl13c mit ofl
             publicDomain x11 ];

--- a/pkgs/tools/typesetting/tex/texlive/fixed-hashes.nix
+++ b/pkgs/tools/typesetting/tex/texlive/fixed-hashes.nix
@@ -8636,12 +8636,12 @@
 "texlive-scripts-extra.r62517"="193v0r4i3p4psn5b4q0ggpgaazwn6jadjlzh5gjm3igg9k73i1wj";
 "texlive-scripts-extra.doc.r62517"="1izzy295pmxrg0sf2szxxahxm6s8bfi960mbs9z6vy7m5j1szxwl";
 "texlive-scripts.doc.r66570"="0zvji7w8zvykmy97yim0yx0m05pazg0f60bbls0lb3mnx7rx8imj";
-"texlive-scripts.tlpkg.r66570"="0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+"texlive-scripts.tlpkg.r66570"="07b68n9i587v247hpqnhwi052iczwg15z0npc1s5g1yxriy5k1lf";
 "texlive-sr.doc.r54594"="0icavs9jkcr5b5cx5kv202k95j0ydgby9lqrw8wm9h936mbn9bkj";
 "texlive-zh-cn.doc.r54490"="1r8n9k1cy7798g1rg1hyj6g945j9649c5hhqf8hm7a7abzx7w6ll";
-"texlive.infra.r63645"="127ff11k8hamywgvvb4apbg1ra64ig7sghg0qqn8c913mqgxf844";
-"texlive.infra.doc.r63645"="1c9xqbbbn2h7v76kp7bhjwk1g3zzykgdrkrslrzrrhs9x7laicl4";
-"texlive.infra.tlpkg.r63645"="135cgamyq6dnffa7r8xvyr8krx65gqdgy88v3wwprqwz4dfhvzpi";
+"texlive.infra.r63645.tlpdb66590"="127ff11k8hamywgvvb4apbg1ra64ig7sghg0qqn8c913mqgxf844";
+"texlive.infra.doc.r63645.tlpdb66590"="1c9xqbbbn2h7v76kp7bhjwk1g3zzykgdrkrslrzrrhs9x7laicl4";
+"texlive.infra.tlpkg.r63645.tlpdb66590"="0msr7i7vp5wf63fkjmmx0c2h13ky17j5qlrq7rbnym732ryzlx7r";
 "texliveonfly.r55777"="03i9pzqv2dz4z9nlq60kzwiyfvzhhaalhczqa9146jp4wvcib9l3";
 "texliveonfly.doc.r55777"="1fsabzkbcrk42rsp8ssx0kvap31y1rqnkq582129946q3njvmylx";
 "texloganalyser.r54526"="0icav63nll0lj85cqlbg1lx1r6ysjf1lyv5bydxr3flr1c7yqx2r";


### PR DESCRIPTION
## Description of changes
Minimal changes to make tlmgr and tlshell work when called with `--usermode`. Among the `texlive.infra` changes, it also adds the GPL2 and GPL2+ licenses for respective `bin.core` (which is included in all schemes) and `tlmgr` itself (whose license is not flagged in texlive.tlpdb).

This is hacky in that the shipped texlive.tlpdb does not contain the installed packages, so tlmgr/tlshell do not know which packages are already installed in the system tree. Generating the correct texlive.tlpdb seems tricky anyway.

**Note:** this includes a fix for the scheme licenses as reported in https://github.com/NixOS/nixpkgs/pull/247738#pullrequestreview-1565710684 and it is written on top of #247738. @apfelkuchen6 could you please double check why we had `artistic1` and `gpl1Only`? I don't find them in `tlpdb.nix` nor in `bin.nix` so I am a little worried now at how they got in.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).