### PR TITLE
Add myself as a code owner of the contributing documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,8 +59,12 @@
 /maintainers/scripts/doc @jtojnar @ryantm
 
 /doc/build-aux/pandoc-filters @jtojnar
-/doc/contributing/ @fricklerhandwerk
-/doc/contributing/contributing-to-documentation.chapter.md @jtojnar @fricklerhandwerk
+
+# Contributor documentation
+/CONTRIBUTING.md @infinisil
+/.github/PULL_REQUEST_TEMPLATE.md
+/doc/contributing/ @fricklerhandwerk @infinisil
+/doc/contributing/contributing-to-documentation.chapter.md @jtojnar @fricklerhandwerk @infinisil
 
 # NixOS Internals
 /nixos/default.nix                                    @infinisil

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,8 +58,6 @@
 /maintainers/scripts/db-to-md.sh @jtojnar @ryantm
 /maintainers/scripts/doc @jtojnar @ryantm
 
-/doc/build-aux/pandoc-filters @jtojnar
-
 # Contributor documentation
 /CONTRIBUTING.md @infinisil
 /.github/PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
I want to take ownership of this part of the documentation, especially with the cleanup in https://github.com/NixOS/nixpkgs/pull/245243. Doing so before that PR is merged also allows me to get notified about any potential future merge conflicts before they happen.