### PR TITLE
python3.pkgs.xsdata: 22.12 -> 23.7

### DIFF
--- a/pkgs/development/python-modules/xsdata/default.nix
+++ b/pkgs/development/python-modules/xsdata/default.nix
@@ -2,44 +2,44 @@
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
-, fetchpatch
 , click
 , click-default-group
 , docformatter
 , jinja2
 , toposort
+, typing-extensions
 , lxml
 , requests
 , pytestCheckHook
+, setuptools
+, wheel
 }:
 
 buildPythonPackage rec {
   pname = "xsdata";
-  version = "22.12";
+  version = "23.7";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
-  format = "setuptools";
-
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-o9Xxt7b/+MkW94Jcg26ihaTn0/OpTcu+0OY7oV3JRGY=";
+    hash = "sha256-jXnpB42P9PjEgw7NoSCGE6S14oOkHkzTBFYb9vypaqw=";
   };
 
-  patches = [
-    # https://github.com/tefra/xsdata/pull/741
-    (fetchpatch {
-      name = "use-docformatter-1.5.1.patch";
-      url = "https://github.com/tefra/xsdata/commit/040692db47e6e51028fd959c793e757858c392d7.patch";
-      excludes = [ "setup.cfg" ];
-      hash = "sha256-ncecMJLJUiUb4lB8ys+nyiGU/UmayK++o89h3sAwREQ=";
-    })
-  ];
-
   postPatch = ''
-    substituteInPlace setup.cfg \
+    substituteInPlace pyproject.toml \
       --replace "--benchmark-skip" ""
   '';
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
 
   passthru.optional-dependencies = {
     cli = [


### PR DESCRIPTION
## Description of changes

https://github.com/tefra/xsdata/blob/v23.7/CHANGES.rst

This also fixes the build on `master`, maybe by pulling in https://github.com/tefra/xsdata/pull/796.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
