### PR TITLE
python3.pkgs.snowflake-connector-python: fix build dependencies

### DIFF
--- a/pkgs/development/python-modules/snowflake-connector-python/default.nix
+++ b/pkgs/development/python-modules/snowflake-connector-python/default.nix
@@ -18,6 +18,7 @@
 , requests
 , setuptools
 , typing-extensions
+, wheel
 }:
 
 buildPythonPackage rec {
@@ -32,9 +33,26 @@ buildPythonPackage rec {
     hash = "sha256-F0EbgRSS/kYKUDPhf6euM0eLqIqVjQsHC6C9ZZSRCIE=";
   };
 
+  # snowflake-connector-python requires arrow 10.0.1, which we don't have in
+  # nixpkgs, so we cannot build the C extensions that use it. thus, patch out
+  # cython and pyarrow from the build dependencies
+  #
+  # keep an eye on following issue for improvements to this situation:
+  #
+  #   https://github.com/snowflakedb/snowflake-connector-python/issues/1144
+  #
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"cython",' "" \
+      --replace '"pyarrow>=10.0.1,<10.1.0",' ""
+  '';
+
   nativeBuildInputs = [
     pythonRelaxDepsHook
+    setuptools
+    wheel
   ];
+
   pythonRelaxDeps = [
     "pyOpenSSL"
     "charset-normalizer"


### PR DESCRIPTION
## Description of changes

1. Add setuptools explicitly to nativeBuildInputs. Right now, it's also picking up the one from propagatedBuildInputs, but in theory one is a build dependency and the other is a host dependency. I think it's more correct to have it in both places.
2. Add wheel explicitly to nativeBuildInputs. This is included implicitly right now, but I'm working on changing that.
3. Patch out cython and pyarrow dependencies. We cannot build the C extension with our version of pyarrow, so those dependencies don't make sense for us.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
