### PR TITLE
python3.pkgs.setuptools-git-versioning: init at 1.13.5

### DIFF
--- a/pkgs/development/python-modules/setuptools-git-versioning/default.nix
+++ b/pkgs/development/python-modules/setuptools-git-versioning/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, build
+, coverage
+, git
+, packaging
+, pytestCheckHook
+, pytest-rerunfailures
+, pythonOlder
+, setuptools
+, toml
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "setuptools-git-versioning";
+  version = "1.13.5";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "dolfinus";
+    repo = "setuptools-git-versioning";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-MAHB6hMAcMo1+HCc6g7xQUD2sG+TLjM/6Oa/BKuXpRc=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    packaging
+    setuptools
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    toml
+  ];
+
+  pythonImportsCheck = [
+    "setuptools_git_versioning"
+  ];
+
+  nativeCheckInputs = [
+    build
+    coverage
+    git
+    pytestCheckHook
+    pytest-rerunfailures
+    toml
+  ];
+
+  preCheck = ''
+    # so that its built binary is accessible by tests
+    export PATH="$out/bin:$PATH"
+  '';
+
+  # limit tests because the full suite takes several minutes to run
+  pytestFlagsArray = [ "-m" "important" ];
+
+  disabledTests = [
+    # runs an isolated build that uses internet to download dependencies
+    "test_config_not_used"
+  ];
+
+  meta = with lib; {
+    description = "Use git repo data (latest tag, current commit hash, etc) for building a version number according PEP-440";
+    homepage = "https://github.com/dolfinus/setuptools-git-versioning";
+    changelog = "https://github.com/dolfinus/setuptools-git-versioning/blob/${src.rev}/CHANGELOG.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tjni ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11490,6 +11490,8 @@ self: super: with self; {
 
   setuptools-git = callPackage ../development/python-modules/setuptools-git { };
 
+  setuptools-git-versioning = callPackage ../development/python-modules/setuptools-git-versioning { };
+
   setuptools-lint = callPackage ../development/python-modules/setuptools-lint { };
 
   setuptools-rust = callPackage ../development/python-modules/setuptools-rust { };


### PR DESCRIPTION
## Description of changes

This is used by several projects as a build-time dependency, and I would like to package it to give us options about how we should handle those cases. I did see https://github.com/dolfinus/setuptools-git-versioning/issues/77, and I'm not sure what the best way is yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
