### PR TITLE
linuxPackages.mwprocapture: 1.3.0.4328 -> 1.3.0.4373

### DIFF
--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -12,12 +12,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mwprocapture";
-  subVersion = "4328";
+  subVersion = "4373";
   version = "1.3.0.${subVersion}-${kernel.version}";
 
   src = fetchurl {
     url = "https://www.magewell.com/files/drivers/ProCaptureForLinux_${subVersion}.tar.gz";
-    sha256 = "197l86ad52ijmmq5an6891gd1chhkxqiagamcchirrky4c50qs36";
+    sha256 = "sha256-/6q+6CTlgkHOgq1PF8dSPfl/xm/UFczr/AGkac2mXZ8=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.magewell.com/";
     description = "Linux driver for the Magewell Pro Capture family";
     license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ MP2E ];
+    maintainers = with maintainers; [ flexiondotorg MP2E ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

Version V1.3.0.4236 of mwprocapture (the Linux driver for the Magewell Pro Capture family) FTBFS when building against Linux 6.4 or newer.

I emailed Magewell and received a link to an updated driver. This pull request updates the driver version to 1.3.0.4373 to address this issue.

Tested using a Magewell Pro Capture Dual HDMI (11080). This fixes #247895

I have also added myself as a maintainer for mwcapturepro as I have two workstations using Magewell Pro Capture that I rely on.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Here is the output from `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`:

```
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   ccc33bd3d70c..f971f35f7d79  master     -> refs/nixpkgs-review/0
$ git worktree add /home/martin/.cache/nixpkgs-review/rev-7f1f7e041b0876797f9c5b8a7c96fe238fad217b/nixpkgs f971f35f7d79c53a83c7b10de953f1db032cba0e
Preparing worktree (detached HEAD f971f35f7d79)
Updating files: 100% (36545/36545), done.
HEAD is now at f971f35f7d79 Merge pull request #246426 from dit7ya/sqld
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f /home/martin/.cache/nixpkgs-review/rev-7f1f7e041b0876797f9c5b8a7c96fe238fad217b/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff 7f1f7e041b0876797f9c5b8a7c96fe238fad217b
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f /home/martin/.cache/nixpkgs-review/rev-7f1f7e041b0876797f9c5b8a7c96fe238fad217b/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
23 packages updated:
linuxKernel.packages.linux_4_14.mwprocapture (1.3.0.4328-4.14.320 → 1.3.0.4373-4.14.320) linuxKernel.packages.linux_4_14_hardened.mwprocapture (1.3.0.4328-4.14.320 → 1.3.0.4373-4.14.320) linuxKernel.packages.linux_4_19.mwprocapture (1.3.0.4328-4.19.289 → 1.3.0.4373-4.19.289) linuxKernel.packages.linux_4_19_hardened.mwprocapture (1.3.0.4328-4.19.289 → 1.3.0.4373-4.19.289) linuxKernel.packages.linux_5_10_hardened.mwprocapture (1.3.0.4328-5.10.188 → 1.3.0.4373-5.10.188) linuxKernel.packages.linux_5_10.mwprocapture (1.3.0.4328-5.10.188 → 1.3.0.4373-5.10.188) linuxKernel.packages.linux_5_15_hardened.mwprocapture (1.3.0.4328-5.15.123 → 1.3.0.4373-5.15.123) linuxKernel.packages.linux_5_15.mwprocapture (1.3.0.4328-5.15.124 → 1.3.0.4373-5.15.124) linuxKernel.packages.linux_5_4.mwprocapture (1.3.0.4328-5.4.251 → 1.3.0.4373-5.4.251) linuxKernel.packages.linux_5_4_hardened.mwprocapture (1.3.0.4328-5.4.251 → 1.3.0.4373-5.4.251) linuxKernel.packages.linux_6_1_hardened.mwprocapture (1.3.0.4328-6.1.42 → 1.3.0.4373-6.1.42) linuxKernel.packages.linux_hardened.mwprocapture (1.3.0.4328-6.1.42 → 1.3.0.4373-6.1.42) linuxKernel.packages.linux_xanmod.mwprocapture (1.3.0.4328-6.1.43 → 1.3.0.4373-6.1.43) linuxKernel.packages.linux_6_1.mwprocapture (1.3.0.4328-6.1.43 → 1.3.0.4373-6.1.43) linuxKernel.packages.linux_libre.mwprocapture (1.3.0.4328-6.1.43 → 1.3.0.4373-6.1.43) linuxKernel.packages.linux_zen.mwprocapture (1.3.0.4328-6.4.7 → 1.3.0.4373-6.4.7) linuxKernel.packages.linux_lqx.mwprocapture (1.3.0.4328-6.4.7 → 1.3.0.4373-6.4.7) linuxKernel.packages.linux_6_4_hardened.mwprocapture (1.3.0.4328-6.4.7 → 1.3.0.4373-6.4.7) linuxKernel.packages.linux_xanmod_latest.mwprocapture (1.3.0.4328-6.4.8 → 1.3.0.4373-6.4.8) linuxKernel.packages.linux_latest_libre.mwprocapture (1.3.0.4328-6.4.8 → 1.3.0.4373-6.4.8) linuxKernel.packages.linux_xanmod_stable.mwprocapture (1.3.0.4328-6.4.8 → 1.3.0.4373-6.4.8) linuxKernel.packages.linux_6_4.mwprocapture (1.3.0.4328-6.4.8 → 1.3.0.4373-6.4.8) linuxKernel.packages.linux_testing_bcachefs.mwprocapture (1.3.0.4328-6.4.8 → 1.3.0.4373-6.4.8)

$ nix build --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/martin/.cache/nixpkgs-review/rev-7f1f7e041b0876797f9c5b8a7c96fe238fad217b/build.nix
21 packages built:
linuxKernel.packages.linux_4_14.mwprocapture linuxKernel.packages.linux_4_14_hardened.mwprocapture linuxKernel.packages.linux_4_19.mwprocapture linuxKernel.packages.linux_4_19_hardened.mwprocapture linuxKernel.packages.linux_5_10.mwprocapture linuxKernel.packages.linux_5_10_hardened.mwprocapture linuxKernel.packages.linux_5_15.mwprocapture linuxKernel.packages.linux_5_15_hardened.mwprocapture linuxKernel.packages.linux_5_4.mwprocapture linuxKernel.packages.linux_5_4_hardened.mwprocapture linuxKernel.packages.linux_6_1.mwprocapture linuxKernel.packages.linux_hardened.mwprocapture linuxKernel.packages.linux_6_4.mwprocapture linuxKernel.packages.linux_6_4_hardened.mwprocapture linuxKernel.packages.linux_latest_libre.mwprocapture linuxKernel.packages.linux_libre.mwprocapture linuxKernel.packages.linux_lqx.mwprocapture linuxKernel.packages.linux_testing_bcachefs.mwprocapture linuxKernel.packages.linux_xanmod.mwprocapture linuxKernel.packages.linux_xanmod_latest.mwprocapture linuxKernel.packages.linux_zen.mwprocapture

$ /nix/store/911s0i1cr0n31wv3gigigdw1zb493vgp-nix-2.13.3/bin/nix-shell /home/martin/.cache/nixpkgs-review/rev-7f1f7e041b0876797f9c5b8a7c96fe238fad217b/shell.nix
```