### PR TITLE
qgnomeplatform: Backport cursor fix for Qt6 apps

### DIFF
--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation rec {
       src = ./hardcode-gsettings.patch;
       gds_gsettings_path = glib.getSchemaPath gsettings-desktop-schemas;
     })
+
+    # Backport cursor fix for Qt6 apps
+    # Ajusted from https://github.com/FedoraQt/QGnomePlatform/pull/138
+    ./qt6-cursor-fix.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/qgnomeplatform/qt6-cursor-fix.patch
+++ b/pkgs/development/libraries/qgnomeplatform/qt6-cursor-fix.patch
@@ -1,0 +1,53 @@
+diff --git a/src/common/gnomesettings.cpp b/src/common/gnomesettings.cpp
+index 961f75d..d947eb2 100644
+--- a/src/common/gnomesettings.cpp
++++ b/src/common/gnomesettings.cpp
+@@ -210,7 +210,7 @@ GnomeSettingsPrivate::GnomeSettingsPrivate(QObject *parent)
+                                               QStringLiteral("SettingChanged"), this, SLOT(portalSettingChanged(QString,QString,QDBusVariant)));
+     }
+ 
+-    if (QGuiApplication::platformName() != QStringLiteral("xcb")) {
++    if (true) {
+         cursorSizeChanged();
+         cursorThemeChanged();
+     }
+@@ -347,11 +347,11 @@ void GnomeSettingsPrivate::gsettingPropertyChanged(GSettings *settings, gchar *k
+     } else if (changedProperty == QStringLiteral("monospace-font-name")) {
+         gnomeSettings->fontChanged();
+     } else if (changedProperty == QStringLiteral("cursor-size")) {
+-        if (QGuiApplication::platformName() != QStringLiteral("xcb")) {
++        if (true) {
+             gnomeSettings->cursorSizeChanged();
+         }
+     } else if (changedProperty == QStringLiteral("cursor-theme")) {
+-        if (QGuiApplication::platformName() != QStringLiteral("xcb")) {
++        if (true) {
+             gnomeSettings->cursorThemeChanged();
+         }
+     // Org.gnome.wm.preferences
+@@ -393,13 +393,23 @@ void GnomeSettingsPrivate::cursorBlinkTimeChanged()
+ void GnomeSettingsPrivate::cursorSizeChanged()
+ {
+     int cursorSize = getSettingsProperty<int>(QStringLiteral("cursor-size"));
+-    qputenv("XCURSOR_SIZE", QString::number(cursorSize).toUtf8());
++    if (QGuiApplication::platformName() != QStringLiteral("xcb")) {
++        qputenv("XCURSOR_SIZE", QString::number(cursorSize).toUtf8());
++    }
++#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
++    m_hints[QPlatformTheme::MouseCursorSize] = QSize(cursorSize, cursorSize);
++#endif
+ }
+ 
+ void GnomeSettingsPrivate::cursorThemeChanged()
+ {
+     const QString cursorTheme = getSettingsProperty<QString>(QStringLiteral("cursor-theme"));
+-    qputenv("XCURSOR_THEME", cursorTheme.toUtf8());
++    if (QGuiApplication::platformName() != QStringLiteral("xcb")) {
++        qputenv("XCURSOR_THEME", cursorTheme.toUtf8());
++    }
++#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
++    m_hints[QPlatformTheme::MouseCursorTheme] = cursorTheme;
++#endif
+ }
+ 
+ void GnomeSettingsPrivate::fontChanged()


### PR DESCRIPTION
## Description of changes


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
