### PR TITLE
python3Packages.djangorestframework-stubs: init at 3.14.2

### DIFF
--- a/pkgs/development/python-modules/djangorestframework-stubs/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-stubs/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, django-stubs
+, fetchFromGitHub
+, mypy
+, py
+, pytest-mypy-plugins
+, pytestCheckHook
+, pythonOlder
+, requests
+, types-pyyaml
+, types-requests
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "djangorestframework-stubs";
+  version = "3.14.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "typeddjango";
+    repo = "djangorestframework-stubs";
+    rev = version;
+    hash = "sha256-T357ocJvDC+vt0I4VyAu0Q9YzY9cSK7shgp9fQ1qHyY=";
+  };
+
+  propagatedBuildInputs = [
+    django-stubs
+    mypy
+    requests
+    types-pyyaml
+    types-requests
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    mypy
+    py
+    pytest-mypy-plugins
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "PEP-484 stubs for Django REST Framework";
+    homepage = "https://github.com/typeddjango/djangorestframework-stubs";
+    changelog = "https://github.com/typeddjango/djangorestframework-stubs/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2939,6 +2939,8 @@ self: super: with self; {
 
   djangorestframework-simplejwt = callPackage ../development/python-modules/djangorestframework-simplejwt { };
 
+  djangorestframework-stubs = callPackage ../development/python-modules/djangorestframework-stubs { };
+
   django-reversion = callPackage ../development/python-modules/django-reversion { };
 
   django-sekizai = callPackage ../development/python-modules/django-sekizai { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added djangorestframework-stubs package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
