### PR TITLE
Improve the documentation of `lib.extends` and how it relates to overlays

### DIFF
--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -129,7 +129,20 @@ rec {
       fix (extends (final: prev: { c = final.a + final.b; }) f)
       => { a = 1; b = 3; c = 4; }
   */
-  extends = f: rattrs: self: let super = rattrs self; in super // f self super;
+  extends =
+    # The overlay to apply to the fixed-point function
+    overlay:
+    # The fixed-point function
+    f:
+    # Wrap with parenthesis to prevent nixdoc from rendering the `final` argument in the documentation
+    # The result should be thought of as a function, the argument of that function is not an argument to `extends` itself
+    (
+      final:
+      let
+        prev = f final;
+      in
+      prev // overlay final prev
+    );
 
   /*
     Compose two extending functions of the type expected by 'extends'

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -108,6 +108,26 @@ rec {
     fix g
     => { a = 11; b = 13; c = 24; }
     ```
+
+    Type:
+      extends :: (Attrs -> Attrs -> Attrs) # The overlay to apply to the fixed-point function
+              -> (Attrs -> Attrs) # A fixed-point function
+              -> (Attrs -> Attrs) # The resulting fixed-point function
+
+    Example:
+      f = final: { a = 1; b = final.a + 2; }
+
+      fix f
+      => { a = 1; b = 3; }
+
+      fix (extends (final: prev: { a = prev.a + 10; }) f)
+      => { a = 11; b = 13; }
+
+      fix (extends (final: prev: { b = final.a + 5; }) f)
+      => { a = 1; b = 6; }
+
+      fix (extends (final: prev: { c = final.a + final.b; }) f)
+      => { a = 1; b = 3; c = 4; }
   */
   extends = f: rattrs: self: let super = rattrs self; in super // f self super;
 


### PR DESCRIPTION
## Description of changes
`lib.extends` is the part of Nixpkgs that actually implements how overlays work, but its documentation was rather poor. This is an attempt to improve it.

This also relates to @roberth's suggested improvements to the `lib.fix` documentation in https://github.com/NixOS/nixpkgs/pull/242318 and @amjoseph-nixpkgs's suggested improvements to the `extends` documentation in https://github.com/NixOS/nixpkgs/pull/245825.

## Things done
- [x] Built the documentation and checked that it looks alright.