### PR TITLE
Update Gambit, Gerbil, Glow

### DIFF
--- a/pkgs/development/compilers/gambit/build.nix
+++ b/pkgs/development/compilers/gambit/build.nix
@@ -1,6 +1,11 @@
-{ gccStdenv, lib, git, openssl, autoconf, pkgs, makeStaticLibraries, gcc, coreutils, gnused, gnugrep,
-  src, version, git-version, stampYmd ? 0, stampHms ? 0,
-  gambit-support, optimizationSetting ? "-O1", gambit-params ? pkgs.gambit-support.stable-params }:
+{ gccStdenv, lib, pkgs,
+  git, openssl, autoconf, gcc, coreutils, gnused, gnugrep,
+  makeStaticLibraries,
+  src, version, git-version,
+  stampYmd ? 0, stampHms ? 0,
+  gambit-support,
+  optimizationSetting ? "-O1",
+  gambit-params ? pkgs.gambit-support.stable-params }:
 
 # Note that according to a benchmark run by Marc Feeley on May 2018,
 # clang is 10x (with default settings) to 15% (with -O2) slower than GCC at compiling
@@ -45,6 +50,7 @@ gccStdenv.mkDerivation rec {
     "--enable-shared"
     "--enable-absolute-shared-libs" # Yes, NixOS will want an absolute path, and fix it.
     "--enable-openssl"
+    "--enable-dynamic-clib"
     #"--enable-default-compile-options='(compactness 9)'" # Make life easier on the JS backend
     "--enable-default-runtime-options=${gambit-params.defaultRuntimeOptions}"
     # "--enable-rtlib-debug" # used by Geiser, but only on recent-enough gambit, and messes js runtime
@@ -62,6 +68,7 @@ gccStdenv.mkDerivation rec {
     # "--enable-coverage"
     # "--enable-inline-jumps"
     # "--enable-char-size=1" # default is 4
+    # "--enable-march=native" # Nope, makes it not work on machines older than the builder
   ] ++ gambit-params.extraOptions
     # Do not enable poll on darwin due to https://github.com/gambit/gambit/issues/498
     ++ lib.optional (!gccStdenv.isDarwin) "--enable-poll";

--- a/pkgs/development/compilers/gambit/gambit-support.nix
+++ b/pkgs/development/compilers/gambit/gambit-support.nix
@@ -16,12 +16,13 @@ rec {
         --replace "echo > stamp.h;" "(echo '#define ___STAMP_VERSION \"${git-version}\"'; echo '#define ___STAMP_YMD ${toString stampYmd}'; echo '#define ___STAMP_HMS ${toString stampHms}';) > stamp.h;";
     '';
     modules = true;
-    extraOptions = [];
+    #extraOptions = [];
+    extraOptions = ["--enable-trust-c-tco" "CFLAGS=-foptimize-sibling-calls"];
   };
 
   unstable-params = stable-params // {
     stable = false;
-    extraOptions = ["--enable-trust-c-tco"];
+    extraOptions = ["--enable-trust-c-tco"]; # "CFLAGS=-foptimize-sibling-calls" not necessary in latest unstable
   };
 
   export-gambopt = params : "export GAMBOPT=${params.buildRuntimeOptions} ;";

--- a/pkgs/development/compilers/gambit/unstable.nix
+++ b/pkgs/development/compilers/gambit/unstable.nix
@@ -1,15 +1,15 @@
 { callPackage, fetchFromGitHub, gambit-support }:
 
 callPackage ./build.nix {
-  version = "unstable-2023-07-30";
-  git-version = "4.9.5-3-ge059fffd";
-  stampYmd = 20230730;
-  stampHms = 151945;
+  version = "unstable-2023-08-06";
+  git-version = "4.9.5-5-gf1fbe9aa";
+  stampYmd = 20230806;
+  stampHms = 195822;
   src = fetchFromGitHub {
     owner = "gambit";
     repo = "gambit";
-    rev = "e059fffdfbd91e27c350ff2ebd671adefadd5212";
-    sha256 = "0q7hdfchl6lw53xawmmjvhyjdmqxjdsnzjqv9vpkl2qa4vyir5fs";
+    rev = "f1fbe9aa0f461e89f2a91bc050c1373ee6d66482";
+    sha256 = "0b0gd6cwj8zxwcqglpsnmanysiq4mvma2mrgdfr6qy99avhbhzxm";
   };
   gambit-params = gambit-support.unstable-params;
 }

--- a/pkgs/development/compilers/gerbil/build.nix
+++ b/pkgs/development/compilers/gerbil/build.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     grep -Fl '#!/usr/bin/env' `find . -type f -executable` | while read f ; do
       substituteInPlace "$f" --replace '#!/usr/bin/env' '#!${coreutils}/bin/env' ;
     done ;
-'';
+  '';
 
 ## TODO: make static compilation work.
 ## For that, get all the packages below to somehow expose static libraries,
@@ -92,8 +92,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Gerbil Scheme";
     homepage    = "https://github.com/vyzo/gerbil";
-    license     = lib.licenses.lgpl21; # also asl20, like Gambit
-    # NB regarding platforms: regularly tested on Linux, only occasionally on macOS.
+    license     = lib.licenses.lgpl21Only; # dual, also asl20, like Gambit
+    # NB regarding platforms: regularly tested on Linux and on macOS.
     # Please report success and/or failure to fare.
     platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ fare ];

--- a/pkgs/development/compilers/gerbil/default.nix
+++ b/pkgs/development/compilers/gerbil/default.nix
@@ -1,12 +1,12 @@
 { callPackage, fetchFromGitHub }:
 
 callPackage ./build.nix rec {
-  version = "0.16";
+  version = "0.17";
   git-version = version;
   src = fetchFromGitHub {
     owner = "vyzo";
     repo = "gerbil";
     rev = "v${version}";
-    sha256 = "0vng0kxpnwsg8jbjdpyn4sdww36jz7zfpfbzayg9sdpz6bjxjy0f";
+    sha256 = "0xzi9mhrmzcajhlz5qcnz4yjlljvbkbm9426iifgjn47ac0965zw";
   };
 }

--- a/pkgs/development/compilers/gerbil/ftw.nix
+++ b/pkgs/development/compilers/gerbil/ftw.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, gerbilPackages, ... }:
+
+{
+  pname = "ftw";
+  version = "unstable-2022-01-14";
+  git-version = "8ba16b3";
+  softwareName = "FTW: For The Web!";
+  gerbil-package = "drewc/ftw";
+
+  gerbilInputs = with gerbilPackages; [ gerbil-utils ];
+
+  pre-src = {
+    fun = fetchFromGitHub;
+    owner = "drewc";
+    repo = "ftw";
+    rev = "8ba16b3c1cdc2150df5af8ef3c92040ef8b563b9";
+    sha256 = "153i6whm5jfcj9s1qpxz03sq67969lq11brssyjc3yv3wyb1b07h";
+  };
+
+  meta = with lib; {
+    description = "Simple web handlers for Gerbil Scheme";
+    homepage    = "https://github.com/drewc/ftw";
+    license     = licenses.mit;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
+  };
+}

--- a/pkgs/development/compilers/gerbil/gerbil-crypto.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-crypto.nix
@@ -1,6 +1,5 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
-
-gerbil-support.gerbilPackage {
+{
   pname = "gerbil-crypto";
   version = "unstable-2020-08-01";
   git-version = "0.0-6-ga228862";
@@ -12,7 +11,8 @@ gerbil-support.gerbilPackage {
   gambit-params = gambit-support.unstable-params;
   version-path = "version";
   softwareName = "Gerbil-crypto";
-  src = fetchFromGitHub {
+  pre-src = {
+    fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-crypto";
     rev = "a22886260849ec92c3a34bfeedc1574e41e49e33";

--- a/pkgs/development/compilers/gerbil/gerbil-crypto.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-crypto.nix
@@ -1,28 +1,29 @@
-{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+{ pkgs, lib, fetchFromGitHub, gerbilPackages, ... }:
+
 {
   pname = "gerbil-crypto";
-  version = "unstable-2020-08-01";
-  git-version = "0.0-6-ga228862";
+  version = "unstable-2023-03-27";
+  git-version = "0.0-18-ge57f887";
   gerbil-package = "clan/crypto";
-  gerbil = gerbil-unstable;
-  gerbilInputs = [gerbil-support.gerbilPackages-unstable.gerbil-utils];
+  gerbilInputs = with gerbilPackages; [ gerbil-utils gerbil-poo ];
   nativeBuildInputs = [ pkgs.pkg-config ];
-  buildInputs = [pkgs.secp256k1 ];
-  gambit-params = gambit-support.unstable-params;
+  buildInputs = [ pkgs.secp256k1 ];
   version-path = "version";
   softwareName = "Gerbil-crypto";
+
   pre-src = {
     fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-crypto";
-    rev = "a22886260849ec92c3a34bfeedc1574e41e49e33";
-    sha256 = "0qbanw2vnw2ymmr4pr1jap29cyc3icbhyq0apibpfnj2znns7w47";
+    rev = "e57f88742d9b41640b4a7d9bd3e86c688d4a83f9";
+    sha256 = "08hrk3s82hbigvza75vgx9kc7qf64yhhn3xm5calc859sy6ai4ka";
   };
-  meta = {
+
+  meta = with lib; {
     description = "Gerbil Crypto: Extra Cryptographic Primitives for Gerbil";
     homepage    = "https://github.com/fare/gerbil-crypto";
-    license     = lib.licenses.asl20;
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ fare ];
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
   };
 }

--- a/pkgs/development/compilers/gerbil/gerbil-ethereum.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-ethereum.nix
@@ -1,6 +1,5 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
-
-gerbil-support.gerbilPackage {
+{
   pname = "gerbil-ethereum";
   version = "unstable-2020-10-18";
   git-version = "0.0-26-gf27ada8";
@@ -12,7 +11,8 @@ gerbil-support.gerbilPackage {
   gambit-params = gambit-support.unstable-params;
   version-path = "version";
   softwareName = "Gerbil-ethereum";
-  src = fetchFromGitHub {
+  pre-src = {
+    fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-ethereum";
     rev = "f27ada8e7f4de4f8fbdfede9fe055914b254d8e7";

--- a/pkgs/development/compilers/gerbil/gerbil-ethereum.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-ethereum.nix
@@ -1,28 +1,49 @@
-{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
-{
+{ lib, fetchFromGitHub, gerbilPackages, gerbil-support, gerbil, ... }:
+
+rec {
   pname = "gerbil-ethereum";
-  version = "unstable-2020-10-18";
-  git-version = "0.0-26-gf27ada8";
-  gerbil-package = "mukn/ethereum";
-  gerbil = gerbil-unstable;
-  gerbilInputs = with gerbil-support.gerbilPackages-unstable;
-    [gerbil-utils gerbil-crypto gerbil-poo gerbil-persist];
-  buildInputs = [];
-  gambit-params = gambit-support.unstable-params;
-  version-path = "version";
+  version = "unstable-2023-05-30";
+  git-version = "0.0-375-g989a5ca";
   softwareName = "Gerbil-ethereum";
+  gerbil-package = "mukn/ethereum";
+  version-path = "version";
+
+  gerbilInputs = with gerbilPackages; [ gerbil-utils gerbil-crypto gerbil-poo gerbil-persist ];
+
   pre-src = {
     fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-ethereum";
-    rev = "f27ada8e7f4de4f8fbdfede9fe055914b254d8e7";
-    sha256 = "1lykjqim6a44whj1r8kkpiz68wghkfqx5vjlrc2ldxlmgd4r9gvd";
+    rev = "989a5ca78958e42c4a1ec242786ade89f1887e48";
+    sha256 = "0bs2knhx3hy3k72yidgaplwjd48y86arqscdik8hgxwmhm9z8kwp";
   };
-  meta = {
+
+  postInstall = ''
+    cp scripts/{croesus.prv,genesis.json,logback.xml,yolo-evm.conf,yolo-kevm.conf,run-ethereum-test-net.ss} $out/gerbil/lib/mukn/ethereum/scripts/
+    mkdir -p $out/bin
+    cat > $out/bin/run-ethereum-test-net <<EOF
+    #!/bin/sh
+    #|
+    ORIG_GERBIL_LOADPATH="\$GERBIL_LOADPATH"
+    ORIG_GERBIL_PATH="\$GERBIL_PATH"
+    ORIG_GERBIL_HOME="\$GERBIL_HOME"
+    unset GERBIL_HOME
+    GERBIL_LOADPATH="${gerbil-support.gerbilLoadPath (["$out"] ++ gerbilInputs)}"
+    GERBIL_PATH="\$HOME/.cache/gerbil-ethereum/gerbil"
+    export GERBIL_PATH GERBIL_LOADPATH GLOW_SOURCE ORIG_GERBIL_PATH ORIG_GERBIL_LOADPATH
+    exec ${gerbil}/bin/gxi "\$0" "\$@"
+    |#
+    (import :mukn/ethereum/scripts/run-ethereum-test-net :clan/multicall)
+    (apply call-entry-point (cdr (command-line)))
+    EOF
+    chmod a+x $out/bin/run-ethereum-test-net
+    '';
+
+  meta = with lib; {
     description = "Gerbil Ethereum: a Scheme alternative to web3.js";
     homepage    = "https://github.com/fare/gerbil-ethereum";
-    license     = lib.licenses.asl20;
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ fare ];
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
   };
 }

--- a/pkgs/development/compilers/gerbil/gerbil-libp2p.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-libp2p.nix
@@ -1,6 +1,5 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
-
-gerbil-support.gerbilPackage {
+{
   pname = "gerbil-libp2p";
   version = "unstable-2018-12-27";
   git-version = "2376b3f";
@@ -11,7 +10,8 @@ gerbil-support.gerbilPackage {
   gambit-params = gambit-support.unstable-params;
   version-path = "version";
   softwareName = "Gerbil-libp2p";
-  src = fetchFromGitHub {
+  pre-src = {
+    fun = fetchFromGitHub;
     owner = "vyzo";
     repo = "gerbil-libp2p";
     rev = "2376b3f39cee04dd4ec455c8ea4e5faa93c2bf88";

--- a/pkgs/development/compilers/gerbil/gerbil-libp2p.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-libp2p.nix
@@ -1,27 +1,27 @@
-{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+{ lib, fetchFromGitHub, ... }:
+
 {
   pname = "gerbil-libp2p";
-  version = "unstable-2018-12-27";
-  git-version = "2376b3f";
-  gerbil-package = "vyzo";
-  gerbil = gerbil-unstable;
-  gerbilInputs = [];
-  buildInputs = []; # Note: at *runtime*, depends on go-libp2p-daemon
-  gambit-params = gambit-support.unstable-params;
-  version-path = "version";
+  version = "unstable-2022-02-03";
+  git-version = "15b3246";
   softwareName = "Gerbil-libp2p";
+  gerbil-package = "vyzo";
+
+  buildInputs = []; # Note: at *runtime*, this depends on go-libp2p-daemon running
+
   pre-src = {
     fun = fetchFromGitHub;
     owner = "vyzo";
     repo = "gerbil-libp2p";
-    rev = "2376b3f39cee04dd4ec455c8ea4e5faa93c2bf88";
-    sha256 = "0jcy7hfg953078msigyfwp2g4ii44pi6q7vcpmq01cbbvxpxz6zw";
+    rev = "15b32462e683d89ffce0ff15ad373d293ea0ee5d";
+    sha256 = "059lydp7d6pjgrd4pdnqq2zffzlba62ch102f01rgzf9aps3c8lz";
   };
-  meta = {
+
+  meta = with lib; {
     description = "Gerbil libp2p: use libp2p from Gerbil";
     homepage    = "https://github.com/vyzo/gerbil-libp2p";
-    license     = lib.licenses.mit;
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ fare ];
+    license     = licenses.mit;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
   };
 }

--- a/pkgs/development/compilers/gerbil/gerbil-persist.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-persist.nix
@@ -1,6 +1,5 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
-
-gerbil-support.gerbilPackage {
+{
   pname = "gerbil-persist";
   version = "unstable-2020-08-31";
   git-version = "0.0-8-gd211390";
@@ -11,7 +10,8 @@ gerbil-support.gerbilPackage {
   gambit-params = gambit-support.unstable-params;
   version-path = "version";
   softwareName = "Gerbil-persist";
-  src = fetchFromGitHub {
+  pre-src = {
+    fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-persist";
     rev = "d211390c8a199cf2b8c7400cd98977524e960015";

--- a/pkgs/development/compilers/gerbil/gerbil-persist.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-persist.nix
@@ -1,27 +1,27 @@
-{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+{ lib, fetchFromGitHub, gerbilPackages, ... }:
 {
   pname = "gerbil-persist";
-  version = "unstable-2020-08-31";
-  git-version = "0.0-8-gd211390";
-  gerbil-package = "clan/persist";
-  gerbil = gerbil-unstable;
-  gerbilInputs = with gerbil-support.gerbilPackages-unstable; [gerbil-utils gerbil-crypto gerbil-poo];
-  buildInputs = [];
-  gambit-params = gambit-support.unstable-params;
-  version-path = "version";
+  version = "unstable-2023-03-02";
+  git-version = "0.1.0-24-ge2305f5";
   softwareName = "Gerbil-persist";
+  gerbil-package = "clan/persist";
+  version-path = "version";
+
+  gerbilInputs = with gerbilPackages; [ gerbil-utils gerbil-crypto gerbil-poo ];
+
   pre-src = {
     fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-persist";
-    rev = "d211390c8a199cf2b8c7400cd98977524e960015";
-    sha256 = "13s6ws8ziwalfp23nalss41qnz667z2712lr3y123sypm5n5axk7";
+    rev = "e2305f53571e55292179286ca2d88e046ec6638b";
+    sha256 = "1vsi4rfzpqg4hhn53d2r26iw715vzwz0hiai9r34z4diwzqixfgn";
   };
-  meta = {
+
+  meta = with lib; {
     description = "Gerbil Persist: Persistent data and activities";
     homepage    = "https://github.com/fare/gerbil-persist";
-    license     = lib.licenses.asl20;
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ fare ];
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
   };
 }

--- a/pkgs/development/compilers/gerbil/gerbil-poo.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-poo.nix
@@ -1,17 +1,17 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
-
-gerbil-support.gerbilPackage {
-  pname = "gerbil-ethereum";
+{
+  pname = "gerbil-poo";
+  gerbil-package = "clan/poo";
   version = "unstable-2020-10-17";
   git-version = "0.0-35-g44d490d";
-  gerbil-package = "clan/poo";
   gerbil = gerbil-unstable;
   gerbilInputs = with gerbil-support.gerbilPackages-unstable; [gerbil-utils gerbil-crypto];
   buildInputs = [];
   gambit-params = gambit-support.unstable-params;
   version-path = "version";
   softwareName = "Gerbil-POO";
-  src = fetchFromGitHub {
+  pre-src = {
+    fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-poo";
     rev = "44d490d95b9d1b5d54eaedf2602419af8e086837";

--- a/pkgs/development/compilers/gerbil/gerbil-poo.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-poo.nix
@@ -1,27 +1,28 @@
-{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+{ lib, fetchFromGitHub, gerbilPackages, ... }:
+
 {
   pname = "gerbil-poo";
-  gerbil-package = "clan/poo";
-  version = "unstable-2020-10-17";
-  git-version = "0.0-35-g44d490d";
-  gerbil = gerbil-unstable;
-  gerbilInputs = with gerbil-support.gerbilPackages-unstable; [gerbil-utils gerbil-crypto];
-  buildInputs = [];
-  gambit-params = gambit-support.unstable-params;
-  version-path = "version";
+  version = "unstable-2023-04-28";
+  git-version = "0.0-106-g418b582";
   softwareName = "Gerbil-POO";
+  gerbil-package = "clan/poo";
+  version-path = "version";
+
+  gerbilInputs = with gerbilPackages; [ gerbil-utils ];
+
   pre-src = {
     fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-poo";
-    rev = "44d490d95b9d1b5d54eaedf2602419af8e086837";
-    sha256 = "082ndpy281saybcnp3bdidcibkk2ih6glrkbb5fdj1524ban4d0k";
+    rev = "418b582ae72e1494cf3a5f334d31d4f6503578f5";
+    sha256 = "0qdzs7l6hp45dji5bc3879k4c8k9x6cj4qxz68cskjhn8wrc5lr8";
   };
-  meta = {
+
+  meta = with lib; {
     description = "Gerbil POO: Prototype Object Orientation for Gerbil Scheme";
     homepage    = "https://github.com/fare/gerbil-poo";
-    license     = lib.licenses.asl20;
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ fare ];
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
   };
 }

--- a/pkgs/development/compilers/gerbil/gerbil-support.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-support.nix
@@ -1,54 +1,112 @@
-{ pkgs, lib, gccStdenv, callPackage, fetchFromGitHub }:
-# See ../gambit/build.nix regarding gccStdenv
+{ pkgs, lib, callPackage, ... }:
 
-rec {
-  # Gerbil libraries
-  gerbilPackages-unstable = {
-    gerbil-libp2p = callPackage ./gerbil-libp2p.nix { };
-    gerbil-utils = callPackage ./gerbil-utils.nix { };
-    gerbil-crypto = callPackage ./gerbil-crypto.nix { };
-    gerbil-poo = callPackage ./gerbil-poo.nix { };
-    gerbil-persist = callPackage ./gerbil-persist.nix { };
-    gerbil-ethereum = callPackage ./gerbil-ethereum.nix { };
-    smug-gerbil = callPackage ./smug-gerbil.nix { };
+  with pkgs.gerbil-support; {
+
+  prePackages-unstable =
+    let pks = [ ./gerbil-libp2p.nix ./smug-gerbil.nix
+                ./gerbil-utils.nix ./gerbil-crypto.nix ./gerbil-poo.nix
+                ./gerbil-persist.nix ./gerbil-ethereum.nix ];
+        call = pkg: callPackage pkg prePackage-defaults;
+        pkgName = pkg: lib.removeSuffix ".nix" (baseNameOf pkg);
+        f = pkg: { name = pkgName pkg; value = call pkg; }; in
+    builtins.listToAttrs (map f pks);
+
+  prePackage-defaults = {
+    gerbil = pkgs.gerbil-unstable;
+    gambit-params = pkgs.gambit-support.unstable-params;
+    gerbilPackages = gerbilPackages-unstable;
+    git-version = "";
+    version-path = "";
+    gerbilInputs = [];
+    nativeBuildInputs = [];
+    buildInputs = [];
+    buildScript = "./build.ss";
+    postInstall = "";
+    softwareName = "";
   };
+
+  gerbilPackages-unstable =
+    builtins.mapAttrs (_: gerbilPackage) prePackages-unstable;
+
+  resolve-pre-src = pre-src: pre-src.fun (removeAttrs pre-src ["fun"]);
+
+  gerbilVersionFromGit = pkg:
+    let version-path = "${pkg.passthru.pre-pkg.version-path}.ss"; in
+    if builtins.pathExists version-path then
+      let m =
+        builtins.match "\\(import :clan/versioning.*\\)\n\\(register-software \"([-_.A-Za-z0-9]+)\" \"([-_.A-Za-z0-9]+)\"\\) ;; ([-0-9]+)\n"
+          (builtins.readFile version-path); in
+          { version = builtins.elemAt m 2; git-version = builtins.elemAt m 1; }
+     else { version = "0.0";
+            git-version = let gitpath = "${toString pkg.src}/.git"; in
+              if builtins.pathExists gitpath then lib.commitIdFromGitRepo gitpath else "0"; };
+
+  gerbilSkippableFiles = [".git" ".build" ".build_outputs" "run" "result" "dep" "BLAH"
+                          "version.ss" "tmp.nix"];
+
+  gerbilSourceFilter = path: type:
+    let baseName = baseNameOf path; in
+      ! (builtins.elem baseName gerbilSkippableFiles || lib.hasSuffix "~" baseName);
+
+  gerbilFilterSource = builtins.filterSource gerbilSourceFilter;
 
   # Use this function in any package that uses Gerbil libraries, to define the GERBIL_LOADPATH.
   gerbilLoadPath =
-    gerbilInputs : builtins.concatStringsSep ":" (map (x : x + "/gerbil/lib") gerbilInputs);
+    gerbilInputs: builtins.concatStringsSep ":" (map (x: x + "/gerbil/lib") gerbilInputs);
+
+  path-src = path: { fun = _: path; };
+
+  view = lib.debug.traceSeqN 4;
+
+  sha256-of-pre-src = pre-src: if pre-src ? sha256 then pre-src.sha256 else "none";
+
+  overrideSrcIfShaDiff = name: new-pre-src: super:
+    let old-sha256 = sha256-of-pre-src super.${name}.pre-src;
+        new-sha256 = sha256-of-pre-src new-pre-src; in
+    if old-sha256 == new-sha256 then {} else
+    view "Overriding ${name} old-sha256: ${old-sha256} new-sha256: ${new-sha256}"
+    { ${name} = super.${name} // {
+        pre-src = new-pre-src;
+        version = "override";
+        git-version = if new-pre-src ? rev then lib.substring 0 7 new-pre-src.rev else "unknown";};};
+
+  pkgsOverrideGerbilPackageSrc = name: pre-src: pkgs: super: {
+    gerbil-support = (super-support:
+      { prePackages-unstable =
+          (super-ppu: super-ppu // (overrideSrcIfShaDiff name pre-src super-ppu))
+          super-support.prePackages-unstable;}) super.gerbil-support;};
 
   # Use this function to create a Gerbil library. See gerbil-utils as an example.
-  gerbilPackage = {
-    pname, version, src, meta, gerbil-package,
-    git-version ? "", version-path ? "",
-    gerbil ? pkgs.gerbil-unstable,
-    gambit-params ? pkgs.gambit-support.stable-params,
-    gerbilInputs ? [],
-    nativeBuildInputs ? [],
-    buildInputs ? [],
-    buildScript ? "./build.ss",
-    softwareName ? ""} :
-    let buildInputs_ = buildInputs; in
-    gccStdenv.mkDerivation rec {
-      inherit src meta pname version nativeBuildInputs;
-      passthru = { inherit gerbil-package version-path ;};
+  gerbilPackage = prePackage:
+    let pre-pkg = prePackage-defaults // prePackage;
+        inherit (pre-pkg) pname version pre-src git-version meta
+          softwareName gerbil-package version-path gerbil gambit-params
+          gerbilInputs nativeBuildInputs buildInputs buildScript postInstall;
+        buildInputs_ = buildInputs; in
+    pkgs.gccStdenv.mkDerivation rec { # See ../gambit/build.nix regarding why we use gccStdenv
+      inherit meta pname version nativeBuildInputs postInstall;
+      passthru = {
+        inherit pre-pkg;
+      };
+      src = resolve-pre-src pre-src;
       buildInputs = [ gerbil ] ++ gerbilInputs ++ buildInputs_;
+
       postPatch = ''
         set -e ;
-        if [ -n "${version-path}.ss" ] ; then
-          echo -e '(import :clan/versioning${builtins.concatStringsSep ""
-                     (map (x : lib.optionalString (x.passthru.version-path != "")
-                               " :${x.passthru.gerbil-package}/${x.passthru.version-path}")
+        ${lib.optionalString (version-path != "")
+          ''echo -e '(import :clan/versioning${builtins.concatStringsSep ""
+                     (map (x: let px = x.passthru.pre-pkg; in
+                              lib.optionalString (px.version-path != "")
+                                " :${px.gerbil-package}/${px.version-path}")
                           gerbilInputs)
-                     })\n(register-software "${softwareName}" "v${git-version}")\n' > "${passthru.version-path}.ss"
-        fi
+                     })\n(register-software "${softwareName}" "v${git-version}")\n' > "${version-path}.ss"''}
         patchShebangs . ;
       '';
 
       postConfigure = ''
         export GERBIL_BUILD_CORES=$NIX_BUILD_CORES
         export GERBIL_PATH=$PWD/.build
-        export GERBIL_LOADPATH=${gerbilLoadPath gerbilInputs}
+        export GERBIL_LOADPATH=${gerbilLoadPath (["$out"] ++ gerbilInputs)}
         ${pkgs.gambit-support.export-gambopt gambit-params}
       '';
 
@@ -60,18 +118,36 @@ rec {
 
       installPhase = ''
         runHook preInstall
-        mkdir -p $out/gerbil/lib
-        cp -fa .build/lib $out/gerbil/
-        bins=(.build/bin/*)
-        if [ 0 -lt ''${#bins} ] ; then
-          cp -fa .build/bin $out/gerbil/
-          mkdir $out/bin
-          cd $out/bin
-          ln -s ../gerbil/bin/* .
+        mkdir -p $out/gerbil
+        cp -fa .build/* $out/gerbil/
+        if [[ -d $out/gerbil/bin ]] ; then
+          ( cd $out/gerbil
+            bins=$(find ../gerbil/bin -type f)
+            if [[ -n $bins ]] ; then
+              ( mkdir -p ../bin
+                cd ..
+                ln -s $bins bin
+              )
+            fi
+          )
         fi
         runHook postInstall
       '';
 
       dontFixup = true;
+
+      checkPhase = ''
+        runHook preCheck
+        if [[ -f unit-tests.ss ]] ; then
+          export GERBIL_APPLICATION_HOME=$PWD
+          ./unit-tests.ss version
+          ./unit-tests.ss
+        else
+          echo "No gerbil-utils style unit-tests.ss detected for ${pname} ${version}.";
+        fi
+        runHook postCheck
+      '';
+
+      doCheck = true;
     };
 }

--- a/pkgs/development/compilers/gerbil/gerbil-support.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-support.nix
@@ -3,7 +3,7 @@
   with pkgs.gerbil-support; {
 
   prePackages-unstable =
-    let pks = [ ./gerbil-libp2p.nix ./smug-gerbil.nix
+    let pks = [ ./gerbil-libp2p.nix ./smug-gerbil.nix ./ftw.nix
                 ./gerbil-utils.nix ./gerbil-crypto.nix ./gerbil-poo.nix
                 ./gerbil-persist.nix ./gerbil-ethereum.nix ];
         call = pkg: callPackage pkg prePackage-defaults;

--- a/pkgs/development/compilers/gerbil/gerbil-support.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-support.nix
@@ -5,7 +5,7 @@
   prePackages-unstable =
     let pks = [ ./gerbil-libp2p.nix ./smug-gerbil.nix ./ftw.nix
                 ./gerbil-utils.nix ./gerbil-crypto.nix ./gerbil-poo.nix
-                ./gerbil-persist.nix ./gerbil-ethereum.nix ];
+                ./gerbil-persist.nix ./gerbil-ethereum.nix ./glow-lang.nix ];
         call = pkg: callPackage pkg prePackage-defaults;
         pkgName = pkg: lib.removeSuffix ".nix" (baseNameOf pkg);
         f = pkg: { name = pkgName pkg; value = call pkg; }; in

--- a/pkgs/development/compilers/gerbil/gerbil-utils.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-utils.nix
@@ -1,6 +1,5 @@
 { lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
-
-gerbil-support.gerbilPackage {
+{
   pname = "gerbil-utils";
   version = "unstable-2020-10-18";
   git-version = "0.2-36-g8b481b7";
@@ -9,7 +8,8 @@ gerbil-support.gerbilPackage {
   gambit-params = gambit-support.unstable-params;
   version-path = "version";
   softwareName = "Gerbil-utils";
-  src = fetchFromGitHub {
+  pre-src = {
+    fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-utils";
     rev = "8b481b787e13e07e14d0718d670aab016131a090";

--- a/pkgs/development/compilers/gerbil/gerbil-utils.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-utils.nix
@@ -1,25 +1,26 @@
-{ lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+{ lib, fetchFromGitHub, ... }:
+
 {
   pname = "gerbil-utils";
-  version = "unstable-2020-10-18";
-  git-version = "0.2-36-g8b481b7";
-  gerbil-package = "clan";
-  gerbil = gerbil-unstable;
-  gambit-params = gambit-support.unstable-params;
-  version-path = "version";
+  version = "unstable-2023-07-22";
+  git-version = "0.2-198-g2fb01ce";
   softwareName = "Gerbil-utils";
+  gerbil-package = "clan";
+  version-path = "version";
+
   pre-src = {
     fun = fetchFromGitHub;
     owner = "fare";
     repo = "gerbil-utils";
-    rev = "8b481b787e13e07e14d0718d670aab016131a090";
-    sha256 = "0br8k5b2wcv4wcp65r2bfhji3af2qgqjspf41syqslq9awx47f3m";
+    rev = "2fb01ce0b302f232f5c4daf4987457b6357d609d";
+    sha256 = "127q98gk1x6y1nlkkpnbnkz989ybpszy7aiy43hzai2q6xn4nv72";
   };
-  meta = {
+
+  meta = with lib; {
     description = "Gerbil Clan: Community curated Collection of Common Utilities";
     homepage    = "https://github.com/fare/gerbil-utils";
-    license     = lib.licenses.lgpl21;
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ fare ];
+    license     = licenses.lgpl21;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
   };
 }

--- a/pkgs/development/compilers/gerbil/glow-lang.nix
+++ b/pkgs/development/compilers/gerbil/glow-lang.nix
@@ -1,0 +1,55 @@
+{ lib, fetchFromGitHub, gerbil-support, gerbilPackages, gerbil, ... }:
+
+rec {
+  pname = "glow-lang";
+  version = "unstable-2023-04-26";
+  git-version = "0.3.2-222-gb19cd980";
+  softwareName = "Glow";
+  gerbil-package = "mukn/glow";
+  version-path = "version";
+
+  gerbilInputs = with gerbilPackages;
+    [ gerbil-utils gerbil-crypto gerbil-poo gerbil-persist gerbil-ethereum
+      gerbil-libp2p smug-gerbil ftw ];
+
+  pre-src = {
+    fun = fetchFromGitHub;
+    owner = "Glow-Lang";
+    repo = "glow";
+    rev = "b19cd98082dfc5156d1b4fc83cde161572d6a211";
+    sha256 = "0k3qy5826pxqr9ylnnpq4iikxf4j50987vhpa5qiv99j0p643xr3";
+    };
+
+  postPatch = ''
+    substituteInPlace "runtime/glow-path.ss" --replace \
+      '(def glow-install-path (source-path "dapps"))' \
+      '(def glow-install-path "$out")'
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin $out/gerbil/lib/mukn/glow $out/share/glow/dapps
+    cp main.ss $out/gerbil/lib/mukn/glow/
+    cp dapps/{buy_sig,coin_flip,rps_simple}.glow $out/share/glow/dapps/
+    cat > $out/bin/glow <<EOF
+    #!/bin/sh
+    ORIG_GERBIL_LOADPATH="\$GERBIL_LOADPATH"
+    ORIG_GERBIL_PATH="\$GERBIL_PATH"
+    ORIG_GERBIL_HOME="\$GERBIL_HOME"
+    unset GERBIL_HOME
+    GERBIL_LOADPATH="${gerbil-support.gerbilLoadPath (["$out"] ++ gerbilInputs)}"
+    GLOW_SOURCE="\''${GLOW_SOURCE:-$out/share/glow}"
+    GERBIL_PATH="\$HOME/.cache/glow/gerbil"
+    export GERBIL_PATH GERBIL_LOADPATH GLOW_SOURCE ORIG_GERBIL_PATH ORIG_GERBIL_LOADPATH ORIG_GERBIL_HOME
+    exec ${gerbil}/bin/gxi $out/gerbil/lib/mukn/glow/main.ss "\$@"
+    EOF
+    chmod a+x $out/bin/glow
+    '';
+
+  meta = with lib; {
+    description = "Glow: language for safe Decentralized Applications (DApps)";
+    homepage    = "https://glow-lang.org";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
+  };
+}

--- a/pkgs/development/compilers/gerbil/smug-gerbil.nix
+++ b/pkgs/development/compilers/gerbil/smug-gerbil.nix
@@ -1,30 +1,25 @@
-{ pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
+{ lib, fetchFromGitHub, ... }:
+
 {
   pname = "smug-gerbil";
-  version = "unstable-2019-12-24";
-  git-version = "95d60d4";
-  gerbil-package = "drewc/smug";
-  gerbil = gerbil-unstable;
-  gerbilInputs = [];
-  buildInputs = [];
-  gambit-params = gambit-support.unstable-params;
-  version-path = ""; #"version";
+  version = "unstable-2020-12-12";
+  git-version = "0.4.20";
   softwareName = "Smug-Gerbil";
+  gerbil-package = "drewc/smug";
+
   pre-src = {
     fun = fetchFromGitHub;
     owner = "drewc";
     repo = "smug-gerbil";
-    rev = "95d60d486c1603743c6d3c525e6d5f5761b984e5";
-    sha256 = "0ys07z78gq60z833si2j7xa1scqvbljlx1zb32vdf32f1b27c04j";
+    rev = "cf23a47d0891aa9e697719309d04dd25dd1d840b";
+    sha256 = "13fdijd71m3fzp9fw9xp6ddgr38q1ly6wnr53salp725w6i4wqid";
   };
-  meta = {
+
+  meta = with lib; {
     description = "Super Monadic Über Go-into : Parsers and Gerbil Scheme";
     homepage    = "https://github.com/drewc/smug-gerbil";
-    license     = lib.licenses.mit;
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ fare ];
+    license     = licenses.mit;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
   };
-  buildScript = ''
-    for i in primitive simple tokens smug ; do gxc -O $i.ss ; done
-  '';
 }

--- a/pkgs/development/compilers/gerbil/smug-gerbil.nix
+++ b/pkgs/development/compilers/gerbil/smug-gerbil.nix
@@ -1,6 +1,5 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
-
-gerbil-support.gerbilPackage {
+{
   pname = "smug-gerbil";
   version = "unstable-2019-12-24";
   git-version = "95d60d4";
@@ -11,7 +10,8 @@ gerbil-support.gerbilPackage {
   gambit-params = gambit-support.unstable-params;
   version-path = ""; #"version";
   softwareName = "Smug-Gerbil";
-  src = fetchFromGitHub {
+  pre-src = {
+    fun = fetchFromGitHub;
     owner = "drewc";
     repo = "smug-gerbil";
     rev = "95d60d486c1603743c6d3c525e6d5f5761b984e5";

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,13 +1,13 @@
 { callPackage, fetchFromGitHub, gambit-unstable, gambit-support }:
 
 callPackage ./build.nix rec {
-  version = "unstable-2020-11-05";
-  git-version = "0.16-152-g808929ae";
+  version = "unstable-2023-08-07";
+  git-version = "0.17.0-187-gba545b77";
   src = fetchFromGitHub {
     owner = "vyzo";
     repo = "gerbil";
-    rev = "808929aeb8823959191f35df53bc0c0150911b4b";
-    sha256 = "0d9k2gkrs9qvlnk7xa3gjzs3gln3ydds7yd2313pvbw4q2lcz8iw";
+    rev = "ba545b77e8e85118089232e3cd263856e414b24b";
+    sha256 = "1f4v1qawx2i8333kshj4pbj5r21z0868pwrr3r710n6ng3pd9gqn";
   };
   inherit gambit-support;
   gambit = gambit-unstable;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15507,7 +15507,8 @@ with pkgs;
   gerbil = callPackage ../development/compilers/gerbil { };
   gerbil-unstable = callPackage ../development/compilers/gerbil/unstable.nix { };
   gerbil-support = callPackage ../development/compilers/gerbil/gerbil-support.nix { };
-  gerbilPackages-unstable = gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
+  gerbilPackages-unstable = pkgs.gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
+  glow-lang = pkgs.gerbilPackages-unstable.glow-lang;
 
   gbforth = callPackage ../development/compilers/gbforth { };
 


### PR DESCRIPTION
## Description of changes

Update Gambit, Gerbil (after a few years), and add Glow.

Previous PR to update Gerbil was rejected a few years back, because I imported a new object system POP to replace or complement the Nix extension system. I have wholly removed POP from this PR, because the fight was not worth the benefits.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update the packaging and the packages for the Gerbil ecosystem.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
