### PR TITLE
nixos/adguardhome: update config to match new schema, update package and fix update script

### DIFF
--- a/nixos/modules/services/networking/adguardhome.nix
+++ b/nixos/modules/services/networking/adguardhome.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   cfg = config.services.adguardhome;
+  settingsFormat = pkgs.formats.yaml { };
 
   args = concatStringsSep " " ([
     "--no-check-update"
@@ -12,26 +13,32 @@ let
     "--config /var/lib/AdGuardHome/AdGuardHome.yaml"
   ] ++ cfg.extraArgs);
 
-  configFile = pkgs.writeTextFile {
-    name = "AdGuardHome.yaml";
-    text = builtins.toJSON cfg.settings;
-    checkPhase = "${pkgs.adguardhome}/bin/adguardhome -c $out --check-config";
-  };
-  defaultBindPort = 3000;
+  settings = if (cfg.settings != null) then
+    cfg.settings // (if cfg.settings.schema_version < 23 then {
+      bind_host = cfg.host;
+      bind_port = cfg.port;
+    } else {
+      http.address = "${cfg.host}:${toString cfg.port}";
+    })
+  else
+    null;
 
-in
-{
-
-  imports =
-    let cfgPath = [ "services" "adguardhome" ];
-    in
-    [
-      (mkRenamedOptionModuleWith { sinceRelease = 2211; from = cfgPath ++ [ "host" ]; to = cfgPath ++ [ "settings" "bind_host" ]; })
-      (mkRenamedOptionModuleWith { sinceRelease = 2211; from = cfgPath ++ [ "port" ]; to = cfgPath ++ [ "settings" "bind_port" ]; })
-    ];
-
+  configFile =
+    (settingsFormat.generate "AdGuardHome.yaml" settings).overrideAttrs (_: {
+      checkPhase = "${cfg.package}/bin/adguardhome -c $out --check-config";
+    });
+in {
   options.services.adguardhome = with types; {
     enable = mkEnableOption "AdGuard Home network-wide ad blocker";
+
+    package = mkOption {
+      type = package;
+      default = pkgs.adguardhome;
+      defaultText = literalExpression "pkgs.adguardhome";
+      description = ''
+        The package that runs adguardhome.
+      '';
+    };
 
     openFirewall = mkOption {
       default = false;
@@ -43,8 +50,8 @@ in
     };
 
     allowDHCP = mkOption {
-      default = cfg.settings.dhcp.enabled or false;
-      defaultText = literalExpression ''config.services.adguardhome.settings.dhcp.enabled or false'';
+      default = settings.dhcp.enabled or false;
+      defaultText = literalExpression "config.services.adguardhome.settings.dhcp.enabled or false";
       type = bool;
       description = ''
         Allows AdGuard Home to open raw sockets (`CAP_NET_RAW`), which is
@@ -65,32 +72,34 @@ in
       '';
     };
 
+    host = mkOption {
+      default = "0.0.0.0";
+      type = str;
+      description = ''
+        Host address to bind HTTP server to.
+      '';
+    };
+
+    port = mkOption {
+      default = 3000;
+      type = port;
+      description = ''
+        Port to serve HTTP pages on.
+      '';
+    };
+
     settings = mkOption {
       default = null;
       type = nullOr (submodule {
-        freeformType = (pkgs.formats.yaml { }).type;
+        freeformType = settingsFormat.type;
         options = {
           schema_version = mkOption {
-            default = pkgs.adguardhome.schema_version;
-            defaultText = literalExpression "pkgs.adguardhome.schema_version";
+            default = cfg.package.schema_version;
+            defaultText = literalExpression "cfg.package.schema_version";
             type = int;
             description = ''
               Schema version for the configuration.
-              Defaults to the `schema_version` supplied by `pkgs.adguardhome`.
-            '';
-          };
-          bind_host = mkOption {
-            default = "0.0.0.0";
-            type = str;
-            description = ''
-              Host address to bind HTTP server to.
-            '';
-          };
-          bind_port = mkOption {
-            default = defaultBindPort;
-            type = port;
-            description = ''
-              Port to serve HTTP pages on.
+              Defaults to the `schema_version` supplied by `cfg.package`.
             '';
           };
         };
@@ -107,7 +116,7 @@ in
 
         Set this to `null` (default) for a non-declarative configuration without any
         Nix-supplied values.
-        Declarative configurations are supplied with a default `schema_version`, `bind_host`, and `bind_port`.
+        Declarative configurations are supplied with a default `schema_version`, and `http.address`.
         :::
       '';
     };
@@ -124,17 +133,25 @@ in
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.settings != null -> cfg.mutableSettings
-          || (hasAttrByPath [ "dns" "bind_host" ] cfg.settings)
-          || (hasAttrByPath [ "dns" "bind_hosts" ] cfg.settings);
-        message =
-          "AdGuard setting dns.bind_host or dns.bind_hosts needs to be configured for a minimal working configuration";
+        assertion = cfg.settings != null
+          -> !(hasAttrByPath [ "bind_host" ] cfg.settings);
+        message = "AdGuard option `settings.bind_host' has been superseded by `services.adguardhome.host'";
       }
       {
-        assertion = cfg.settings != null -> cfg.mutableSettings
-          || hasAttrByPath [ "dns" "bootstrap_dns" ] cfg.settings;
-        message =
-          "AdGuard setting dns.bootstrap_dns needs to be configured for a minimal working configuration";
+        assertion = cfg.settings != null
+          -> !(hasAttrByPath [ "bind_port" ] cfg.settings);
+        message = "AdGuard option `settings.bind_host' has been superseded by `services.adguardhome.port'";
+      }
+      {
+        assertion = settings != null -> cfg.mutableSettings
+          || hasAttrByPath [ "dns" "bootstrap_dns" ] settings;
+        message = "AdGuard setting dns.bootstrap_dns needs to be configured for a minimal working configuration";
+      }
+      {
+        assertion = settings != null -> cfg.mutableSettings
+          || hasAttrByPath [ "dns" "bootstrap_dns" ] settings
+          && isList settings.dns.bootstrap_dns;
+        message = "AdGuard setting dns.bootstrap_dns needs to be a list";
       }
     ];
 
@@ -147,7 +164,7 @@ in
         StartLimitBurst = 10;
       };
 
-      preStart = optionalString (cfg.settings != null) ''
+      preStart = optionalString (settings != null) ''
         if    [ -e "$STATE_DIRECTORY/AdGuardHome.yaml" ] \
            && [ "${toString cfg.mutableSettings}" = "1" ]; then
           # Writing directly to AdGuardHome.yaml results in empty file
@@ -161,8 +178,9 @@ in
 
       serviceConfig = {
         DynamicUser = true;
-        ExecStart = "${pkgs.adguardhome}/bin/adguardhome ${args}";
-        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ] ++ optionals cfg.allowDHCP [ "CAP_NET_RAW" ];
+        ExecStart = "${cfg.package}/bin/adguardhome ${args}";
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ]
+          ++ optionals cfg.allowDHCP [ "CAP_NET_RAW" ];
         Restart = "always";
         RestartSec = 10;
         RuntimeDirectory = "AdGuardHome";
@@ -170,6 +188,6 @@ in
       };
     };
 
-    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.settings.bind_port or defaultBindPort ];
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
   };
 }

--- a/nixos/tests/adguardhome.nix
+++ b/nixos/tests/adguardhome.nix
@@ -2,41 +2,39 @@
   name = "adguardhome";
 
   nodes = {
-    nullConf = { ... }: { services.adguardhome = { enable = true; }; };
+    nullConf = { services.adguardhome.enable = true; };
 
-    emptyConf = { lib, ... }: {
+    emptyConf = {
       services.adguardhome = {
         enable = true;
+
+        settings = { };
       };
     };
 
-    declarativeConf = { ... }: {
+    schemaVersionBefore23 = {
+      services.adguardhome = {
+        enable = true;
+
+        settings.schema_version = 20;
+      };
+    };
+
+    declarativeConf = {
       services.adguardhome = {
         enable = true;
 
         mutableSettings = false;
-        settings = {
-          schema_version = 0;
-          dns = {
-            bind_host = "0.0.0.0";
-            bootstrap_dns = "127.0.0.1";
-          };
-        };
+        settings.dns.bootstrap_dns = [ "127.0.0.1" ];
       };
     };
 
-    mixedConf = { ... }: {
+    mixedConf = {
       services.adguardhome = {
         enable = true;
 
         mutableSettings = true;
-        settings = {
-          schema_version = 0;
-          dns = {
-            bind_host = "0.0.0.0";
-            bootstrap_dns = "127.0.0.1";
-          };
-        };
+        settings.dns.bootstrap_dns = [ "127.0.0.1" ];
       };
     };
 
@@ -70,11 +68,7 @@
         allowDHCP = true;
         mutableSettings = false;
         settings = {
-          schema_version = 0;
-          dns = {
-            bind_host = "0.0.0.0";
-            bootstrap_dns = "127.0.0.1";
-          };
+          dns.bootstrap_dns = [ "127.0.0.1" ];
           dhcp = {
             # This implicitly enables CAP_NET_RAW
             enabled = true;
@@ -104,33 +98,38 @@
 
   testScript = ''
     with subtest("Minimal (settings = null) config test"):
-        nullConf.wait_for_unit("adguardhome.service")
+      nullConf.wait_for_unit("adguardhome.service")
+      nullConf.wait_for_open_port(3000)
 
     with subtest("Default config test"):
-        emptyConf.wait_for_unit("adguardhome.service")
-        emptyConf.wait_for_open_port(3000)
+      emptyConf.wait_for_unit("adguardhome.service")
+      emptyConf.wait_for_open_port(3000)
+
+    with subtest("Default schema_version 23 config test"):
+      schemaVersionBefore23.wait_for_unit("adguardhome.service")
+      schemaVersionBefore23.wait_for_open_port(3000)
 
     with subtest("Declarative config test, DNS will be reachable"):
-        declarativeConf.wait_for_unit("adguardhome.service")
-        declarativeConf.wait_for_open_port(53)
-        declarativeConf.wait_for_open_port(3000)
+      declarativeConf.wait_for_unit("adguardhome.service")
+      declarativeConf.wait_for_open_port(53)
+      declarativeConf.wait_for_open_port(3000)
 
     with subtest("Mixed config test, check whether merging works"):
-        mixedConf.wait_for_unit("adguardhome.service")
-        mixedConf.wait_for_open_port(53)
-        mixedConf.wait_for_open_port(3000)
-        # Test whether merging works properly, even if nothing is changed
-        mixedConf.systemctl("restart adguardhome.service")
-        mixedConf.wait_for_unit("adguardhome.service")
-        mixedConf.wait_for_open_port(3000)
+      mixedConf.wait_for_unit("adguardhome.service")
+      mixedConf.wait_for_open_port(53)
+      mixedConf.wait_for_open_port(3000)
+      # Test whether merging works properly, even if nothing is changed
+      mixedConf.systemctl("restart adguardhome.service")
+      mixedConf.wait_for_unit("adguardhome.service")
+      mixedConf.wait_for_open_port(3000)
 
     with subtest("Testing successful DHCP start"):
-        dhcpConf.wait_for_unit("adguardhome.service")
-        client.systemctl("start network-online.target")
-        client.wait_for_unit("network-online.target")
-        # Test IP assignment via DHCP
-        dhcpConf.wait_until_succeeds("ping -c 5 10.0.10.100")
-        # Test hostname resolution over DHCP-provided DNS
-        dhcpConf.wait_until_succeeds("ping -c 5 client.lan")
+      dhcpConf.wait_for_unit("adguardhome.service")
+      client.systemctl("start network-online.target")
+      client.wait_for_unit("network-online.target")
+      # Test IP assignment via DHCP
+      dhcpConf.wait_until_succeeds("ping -c 5 10.0.10.100")
+      # Test hostname resolution over DHCP-provided DNS
+      dhcpConf.wait_until_succeeds("ping -c 5 client.lan")
   '';
 }

--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,31 +1,31 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-jIrzE1Je2dhMJuq3k8KL1VoHru5qaUAJCR3kumE9aO0=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-97o4rMNwikQZR3DPhhE+OPlY3gA9HqCQxBf+mZSfDMs=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-9BgGGCP8n+5Op+S1/yT/kdMvmiNgKkkXLQmqF2plJZY=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-ZTGqn6xM9vRHmw2ask5P4vu+5BqkWfGS3ROzTN9VfXM=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-yPxLYXtH4bwQk2M2VTS5aJWTJciNaeXRRAcMBHuvkcA=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-EbRiiThZsmBD/grtm58Su78OeF/6buwMbx6eBsusgII=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-sG64t1x70uKk844dT1g9GzJ+DgHuv7sUEBaVqoEmWOw=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-FUnQJ3RRtsWz4DIO8Zi9Y6dO130qTdwj6RhJ6RNpljc=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-rUSfo1uJGbxx1n/VcLyq5zqiDo4g0caCpVcL2uZUSkE=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-OZDryRiwyM6XgoiOhCsM6AFOE9masnGu2m6sDRUAaeY=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_arm64.tar.gz";
 };
 armv6l-linux = fetchurl {
-  sha256 = "sha256-ruICFAGEMXDeLvoOxHg2oEaYDHkoGZI+SozDXmmD9VU=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_armv6.tar.gz";
+  sha256 = "sha256-aL/wKQ9lbPgaTGCjZAph5iggSTJB1+Rrxbpf6IVgjuU=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_armv6.tar.gz";
 };
 armv7l-linux = fetchurl {
-  sha256 = "sha256-mTGufMIKkj2R7QuNWKSKMt9KdwlZe9ORtJK5hIaeH/E=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_armv7.tar.gz";
+  sha256 = "sha256-siWf7frIciYGVP7KgqS4Dr7o52y3QqGYvQlxtw2HnEo=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_armv7.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.36";
+  version = "0.107.48";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = ./update.sh;
-    schema_version = 24;
+    schema_version = 28;
     tests.adguardhome = nixosTests.adguardhome;
   };
 

--- a/pkgs/servers/adguardhome/update.sh
+++ b/pkgs/servers/adguardhome/update.sh
@@ -13,8 +13,8 @@ version=$(jq -r '.tag_name' <<<"$latest_release")
 
 echo "got version $version"
 
-schema_version=$(curl --silent "https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/${version}/internal/home/upgrade.go" \
-    | grep -Po '(?<=const currentSchemaVersion = )[[:digit:]]+$')
+schema_version=$(curl --silent "https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/${version}/internal/configmigrate/configmigrate.go" \
+    | grep -Po '(?<=const LastSchemaVersion uint = )[[:digit:]]+$')
 
 echo "got schema_version $schema_version"
 


### PR DESCRIPTION
## Description of changes

Update config to match new schema. Add package option. Also, run tests against the latest schema and not 0, since we don't care if AdGuard can migrate it.

This PR does not fix the schema migration issue mentioned in #246461.

Also updated `adguardhome` and fixed update script. 

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
