### PR TITLE
python310Packages.speechbrain: 0.5.14 -> 0.5.15

### DIFF
--- a/pkgs/development/python-modules/hyperpyyaml/default.nix
+++ b/pkgs/development/python-modules/hyperpyyaml/default.nix
@@ -1,9 +1,9 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchFromGitHub
-, lib
-, pytestCheckHook
 , pyyaml
 , ruamel-yaml
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -35,5 +35,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/speechbrain/HyperPyYAML/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ GaetanLepage ];
+    # hyperpyyaml is not compatible with the too new version of `ruaml-yaml`
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/speechbrain/default.nix
+++ b/pkgs/development/python-modules/speechbrain/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "speechbrain";
-  version = "0.5.14";
+  version = "0.5.15";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "speechbrain";
     repo = "speechbrain";
     rev = "refs/tags/v${version}";
-    hash = "sha256-r1q7JO+H7ynfrzlihRTY0PtMGmvwm98BHUZV534ABXw=";
+    hash = "sha256-d0+3bry69ML65JR8XDppG8RO200ZTTHyd7PrTP7SJkk=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

`python310Packages.hyperpyyaml` currently fails to build because the version of one of its dependencies (`ruamel-yaml`) is now too recent.
~~This PR overrides this dependency and sets its version to the one compatible with `hyperpyyaml`.
The package now builds fine.~~
This PR marks `hyperpyyaml` as broken and also update `speechbrain` to its latest version.
The latter is broken as it depends on `hyperpyyaml`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
