### PR TITLE
goldendict-ng: fix crash due to GLib error

### DIFF
--- a/pkgs/applications/misc/goldendict-ng/default.nix
+++ b/pkgs/applications/misc/goldendict-ng/default.nix
@@ -26,6 +26,7 @@
 , qtmultimedia
 , qtspeech
 , wrapQtAppsHook
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ZKbrO5L4KFmr2NsGDihRWBeW0OXHoPRwZGj6kt1Anc8=";
   };
 
-  nativeBuildInputs = [ pkg-config cmake wrapQtAppsHook ];
+  nativeBuildInputs = [ pkg-config cmake wrapQtAppsHook wrapGAppsHook ];
   buildInputs = [
     qtbase
     qtsvg
@@ -63,6 +64,13 @@ stdenv.mkDerivation (finalAttrs: {
     xapian
     libzim
   ];
+
+  # to prevent double wrapping of wrapQtApps and wrapGApps
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
   cmakeFlags = [
     "-DWITH_XAPIAN=ON"


### PR DESCRIPTION
## Description of changes

This PR fixes the crash when trying to add new paths to search dictionaries (via Edit > Dictionaries > Source > Add...),
which will invoke the native file picker in the system.

It usually happens when no desktop environment is used (e.g. using a window manager only).
The error message for this crash is:

```
(goldendict:1967841): GLib-GIO-ERROR **: 10:50:44.073: No GSettings schemas are installed on the system
zsh: trace trap (core dumped)  ./result/bin/goldendict
```

This is a known issue mentioned [here](https://nixos.org/manual/nixpkgs/stable/#ssec-gnome-common-issues), and it's fixed by adding wrapGAppsHook

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
