### PR TITLE
mate.engrampa: support cross compilation

### DIFF
--- a/pkgs/desktops/mate/engrampa/default.nix
+++ b/pkgs/desktops/mate/engrampa/default.nix
@@ -6,11 +6,12 @@
 , itstool
 , libxml2
 , gtk3
-, file
 , mate
 , hicolor-icon-theme
 , wrapGAppsHook
 , mateUpdateScript
+# can be defaulted to true once engrampa builds with meson (version > 1.27.0)
+, withMagic ? stdenv.buildPlatform.canExecute stdenv.hostPlatform, file
 }:
 
 stdenv.mkDerivation rec {
@@ -26,20 +27,22 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     itstool
+    libxml2  # for xmllint
     wrapGAppsHook
   ];
 
   buildInputs = [
-    libxml2
     gtk3
-    file #libmagic
     mate.caja
     hicolor-icon-theme
     mate.mate-desktop
+  ] ++ lib.optionals withMagic [
+    file
   ];
 
   configureFlags = [
     "--with-cajadir=$$out/lib/caja/extensions-2.0"
+  ] ++ lib.optionals withMagic [
     "--enable-magic"
   ];
 


### PR DESCRIPTION
## Description of changes

can be built with `nix build '.#pkgsCross.aarch64-multiplatform.mate.engrampa'`.

libmagic (disabled for cross builds) is used for things compressed with zstd. deploying a cross-build of engrampa to an aarch64 box, it was able to extract all the archives i had handy (.tar.gz, .tar.xz) even without libmagic.

~~PR targets staging because of a dependency on `p11-kit`, which cross-compiles only on staging/staging-next.~~  (**edit**: builds against master now; thanks Artturi for rebasing the PR)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
