### PR TITLE
python3Packages.equinox: init at 0.10.11

### DIFF
--- a/pkgs/development/python-modules/equinox/default.nix
+++ b/pkgs/development/python-modules/equinox/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hatchling
+, jax
+, jaxlib
+, jaxtyping
+, typing-extensions
+, beartype
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "equinox";
+  version = "0.10.11";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "patrick-kidger";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-JffuPplIROPog29FBsWH9cQHSkrFKuXjaTjjEwIqW/0=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    jax
+    jaxlib
+    jaxtyping
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    beartype
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "equinox" ];
+
+  meta = with lib; {
+    description = "A JAX library based around a simple idea: represent parameterised functions (such as neural networks) as PyTrees";
+    homepage = "https://github.com/patrick-kidger/equinox";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/jaxtyping/default.nix
+++ b/pkgs/development/python-modules/jaxtyping/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hatchling
+, numpy
+, typeguard
+, typing-extensions
+, cloudpickle
+, equinox
+, jax
+, jaxlib
+, torch
+, pytestCheckHook
+}:
+
+let
+  jaxtyping = buildPythonPackage rec {
+    pname = "jaxtyping";
+    version = "0.2.20";
+    format = "pyproject";
+
+    src = fetchFromGitHub {
+      owner = "google";
+      repo = pname;
+      rev = "refs/tags/v${version}";
+      hash = "sha256-q/KQGV7I7w5p7VP8C9BDUHfPsuCMf2v304qiH+XCzyU=";
+    };
+
+    nativeBuildInputs = [
+      hatchling
+    ];
+
+    propagatedBuildInputs = [
+      numpy
+      typeguard
+      typing-extensions
+    ];
+
+    nativeCheckInputs = [
+      cloudpickle
+      equinox
+      jax
+      jaxlib
+      pytestCheckHook
+      torch
+    ];
+
+    doCheck = false;
+
+    # Enable tests via passthru to avoid cyclic dependency with equinox.
+    passthru.tests = {
+      check = jaxtyping.overridePythonAttrs { doCheck = true; };
+    };
+
+    pythonImportsCheck = [ "jaxtyping" ];
+
+    meta = with lib; {
+      description = "Type annotations and runtime checking for JAX arrays and PyTrees";
+      homepage = "https://github.com/google/jaxtyping";
+      license = licenses.mit;
+      maintainers = with maintainers; [ GaetanLepage ];
+    };
+  };
+ in jaxtyping

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3406,6 +3406,8 @@ self: super: with self; {
 
   epson-projector = callPackage ../development/python-modules/epson-projector { };
 
+  equinox = callPackage ../development/python-modules/equinox { };
+
   eradicate = callPackage ../development/python-modules/eradicate { };
 
   es-client = callPackage ../development/python-modules/es-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5336,6 +5336,8 @@ self: super: with self; {
 
   jaxopt = callPackage ../development/python-modules/jaxopt { };
 
+  jaxtyping = callPackage ../development/python-modules/jaxtyping { };
+
   jaydebeapi = callPackage ../development/python-modules/jaydebeapi { };
 
   jc = callPackage ../development/python-modules/jc { };


### PR DESCRIPTION
## Description of changes

Add [equinox](https://github.com/patrick-kidger/equinox), a neural network library in JAX.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
