### PR TITLE
linuxPackages.keymash: init at 0.1.1

### DIFF
--- a/pkgs/os-specific/linux/keymash/default.nix
+++ b/pkgs/os-specific/linux/keymash/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchFromGitea, kernel, kmod }:
+let
+  version = "0.1.1";
+in
+stdenv.mkDerivation {
+  pname = "keymash";
+  version = "${version}-${kernel.version}";
+
+  src = fetchFromGitea {
+    domain = "git.bsd.gay";
+    owner = "fef";
+    repo = "keymash";
+    rev = "v${version}";
+    hash = "sha256-sET3NKH8sS9tIvf68nLiNBVQ1so9bISim0Nxr4kd/0I=";
+  };
+
+  hardeningDisable = [ "pic" "format" ];
+  nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  meta = with lib; {
+    longDescription = ''
+      The gay keymash device driver!
+      /dev/keymash provides an endless supply of lowercase characters from the QWERTY home row in a cryptographically secure random order.
+    '';
+    homepage = "https://git.bsd.gay/fef/keymash";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.aprl ];
+    platforms = platforms.linux;
+    broken = lib.versionOlder kernel.version "5.10";
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -368,6 +368,8 @@ in {
 
     ena = callPackage ../os-specific/linux/ena {};
 
+    keymash = callPackage ../os-specific/linux/keymash {};
+
     kvdo = callPackage ../os-specific/linux/kvdo {};
 
     lenovo-legion-module = callPackage ../os-specific/linux/lenovo-legion { };


### PR DESCRIPTION
## Description of changes

Added the keymash kernel module. It provides a device driver that supplies endless chars from the QWERTY home row.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
