### PR TITLE
lib.types.string: Deprecation error instead of warning

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -436,10 +436,7 @@ rec {
 
     # Deprecated; should not be used because it quietly concatenates
     # strings, which is usually not what you want.
-    string = separatedString "" // {
-      name = "string";
-      deprecationMessage = "See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.";
-    };
+    string = throw "The type `types.string` is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.";
 
     passwdEntry = entryType: addCheck entryType (str: !(hasInfix ":" str || hasInfix "\n" str)) // {
       name = "passwdEntry ${entryType.name}";


### PR DESCRIPTION
## Description of changes

The type has given a warning on use since [4 years ago](../commit/03391cd336b128a1639c648baf0f6c1a1271e0d2), I think it's safe to move the deprecation to the next stage: An error instead of a warning.

Before:
```
trace: warning: The type `types.string' of option `foo.enable' defined in `<unknown-file>' is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.
```

After:
```
error: The type `types.string` is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.
```

## Things done
- [x] Tested it manually