### PR TITLE
gtk{3,4}: compile schemas even when cross compiling

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -24,6 +24,7 @@
 , gobject-introspection
 , buildPackages
 , withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
+, compileSchemas ? stdenv.hostPlatform.emulatorAvailable buildPackages
 , fribidi
 , xorg
 , libepoxy
@@ -110,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     gtk-doc
     # For xmllint
     libxml2
-  ] ++ lib.optionals (withIntrospection && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+  ] ++ lib.optionals ((withIntrospection || compileSchemas) && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     mesonEmulatorHook
   ] ++ lib.optionals waylandSupport [
     wayland-scanner
@@ -182,6 +183,10 @@ stdenv.mkDerivation (finalAttrs: {
     # See https://github.com/NixOS/nixpkgs/issues/132259
     substituteInPlace meson.build \
       --replace "x11_enabled = false" ""
+
+    # this conditional gates the installation of share/gsettings-schemas/.../glib-2.0/schemas/gschemas.compiled.
+    substituteInPlace meson.build \
+      --replace 'if not meson.is_cross_build()' 'if ${lib.boolToString compileSchemas}'
 
     files=(
       build-aux/meson/post-install.py


### PR DESCRIPTION
## The problem this patch addresses

this fixes a bug that can be observed by launching any cross-compiled application which uses the gtk FileChooser dialog, e.g. [mate.engrampa](https://github.com/NixOS/nixpkgs/pull/247841). such cross-compiled applications today fail when they try to open the FileChooser with:

```
Settings schema 'org.gtk.Settings.FileChooser' is not installed
```

that failure isn't due to applications not setting XDG_DATA_DIRS correctly, but rather a difference in the schema outputs between native and cross gtk builds:
```
~/nixpkgs $ git checkout master
~/nixpkgs $ nix build '.#gtk3'
~/nixpkgs $ ls ./result/share/gsettings-schemas/gtk+3-3.24.38/glib-2.0/schemas
gschemas.compiled
org.gtk.Demo.gschema.xml
org.gtk.exampleapp.gschema.xml
org.gtk.Settings.ColorChooser.gschema.xml
org.gtk.Settings.Debug.gschema.xml
org.gtk.Settings.EmojiChooser.gschema.xml
org.gtk.Settings.FileChooser.gschema.xml

~/nixpkgs $ nix build '.#pkgsCross.aarch64-multiplatform.gtk3'
~/nixpkgs $ ls ./result//share/gsettings-schemas/gtk+3-aarch64-unknown-linux-gnu-3.24.38/glib-2.0/schemas
org.gtk.Demo.gschema.xml
org.gtk.exampleapp.gschema.xml
org.gtk.Settings.ColorChooser.gschema.xml
org.gtk.Settings.Debug.gschema.xml
org.gtk.Settings.EmojiChooser.gschema.xml
org.gtk.Settings.FileChooser.gschema.xml
```

notice: the cross-compiled build **is missing gschemas.compiled**

## Solution

[upstream](https://gitlab.gnome.org/GNOME/gtk/-/blob/d603925ab2cd20bff8ead21d541eea2bb8151eb2/meson.build#L883) explicitly doesn't compile schemas on cross compilation:
```meson
if not meson.is_cross_build()
  gnome.post_install(
    glib_compile_schemas: true,
    gio_querymodules: gio_module_dirs,
    gtk_update_icon_cache: get_option('build-demos'),
  )
else
  message('Not executing post-install steps automatically when cross compiling')
endif
```

indeed, without an emulator, `gnome.post_install` fails on cross-compiled builds. but, like the introspection feature, it succeeds when providing `mesonEmulatorHook`. unlike with introspection, upstream provides no meson option to control this behavior (and there are no PRs or issues for doing so yet). this PR just patches in the desired behavior: a longer-term fix will be to work with upstream to provide such an option, but i'm sharing this patch here first to make sure this is the approach we want.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
