### PR TITLE
mvebu64boot: init at unstable-2022-10-20

### DIFF
--- a/pkgs/tools/misc/mvebu64boot/default.nix
+++ b/pkgs/tools/misc/mvebu64boot/default.nix
@@ -1,0 +1,34 @@
+{ fetchFromGitHub
+, stdenv
+, lib
+, ncurses
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mvebu64boot";
+  version = "unstable-2022-10-20";
+
+  src = fetchFromGitHub {
+    owner = "pali";
+    repo = "mvebu64boot";
+    rev = "e7ca70eff2dc278607cc07f6654bbddacb2e4ff6";
+    hash = "sha256-Y2yVr/BuOah5yMvF5EvM7frEUY8r+Hf4bNIKVkHgvQs=";
+  };
+
+  buildInputs = [
+    ncurses
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D mvebu64boot $out/bin/mvebu64boot
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Boot 64-bit Marvell EBU SoC over UART";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ lukegb ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9968,6 +9968,8 @@ with pkgs;
 
   multitail = callPackage ../tools/misc/multitail { };
 
+  mvebu64boot = callPackage ../tools/misc/mvebu64boot { };
+
   mx-puppet-discord = callPackage ../servers/mx-puppet-discord { };
 
   mx-takeover = callPackage ../tools/security/mx-takeover { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A tool for booting Marvell SPI flash images from the BootROM by sending a special initialisation sequence and then transmitting the image via X-Modem.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
