### PR TITLE
geeqie: 2.0.1 -> 2.1

### DIFF
--- a/pkgs/applications/graphics/geeqie/default.nix
+++ b/pkgs/applications/graphics/geeqie/default.nix
@@ -8,20 +8,35 @@
 
 stdenv.mkDerivation rec {
   pname = "geeqie";
-  version = "2.0.1";
+  version = "2.1";
 
   src = fetchFromGitHub {
     owner = "BestImageViewer";
     repo = "geeqie";
     rev = "v${version}";
-    sha256 = "sha256-0GOX77vZ4KZkvwnR1vlv52tlbR+ciwl3ycxbOIcDOqU=";
+    hash = "sha256-qkM/7auZ9TMF2r8KLnitxmvlyPmIjh7q9Ugh+QKh8hw=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "exiv2-0.28.0-support-1.patch";
+      url = "https://github.com/BestImageViewer/geeqie/commit/c45cca777aa3477eaf297db99f337e18d9683c61.patch";
+      hash = "sha256-YiFzAj3G3Z2w7p+8zZlDBjWqUqnfSqvaxMkESfPFdzc=";
+    })
+    (fetchpatch {
+      name = "exiv2-0.28.0-support-2.patch";
+      url = "https://github.com/BestImageViewer/geeqie/commit/b04f7cd0546976dc4f7ea440648ac0eedd8df3ce.patch";
+      hash = "sha256-V0ZOHbAZOrhLcNN+Al1/kvxvbw0vc/R7r99CegjuBQg=";
+    })
+    (fetchpatch {
+      name = "fix-compilation-with-lua.patch";
+      url = "https://github.com/BestImageViewer/geeqie/commit/a132645ee87e612217ac955b227cad04f21a5722.patch";
+      hash = "sha256-BozarBPoIKxZS3qpjuzHHAWZGIWZAwvJyqsNC8v+TMk=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs .
-    # libtiff detection is broken and looks for liblibtiff...
-    # fixed upstream, to remove for 2.1
-    substituteInPlace meson.build --replace 'libtiff' 'tiff'
   '';
 
   nativeBuildInputs =


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
