### PR TITLE
softether: update (including multiple security fix), multple module bug fixes, optional regional-lockout removing patch

### DIFF
--- a/nixos/modules/services/networking/softether.nix
+++ b/nixos/modules/services/networking/softether.nix
@@ -85,6 +85,16 @@ in
           Type = "forking";
           ExecStart = "${package}/bin/vpnserver start";
           ExecStop = "${package}/bin/vpnserver stop";
+          KillMode = "process";
+          Restart = "on-failure";
+
+          # Hardening
+          PrivateTmp = true;
+          ProtectHome = true;
+          ProtectSystem = "full";
+          ReadOnlyPaths = [ "/" ];
+          ReadWritePaths = [ "-${cfg.dataDir}/vpnserver" ];
+          CapabilityBoundingSet = [ "CAP_NET_ADMIN" "CAP_NET_BIND_SERVICE" "CAP_NET_BROADCAST" "CAP_NET_RAW" "CAP_SYS_NICE" "CAP_SYSLOG" "CAP_SETUID" ];
         };
       };
     })
@@ -97,6 +107,16 @@ in
           Type = "forking";
           ExecStart = "${package}/bin/vpnbridge start";
           ExecStop = "${package}/bin/vpnbridge stop";
+          KillMode = "process";
+          Restart = "on-failure";
+
+          # Hardening
+          PrivateTmp = true;
+          ProtectHome = true;
+          ProtectSystem = "full";
+          ReadOnlyPaths = [ "/" ];
+          ReadWritePaths = [ "-${cfg.dataDir}/vpnbridge" ];
+          CapabilityBoundingSet = [ "CAP_NET_ADMIN" "CAP_NET_BIND_SERVICE" "CAP_NET_BROADCAST" "CAP_NET_RAW" "CAP_SYS_NICE" "CAP_SYSLOG" "CAP_SETUID" ];
         };
       };
     })
@@ -109,6 +129,16 @@ in
           Type = "forking";
           ExecStart = "${package}/bin/vpnclient start";
           ExecStop = "${package}/bin/vpnclient stop";
+          KillMode = "process";
+          Restart = "on-failure";
+
+          # Hardening
+          PrivateTmp = true;
+          ProtectHome = true;
+          ProtectSystem = "full";
+          ReadOnlyPaths = [ "/" ];
+          ReadWritePaths = [ "-${cfg.dataDir}/vpnclient" ];
+          CapabilityBoundingSet = [ "CAP_NET_ADMIN" "CAP_NET_BIND_SERVICE" "CAP_NET_BROADCAST" "CAP_NET_RAW" "CAP_SYS_NICE" "CAP_SYSLOG" "CAP_SETUID" ];
         };
         postStart = ''
             sleep 1

--- a/nixos/modules/services/networking/softether.nix
+++ b/nixos/modules/services/networking/softether.nix
@@ -61,89 +61,60 @@ in
     mkMerge [{
       environment.systemPackages = [ package ];
 
-      systemd.services.softether-init = {
-        description = "SoftEther VPN services initial task";
-        wantedBy = [ "network.target" ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = false;
-        };
-        script = ''
-            for d in vpnserver vpnbridge vpnclient vpncmd; do
-                if ! test -e ${cfg.dataDir}/$d; then
-                    ${pkgs.coreutils}/bin/mkdir -m0700 -p ${cfg.dataDir}/$d
-                    install -m0600 ${package}${cfg.dataDir}/$d/hamcore.se2 ${cfg.dataDir}/$d/hamcore.se2
-                fi
-            done
-            rm -rf ${cfg.dataDir}/vpncmd/vpncmd
-            ln -s ${package}${cfg.dataDir}/vpncmd/vpncmd ${cfg.dataDir}/vpncmd/vpncmd
-        '';
-      };
+      systemd.tmpfiles.rules = [
+        "d  ${cfg.dataDir}/vpnserver             755 root root"
+        "L+ ${cfg.dataDir}/vpnserver/hamcore.se2 -   -    -     - ${package}${cfg.dataDir}/vpnserver/hamcore.se2"
+        "L+ ${cfg.dataDir}/vpnserver/vpnserver   -   -    -     - ${package}${cfg.dataDir}/vpnserver/vpnserver"
+        "d  ${cfg.dataDir}/vpnbridge             755 root root"
+        "L+ ${cfg.dataDir}/vpnbridge/hamcore.se2 -   -    -     - ${package}${cfg.dataDir}/vpnbridge/hamcore.se2"
+        "L+ ${cfg.dataDir}/vpnbridge/vpnbridge   -   -    -     - ${package}${cfg.dataDir}/vpnbridge/vpnbridge"
+        "d  ${cfg.dataDir}/vpnclient             755 root root"
+        "L+ ${cfg.dataDir}/vpnclient/hamcore.se2 -   -    -     - ${package}${cfg.dataDir}/vpnclient/hamcore.se2"
+        "L+ ${cfg.dataDir}/vpnclient/vpnclient   -   -    -     - ${package}${cfg.dataDir}/vpnclient/vpnclient"
+        "d  ${cfg.dataDir}/vpncmd                755 root root"
+        "L+ ${cfg.dataDir}/vpncmd/hamcore.se2    -   -    -     - ${package}${cfg.dataDir}/vpncmd/hamcore.se2"
+        "L+ ${cfg.dataDir}/vpncmd/vpncmd         -   -    -     - ${package}${cfg.dataDir}/vpncmd/vpncmd"
+      ];
     }
 
     (mkIf cfg.vpnserver.enable {
       systemd.services.vpnserver = {
         description = "SoftEther VPN Server";
-        after = [ "softether-init.service" ];
-        requires = [ "softether-init.service" ];
         wantedBy = [ "network.target" ];
         serviceConfig = {
           Type = "forking";
           ExecStart = "${package}/bin/vpnserver start";
           ExecStop = "${package}/bin/vpnserver stop";
         };
-        preStart = ''
-            rm -rf ${cfg.dataDir}/vpnserver/vpnserver
-            ln -s ${package}${cfg.dataDir}/vpnserver/vpnserver ${cfg.dataDir}/vpnserver/vpnserver
-        '';
-        postStop = ''
-            rm -rf ${cfg.dataDir}/vpnserver/vpnserver
-        '';
       };
     })
 
     (mkIf cfg.vpnbridge.enable {
       systemd.services.vpnbridge = {
         description = "SoftEther VPN Bridge";
-        after = [ "softether-init.service" ];
-        requires = [ "softether-init.service" ];
         wantedBy = [ "network.target" ];
         serviceConfig = {
           Type = "forking";
           ExecStart = "${package}/bin/vpnbridge start";
           ExecStop = "${package}/bin/vpnbridge stop";
         };
-        preStart = ''
-            rm -rf ${cfg.dataDir}/vpnbridge/vpnbridge
-            ln -s ${package}${cfg.dataDir}/vpnbridge/vpnbridge ${cfg.dataDir}/vpnbridge/vpnbridge
-        '';
-        postStop = ''
-            rm -rf ${cfg.dataDir}/vpnbridge/vpnbridge
-        '';
       };
     })
 
     (mkIf cfg.vpnclient.enable {
       systemd.services.vpnclient = {
         description = "SoftEther VPN Client";
-        after = [ "softether-init.service" ];
-        requires = [ "softether-init.service" ];
         wantedBy = [ "network.target" ];
         serviceConfig = {
           Type = "forking";
           ExecStart = "${package}/bin/vpnclient start";
           ExecStop = "${package}/bin/vpnclient stop";
         };
-        preStart = ''
-            rm -rf ${cfg.dataDir}/vpnclient/vpnclient
-            ln -s ${package}${cfg.dataDir}/vpnclient/vpnclient ${cfg.dataDir}/vpnclient/vpnclient
-        '';
         postStart = ''
             sleep 1
             ${cfg.vpnclient.up}
         '';
         postStop = ''
-            rm -rf ${cfg.dataDir}/vpnclient/vpnclient
             sleep 1
             ${cfg.vpnclient.down}
         '';

--- a/pkgs/servers/softether/default.nix
+++ b/pkgs/servers/softether/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitHub
 , openssl, readline, ncurses, zlib
-, dataDir ? "/var/lib/softether" }:
+, dataDir ? "/var/lib/softether"
+, removeRegionLock ? false }:
 
 stdenv.mkDerivation rec {
   pname = "softether";
@@ -13,6 +14,11 @@ stdenv.mkDerivation rec {
     rev = "v${version}-${build}-rtm";
     sha256 = "uSI5IV/Xhu+jnjVUWbYizTcSiOkG7N8IjQPPUSJby+I=";
   };
+
+  patches = lib.optionals removeRegionLock [
+    # https://github.com/SoftEtherVPN/SoftEtherVPN/blob/5f12684b42f747c2d15f3b89a03133c15dd902ea/src/Cedar/Server.c#L10586-L10637
+    ./remove-region-lock.patch
+  ];
 
   buildInputs = [ openssl readline ncurses zlib ];
 

--- a/pkgs/servers/softether/default.nix
+++ b/pkgs/servers/softether/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub
-, openssl, readline, ncurses, zlib
+, openssl, readline, ncurses, zlib, libpcap, libiconv
 , dataDir ? "/var/lib/softether"
 , removeRegionLock ? false }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     ./remove-region-lock.patch
   ];
 
-  buildInputs = [ openssl readline ncurses zlib ];
+  buildInputs = [ openssl readline ncurses zlib ] ++ lib.optionals stdenv.isDarwin [ libpcap libiconv ];
 
   preConfigure = ''
     ./configure
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.softether.org/";
     license = licenses.asl20;
     maintainers = [ maintainers.rick68 ];
-    platforms = [ "x86_64-linux" ];
+    platforms = intersectLists (platforms.linux ++ platforms.freebsd ++ platforms.darwin ++ platforms.openbsd) (platforms.x86 ++ platforms.arm ++ platforms.aarch64 ++ platforms.mips ++ platforms.power);
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/servers/softether/default.nix
+++ b/pkgs/servers/softether/default.nix
@@ -1,15 +1,17 @@
-{ lib, stdenv, fetchurl
+{ lib, stdenv, fetchFromGitHub
 , openssl, readline, ncurses, zlib
 , dataDir ? "/var/lib/softether" }:
 
 stdenv.mkDerivation rec {
   pname = "softether";
-  version = "4.38";
-  build = "9760";
+  version = "4.42";
+  build = "9798";
 
-  src = fetchurl {
-    url = "https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/releases/download/v${version}-${build}-rtm/softether-src-v${version}-${build}-rtm.tar.gz";
-    sha256 = "0d8zahi9lkv72jh8yj66pwrsi4451vk113d3khzrzgbic6s2i0g6";
+  src = fetchFromGitHub {
+    owner = "SoftEtherVPN";
+    repo = "SoftEtherVPN_Stable";
+    rev = "v${version}-${build}-rtm";
+    sha256 = "uSI5IV/Xhu+jnjVUWbYizTcSiOkG7N8IjQPPUSJby+I=";
   };
 
   buildInputs = [ openssl readline ncurses zlib ];
@@ -27,6 +29,8 @@ stdenv.mkDerivation rec {
       -e "/echo/s|echo $out/|echo |g" \
       Makefile
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "An Open-Source Free Cross-platform Multi-protocol VPN Program";

--- a/pkgs/servers/softether/remove-region-lock.patch
+++ b/pkgs/servers/softether/remove-region-lock.patch
@@ -1,0 +1,10 @@
+--- v4.42-9798/src/Cedar/Server.c	2023-08-08 14:50:00.240140548 +0900
++++ v4.42-9798/src/Cedar/Server.c	2023-08-08 14:50:33.271800128 +0900
+@@ -10905,6 +10905,7 @@
+ // 
+ bool SiIsEnterpriseFunctionsRestrictedOnOpenSource(CEDAR *c)
+ {
++	return false;
+ 	char region[128];
+ 	bool ret = false;
+ 	// Validate arguments

--- a/pkgs/servers/softether/update.sh
+++ b/pkgs/servers/softether/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq nix-prefetch-github
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+pname=softether
+owner=SoftEtherVPN
+repo=SoftEtherVPN_Stable
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+current_ver=$(nix-instantiate --eval -E "(import \"$nixpkgs\" { config = {}; overlays = []; }).${pname}.version" | tr -d '"')
+latest_tag=$(curl -s "https://api.github.com/repos/$owner/$repo/tags" | jq -r ".[].name" | grep -- "-rtm" | head -n1)
+latest_ver=$(sed -E 's/v(.+)-.+-rtm/\1/' <<<"$latest_tag")
+latest_build=$(sed -E 's/v.+-(.+)-rtm/\1/' <<<"$latest_tag")
+
+if [[ $current_ver == $latest_ver ]]; then
+  echo "Already at latest version $latest_ver"
+  exit 0
+fi
+echo "New version: $latest_ver"
+
+newhash=$(nix-prefetch-github --json "$owner" "$repo" --rev "$latest_tag" | jq -r .sha256)
+
+sed -i "s#version = \".*\"#version = \"$latest_ver\"#" default.nix
+sed -i "s#build = \".*\"#build = \"$latest_build\"#" default.nix
+sed -i "s#sha256 = \".*\"#sha256 = \"$newhash\"#" default.nix


### PR DESCRIPTION
## Description of changes
- softether: 4.38->4.42
   Fixes CVE-2023-27395, CVE-2023-22325, CVE-2023-32275, CVE-2023-27516, CVE-2023-32634, and CVE-2023-31192.
   https://www.softether.org/5-download/history
- add update script
- add an optional regional lockout removing patch
- fix softether module bugs
  - change `${dataDir}/vpn*` modes from `0700` to upstream `0755`.
    - non-root users can't run `vpncmd` due to too tight permission.
  - replace setup and teardown scripts with systemd-tmpfiles rules.
    - it also ensure `hamcore.se2` getting updates
      - `softether-init` service does not update `hamcore.se2` after first run (when `${dataDir}/vpn*` exists)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
