### PR TITLE
caddy: 2.6.4 -> 2.7.3; nixosTests.caddy: remove etag subtest

### DIFF
--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -22,22 +22,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       '';
       services.caddy.enableReload = true;
 
-      specialisation.etag.configuration = {
-        services.caddy.extraConfig = lib.mkForce ''
-          http://localhost {
-            encode gzip
-
-            file_server
-            root * ${
-              pkgs.runCommand "testdir2" {} ''
-                mkdir "$out"
-                echo changed > "$out/example.html"
-              ''
-            }
-          }
-        '';
-      };
-
       specialisation.config-reload.configuration = {
         services.caddy.extraConfig = ''
           http://localhost:8080 {
@@ -55,7 +39,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
   testScript = { nodes, ... }:
     let
-      etagSystem = "${nodes.webserver.system.build.toplevel}/specialisation/etag";
       justReloadSystem = "${nodes.webserver.system.build.toplevel}/specialisation/config-reload";
       multipleConfigs = "${nodes.webserver.system.build.toplevel}/specialisation/multiple-configs";
     in
@@ -64,33 +47,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       webserver.wait_for_unit("caddy")
       webserver.wait_for_open_port(80)
 
-
-      def check_etag(url):
-          etag = webserver.succeed(
-              "curl --fail -v '{}' 2>&1 | sed -n -e \"s/^< [Ee][Tt][Aa][Gg]: *//p\"".format(
-                  url
-              )
-          )
-          etag = etag.replace("\r\n", " ")
-          http_code = webserver.succeed(
-              "curl --fail --silent --show-error -o /dev/null -w \"%{{http_code}}\" --head -H 'If-None-Match: {}' {}".format(
-                  etag, url
-              )
-          )
-          assert int(http_code) == 304, "HTTP code is {}, expected 304".format(http_code)
-          return etag
-
-
-      with subtest("check ETag if serving Nix store paths"):
-          old_etag = check_etag(url)
-          webserver.succeed(
-              "${etagSystem}/bin/switch-to-configuration test >&2"
-          )
-          webserver.sleep(1)
-          new_etag = check_etag(url)
-          assert old_etag != new_etag, "Old ETag {} is the same as {}".format(
-              old_etag, new_etag
-          )
 
       with subtest("config is reloaded on nixos-rebuild switch"):
           webserver.succeed(

--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -7,12 +7,12 @@
 , installShellFiles
 }:
 let
-  version = "2.6.4";
+  version = "2.7.3";
   dist = fetchFromGitHub {
     owner = "caddyserver";
     repo = "dist";
     rev = "v${version}";
-    hash = "sha256-SJO1q4g9uyyky9ZYSiqXJgNIvyxT5RjrpYd20YDx8ec=";
+    hash = "sha256-fQhujBYyl2p3cdqyf+LVebPBGxXn2lKMB/dsvTo5+NM=";
   };
 in
 buildGoModule {
@@ -23,10 +23,10 @@ buildGoModule {
     owner = "caddyserver";
     repo = "caddy";
     rev = "v${version}";
-    hash = "sha256-3a3+nFHmGONvL/TyQRqgJtrSDIn0zdGy9YwhZP17mU0=";
+    hash = "sha256-KezKMpx3M7rdKXEWf5XUSXqY5SEimACkv3OB/4XccCE=";
   };
 
-  vendorHash = "sha256-toi6efYZobjDV3YPT9seE/WZAzNaxgb1ioVG4txcuXM=";
+  vendorHash = "sha256-mTHEM+0yakKiy4ZFi+2qakjSlKFyRkbjeXOXdvx+9lA=";
 
   subPackages = [ "cmd/caddy" ];
 


### PR DESCRIPTION
## Description of changes

Supersedes #246859 due to inactivity.

2.7.0-2.7.2 have been skipped due to bugs in the release.

https://github.com/caddyserver/caddy/releases/tag/v2.7.3
https://github.com/caddyserver/caddy/releases/tag/v2.7.2
https://github.com/caddyserver/caddy/releases/tag/v2.7.1
https://github.com/caddyserver/caddy/releases/tag/v2.7.0

diff: https://github.com/caddyserver/caddy/compare/v2.6.4...v2.7.3

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
