### PR TITLE
libtickit: enable check phase

### DIFF
--- a/pkgs/development/libraries/libtickit/default.nix
+++ b/pkgs/development/libraries/libtickit/default.nix
@@ -2,9 +2,10 @@
 , stdenv
 , fetchFromGitHub
 , pkg-config
+, libtool
+, perl
 , libtermkey
 , unibilium
-, libtool
 }:
 stdenv.mkDerivation rec {
   pname = "libtickit";
@@ -22,8 +23,21 @@ stdenv.mkDerivation rec {
     "LIBTOOL=${lib.getExe libtool}"
   ];
 
-  nativeBuildInputs = [ pkg-config libtool ];
-  buildInputs = [ libtermkey unibilium ];
+  nativeBuildInputs = [
+    pkg-config
+    libtool
+  ];
+  buildInputs = [
+    libtermkey
+    unibilium
+  ];
+  nativeCheckInputs = [ perl ];
+
+  patches = [
+    ./skipTestMacOS.patch
+  ];
+
+  doCheck = true;
 
   meta = with lib; {
     description = "A terminal interface construction kit";

--- a/pkgs/development/libraries/libtickit/skipTestMacOS.patch
+++ b/pkgs/development/libraries/libtickit/skipTestMacOS.patch
@@ -1,0 +1,27 @@
+From 6179359c0b9247ae981b8b2a2897eabc921147fd Mon Sep 17 00:00:00 2001
+From: Gustavo Coutinho de Souza <dev@onemoresuza.mailer.me>
+Date: Tue, 8 Aug 2023 15:45:43 -0300
+Subject: [PATCH] test: skip test 18 if on MacOS
+
+---
+ t/18term-builder.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/t/18term-builder.c b/t/18term-builder.c
+index 8b23ab4..c1b64a2 100644
+--- a/t/18term-builder.c
++++ b/t/18term-builder.c
+@@ -21,6 +21,11 @@ static void output(TickitTerm *tt, const char *bytes, size_t len, void *user)
+ 
+ int main(int argc, char *argv[])
+ {
++
++  #if defined(__APPLE__) || defined(__MACH__)
++    skip_all("the test does not seem to work on MacOS");
++    return exit_status();
++  #endif
+   // getstr override
+   {
+     /* We need a termtype that isn't xterm, but that will actually load.
+-- 
+2.41.0


### PR DESCRIPTION
The `test` target was not working, because `prove` was not found. Fix it by adding `pearl` to `checkInputs`.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Enable the `checkPhase` for the [libtickit package](https://github.com/NixOS/nixpkgs/blob/d717d897135a2dc5ecb31df06ce724f09fa7cfed/pkgs/development/libraries/libtickit/default.nix).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
