### PR TITLE
Revert "invidious: unstable-2023-06-06 -> unstable-2023-07-05"

### DIFF
--- a/pkgs/servers/invidious/versions.json
+++ b/pkgs/servers/invidious/versions.json
@@ -4,9 +4,9 @@
     "sha256": "sha256-EU6T9yQCdOLx98Io8o01rEsgxDFF/Xoy42LgPopD2/A="
   },
   "invidious": {
-    "rev": "507bed6313b49564e53b69a5c9b4d072d1e05e4b",
+    "rev": "545a5937d87d31622e87bb2ba8151f8aecd66c81",
     "sha256": "sha256-1Ra3nLO2DsnTvyovteF0cOIl07GHbJyPbTYBRIyKuAs=",
-    "version": "unstable-2023-07-05"
+    "version": "unstable-2023-06-06"
   },
   "lsquic": {
     "sha256": "sha256-hG8cUvhbCNeMOsKkaJlgGpzUrIx47E/WhmPIdI5F3qM=",


### PR DESCRIPTION
Reverts NixOS/nixpkgs#243077

The hash wasn't updated in that PR, so everybody was still running the old version. Discovered by @miangraham here: https://github.com/NixOS/nixpkgs/pull/246447#issuecomment-1672049355