### PR TITLE
python310Packages.jupyterlab_server: run tests

### DIFF
--- a/pkgs/development/python-modules/jupyterlab_server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab_server/default.nix
@@ -11,9 +11,10 @@
 , jupyter-server
 , tomli
 , openapi-core
-, pytest-timeout
-, pytest-tornasync
+, pytest-jupyter
+, requests-mock
 , ruamel-yaml
+, strict-rfc3339
 , importlib-metadata
 }:
 
@@ -47,18 +48,15 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     openapi-core
     pytestCheckHook
-    pytest-timeout
-    pytest-tornasync
+    pytest-jupyter
+    requests-mock
     ruamel-yaml
+    strict-rfc3339
   ];
 
   postPatch = ''
-    # translation tests try to install additional packages into read only paths
-    rm -r tests/translations/
+    sed -i "/timeout/d" pyproject.toml
   '';
-
-  # https://github.com/jupyterlab/jupyterlab_server/blob/v2.15.2/pyproject.toml#L61
-  doCheck = false;
 
   preCheck = ''
     export HOME=$(mktemp -d)
@@ -68,6 +66,17 @@ buildPythonPackage rec {
     # DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12.
     # Use setuptools or check PEP 632 for potential alternatives.
     "-W ignore::DeprecationWarning"
+  ];
+
+  disabledTestPaths = [
+    "tests/test_settings_api.py"
+    "tests/test_themes_api.py"
+    "tests/test_translation_api.py"
+    "tests/test_workspaces_api.py"
+  ];
+
+  disabledTests = [
+    "test_get_listing"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/python-openapi/openapi-core/compare/refs/tags/0.17.1...0.18.0

Changelog: https://github.com/python-openapi/openapi-core/releases/tag/0.17.2
           https://github.com/python-openapi/openapi-core/releases/tag/0.18.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
