### PR TITLE
gthumb, cinnamon.pix: Fix build with exiv2 0.28

### DIFF
--- a/pkgs/applications/graphics/gthumb/default.nix
+++ b/pkgs/applications/graphics/gthumb/default.nix
@@ -49,6 +49,13 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/gthumb/-/commit/da0d3f22a5c3a141211d943e7d963d14090011ec.patch";
       sha256 = "sha256-/l9US19rKxIUJjZ+oynGLr/9PKJPg9VUuA/VSuIT5AQ=";
     })
+
+    # Fix build with exiv2 0.28, can be removed on next update
+    # https://gitlab.gnome.org/GNOME/gthumb/-/issues/282
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gthumb/-/commit/3376550ae109286de09ce5f89e05060eb80230a7.patch";
+      sha256 = "sha256-zHX+kV7RaHXFqbR15RTaRcZJPU/P3uUj03tFUv0DR5o=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/pix/default.nix
+++ b/pkgs/desktops/cinnamon/pix/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
-, fetchurl
 , fetchFromGitHub
+, fetchpatch
 , pkg-config
 , meson
 , ninja
@@ -42,6 +42,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-iNUhcHG4nCZ4WNELodyLdztzfNg9g+F0eQrZHXS6Zj0=";
   };
+
+  patches = [
+    # Fix build with exiv2 0.28, can be removed on next update
+    # https://github.com/linuxmint/pix/pull/178
+    (fetchpatch {
+      url = "https://github.com/linuxmint/pix/commit/46e19703a973d51fa97e6a22121560f5ba200eea.patch";
+      sha256 = "sha256-Z+pUxoy0m/agXW++YxEUhRuax0qvuGVXNhU8d9mvGh4=";
+    })
+  ];
 
   nativeBuildInputs = [
     bison


### PR DESCRIPTION
## Description of changes

Tested building with exiv2 0.28

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
