### PR TITLE
haskellPackages.reflex-dom: Fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1438,7 +1438,6 @@ self: super: {
     });
   };
 
-  # 2023-06-24: too strict upper bound on bytestring
   jsaddle-webkit2gtk =
     appendPatches [
       (pkgs.fetchpatch {
@@ -1455,7 +1454,14 @@ self: super: {
         stripLen = 1;
         includes = [ "jsaddle-webkit2gtk.cabal" ];
       })
-    ] super.jsaddle-webkit2gtk;
+    ]
+    (overrideCabal (old: {
+      postPatch = old.postPatch or "" + ''
+        sed -i 's/aeson.*,/aeson,/' jsaddle-webkit2gtk.cabal
+        sed -i 's/text.*,/text,/' jsaddle-webkit2gtk.cabal
+      '';
+    })
+    super.jsaddle-webkit2gtk);
 
   # 2022-03-16: lens bound can be loosened https://github.com/ghcjs/jsaddle-dom/issues/19
   jsaddle-dom = overrideCabal (old: {

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1314,7 +1314,10 @@ self: super: builtins.intersectAttrs super {
   sydtest = dontCheck super.sydtest;
 
   # Prevent argv limit being exceeded when invoking $CC.
-  gi-javascriptcore = overrideCabal {
+  inherit (lib.mapAttrs (_: overrideCabal {
     __onlyPropagateKnownPkgConfigModules = true;
-  } super.gi-javascriptcore;
+    }) super)
+      gi-javascriptcore
+      webkit2gtk3-javascriptcore
+      gi-webkit2;
 }


### PR DESCRIPTION
Based on #247939

- haskellPackages.{webkit2gtk3-javascriptscore,gi-webkit2}: Populate pkg-config based on metadata
- haskellPackages.jsaddle-webkit2gtk: allow-newer: aeson, text

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
