### PR TITLE
pinocchio: 2.6.19 -> 2.6.20

### DIFF
--- a/pkgs/development/libraries/example-robot-data/default.nix
+++ b/pkgs/development/libraries/example-robot-data/default.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
+  # The package expect to find an `example-robot-data/robots` folder somewhere
+  # either in install prefix or in the sources
+  # where it can find the meshes for unit tests
+  preCheck = "ln -s source ../../${finalAttrs.pname}";
   pythonImportsCheck = [
     "example_robot_data"
   ];

--- a/pkgs/development/libraries/pinocchio/default.nix
+++ b/pkgs/development/libraries/pinocchio/default.nix
@@ -4,21 +4,22 @@
 , cmake
 , boost
 , eigen
+, hpp-fcl
 , urdfdom
 , pythonSupport ? false
 , python3Packages
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pinocchio";
-  version = "2.6.19";
+  version = "2.6.20";
 
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
-    repo = pname;
-    rev = "v${version}";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-P7jSAQ6LYcboJHqtpneT4W8Pu5G3fd3/a8Gju9im1e8=";
+    hash = "sha256-Pu/trCpqdue7sQKDbLhyxTfgj/+xRiVcG7Luz6ZQXtM=";
   };
 
   # error: use of undeclared identifier '__sincos'
@@ -38,20 +39,31 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (!pythonSupport) [
     boost
     eigen
+    hpp-fcl
   ] ++ lib.optionals pythonSupport [
     python3Packages.boost
     python3Packages.eigenpy
+    python3Packages.hpp-fcl
   ];
 
-  cmakeFlags = lib.optionals (!pythonSupport) [
+  cmakeFlags = [
+    "-DBUILD_WITH_COLLISION_SUPPORT=ON"
+  ] ++ lib.optionals (pythonSupport) [
+    "-DBUILD_WITH_LIBPYTHON=ON"
+  ] ++ lib.optionals (!pythonSupport) [
     "-DBUILD_PYTHON_INTERFACE=OFF"
+  ];
+
+  doCheck = true;
+  pythonImportsCheck = lib.optionals (!pythonSupport) [
+    "pinocchio"
   ];
 
   meta = with lib; {
     description = "A fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives";
     homepage = "https://github.com/stack-of-tasks/pinocchio";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ wegank ];
+    maintainers = with maintainers; [ nim65s wegank ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION

## Description of changes


Upstream release for changelog: https://github.com/stack-of-tasks/pinocchio/releases/tag/v2.6.20

While here:
- add hpp-fcl dependency
- enable libpython dependency when python support is activated
- use finalAttrs instead of rec
- add check & python import check
- add myself in maintainers

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
