### PR TITLE
libsForQt5.kirigami-addons: Add myself as maintainer

### DIFF
--- a/pkgs/development/libraries/kirigami-addons/default.nix
+++ b/pkgs/development/libraries/kirigami-addons/default.nix
@@ -38,7 +38,7 @@ mkDerivation rec {
     homepage = "https://invent.kde.org/libraries/kirigami-addons";
     # https://invent.kde.org/libraries/kirigami-addons/-/blob/b197d98fdd079b6fc651949bd198363872d1be23/src/treeview/treeviewplugin.cpp#L1-5
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ samueldr ];
+    maintainers = with maintainers; [ samueldr matthiasbeyer ];
   };
 }
 


### PR DESCRIPTION
## Description of changes

I'd like to add my maintainership here because I am using KDE software daily and would like to keep this package up to date.