### PR TITLE
tango-controls: init at 9.4.2

### DIFF
--- a/pkgs/applications/system/tango-controls/astor.nix
+++ b/pkgs/applications/system/tango-controls/astor.nix
@@ -1,0 +1,41 @@
+{ fetchFromGitLab
+, lib
+, makeWrapper
+, jre
+, maven
+}:
+maven.buildMavenPackage rec {
+  pname = "astor";
+  # tango 9.4.2 bundles astor version 7.4.4, but this doesn't install
+  # properly ("mainClass" attribute missing), so we take a newer one
+  version = "7.5.3";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = pname;
+    rev = version;
+    hash = "sha256-XqZMIYtpGv9jpS3l1OD1BPzeeH+RDZImfzemrktRRrQ=";
+  };
+
+  mvnHash = "sha256-w37+COCV5Rs/9ayCypa4x3LWHqzq1kaYBoM64kSaPfk=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/astor
+    install -Dm644 target/Astor-${version}-jar-with-dependencies.jar $out/share/astor/astor.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/astor --add-flags "-jar $out/share/astor/astor.jar"
+  '';
+
+  meta = with lib; {
+    description = "Administration tool for the Tango controls system";
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/astor.nix
+++ b/pkgs/applications/system/tango-controls/astor.nix
@@ -17,7 +17,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-XqZMIYtpGv9jpS3l1OD1BPzeeH+RDZImfzemrktRRrQ=";
   };
 
-  mvnHash = "sha256-w37+COCV5Rs/9ayCypa4x3LWHqzq1kaYBoM64kSaPfk=";
+  mvnHash = "sha256-3ahyxk5UbTCkb8e+P1PS2uwDzt1f8HbdzAT2wjFL7OA=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/system/tango-controls/cpptango.nix
+++ b/pkgs/applications/system/tango-controls/cpptango.nix
@@ -1,0 +1,82 @@
+{ cmake
+, cppzmq
+, doxygen
+, fetchurl
+, fetchFromGitLab
+, tango-idl
+, graphviz
+, lib
+, libjpeg_turbo
+, libsodium
+, pkg-config
+, stdenv
+, zeromq
+, omniorb
+, zlib
+}:
+let
+  # tango doesn't support the latest version of omniorb
+  omniorb_4_2 = omniorb.overrideAttrs (self: super: rec {
+    version = "4.2.5";
+
+    src = fetchurl {
+      url = "mirror://sourceforge/project/omniorb/omniORB/omniORB-${version}/omniORB-${version}.tar.bz2";
+      sha256 = "1fvkw3pn9i2312n4k3d4s7892m91jynl8g1v2z0j8k1gzfczjp7h";
+    };
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "cpptango";
+  version = "9.4.2";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = pname;
+    rev = version;
+    hash = "sha256-ji5Ti5Lc4wKYydgAzj+rZiCcVZHCzy/NUqh+koO5rhg=";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    zlib
+    omniorb_4_2
+    zeromq
+    cppzmq
+    tango-idl
+    libjpeg_turbo
+    libsodium
+    doxygen
+    # needed for the docs
+    graphviz
+  ];
+  propagatedBuildInputs = [
+    omniorb_4_2
+    cppzmq
+    zeromq
+    libjpeg_turbo
+    libsodium
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_RPATH=ON"
+  ];
+
+  postPatch = ''
+    sed -i -e 's#Requires: libzmq#Requires: libzmq cppzmq#' -e 's#libdir=.*#libdir=@CMAKE_INSTALL_FULL_LIBDIR@#' tango.pc.cmake
+  '';
+
+  meta = with lib; {
+    description = "Open Source solution for SCADA and DCS";
+    longDescription = ''
+      Tango Controls is a toolkit for connecting hardware and software together. It is a mature software which is used by tens of sites to run highly complicated accelerator complexes and experiments 24 hours a day. It is free and Open Source. It is ideal for small and large installations. It provides full support for 3 programming languages - C++, Python and Java.
+    '';
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/default.nix
+++ b/pkgs/applications/system/tango-controls/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ omniorb_4_2 cppzmq zeromq libjpeg_turbo ];
 
   cmakeFlags = [
-    "-DMySQL_LIBRARY_RELEASE=${mariadb-connector-c}/lib/mariadb/libmariadb.so"
+    "-DMySQL_LIBRARY_RELEASE=${mariadb-connector-c}/lib/mariadb/libmariadb${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DMySQL_INCLUDE_DIR=${mariadb-connector-c.dev}/include/mariadb"
     "-DMySQL_EXECUTABLE=${mariadb-connector-c}/bin/mariadb"
     "-DCMAKE_VERBOSE_MAKEFILE=TRUE"

--- a/pkgs/applications/system/tango-controls/default.nix
+++ b/pkgs/applications/system/tango-controls/default.nix
@@ -1,0 +1,104 @@
+{ cmake
+, cppzmq
+, doxygen
+, fetchurl
+, graphviz
+, lib
+, libjpeg_turbo
+, libsodium
+, mariadb-connector-c
+, openjdk11
+, pkg-config
+, python3
+, stdenv
+, systemd
+, zeromq
+, zlib
+}:
+let
+  # omniorb is in nixpkgs, but tango doesn't support the latest version
+  omniorb_4_2 = stdenv.mkDerivation rec {
+    pname = "omniorb";
+    version = "4.2.5";
+
+    src = fetchurl {
+      url = "mirror://sourceforge/project/omniorb/omniORB/omniORB-${version}/omniORB-${version}.tar.bz2";
+      sha256 = "1fvkw3pn9i2312n4k3d4s7892m91jynl8g1v2z0j8k1gzfczjp7h";
+    };
+
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ python3 ];
+
+    enableParallelBuilding = true;
+    hardeningDisable = [ "format" ];
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "tango-controls";
+  version = "9.4.2";
+
+  src = fetchurl {
+    url = "https://gitlab.com/api/v4/projects/24125890/packages/generic/TangoSourceDistribution/${version}/tango-${version}.tar.gz";
+    hash = "sha256-3KQYBNd450gBRqJBa0SHXWXIADfpdNPeBLskXGTPqBY=";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    zlib
+    omniorb_4_2
+    zeromq
+    cppzmq
+    libjpeg_turbo
+    mariadb-connector-c
+    libsodium
+    doxygen
+    # needed for the docs
+    graphviz
+    systemd
+  ];
+  propagatedBuildInputs = [ omniorb_4_2 cppzmq zeromq libjpeg_turbo ];
+
+  cmakeFlags = [
+    "-DMySQL_LIBRARY_RELEASE=${mariadb-connector-c}/lib/mariadb/libmariadb.so"
+    "-DMySQL_INCLUDE_DIR=${mariadb-connector-c.dev}/include/mariadb"
+    "-DMySQL_EXECUTABLE=${mariadb-connector-c}/bin/mariadb"
+    "-DCMAKE_VERBOSE_MAKEFILE=TRUE"
+    "-DCMAKE_SKIP_RPATH=ON"
+    "-DTSD_TAC=ON"
+    "-DTSD_JAVA_PATH=${openjdk11}"
+  ];
+
+  patches = [
+    # To build proper systemd services for Tango, we need a way to tell when the DB service is started.
+    # This patch adds systemd support for this.
+    ./sd_notify_cmake.patch
+  ];
+
+  postPatch = ''
+    sed -i -e 's#Requires: libzmq#Requires: libzmq cppzmq#' -e 's#libdir=.*#libdir=@CMAKE_INSTALL_FULL_LIBDIR@#' lib/cpp/tango.pc.cmake
+    sed -i -e 's#libdir=.*#libdir=@CMAKE_INSTALL_FULL_LIBDIR@#' lib/idl/tangoidl.pc.cmake
+  '';
+
+  # Make sql migration scripts executable from anywhere (don't depend on relative paths)
+  postInstall = ''
+    mkdir -p $out/share/sql
+    for fn in cppserver/database/*sql; do
+      sed -e "s#^source #source $out/share/sql/#" "$fn" > $out/share/sql/$(basename "$fn")
+    done
+  '';
+
+  meta = with lib; {
+    description = "Open Source solution for SCADA and DCS";
+    longDescription = ''
+      Tango Controls is a toolkit for connecting hardware and software together. It is a mature software which is used by tens of sites to run highly complicated accelerator complexes and experiments 24 hours a day. It is free and Open Source. It is ideal for small and large installations. It provides full support for 3 programming languages - C++, Python and Java.
+    '';
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/main/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/default.nix
+++ b/pkgs/applications/system/tango-controls/default.nix
@@ -13,25 +13,19 @@
 , stdenv
 , systemd
 , zeromq
+, omniorb
 , zlib
 }:
 let
-  # omniorb is in nixpkgs, but tango doesn't support the latest version
-  omniorb_4_2 = stdenv.mkDerivation rec {
-    pname = "omniorb";
+  # tango doesn't support the latest version of omniorb
+  omniorb_4_2 = omniorb.overrideAttrs (self: super: rec {
     version = "4.2.5";
 
     src = fetchurl {
       url = "mirror://sourceforge/project/omniorb/omniORB/omniORB-${version}/omniORB-${version}.tar.bz2";
       sha256 = "1fvkw3pn9i2312n4k3d4s7892m91jynl8g1v2z0j8k1gzfczjp7h";
     };
-
-    nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ python3 ];
-
-    enableParallelBuilding = true;
-    hardeningDisable = [ "format" ];
-  };
+  });
 in
 stdenv.mkDerivation rec {
   pname = "tango-controls";
@@ -55,7 +49,7 @@ stdenv.mkDerivation rec {
     doxygen
     # needed for the docs
     graphviz
-  ] ++ lib.optional (!stdenv.isDarwin) systemd;
+  ] ++ lib.optional stdenv.isLinux systemd;
   propagatedBuildInputs = [ omniorb_4_2 cppzmq zeromq libjpeg_turbo ];
 
   cmakeFlags = [
@@ -70,7 +64,7 @@ stdenv.mkDerivation rec {
 
   # To build proper systemd services for Tango, we need a way to tell when the DB service is started.
   # This patch adds systemd support for this.
-  patches = lib.optional (!stdenv.isDarwin) ./sd_notify_cmake.patch;
+  patches = lib.optional stdenv.isLinux ./sd_notify_cmake.patch;
 
   postPatch = ''
     sed -i -e 's#Requires: libzmq#Requires: libzmq cppzmq#' -e 's#libdir=.*#libdir=@CMAKE_INSTALL_FULL_LIBDIR@#' lib/cpp/tango.pc.cmake
@@ -91,7 +85,7 @@ stdenv.mkDerivation rec {
       Tango Controls is a toolkit for connecting hardware and software together. It is a mature software which is used by tens of sites to run highly complicated accelerator complexes and experiments 24 hours a day. It is free and Open Source. It is ideal for small and large installations. It provides full support for 3 programming languages - C++, Python and Java.
     '';
     homepage = "https://www.tango-controls.org";
-    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/main/RELEASE_NOTES.md";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
     downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ pmiddend ];

--- a/pkgs/applications/system/tango-controls/default.nix
+++ b/pkgs/applications/system/tango-controls/default.nix
@@ -55,8 +55,7 @@ stdenv.mkDerivation rec {
     doxygen
     # needed for the docs
     graphviz
-    systemd
-  ];
+  ] ++ lib.optional (!stdenv.isDarwin) systemd;
   propagatedBuildInputs = [ omniorb_4_2 cppzmq zeromq libjpeg_turbo ];
 
   cmakeFlags = [
@@ -69,11 +68,9 @@ stdenv.mkDerivation rec {
     "-DTSD_JAVA_PATH=${openjdk11}"
   ];
 
-  patches = [
-    # To build proper systemd services for Tango, we need a way to tell when the DB service is started.
-    # This patch adds systemd support for this.
-    ./sd_notify_cmake.patch
-  ];
+  # To build proper systemd services for Tango, we need a way to tell when the DB service is started.
+  # This patch adds systemd support for this.
+  patches = lib.optional (!stdenv.isDarwin) ./sd_notify_cmake.patch;
 
   postPatch = ''
     sed -i -e 's#Requires: libzmq#Requires: libzmq cppzmq#' -e 's#libdir=.*#libdir=@CMAKE_INSTALL_FULL_LIBDIR@#' lib/cpp/tango.pc.cmake

--- a/pkgs/applications/system/tango-controls/default.nix
+++ b/pkgs/applications/system/tango-controls/default.nix
@@ -1,95 +1,14 @@
-{ cmake
-, cppzmq
-, doxygen
-, fetchurl
-, graphviz
-, lib
-, libjpeg_turbo
-, libsodium
-, mariadb-connector-c
-, openjdk11
-, pkg-config
-, python3
-, stdenv
-, systemd
-, zeromq
-, omniorb
-, zlib
+{ callPackage
 }:
-let
-  # tango doesn't support the latest version of omniorb
-  omniorb_4_2 = omniorb.overrideAttrs (self: super: rec {
-    version = "4.2.5";
-
-    src = fetchurl {
-      url = "mirror://sourceforge/project/omniorb/omniORB/omniORB-${version}/omniORB-${version}.tar.bz2";
-      sha256 = "1fvkw3pn9i2312n4k3d4s7892m91jynl8g1v2z0j8k1gzfczjp7h";
-    };
-  });
-in
-stdenv.mkDerivation rec {
-  pname = "tango-controls";
-  version = "9.4.2";
-
-  src = fetchurl {
-    url = "https://gitlab.com/api/v4/projects/24125890/packages/generic/TangoSourceDistribution/${version}/tango-${version}.tar.gz";
-    hash = "sha256-3KQYBNd450gBRqJBa0SHXWXIADfpdNPeBLskXGTPqBY=";
-  };
-
-  enableParallelBuilding = true;
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [
-    zlib
-    omniorb_4_2
-    zeromq
-    cppzmq
-    libjpeg_turbo
-    mariadb-connector-c
-    libsodium
-    doxygen
-    # needed for the docs
-    graphviz
-  ] ++ lib.optional stdenv.isLinux systemd;
-  propagatedBuildInputs = [ omniorb_4_2 cppzmq zeromq libjpeg_turbo ];
-
-  cmakeFlags = [
-    "-DMySQL_LIBRARY_RELEASE=${mariadb-connector-c}/lib/mariadb/libmariadb${stdenv.hostPlatform.extensions.sharedLibrary}"
-    "-DMySQL_INCLUDE_DIR=${mariadb-connector-c.dev}/include/mariadb"
-    "-DMySQL_EXECUTABLE=${mariadb-connector-c}/bin/mariadb"
-    "-DCMAKE_VERBOSE_MAKEFILE=TRUE"
-    "-DCMAKE_SKIP_RPATH=ON"
-    "-DTSD_TAC=ON"
-    "-DTSD_JAVA_PATH=${openjdk11}"
-  ];
-
-  # To build proper systemd services for Tango, we need a way to tell when the DB service is started.
-  # This patch adds systemd support for this.
-  patches = lib.optional stdenv.isLinux ./sd_notify_cmake.patch;
-
-  postPatch = ''
-    sed -i -e 's#Requires: libzmq#Requires: libzmq cppzmq#' -e 's#libdir=.*#libdir=@CMAKE_INSTALL_FULL_LIBDIR@#' lib/cpp/tango.pc.cmake
-    sed -i -e 's#libdir=.*#libdir=@CMAKE_INSTALL_FULL_LIBDIR@#' lib/idl/tangoidl.pc.cmake
-  '';
-
-  # Make sql migration scripts executable from anywhere (don't depend on relative paths)
-  postInstall = ''
-    mkdir -p $out/share/sql
-    for fn in cppserver/database/*sql; do
-      sed -e "s#^source #source $out/share/sql/#" "$fn" > $out/share/sql/$(basename "$fn")
-    done
-  '';
-
-  meta = with lib; {
-    description = "Open Source solution for SCADA and DCS";
-    longDescription = ''
-      Tango Controls is a toolkit for connecting hardware and software together. It is a mature software which is used by tens of sites to run highly complicated accelerator complexes and experiments 24 hours a day. It is free and Open Source. It is ideal for small and large installations. It provides full support for 3 programming languages - C++, Python and Java.
-    '';
-    homepage = "https://www.tango-controls.org";
-    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
-    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ pmiddend ];
-    platforms = platforms.unix;
-  };
-
+rec {
+  cpptango = callPackage ./cpptango.nix { inherit tango-idl; };
+  tango-idl = callPackage ./tango-idl.nix { };
+  database = callPackage ./tango-database.nix { inherit cpptango; };
+  access-control = callPackage ./tango-access-control.nix { inherit cpptango; };
+  starter = callPackage ./tango-starter.nix { inherit cpptango; };
+  admin = callPackage ./tango-admin.nix { inherit cpptango; };
+  test = callPackage ./tango-test.nix { inherit cpptango; };
+  pogo = callPackage ./pogo.nix { };
+  jive = callPackage ./jive.nix { };
+  astor = callPackage ./astor.nix { };
 }

--- a/pkgs/applications/system/tango-controls/fix-pc-file.patch
+++ b/pkgs/applications/system/tango-controls/fix-pc-file.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/cpp/tango.pc.cmake b/lib/cpp/tango.pc.cmake
+index 39facaf..2ac216c 100644
+--- a/lib/cpp/tango.pc.cmake
++++ b/lib/cpp/tango.pc.cmake
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}/bin
+ includedir=${prefix}/include
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ 
+ Name: @CMAKE_PROJECT_NAME@
+ Description: Tango client/server API library
+diff --git a/lib/idl/tangoidl.pc.cmake b/lib/idl/tangoidl.pc.cmake
+index 8ff1231..dde5aeb 100644
+--- a/lib/idl/tangoidl.pc.cmake
++++ b/lib/idl/tangoidl.pc.cmake
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+ includedir=${prefix}/include
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ 
+ Name: @CMAKE_PROJECT_NAME@
+ Description: TANGO IDL

--- a/pkgs/applications/system/tango-controls/jive.nix
+++ b/pkgs/applications/system/tango-controls/jive.nix
@@ -1,0 +1,39 @@
+{ fetchFromGitLab
+, lib
+, makeWrapper
+, jre
+, maven
+}:
+maven.buildMavenPackage rec {
+  pname = "jive";
+  version = "7.36";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = pname;
+    rev = version;
+    hash = "sha256-TyCCD//b71XI28O3R0WFeRXu4H5/e0H+WF8MI3Yvvnc=";
+  };
+
+  mvnHash = "sha256-caLHQfBE5Kn351wkkFtmr7rQz9eT76H7BbTzS47dqx8=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/jive
+    install -Dm644 target/Jive-${version}-jar-with-dependencies.jar $out/share/jive/jive.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/jive --add-flags "-jar $out/share/jive/jive.jar"
+  '';
+
+  meta = with lib; {
+    description = "Administration tool for the Tango controls system";
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/jive.nix
+++ b/pkgs/applications/system/tango-controls/jive.nix
@@ -15,7 +15,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-TyCCD//b71XI28O3R0WFeRXu4H5/e0H+WF8MI3Yvvnc=";
   };
 
-  mvnHash = "sha256-caLHQfBE5Kn351wkkFtmr7rQz9eT76H7BbTzS47dqx8=";
+  mvnHash = "sha256-qKUTqT9r9gW+WIAjEldGRg9i/FqTxIkMnt2si9RW+nc=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/system/tango-controls/pogo-pom-version-enforce.patch
+++ b/pkgs/applications/system/tango-controls/pogo-pom-version-enforce.patch
@@ -1,0 +1,53 @@
+diff --git a/fr.esrf.tango.pogo.parent/pom.xml b/fr.esrf.tango.pogo.parent/pom.xml
+index b64de38..6083d28 100755
+--- a/fr.esrf.tango.pogo.parent/pom.xml
++++ b/fr.esrf.tango.pogo.parent/pom.xml
+@@ -91,8 +91,46 @@
+     </distributionManagement>
+ 
+     <build>
+-        <plugins>
+-            <plugin>
++      <plugins>
++	<plugin>
++	  <groupId>org.apache.maven.plugins</groupId>
++	  <artifactId>maven-install-plugin</artifactId>
++	  <version>2.4</version>
++	</plugin>
++	<plugin>
++	  <groupId>org.apache.maven.plugins</groupId>
++	  <artifactId>maven-site-plugin</artifactId>
++	  <version>3.3</version>
++	</plugin>
++	<plugin>
++	  <groupId>org.apache.maven.plugins</groupId>
++	  <artifactId>maven-surefire-plugin</artifactId>
++	  <version>2.12.4</version>
++	</plugin>
++	<plugin>
++	  <groupId>org.apache.maven.plugins</groupId>
++	  <artifactId>maven-jar-plugin</artifactId>
++	  <version>2.4</version>
++	</plugin>
++	  <plugin>
++	    <groupId>org.apache.maven.plugins</groupId>
++	    <artifactId>maven-enforcer-plugin</artifactId>
++	    <version>3.3.0</version>
++	    <executions>
++	      <execution>
++		<id>enforce-plugin-versions</id>
++		<goals>
++		  <goal>enforce</goal>
++		</goals>
++		<configuration>
++		  <rules>
++		    <requirePluginVersions />
++		  </rules>
++		</configuration>
++	      </execution>
++	    </executions>
++	  </plugin>
++	  <plugin>
+                 <artifactId>maven-deploy-plugin</artifactId>
+                 <version>3.0.0-M1</version>
+             </plugin>

--- a/pkgs/applications/system/tango-controls/pogo.nix
+++ b/pkgs/applications/system/tango-controls/pogo.nix
@@ -1,0 +1,65 @@
+{ fetchFromGitLab
+, lib
+, makeWrapper
+, jre
+, jdk11
+, maven
+}:
+let
+  mavenJdk11 = maven.override { jdk = jdk11; };
+in
+mavenJdk11.buildMavenPackage rec {
+  pname = "pogo";
+  version = "9.8.3";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = pname;
+    rev = version;
+    hash = "sha256-e2uZgq57Xf9b2i0ZBkijoMWjSGtmgJ+nz8NVT1qMQE4=";
+  };
+
+  postUnpack = ''
+    rm -r source/org.tango.pogo.pogo_gui/src/existingcode
+  '';
+
+  # Passing "-f fr.esrf.tango.pogo.parent/pom.xml" to "mvnParameters" is not enough - you have to "cd"
+  preBuild = ''
+    cd fr.esrf.tango.pogo.parent
+  '';
+
+  mvnFetchExtraArgs = {
+    buildPhase = ''
+      rm -r org.tango.pogo.pogo_gui/src/existingcode
+      cd fr.esrf.tango.pogo.parent
+      mvn package -Dmaven.repo.local=$out/.m2
+    '';
+  };
+
+  mvnHash = "sha256-TspWKitRfbrg6vRd6pmRAkbF0m7PqHSvcrT+wwyLzvg=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    echo "========================================="
+    find .. -name '*.jar'
+    echo "========================================="
+    mkdir -p $out/bin $out/share/pogo
+    install -Dm644 ../org.tango.pogo.pogo_gui/target/Pogo-${version}-SNAPSHOT.jar $out/share/pogo/pogo.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/pogo --add-flags "-jar $out/share/pogo/pogo.jar"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Administration tool for the Tango controls system";
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/pogo.nix
+++ b/pkgs/applications/system/tango-controls/pogo.nix
@@ -19,6 +19,8 @@ mavenJdk11.buildMavenPackage rec {
     hash = "sha256-e2uZgq57Xf9b2i0ZBkijoMWjSGtmgJ+nz8NVT1qMQE4=";
   };
 
+  patches = [ ./pogo-pom-version-enforce.patch ];
+
   postUnpack = ''
     rm -r source/org.tango.pogo.pogo_gui/src/existingcode
   '';
@@ -36,7 +38,7 @@ mavenJdk11.buildMavenPackage rec {
     '';
   };
 
-  mvnHash = "sha256-mN8FfPAGhjJVHGAfd0AYwLuzkE4uaQjE1mr1AKuQapo=";
+  mvnHash = "sha256-o+sz1r/IsDQ+kSSROHaH/UPNyrluGd687iXFTnylXCQ=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/system/tango-controls/pogo.nix
+++ b/pkgs/applications/system/tango-controls/pogo.nix
@@ -36,7 +36,7 @@ mavenJdk11.buildMavenPackage rec {
     '';
   };
 
-  mvnHash = "sha256-TspWKitRfbrg6vRd6pmRAkbF0m7PqHSvcrT+wwyLzvg=";
+  mvnHash = "sha256-mN8FfPAGhjJVHGAfd0AYwLuzkE4uaQjE1mr1AKuQapo=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/system/tango-controls/sd_notify_cmake.patch
+++ b/pkgs/applications/system/tango-controls/sd_notify_cmake.patch
@@ -1,0 +1,36 @@
+diff --git a/cppserver/database/CMakeLists.txt b/cppserver/database/CMakeLists.txt
+index 00c89fd..89ed4e1 100644
+--- a/cppserver/database/CMakeLists.txt
++++ b/cppserver/database/CMakeLists.txt
+@@ -29,8 +29,9 @@ set(ADDITIONAL_SOURCES  DataBaseUtils.cpp
+                         update_starter.cpp)
+ 
+ add_executable(Databaseds ${SOURCES} ${ADDITIONAL_SOURCES})
+-target_include_directories(Databaseds PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+-target_link_libraries(Databaseds PUBLIC Tango::Tango MySQL::MySQL)
++pkg_check_modules(SYSTEMD libsystemd REQUIRED)
++target_include_directories(Databaseds PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${SYSTEMD_INCLUDE_DIRS})
++target_link_libraries(Databaseds PUBLIC Tango::Tango MySQL::MySQL ${SYSTEMD_LIBRARIES})
+ 
+ if (WIN32 AND (Tango_IS_STATIC OR Tango_FORCE_STATIC))
+     set_target_properties(Databaseds PROPERTIES
+diff --git a/cppserver/database/main.cpp b/cppserver/database/main.cpp
+index 2d7b369..2f4686b 100644
+--- a/cppserver/database/main.cpp
++++ b/cppserver/database/main.cpp
+@@ -37,6 +37,7 @@
+ // along with Tango.  If not, see <http://www.gnu.org/licenses/>.
+ //
+ 
++#include <systemd/sd-daemon.h>
+ #include <tango/tango.h>
+ #include "DataBase.h"
+ #include "Logging.h"
+@@ -336,6 +337,7 @@ int main(int argc,char *argv[])
+ //
+ 
+ 		TANGO_LOG << "Ready to accept request" << std::endl;
++		sd_notify(0, "READY=1");
+ 		(tango_util->get_orb())->run();
+ 	}
+ 	catch (std::bad_alloc&)

--- a/pkgs/applications/system/tango-controls/sd_notify_cmake.patch
+++ b/pkgs/applications/system/tango-controls/sd_notify_cmake.patch
@@ -1,7 +1,7 @@
-diff --git a/cppserver/database/CMakeLists.txt b/cppserver/database/CMakeLists.txt
+diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 00c89fd..89ed4e1 100644
---- a/cppserver/database/CMakeLists.txt
-+++ b/cppserver/database/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -29,8 +29,9 @@ set(ADDITIONAL_SOURCES  DataBaseUtils.cpp
                          update_starter.cpp)
  
@@ -14,10 +14,10 @@ index 00c89fd..89ed4e1 100644
  
  if (WIN32 AND (Tango_IS_STATIC OR Tango_FORCE_STATIC))
      set_target_properties(Databaseds PROPERTIES
-diff --git a/cppserver/database/main.cpp b/cppserver/database/main.cpp
+diff --git a/main.cpp b/main.cpp
 index 2d7b369..2f4686b 100644
---- a/cppserver/database/main.cpp
-+++ b/cppserver/database/main.cpp
+--- a/main.cpp
++++ b/main.cpp
 @@ -37,6 +37,7 @@
  // along with Tango.  If not, see <http://www.gnu.org/licenses/>.
  //

--- a/pkgs/applications/system/tango-controls/tango-access-control.nix
+++ b/pkgs/applications/system/tango-controls/tango-access-control.nix
@@ -1,0 +1,45 @@
+{ cmake
+, cpptango
+, fetchFromGitLab
+, lib
+, mariadb-connector-c
+, pkg-config
+, stdenv
+}:
+stdenv.mkDerivation rec {
+  pname = "tango-access-control";
+  version = "2.20";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = "TangoAccessControl";
+    rev = "TangoAccessControl-Release-${version}";
+    hash = "sha256-5LrF18o3CWveX4zoUhKB0tgIIVDXnhxL2UcYoL33r4g=";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cpptango ];
+
+  cmakeFlags = [
+    "-DMySQL_LIBRARY_RELEASE=${mariadb-connector-c}/lib/mariadb/libmariadb${stdenv.hostPlatform.extensions.sharedLibrary}"
+    "-DMySQL_INCLUDE_DIR=${mariadb-connector-c.dev}/include/mariadb"
+    "-DMySQL_EXECUTABLE=${mariadb-connector-c}/bin/mariadb"
+    "-DCMAKE_SKIP_RPATH=ON"
+  ];
+
+  preConfigure = ''
+    cd TangoAccessControl
+  '';
+
+  meta = with lib; {
+    description = "Access control device server for the Tango controls system";
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/tango-admin.nix
+++ b/pkgs/applications/system/tango-controls/tango-admin.nix
@@ -1,0 +1,37 @@
+{ cmake
+, cpptango
+, fetchFromGitLab
+, lib
+, pkg-config
+, stdenv
+}:
+stdenv.mkDerivation rec {
+  pname = "tango-admin";
+  version = "1.19";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = "tango_admin";
+    rev = "Release_${version}";
+    hash = "sha256-ae56c+RuMT8FlnAtAs3FrtkRFCySE8w6V/cTUi4TMp8=";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cpptango ];
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_RPATH=ON"
+  ];
+
+  meta = with lib; {
+    description = "Admin device server for the Tango controls system";
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/tango-database.nix
+++ b/pkgs/applications/system/tango-controls/tango-database.nix
@@ -1,0 +1,46 @@
+{ cmake
+, cpptango
+, fetchFromGitLab
+, lib
+, mariadb-connector-c
+, pkg-config
+, stdenv
+, systemd
+}:
+stdenv.mkDerivation rec {
+  pname = "tango-database";
+  version = "5.22";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = "TangoDatabase";
+    rev = "Database-Release-${version}";
+    hash = "sha256-SibxtXL7DKQGua8VEr6hd/5sRjQUIWURIS3MxQ13Qfc=";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cpptango ] ++ lib.optional stdenv.isLinux systemd;
+
+  cmakeFlags = [
+    "-DMySQL_LIBRARY_RELEASE=${mariadb-connector-c}/lib/mariadb/libmariadb${stdenv.hostPlatform.extensions.sharedLibrary}"
+    "-DMySQL_INCLUDE_DIR=${mariadb-connector-c.dev}/include/mariadb"
+    "-DMySQL_EXECUTABLE=${mariadb-connector-c}/bin/mariadb"
+    "-DCMAKE_SKIP_RPATH=ON"
+  ];
+
+  # To build proper systemd services for Tango, we need a way to tell when the DB service is started.
+  # This patch adds systemd support for this.
+  patches = lib.optional stdenv.isLinux ./sd_notify_cmake.patch;
+
+  meta = with lib; {
+    description = "Database server for the Tango controls system";
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/tango-idl.nix
+++ b/pkgs/applications/system/tango-controls/tango-idl.nix
@@ -1,0 +1,35 @@
+{ cmake
+, fetchFromGitLab
+, lib
+, pkg-config
+, stdenv
+}:
+stdenv.mkDerivation rec {
+  pname = "tango-idl";
+  version = "5.1.2";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = pname;
+    rev = version;
+    hash = "sha256-VrUftmADFvl1UaJzXT0pMvVXUqOJxlVsQg2NgP+YcU0=";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  postPatch = ''
+    sed -i -e 's#libdir=.*#libdir=@CMAKE_INSTALL_FULL_LIBDIR@#' tangoidl.pc.cmake
+  '';
+
+  meta = with lib; {
+    description = "Tango CORBA IDL file";
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/tango-starter.nix
+++ b/pkgs/applications/system/tango-controls/tango-starter.nix
@@ -1,0 +1,37 @@
+{ cmake
+, cpptango
+, fetchFromGitLab
+, lib
+, pkg-config
+, stdenv
+}:
+stdenv.mkDerivation rec {
+  pname = "tango-starter";
+  version = "8.1";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = "starter";
+    rev = "Starter-${version}";
+    hash = "sha256-pO43OFYUcL9kePR0ixiR4GBWKJmD3xiqp7kCZUAm/Y4=";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cpptango ];
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_RPATH=ON"
+  ];
+
+  meta = with lib; {
+    description = "Starter device server for the Tango controls system";
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/system/tango-controls/tango-test.nix
+++ b/pkgs/applications/system/tango-controls/tango-test.nix
@@ -1,0 +1,35 @@
+{ cmake
+, cpptango
+, fetchFromGitLab
+, lib
+, mariadb-connector-c
+, pkg-config
+, stdenv
+, systemd
+}:
+stdenv.mkDerivation rec {
+  pname = "tango-test";
+  version = "3.8";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = "TangoTest";
+    rev = version;
+    hash = "sha256-PJA0OCoqn31W9VelMz29fdVuJcq//lMbbJ/7xzbi1mw=";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cpptango ];
+
+  meta = with lib; {
+    description = "Test device server for the Tango controls system";
+    homepage = "https://www.tango-controls.org";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${version}/RELEASE_NOTES.md";
+    downloadPage = "https://gitlab.com/tango-controls/TangoSourceDistribution/-/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1936,6 +1936,8 @@ with pkgs;
 
   tailwindcss = callPackage ../development/tools/tailwindcss { };
 
+  tango-controls = callPackage ../applications/system/tango-controls { };
+
   tauon = callPackage ../applications/audio/tauon { };
 
   tere = callPackage ../tools/misc/tere { };


### PR DESCRIPTION
## Description of changes

This adds the [Tango](https://www.tango-controls.org/) controls system that is being widely used by different particle accelerator facilities across the globe. We're using it here at [DESY](https://www.desy.de/) to control our motors, detectors etc., and we're using Nix as well, so it makes sense to put it into nixpkgs.

This derivation is sort of battle-tested by now, but it's hard to give an example. You could build the derivation and try to run one of the Java-based UIs for Tango, Jive: `result/bin/jive`. This needs a working Tango server, however, and that's not trivial to set up because it needs a MariaDB database.

I have systemd services for that as well, but I wanted to contribute just the core.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
