### PR TITLE
qscreenshot: 1.0 -> unstable-2021-10-18

### DIFF
--- a/pkgs/applications/graphics/qscreenshot/default.nix
+++ b/pkgs/applications/graphics/qscreenshot/default.nix
@@ -1,22 +1,35 @@
-{ lib, stdenv, fetchurl, dos2unix, which, qt, Carbon }:
+{ stdenv
+, lib
+, fetchgit
+, dos2unix
+, qtbase
+, qttools
+, qtx11extras
+, wrapQtAppsHook
+, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "qscreenshot";
-  version = "1.0";
+  version = "unstable-2021-10-18";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/qscreenshot/qscreenshot-${version}-src.tar.gz";
-    sha256 = "1spj5fg2l8p5bk81xsv6hqn1kcrdiy54w19jsfb7g5i94vcb1pcx";
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/qscreenshot/code";
+    rev = "e340f06ae2f1a92a353eaa68e103d1c840adc12d";
+    hash = "sha256-L8pktNt5NTNjNryJ5jniv2wrhxMH05G/8vHZTY7lsVU=";
   };
 
-  buildInputs = [ dos2unix which qt ]
-    ++ lib.optional stdenv.isDarwin Carbon;
+  sourceRoot = "${src.name}/qScreenshot/";
 
-  # Remove carriage returns that cause /bin/sh to abort
-  preConfigure = ''
-    dos2unix configure
-    sed -i "s|lrelease-qt4|lrelease|" src/src.pro
-  '';
+  nativeBuildInputs = [
+    cmake
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qtx11extras
+  ];
 
   meta = with lib; {
     description = "Simple creation and editing of screenshots";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34819,10 +34819,7 @@ with pkgs;
 
   qsampler = libsForQt5.callPackage ../applications/audio/qsampler { };
 
-  qscreenshot = callPackage ../applications/graphics/qscreenshot {
-    inherit (darwin.apple_sdk.frameworks) Carbon;
-    qt = qt4;
-  };
+  qscreenshot = libsForQt5.callPackage ../applications/graphics/qscreenshot { };
 
   qsstv = qt5.callPackage ../applications/radio/qsstv { };
 


### PR DESCRIPTION
qt4 -> qt5

(cherry picked from commit b0823dbd819aa6cbbccf256f9a8754b536475063)
Signed-off-by: Matthias Beyer <mail@beyermatthias.de>

---

Extracted from #174634
because this can be PRed independently and can land earlier than the PR above.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
