### PR TITLE
Added security to hardened.nix profile

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -118,4 +118,4 @@ with lib;
   boot.loader.systemd-boot.editor = false;
   # Coredump gives infomation (sometimes sensitive) during crash, it also slows down the system.
   systemd.coredump.enable = false; 
-}
+}  

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -118,4 +118,4 @@ with lib;
   boot.loader.systemd-boot.editor = false;
   # Coredump gives infomation (sometimes sensitive) during crash, it also slows down the system.
   systemd.coredump.enable = false; 
-}  
+}

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -114,10 +114,8 @@ with lib;
   # Ignore outgoing ICMP redirects (this is ipv4 only)
   boot.kernel.sysctl."net.ipv4.conf.all.send_redirects" = mkDefault false;
   boot.kernel.sysctl."net.ipv4.conf.default.send_redirects" = mkDefault false;
-  
   # Disabling this so  an attacker cannot gain root access by passing init=/bin/sh as a kernel parameter.
   boot.loader.systemd-boot.editor = false;
- 
   # Coredump gives infomation (sometimes sensitive) during crash, it also slows down the system.
   systemd.coredump.enable = false; 
 }

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -117,5 +117,5 @@ with lib;
   # Disabling this so  an attacker cannot gain root access by passing init=/bin/sh as a kernel parameter.
   boot.loader.systemd-boot.editor = false;
   # Coredump gives infomation (sometimes sensitive) during crash, it also slows down the system.
-  systemd.coredump.enable = false; 
+  systemd.coredump.enable = false;
 }

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -19,9 +19,6 @@ with lib;
 
   nix.settings.allowed-users = mkDefault [ "@users" ];
 
-  environment.memoryAllocator.provider = mkDefault "scudo";
-  environment.variables.SCUDO_OPTIONS = mkDefault "ZeroContents=1";
-
   security.lockKernelModules = mkDefault true;
 
   security.protectKernelImage = mkDefault true;
@@ -29,6 +26,8 @@ with lib;
   security.allowSimultaneousMultithreading = mkDefault false;
 
   security.forcePageTableIsolation = mkDefault true;
+
+  security.sudo.execWheelOnly = true;
 
   # This is required by podman to run containers in rootless mode.
   security.unprivilegedUsernsClone = mkDefault config.virtualisation.containers.enable;
@@ -115,4 +114,10 @@ with lib;
   # Ignore outgoing ICMP redirects (this is ipv4 only)
   boot.kernel.sysctl."net.ipv4.conf.all.send_redirects" = mkDefault false;
   boot.kernel.sysctl."net.ipv4.conf.default.send_redirects" = mkDefault false;
+  
+  # Disabling this so  an attacker cannot gain root access by passing init=/bin/sh as a kernel parameter.
+  boot.loader.systemd-boot.editor = false;
+ 
+  # Coredump gives infomation (sometimes sensitive) during crash, it also slows down the system.
+  systemd.coredump.enable = false; 
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
### Added new security measures:
  Coredump: It can expose information, such as passwords or private keys
    https://www.cyberciti.biz/faq/disable-core-dumps-in-linux-with-systemd-sysctl/
    https://search.nixos.org/options?channel=23.05&show=systemd.coredump.enable&from=0&size=50&sort=relevance&type=packages&query=coredump

  security.sudo.execWheelOnly: This mitigates exploits like CVE-2021-3156.
    https://search.nixos.org/options?channel=23.05&show=security.sudo.execWheelOnly&from=0&size=50&sort=relevance&type=packages&query=security.sudo.execWheelOnly

Removed the memory allocator, scudo. It crashes applications such as Firefox (can use in safe mode) and minecraft.

### Possible additions:
 Firejail: An application to sandbox apps. like firefox. https://nixos.wiki/wiki/Firejail. If one application is compromised, then it cannot inherently spread to the whole system. An example config would be something like this:

>programs.firejail.enable = true;
>
>  #Firefox config
> programs.firejail.wrappedBinaries = {
>    firefox = {
>      executable = "${pkgs.lib.getBin pkgs.firefox}/bin/firefox";
>        profile = "${pkgs.firejail}/etc/firejail/firefox.profile";
>    };
>    };
- Built on platform(s)
  - [X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
