### PR TITLE
atuin: 15.0.0 -> 16.0.0

### DIFF
--- a/pkgs/tools/misc/atuin/default.nix
+++ b/pkgs/tools/misc/atuin/default.nix
@@ -11,20 +11,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "atuin";
-  version = "15.0.0";
+  version = "16.0.0";
 
   src = fetchFromGitHub {
-    owner = "ellie";
-    repo = pname;
+    owner = "atuinsh";
+    repo = "atuin";
     rev = "v${version}";
-    hash = "sha256-BX1WpvJMcfpepsRX0U6FJBL5/+mpUyTZxm65BbbZLJA=";
+    hash = "sha256-Kh6aaWYV+ZG7Asvw5JdGsV+nxD+xvvQab5wLIedcQcQ=";
   };
 
   # TODO: unify this to one hash because updater do not support this
   cargoHash =
     if stdenv.isLinux
-    then "sha256-EnIR+BXw8oYlv3dpYy4gAkN/zckRI8KEAbbR9wPmMq4="
-    else "sha256-hHcahzrIuXIgOv+sx0HbC9f5guTcTr6L4eeLoiQsAzA=";
+    then "sha256-Ami88ScGj58jCCat4MMDvjZtV5WglmrlggpQfo+LPjs="
+    else "sha256-HQMZ9w1C6go16XGrPNniQZliIQ/5yAp2w/uUwAOQTM0=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -41,9 +41,14 @@ rustPlatform.buildRustPackage rec {
     inherit (nixosTests) atuin;
   };
 
+  checkFlags = [
+    # tries to make a network access
+    "--skip=registration"
+  ];
+
   meta = with lib; {
     description = "Replacement for a shell history which records additional commands context with optional encrypted synchronization between machines";
-    homepage = "https://github.com/ellie/atuin";
+    homepage = "https://github.com/atuinsh/atuin";
     license = licenses.mit;
     maintainers = with maintainers; [ SuperSandro2000 sciencentistguy _0x4A6F ];
   };


### PR DESCRIPTION
## Description of changes

https://github.com/atuinsh/atuin/releases

this mostly fixing a breakage with nushell 0.83 for me, so it would be amazing if this was merged quickly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
