### PR TITLE
Populate meta.pkgConfigModules for more packages

### DIFF
--- a/pkgs/development/libraries/libdatrie/default.nix
+++ b/pkgs/development/libraries/libdatrie/default.nix
@@ -42,5 +42,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ];
+    pkgConfigModules = [ "datrie-0.2" ];
   };
 }

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -72,5 +72,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ goibhniu ];
     platforms = platforms.unix;
+    pkgConfigModules = [ "epoxy" ];
   };
 }

--- a/pkgs/development/libraries/libpsl/default.nix
+++ b/pkgs/development/libraries/libpsl/default.nix
@@ -92,5 +92,6 @@ in stdenv.mkDerivation rec {
     maintainers = [ maintainers.c0bw3b ];
     mainProgram = "psl";
     platforms = platforms.unix;
+    pkgConfigModules = [ "libpsl" ];
   };
 }

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -99,5 +99,9 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.gnome.org/Projects/libsoup";
     license = lib.licenses.lgpl2Plus;
     inherit (glib.meta) maintainers platforms;
+    pkgConfigModules = [
+      "libsoup-2.4"
+      "libsoup-gnome-2.4"
+    ];
   };
 }

--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -63,5 +63,10 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ primeos ttuegel ];
     mainProgram = "xkbcli";
     platforms = with platforms; unix;
+    pkgConfigModules = [
+      "xkbcommon"
+      "xkbcommon-x11"
+      "xkbregistry"
+    ];
   };
 }

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -101,5 +101,6 @@ stdenv.mkDerivation rec {
     mainProgram = "sqlite3";
     maintainers = with maintainers; [ eelco np ];
     platforms = platforms.unix ++ platforms.windows;
+    pkgConfigModules = [ "sqlite3" ];
   };
 }

--- a/pkgs/development/tools/profiling/sysprof/capture.nix
+++ b/pkgs/development/tools/profiling/sysprof/capture.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     description = "Static library for Sysprof capture data generation";
     license = lib.licenses.bsd2Patent;
     platforms = lib.platforms.all;
+    pkgConfigModules = [ "sysprof-capture-4" ];
   };
 }

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -147,6 +147,9 @@ self: super:
 
   libXdmcp = super.libXdmcp.overrideAttrs (attrs: {
     outputs = [ "out" "dev" "doc" ];
+    meta = attrs.meta // {
+      pkgConfigModules = [ "xdmcp" ];
+    };
   });
 
   libXfont = super.libXfont.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -152,6 +152,12 @@ self: super:
     };
   });
 
+  libXtst = super.libXtst.overrideAttrs (attrs: {
+    meta = attrs.meta // {
+      pkgConfigModules = [ "xtst" ];
+    };
+  });
+
   libXfont = super.libXfont.overrideAttrs (attrs: {
     outputs = [ "out" "dev" ];
     propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ freetype ]; # propagate link reqs. like bzip2

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -83,6 +83,34 @@ self: super:
     configureFlags = [ "--enable-xkb" "--enable-xinput" ]
       ++ lib.optional stdenv.hostPlatform.isStatic "--disable-shared";
     outputs = [ "out" "dev" "man" "doc" ];
+    meta = attrs.meta // {
+      pkgConfigModules = [
+        "xcb-composite"
+        "xcb-damage"
+        "xcb-dpms"
+        "xcb-dri2"
+        "xcb-dri3"
+        "xcb-glx"
+        "xcb-present"
+        "xcb-randr"
+        "xcb-record"
+        "xcb-render"
+        "xcb-res"
+        "xcb-screensaver"
+        "xcb-shape"
+        "xcb-shm"
+        "xcb-sync"
+        "xcb-xf86dri"
+        "xcb-xfixes"
+        "xcb-xinerama"
+        "xcb-xinput"
+        "xcb-xkb"
+        "xcb-xtest"
+        "xcb-xv"
+        "xcb-xvmc"
+        "xcb"
+      ];
+    };
   });
 
   libX11 = super.libX11.overrideAttrs (attrs: {


### PR DESCRIPTION
- libdatrie: add meta.pkgConfigModules annotation
- libepoxy: add meta.pkgConfigModules annotation
- libpsl: add meta.pkgConfigModules annotation
- libsoup: add meta.pkgConfigModules annotation
- libxkbcommon: add meta.pkgConfigModules annotation
- sqlite: add meta.pkgConfigModules annotation
- libsysprof-capture: add meta.pkgConfigModules annotation
- xorg.libxcb: add meta.pkgConfigModules annotation
- xorg.libXdmcp: add meta.pkgConfigModules annotation
- xorg.libXtst: add meta.pkgConfigModules annotation

A continuation of #247907.

/cc @sternenseemann 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
