### PR TITLE
cargo-component: unstable-2023-07-28 -> unstable-2023-08-03

### DIFF
--- a/pkgs/development/tools/rust/cargo-component/Cargo.lock
+++ b/pkgs/development/tools/rust/cargo-component/Cargo.lock
@@ -3729,6 +3729,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "bytes",
+ "cargo-component-core",
+ "clap",
+ "futures",
+ "indexmap 2.0.0",
+ "log",
+ "p256",
+ "predicates",
+ "pretty_env_logger",
+ "rand_core",
+ "rpassword",
+ "semver",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "toml_edit",
+ "url",
+ "warg-client",
+ "warg-crypto",
+ "warg-protocol",
+ "warg-server",
+ "wasm-metadata 0.10.1",
+ "wasmparser 0.110.0",
+ "wit-component 0.13.1",
+ "wit-parser",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/pkgs/development/tools/rust/cargo-component/default.nix
+++ b/pkgs/development/tools/rust/cargo-component/default.nix
@@ -9,13 +9,13 @@
 
 rustPlatform.buildRustPackage {
   pname = "cargo-component";
-  version = "unstable-2023-07-28";
+  version = "unstable-2023-08-03";
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = "cargo-component";
-    rev = "b58f10c867f666c1c799b766fb8cd1941ede8ed7";
-    hash = "sha256-BwrbenOg+Q6BAy/Mn8AHB0VvvIZ0cYvq4r791QEFTdo=";
+    rev = "d14cef65719d0d186218d1dfe5f04bbbf295dc80";
+    hash = "sha256-dFaboXF5NXPE2xcJWanyP5WYpqJBq+xKpi6snNfIWJg=";
   };
 
   cargoLock = {


### PR DESCRIPTION
Diff: https://github.com/bytecodealliance/cargo-component/compare/b58f10c867f666c1c799b766fb8cd1941ede8ed7...d14cef65719d0d186218d1dfe5f04bbbf295dc80

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
