### PR TITLE
catch2_3 3.3.2 -> 3.4.0

### DIFF
--- a/pkgs/development/libraries/catch2/3.nix
+++ b/pkgs/development/libraries/catch2/3.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "catchorg";
     repo = "Catch2";
     rev = "v${version}";
-    hash = "sha256-EikouBS3VxcxbHGvab0rQzh2Q7oHam7BbniCv7LfrLs=";
+    hash = "sha256-DqGGfNjKPW9HFJrX9arFHyNYjB61uoL6NabZatTWrr0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/catch2/3.nix
+++ b/pkgs/development/libraries/catch2/3.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "catch2";
-  version = "3.3.2";
+  version = "3.4.0";
 
   src = fetchFromGitHub {
     owner = "catchorg";
     repo = "Catch2";
     rev = "v${version}";
-    hash = "sha256-t/4iCrzPeDZNNlgibVqx5rhe+d3lXwm1GmBMDDId0VQ=";
+    hash = "sha256-EikouBS3VxcxbHGvab0rQzh2Q7oHam7BbniCv7LfrLs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

catch2_3 from version 3.3.2 to version 3.4.0
[Release Notes of Catch2 3.4.0](https://github.com/catchorg/Catch2/releases/tag/v3.4.0)
