### PR TITLE
readexe: init at 0.1.3

### DIFF
--- a/pkgs/by-name/re/readexe/package.nix
+++ b/pkgs/by-name/re/readexe/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "segin";
     repo = "readexe";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-CT1EZQ3t7+5onmcUz5yGxDI24dyelUwYZFcL8YWZgPw=";
   };
 

--- a/pkgs/by-name/re/readexe/package.nix
+++ b/pkgs/by-name/re/readexe/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "readexe";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "segin";
+    repo = "readexe";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-CT1EZQ3t7+5onmcUz5yGxDI24dyelUwYZFcL8YWZgPw=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "Reads out structural information on Microsoft .exe formats";
+    homepage = "https://github.com/segin/readexe";
+    license = with licenses; [
+      isc
+      bsd3
+    ];
+    maintainers = with maintainers; [ evils ];
+    mainProgram = "readexe";
+  };
+})


### PR DESCRIPTION
## Description of changes

packaged it to give it a go, seems like it may be of use to someone

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).