### PR TITLE
qt6.qtbase: fix macdeployqt would not find qmlimportscanner

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -48,6 +48,9 @@ let
           ./patches/0005-qtbase-deal-with-a-font-face-at-index-0-as-Regular-f.patch
           ./patches/0006-qtbase-qt-cmake-always-use-cmake-from-path.patch
           ./patches/0007-qtbase-find-qt-tools-in-QTTOOLSPATH.patch
+          ./patches/0008-qtbase-find-qmlimportscanner-in-macdeployqt-via-environment.patch
+          ./patches/0009-qtbase-check-in-the-QML-folder-of-this-library-does-actuall.patch
+          ./patches/0010-qtbase-pass-to-qmlimportscanner-the-QML2_IMPORT_PATH.patch
         ];
       };
       env = callPackage ./qt-env.nix { };

--- a/pkgs/development/libraries/qt-6/patches/0008-qtbase-find-qmlimportscanner-in-macdeployqt-via-environment.patch
+++ b/pkgs/development/libraries/qt-6/patches/0008-qtbase-find-qmlimportscanner-in-macdeployqt-via-environment.patch
@@ -1,0 +1,35 @@
+From 505391a31aa353b8f1cc5d3feb9861582554d9f1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juan=20Pedro=20Bol=C3=ADvar=20Puente?= <raskolnikov@gnu.org>
+Date: Wed, 9 Aug 2023 16:16:21 +0200
+Subject: [PATCH 1/3] Find qmlimportscanner in macdeployqt via environment
+
+The qmlimportscanner tool is provided by qtdeclarative. Because of the
+modularized installation in Nix, it can not be found via the usual
+mechanisms.  Also, hard-coding it like we do for Qt5 would also not
+work, as it would require making qtbase depend on qtdeclarative.
+
+Here we add an option to provide its location via the environment.
+While this means macdeployqt does not work out of the box, it provides
+a workaround for users.
+---
+ src/tools/macdeployqt/shared/shared.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/tools/macdeployqt/shared/shared.cpp b/src/tools/macdeployqt/shared/shared.cpp
+index 643fe5390a..b8fcc9c9bd 100644
+--- a/src/tools/macdeployqt/shared/shared.cpp
++++ b/src/tools/macdeployqt/shared/shared.cpp
+@@ -1270,6 +1270,10 @@ bool deployQmlImports(const QString &appBundlePath, DeploymentInfo deploymentInf
+     if (!QFile::exists(qmlImportScannerPath))
+         qmlImportScannerPath = QCoreApplication::applicationDirPath() + "/qmlimportscanner";
+ 
++    // Fallback: Pass qml import scanner via environment variable
++    if (!QFile::exists(qmlImportScannerPath))
++        qmlImportScannerPath = ::qgetenv("NIX_QMLIMPORTSCANNER");
++
+     // Verify that we found a qmlimportscanner binary
+     if (!QFile::exists(qmlImportScannerPath)) {
+         LogError() << "qmlimportscanner not found at" << qmlImportScannerPath;
+-- 
+2.26.2
+

--- a/pkgs/development/libraries/qt-6/patches/0009-qtbase-check-in-the-QML-folder-of-this-library-does-actuall.patch
+++ b/pkgs/development/libraries/qt-6/patches/0009-qtbase-check-in-the-QML-folder-of-this-library-does-actuall.patch
@@ -1,0 +1,35 @@
+From 32df59bea18bebc18d6d308750e88be325522d2e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juan=20Pedro=20Bol=C3=ADvar=20Puente?= <raskolnikov@gnu.org>
+Date: Thu, 10 Aug 2023 14:15:34 +0200
+Subject: [PATCH 2/3] Check in the QML folder of this library does actually
+ exist
+
+In a modularized installation, this folder will be the location where
+`qtbase` itself is installed, but `qtbase` does not have any QML
+code, and `qmlimportscanner` will complain that it does not exist.
+---
+ src/tools/macdeployqt/shared/shared.cpp | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/macdeployqt/shared/shared.cpp b/src/tools/macdeployqt/shared/shared.cpp
+index b8fcc9c9bd..676d34d545 100644
+--- a/src/tools/macdeployqt/shared/shared.cpp
++++ b/src/tools/macdeployqt/shared/shared.cpp
+@@ -1290,9 +1290,12 @@ bool deployQmlImports(const QString &appBundlePath, DeploymentInfo deploymentInf
+     }
+     for (const QString &importPath : qmlImportPaths)
+         argumentList << "-importPath" << importPath;
++
+     QString qmlImportsPath = QLibraryInfo::path(QLibraryInfo::QmlImportsPath);
+-    argumentList.append( "-importPath");
+-    argumentList.append(qmlImportsPath);
++    if (QFile::exists(qmlImportsPath)) {
++        argumentList.append( "-importPath");
++        argumentList.append(qmlImportsPath);
++    }
+ 
+     // run qmlimportscanner
+     QProcess qmlImportScanner;
+-- 
+2.26.2
+

--- a/pkgs/development/libraries/qt-6/patches/0010-qtbase-pass-to-qmlimportscanner-the-QML2_IMPORT_PATH.patch
+++ b/pkgs/development/libraries/qt-6/patches/0010-qtbase-pass-to-qmlimportscanner-the-QML2_IMPORT_PATH.patch
@@ -1,0 +1,30 @@
+From 39eb99dcd66f8ffb632fed6308a49896fe5ad2d3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juan=20Pedro=20Bol=C3=ADvar=20Puente?= <raskolnikov@gnu.org>
+Date: Thu, 10 Aug 2023 14:17:03 +0200
+Subject: [PATCH 3/3] Pass to qmlimportscanner the QML2_IMPORT_PATH
+
+---
+ src/tools/macdeployqt/shared/shared.cpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/tools/macdeployqt/shared/shared.cpp b/src/tools/macdeployqt/shared/shared.cpp
+index 676d34d545..7908b07b3c 100644
+--- a/src/tools/macdeployqt/shared/shared.cpp
++++ b/src/tools/macdeployqt/shared/shared.cpp
+@@ -1297,6 +1297,13 @@ bool deployQmlImports(const QString &appBundlePath, DeploymentInfo deploymentInf
+         argumentList.append(qmlImportsPath);
+     }
+ 
++    // In a modularized installation of qt as we have in Nix, instead, we will
++    // read the paths from the environment, as they are spread in multiple
++    // locations and normally set in the environment like this
++    auto envQmlImportPaths = ::qgetenv("QML2_IMPORT_PATH").split(':');
++    for (const QString &importPath : envQmlImportPaths)
++        argumentList << "-importPath" << importPath;
++
+     // run qmlimportscanner
+     QProcess qmlImportScanner;
+     qmlImportScanner.start(qmlImportScannerPath, argumentList);
+-- 
+2.26.2
+


### PR DESCRIPTION
## Description of changes

The qmlimportscanner tool is provided by qtdeclarative. Because of the modularized installation in Nix, it can not be found via the usual mechanisms.  Also, hard-coding it like we do for Qt5 would also not work, as it would require making qtbase depend on qtdeclarative.

Here we add an option to provide its location via the environment. While this means macdeployqt does not work out of the box, it provides a workaround for users.


## Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
