### PR TITLE
zig: default to zig 0.11

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -595,11 +595,7 @@ with pkgs;
 
   dsq = callPackage ../tools/misc/dsq { };
 
-  dt = callPackage ../tools/text/dt {
-    zigHook = zigHook.override {
-      zig = buildPackages.zig_0_11;
-    };
-  };
+  dt = callPackage ../tools/text/dt { };
 
   dtv-scan-tables = callPackage ../data/misc/dtv-scan-tables { };
 
@@ -3016,11 +3012,7 @@ with pkgs;
 
   pikchr = callPackage ../tools/graphics/pikchr { };
 
-  poop = callPackage ../tools/misc/poop {
-    zigHook = zigHook.override {
-      zig = buildPackages.zig_0_11;
-    };
-  };
+  poop = callPackage ../tools/misc/poop { };
 
   popl = callPackage ../development/libraries/popl { };
 
@@ -6149,7 +6141,11 @@ with pkgs;
 
   rex = callPackage ../tools/system/rex { };
 
-  river = callPackage ../applications/window-managers/river { };
+  river = callPackage ../applications/window-managers/river {
+    zigHook = zigHook.override {
+      zig = buildPackages.zig_0_10;
+    };
+  };
 
   rivercarro = callPackage ../applications/misc/rivercarro {
     zigHook = zigHook.override {
@@ -8003,7 +7999,11 @@ with pkgs;
 
   findutils = callPackage ../tools/misc/findutils { };
 
-  findup = callPackage ../tools/misc/findup { };
+  findup = callPackage ../tools/misc/findup {
+    zigHook = zigHook.override {
+      zig = buildPackages.zig_0_10;
+    };
+  };
 
   fingerprintx = callPackage ../tools/security/fingerprintx { };
 
@@ -9726,7 +9726,11 @@ with pkgs;
     ffmpeg = ffmpeg-full;
   };
 
-  linuxwave = callPackage ../tools/audio/linuxwave { };
+  linuxwave = callPackage ../tools/audio/linuxwave {
+    zigHook = zigHook.override {
+      zig = buildPackages.zig_0_10;
+    };
+  };
 
   littlefs-fuse = callPackage ../tools/filesystems/littlefs-fuse { };
 
@@ -14747,7 +14751,11 @@ with pkgs;
     stdenv = if stdenv.isDarwin then llvmPackages_16.stdenv else stdenv;
   };
 
-  clipbuzz = callPackage ../tools/misc/clipbuzz { };
+  clipbuzz = callPackage ../tools/misc/clipbuzz {
+    zigHook = zigHook.override {
+      zig = buildPackages.zig_0_10;
+    };
+  };
 
   xclip = callPackage ../tools/misc/xclip { };
 
@@ -25551,7 +25559,7 @@ with pkgs;
   zig_0_11 = darwin.apple_sdk_11_0.callPackage ../development/compilers/zig/0.11.nix {
     llvmPackages = llvmPackages_16;
   };
-  zig = zig_0_10;
+  zig = zig_0_11;
 
   zigHook = callPackage ../development/compilers/zig/hook.nix { };
 
@@ -41735,7 +41743,11 @@ with pkgs;
 
   duden = callPackage ../applications/misc/duden { };
 
-  zf = callPackage ../tools/misc/zf { };
+  zf = callPackage ../tools/misc/zf {
+    zigHook = zigHook.override {
+      zig = buildPackages.zig_0_10;
+    };
+  };
 
   isolate = callPackage ../tools/security/isolate { };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
