### PR TITLE
protobufc: 1.4.1 -> unstable-2023-07-08

### DIFF
--- a/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
@@ -68,8 +68,11 @@ let
     ];
 
     buildInputs = [
-      abseil-cpp
       zlib
+    ];
+
+    propagatedBuildInputs = [
+      abseil-cpp
     ];
 
     cmakeDir = if lib.versionOlder version "3.22" then "../cmake" else null;

--- a/pkgs/development/libraries/protobufc/default.nix
+++ b/pkgs/development/libraries/protobufc/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , autoreconfHook
 , pkg-config
 , protobuf
@@ -11,28 +10,20 @@
 
 stdenv.mkDerivation rec {
   pname = "protobuf-c";
-  version = "1.4.1";
+  version = "unstable-2023-07-08";
 
   src = fetchFromGitHub {
     owner = "protobuf-c";
     repo = "protobuf-c";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-TJCLzxozuZ8ynrBQ2lKyk03N+QA/lbOwywUjDUdTlbM=";
+    rev = "fa86fddbd000316772d1deb5a8d1201fa7599ef7";
+    hash = "sha256-pmqZYFREPgSrWPekymTglhtAv6gQR1gP3dOl3hqjYig=";
   };
-
-  patches = [
-    # https://github.com/protobuf-c/protobuf-c/pull/534
-    (fetchpatch {
-      url = "https://github.com/protobuf-c/protobuf-c/commit/a6c9ea5207aeac61c57b446ddf5a6b68308881d8.patch";
-      hash = "sha256-wTb8+YbvrCrOVpgthI5SJdG/CpQcOzCX4Bv47FPY804=";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [ protobuf zlib ];
 
-  PROTOC = lib.getExe buildPackages.protobuf;
+  env.PROTOC = lib.getExe buildPackages.protobuf;
 
   meta = with lib; {
     homepage = "https://github.com/protobuf-c/protobuf-c/";


### PR DESCRIPTION
## Description of changes

I have only built this against the new protobuf in staging on my aarch64-darwin machine, since I had everything built already. I don't have the ability to test it on Linux at the moment.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
