### PR TITLE
Change `types.string` error to a warning instead

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -436,7 +436,10 @@ rec {
 
     # Deprecated; should not be used because it quietly concatenates
     # strings, which is usually not what you want.
-    string = throw "The type `types.string` is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.";
+    string = separatedString "" // {
+      name = "string";
+      deprecationMessage = "See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.";
+    };
 
     passwdEntry = entryType: addCheck entryType (str: !(hasInfix ":" str || hasInfix "\n" str)) // {
       name = "passwdEntry ${entryType.name}";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -436,10 +436,12 @@ rec {
 
     # Deprecated; should not be used because it quietly concatenates
     # strings, which is usually not what you want.
-    string = separatedString "" // {
-      name = "string";
-      deprecationMessage = "See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.";
-    };
+    # We use a lib.warn because `deprecationMessage` doesn't trigger in nested types such as `attrsOf string`
+    string = lib.warn
+      "The type `types.string` is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types."
+      (separatedString "" // {
+        name = "string";
+      });
 
     passwdEntry = entryType: addCheck entryType (str: !(hasInfix ":" str || hasInfix "\n" str)) // {
       name = "passwdEntry ${entryType.name}";


### PR DESCRIPTION
## Description of changes
For one, reverts https://github.com/NixOS/nixpkgs/pull/247848.

This was a bit too ambitious, as reported in https://github.com/NixOS/nixpkgs/pull/247937 and other issues, because no warnings were previously triggered when `string` was nested e.g. `attrsOf string`, `nullOr string`, etc.

Support for nested type deprecation warnings was introduced in https://github.com/NixOS/nixpkgs/pull/99132, but had to be reverted in https://github.com/NixOS/nixpkgs/pull/121816 because it caused infinite recursion for some users, and I couldn't remember that it was reverted.

Instead this PR switches `strings` to emit a warning using `lib.warn` instead. This will cause a poorer error message without option location information, but it will catch all uses of its use, hopefully allowing an actual error within a few years, any day now.