### PR TITLE
zbctl: 8.0.6 -> 8.2.11

### DIFF
--- a/pkgs/tools/admin/zbctl/default.nix
+++ b/pkgs/tools/admin/zbctl/default.nix
@@ -5,14 +5,14 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "zbctl";
-  version = "8.0.6";
+  version = "8.2.11";
 
   src = if stdenvNoCC.hostPlatform.system == "x86_64-darwin" then fetchurl {
     url = "https://github.com/camunda/zeebe/releases/download/${version}/zbctl.darwin";
-    sha256 = "17hfjrcr6lmw91jq24nbw5yz61x6larmx39lyfj6pwlz0710y13p";
+    sha256 = "0390n6wmlmfwqf6fvw6wqg6hbrs7bm9x2cdaajlw87377lklypkf";
   } else if stdenvNoCC.hostPlatform.system == "x86_64-linux" then fetchurl {
     url = "https://github.com/camunda/zeebe/releases/download/${version}/zbctl";
-    sha256 = "1xng11x7wcjvc0vipdrqyn97aa4jlgcp7g9aw4d36fw0xp9p47kp";
+    sha256 = "081hc0nynwg014lhsxxyin4rc2i9z6wh8q9i98cjjd8kgr41h096";
   } else throw "Unsupported platform ${stdenvNoCC.hostPlatform.system}";
 
   dontUnpack = true;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
