### PR TITLE
[Backport release-23.05] mozillavpn: 2.14.1 → 2.16.0

### DIFF
--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -2,6 +2,7 @@
 , cargo
 , cmake
 , fetchFromGitHub
+, fetchpatch
 , go
 , lib
 , libsecret
@@ -23,43 +24,56 @@
 
 let
   pname = "mozillavpn";
-  version = "2.14.1";
+  version = "2.15.0";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-xWm21guI+h0bKd/rEyxVMyxypCitLWEbVy7TaVBKh4o=";
+    hash = "sha256-eyYrA8ysfmXxlHNUBkGU9ioYrnbx3L1wP9byNz9L/MA=";
   };
+  patches = [
+    # Force version downgrade for openssl and openssl-sys crates
+    (fetchpatch {
+      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/commit/5911071ea37d12401af32dcdf2a542ca5049bf2f.patch";
+      hash = "sha256-b3yOgn3Et0sYpqzUUdmlGIbzZSz13Q9HW56hyQqRnHc=";
+      revert = true;
+    })
+    # [2.15] Restore qtglean/Cargo.lock
+    (fetchpatch {
+      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7026/commits/13c1b77ee4249883a33b6ac240b3ca143b485ba1.patch";
+      hash = "sha256-L4D71zreDMLAIbP4x1as9QdNmMC1snUZSwlkKehg5yM=";
+    })
+  ];
 
   netfilter-go-modules = (buildGoModule {
-    inherit pname version src;
+    inherit pname version src patches;
     modRoot = "linux/netfilter";
     vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
   }).go-modules;
 
   extensionBridgeDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
+    inherit src patches;
     name = "${pname}-${version}-extension-bridge";
     preBuild = "cd extension/bridge";
-    hash = "sha256-XW47EnNHm5JUWCqDU/iHB6ZRGny4v5x7Fs/1dv5TfzM=";
+    hash = "sha256-R/9ePEhc4qVgg3WC5ng+cD88K/N3PTnx4QWyaZZfRds=";
   };
   signatureDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
+    inherit src patches;
     name = "${pname}-${version}-signature";
     preBuild = "cd signature";
-    hash = "sha256-CNPL1Orn+ZbX0HL+CHMaoXPI9G8MoC+hY8pJTJlWH1U=";
+    hash = "sha256-27g2qnnUrxbThM1cHZquQgWQLWDtZaBnlf8PjvQtBJU=";
   };
-  vpngleanDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
-    name = "${pname}-${version}-vpnglean";
-    preBuild = "cd vpnglean";
-    hash = "sha256-5vazbCqzJG6iA0MFaTNha42jb1pgLhr0P9I8rQxSKtw=";
+  qtgleanDeps = rustPlatform.fetchCargoTarball {
+    inherit src patches;
+    name = "${pname}-${version}-qtglean";
+    preBuild = "cd qtglean";
+    hash = "sha256-cW+nf+Dho+eSzOBo3xhxki7NXpg0wd5ZM9OMA6iOUl4=";
   };
 
 in
 stdenv.mkDerivation {
-  inherit pname version src;
+  inherit pname version src patches;
 
   buildInputs = [
     libsecret
@@ -95,9 +109,9 @@ stdenv.mkDerivation {
     signatureDepsCopy="$cargoDepsCopy"
     popd
 
-    pushd source/vpnglean
-    cargoDeps='${vpngleanDeps}' cargoSetupPostUnpackHook
-    vpngleanDepsCopy="$cargoDepsCopy"
+    pushd source/qtglean
+    cargoDeps='${qtgleanDeps}' cargoSetupPostUnpackHook
+    qtgleanDepsCopy="$cargoDepsCopy"
     popd
   '';
   dontCargoSetupPostUnpack = true;
@@ -128,8 +142,8 @@ stdenv.mkDerivation {
     cargoDepsCopy="$signatureDepsCopy" cargoSetupPostPatchHook
     popd
 
-    pushd vpnglean
-    cargoDepsCopy="$vpngleanDepsCopy" cargoSetupPostPatchHook
+    pushd qtglean
+    cargoDepsCopy="$qtgleanDepsCopy" cargoSetupPostPatchHook
     popd
 
     cargoSetupPostPatchHook() { true; }

--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -2,9 +2,10 @@
 , cargo
 , cmake
 , fetchFromGitHub
-, fetchpatch
 , go
 , lib
+, libgcrypt
+, libgpg-error
 , libsecret
 , pkg-config
 , polkit
@@ -24,29 +25,17 @@
 
 let
   pname = "mozillavpn";
-  version = "2.15.0";
+  version = "2.16.0";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-eyYrA8ysfmXxlHNUBkGU9ioYrnbx3L1wP9byNz9L/MA=";
+    hash = "sha256-Yd53QUnoZ+5imt8kWpfGL6mkWeEFvqRrTpSu6efGgOA=";
   };
-  patches = [
-    # Force version downgrade for openssl and openssl-sys crates
-    (fetchpatch {
-      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/commit/5911071ea37d12401af32dcdf2a542ca5049bf2f.patch";
-      hash = "sha256-b3yOgn3Et0sYpqzUUdmlGIbzZSz13Q9HW56hyQqRnHc=";
-      revert = true;
-    })
-    # [2.15] Restore qtglean/Cargo.lock
-    (fetchpatch {
-      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7026/commits/13c1b77ee4249883a33b6ac240b3ca143b485ba1.patch";
-      hash = "sha256-L4D71zreDMLAIbP4x1as9QdNmMC1snUZSwlkKehg5yM=";
-    })
-  ];
+  patches = [ ];
 
-  netfilter-go-modules = (buildGoModule {
+  netfilterGoModules = (buildGoModule {
     inherit pname version src patches;
     modRoot = "linux/netfilter";
     vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
@@ -56,19 +45,19 @@ let
     inherit src patches;
     name = "${pname}-${version}-extension-bridge";
     preBuild = "cd extension/bridge";
-    hash = "sha256-R/9ePEhc4qVgg3WC5ng+cD88K/N3PTnx4QWyaZZfRds=";
+    hash = "sha256-WKnc2nGXJVhzNluh0RFSdmPtGdo2QnNuEJ7r5xJCGi0=";
   };
   signatureDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-signature";
     preBuild = "cd signature";
-    hash = "sha256-27g2qnnUrxbThM1cHZquQgWQLWDtZaBnlf8PjvQtBJU=";
+    hash = "sha256-XlOnUB0TO6rrLkWU9eT1sTOcDtJdz4yi/ejKcEfFcFc=";
   };
   qtgleanDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}-qtglean";
     preBuild = "cd qtglean";
-    hash = "sha256-cW+nf+Dho+eSzOBo3xhxki7NXpg0wd5ZM9OMA6iOUl4=";
+    hash = "sha256-BU++ZWb4Fp8LS2woohuDSD2iYo/3rBO6xgeLzyrdLkU=";
   };
 
 in
@@ -76,8 +65,9 @@ stdenv.mkDerivation {
   inherit pname version src patches;
 
   buildInputs = [
+    libgcrypt
+    libgpg-error
     libsecret
-    polkit
     qt5compat
     qtbase
     qtnetworkauth
@@ -85,6 +75,7 @@ stdenv.mkDerivation {
     qtwebsockets
   ];
   nativeBuildInputs = [
+    cargo
     cmake
     go
     pkg-config
@@ -92,8 +83,8 @@ stdenv.mkDerivation {
     python3.pkgs.glean-parser
     python3.pkgs.pyyaml
     python3.pkgs.setuptools
+    qttools
     rustPlatform.cargoSetupHook
-    cargo
     rustc
     wrapQtAppsHook
   ];
@@ -117,22 +108,15 @@ stdenv.mkDerivation {
   dontCargoSetupPostUnpack = true;
 
   postPatch = ''
-    substituteInPlace src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.dbus.service --replace /usr/bin/mozillavpn "$out/bin/mozillavpn"
-
-    substituteInPlace scripts/addon/build.py \
-      --replace 'qtbinpath = args.qtpath' 'qtbinpath = "${qttools.dev}/bin"' \
-      --replace 'rcc = os.path.join(qtbinpath, rcc_bin)' 'rcc = "${qtbase.dev}/libexec/rcc"'
-
     substituteInPlace src/apps/vpn/cmake/linux.cmake \
       --replace '/etc/xdg/autostart' "$out/etc/xdg/autostart" \
-      --replace '${"$"}{POLKIT_POLICY_DIR}' "$out/share/polkit-1/actions" \
       --replace '/usr/share/dbus-1' "$out/share/dbus-1" \
       --replace '${"$"}{SYSTEMD_UNIT_DIR}' "$out/lib/systemd/system"
 
     substituteInPlace extension/CMakeLists.txt \
       --replace '/etc' "$out/etc"
 
-    ln -s '${netfilter-go-modules}' linux/netfilter/vendor
+    ln -s '${netfilterGoModules}' linux/netfilter/vendor
 
     pushd extension/bridge
     cargoDepsCopy="$extensionBridgeDepsCopy" cargoSetupPostPatchHook


### PR DESCRIPTION
## Description of changes

Backport to release-23.05:

- #235063
- #247788

This includes an initial fix for [CVE-2023-4104](https://www.openwall.com/lists/oss-security/2023/08/03/1), among other changes.

https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.15.0
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.15.1
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.15.2
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.15.3
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.16.0
https://github.com/mozilla-mobile/mozilla-vpn-client/compare/v2.14.1...v2.16.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
