### PR TITLE
treewide: stop using types.string

### DIFF
--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -19,7 +19,7 @@ in
         '';
       };
       quickPhrase = mkOption {
-        type = with types; attrsOf string;
+        type = with types; attrsOf str;
         default = { };
         example = literalExpression ''
           {

--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -53,7 +53,7 @@ in
     };
 
     preferences = mkOption {
-      type = with types; attrsOf (oneOf [ bool int string ]);
+      type = with types; attrsOf (oneOf [ bool int str ]);
       default = { };
       description = mdDoc ''
         Preferences to set from `about:config`.

--- a/nixos/modules/programs/gamescope.nix
+++ b/nixos/modules/programs/gamescope.nix
@@ -42,7 +42,7 @@ in
     };
 
     args = mkOption {
-      type = types.listOf types.string;
+      type = types.listOf types.str;
       default = [ ];
       example = [ "--rt" "--prefer-vk-device 8086:9bc4" ];
       description = mdDoc ''
@@ -51,7 +51,7 @@ in
     };
 
     env = mkOption {
-      type = types.attrsOf types.string;
+      type = types.attrsOf types.str;
       default = { };
       example = literalExpression ''
         # for Prime render offload on Nvidia laptops.

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -89,7 +89,7 @@ in {
         options = {
           enable = mkEnableOption (mdDoc "GameScope Session");
           args = mkOption {
-            type = types.listOf types.string;
+            type = types.listOf types.str;
             default = [ ];
             description = mdDoc ''
               Arguments to be passed to GameScope for the session.
@@ -97,7 +97,7 @@ in {
           };
 
           env = mkOption {
-            type = types.attrsOf types.string;
+            type = types.attrsOf types.str;
             default = { };
             description = mdDoc ''
               Environmental variables to be passed to GameScope for the session.

--- a/nixos/modules/security/ipa.nix
+++ b/nixos/modules/security/ipa.nix
@@ -86,7 +86,7 @@ in {
       };
 
       ifpAllowedUids = mkOption {
-        type = types.listOf types.string;
+        type = types.listOf types.str;
         default = ["root"];
         description = lib.mdDoc "A list of users allowed to access the ifp dbus interface.";
       };

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -934,7 +934,7 @@ in
       };
       authserver = mkOption {
         default = null;
-        type = with types; nullOr string;
+        type = with types; nullOr str;
         description = lib.mdDoc ''
           This controls the hostname for the 9front authentication server
           that users will be authenticated against.

--- a/nixos/modules/services/cluster/patroni/default.nix
+++ b/nixos/modules/services/cluster/patroni/default.nix
@@ -105,7 +105,7 @@ in
     };
 
     otherNodesIps = mkOption {
-      type = types.listOf types.string;
+      type = types.listOf types.str;
       example = [ "192.168.1.2" "192.168.1.3" ];
       description = mdDoc ''
         IP addresses of the other nodes.

--- a/nixos/modules/services/hardware/keyd.nix
+++ b/nixos/modules/services/hardware/keyd.nix
@@ -7,7 +7,7 @@ let
   keyboardOptions = { ... }: {
     options = {
       ids = mkOption {
-        type = types.listOf types.string;
+        type = types.listOf types.str;
         default = [ "*" ];
         example = [ "*" "-0123:0456" ];
         description = lib.mdDoc ''

--- a/nixos/modules/services/mail/maddy.nix
+++ b/nixos/modules/services/mail/maddy.nix
@@ -142,7 +142,7 @@ in {
 
       user = mkOption {
         default = "maddy";
-        type = with types; uniq string;
+        type = with types; uniq str;
         description = lib.mdDoc ''
           User account under which maddy runs.
 
@@ -156,7 +156,7 @@ in {
 
       group = mkOption {
         default = "maddy";
-        type = with types; uniq string;
+        type = with types; uniq str;
         description = lib.mdDoc ''
           Group account under which maddy runs.
 
@@ -170,7 +170,7 @@ in {
 
       hostname = mkOption {
         default = "localhost";
-        type = with types; uniq string;
+        type = with types; uniq str;
         example = ''example.com'';
         description = lib.mdDoc ''
           Hostname to use. It should be FQDN.
@@ -179,7 +179,7 @@ in {
 
       primaryDomain = mkOption {
         default = "localhost";
-        type = with types; uniq string;
+        type = with types; uniq str;
         example = ''mail.example.com'';
         description = lib.mdDoc ''
           Primary MX domain to use. It should be FQDN.


### PR DESCRIPTION
It is an error[1] now.

[1]: https://github.com/NixOS/nixpkgs/pull/247848

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
