### PR TITLE
cargo-auditable: fix cross compilation

### DIFF
--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, makeRustPlatform, rustc, cargo, installShellFiles, stdenv }:
+{ lib, buildPackages, fetchFromGitHub, makeRustPlatform, installShellFiles, stdenv }:
 
 let
   args = rec {
@@ -30,8 +30,8 @@ let
   };
 
   rustPlatform = makeRustPlatform {
-    inherit rustc;
-    cargo = cargo.override {
+    inherit (buildPackages) rustc;
+    cargo = buildPackages.cargo.override {
       auditable = false;
     };
   };


### PR DESCRIPTION
## Description of changes

This fixes the following error:
...
cargo-auditable>    Doc-tests auditable-extract
cargo-auditable> error: doctest failed, to rerun pass `-p auditable-extract --doc`
cargo-auditable>
cargo-auditable> Caused by:
cargo-auditable>   could not execute process `rustdoc --edition=2018 --crate-type lib --crate-name auditable_extract --test /build/source/auditable-extract/src/lib.rs --target x86_64-unknown-linux-gnu -L dependency=/build/source/target/x86_64-unknown-linux-gnu/release/deps -L dependency=/build/source/target/release/deps --test-args --test-threads=96 --extern auditable_extract=/build/source/target/x86_64-unknown-linux-gnu/release/deps/libauditable_extract-dd1904617e4b78db.rlib --extern binfarce=/build/source/target/x86_64-unknown-linux-gnu/release/deps/libbinfarce-2ba09d21aed0de1a.rlib -C embed-bitcode=no --error-format human` (never executed)
cargo-auditable>
cargo-auditable> Caused by:
cargo-auditable>   No such file or directory (os error 2)

Tested with lanzaboote, same fix as https://github.com/nix-community/lanzaboote/pull/217

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
