### PR TITLE
nwg-displays: add optional Hyprland dependencies

### DIFF
--- a/pkgs/applications/misc/nwg-displays/default.nix
+++ b/pkgs/applications/misc/nwg-displays/default.nix
@@ -8,6 +8,8 @@
 , pango
 , python310Packages
 , wrapGAppsHook
+, hyprlandSupport ? false
+, wlr-randr
 }:
 
 python310Packages.buildPythonApplication rec {
@@ -38,6 +40,8 @@ python310Packages.buildPythonApplication rec {
     python310Packages.gst-python
     python310Packages.i3ipc
     python310Packages.pygobject3
+  ] ++ lib.optionals hyprlandSupport [
+    wlr-randr
   ];
 
   dontWrapGApps = true;


### PR DESCRIPTION
Without the dependencies, running `nix run nixpkgs#nwg-displays` results in:
```
Running on Hyprland
wlr-randr package required, but not found, terminating.
```