### PR TITLE
python.tests.tkinter: init

### DIFF
--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -114,6 +114,10 @@ let
       nix-pythonprefix-mypy = callPackage ./tests/test_nix_pythonprefix {
         interpreter = python;
       };
+      # Make sure tkinter is importable. See https://github.com/NixOS/nixpkgs/issues/238990
+      tkinter = callPackage ./tests/test_tkinter {
+        interpreter = python;
+      };
     }
   );
 

--- a/pkgs/development/interpreters/python/tests/test_tkinter/default.nix
+++ b/pkgs/development/interpreters/python/tests/test_tkinter/default.nix
@@ -1,0 +1,17 @@
+{ interpreter, writeText, runCommand }:
+
+let
+
+  pythonEnv = interpreter.withPackages(ps: [
+    ps.tkinter
+  ]);
+
+  pythonScript = writeText "myscript.py" ''
+    import tkinter
+    print(tkinter)
+  '';
+
+in runCommand "${interpreter.name}-tkinter-test" {} ''
+  ${pythonEnv}/bin/python ${pythonScript}
+  touch $out
+''


### PR DESCRIPTION
###### Motivation for this change

Attempt to avoid https://github.com/NixOS/nixpkgs/issues/238990 in the future.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
