### PR TITLE
treewide: relax numba version

### DIFF
--- a/pkgs/development/python-modules/awkward/default.nix
+++ b/pkgs/development/python-modules/awkward/default.nix
@@ -24,6 +24,12 @@ buildPythonPackage rec {
     hash = "sha256-v06mYdoP/WfIfz6x6+MJvS4YOsTsyWqhCyAykZ1d5v4=";
   };
 
+  patches = [
+    # the version of numba may not be set correctly until the next release, 0.58
+    # see the comment of https://github.com/NixOS/nixpkgs/pull/247678
+    ./relax-numba-version.patch
+  ];
+
   nativeBuildInputs = [
     hatch-fancy-pypi-readme
     hatchling

--- a/pkgs/development/python-modules/awkward/relax-numba-version.patch
+++ b/pkgs/development/python-modules/awkward/relax-numba-version.patch
@@ -1,0 +1,16 @@
+diff --git a/src/awkward/numba.py b/src/awkward/numba.py
+index 12664116..948dbf60 100644
+--- a/src/awkward/numba.py
++++ b/src/awkward/numba.py
+@@ -28,11 +28,6 @@ conda install numba"""
+         ) from err
+ 
+     if not _has_checked_version:
+-        if parse_version(numba.__version__) < parse_version("0.50"):
+-            raise ImportError(
+-                "Awkward Array can only work with numba 0.50 or later "
+-                "(you have version {})".format(numba.__version__)
+-            )
+         _has_checked_version = True
+ 
+     _register()

--- a/pkgs/development/python-modules/clifford/default.nix
+++ b/pkgs/development/python-modules/clifford/default.nix
@@ -7,6 +7,7 @@
 , numba
 , numpy
 , pytestCheckHook
+, pythonRelaxDepsHook
 , scipy
 , sparse
 }:
@@ -21,6 +22,16 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-eVE8FrD0YHoRreY9CrNb8v4v4KrG83ZU0oFz+V+p+Q0=";
   };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    # the version of numba may not be set correctly until the next release, 0.58
+    # see the comment of https://github.com/NixOS/nixpkgs/pull/247678
+    "numba"
+  ];
 
   propagatedBuildInputs = [
     h5py

--- a/pkgs/development/python-modules/librosa/default.nix
+++ b/pkgs/development/python-modules/librosa/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
+, pythonRelaxDepsHook
 
 # build-system
 , setuptools
@@ -43,14 +45,29 @@ buildPythonPackage rec {
     hash = "sha256-MXzPIcbG8b1JwhEyAZG4DRObGaHq+ipVHMrZCzaxLdE=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "support-scipy-1.11.patch";
+      url = "https://github.com/librosa/librosa/commit/12dee8eabed7df14c5622b52c05393ddfeb11f4b.patch";
+      hash = "sha256-JxTXU0Mc+QYpsafjoGLaIccD7EdCYJvIVianeosYpw4=";
+    })
+  ];
+
   nativeBuildInputs = [
     setuptools
+    pythonRelaxDepsHook
   ];
 
   postPatch = ''
     substituteInPlace setup.cfg \
       --replace "--cov-report term-missing --cov librosa --cov-report=xml " ""
   '';
+
+  pythonRelaxDeps = [
+    # the version of numba may not be set correctly until the next release, 0.58
+    # see the comment of https://github.com/NixOS/nixpkgs/pull/247678
+    "numba"
+  ];
 
   propagatedBuildInputs = [
     audioread

--- a/pkgs/development/python-modules/pynndescent/default.nix
+++ b/pkgs/development/python-modules/pynndescent/default.nix
@@ -10,6 +10,7 @@
 , scipy
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -34,6 +35,22 @@ buildPythonPackage rec {
       url = "https://github.com/lmcinnes/pynndescent/commit/e56b92776a4a05f2dabb80d25479bd37e7ebd88e.patch";
       hash = "sha256-zVTaW4syGEHh2HAGPyBN3YXqUGe55v/LxKLX/zjXT5Y=";
     })
+  ];
+
+  postPatch = ''
+    # fix scipy 1.11 compat
+    substituteInPlace pynndescent/tests/test_distances.py \
+      --replace '"kulsinski",' ""
+  '';
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    # the version of numba may not be set correctly until the next release, 0.58
+    # see the comment of https://github.com/NixOS/nixpkgs/pull/247678
+    "numba"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/resampy/default.nix
+++ b/pkgs/development/python-modules/resampy/default.nix
@@ -6,6 +6,7 @@
 , numpy
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 , scipy
 }:
 
@@ -23,10 +24,20 @@ buildPythonPackage rec {
     hash = "sha256-t5I7NJmIeV0uucPyvR+UJ24NK7fIzYlNJ8bECkbvdjI=";
   };
 
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
   propagatedBuildInputs = [
     numpy
     cython
     numba
+  ];
+
+  pythonRelaxDeps = [
+    # the version of numba may not be set correctly until the next release, 0.58
+    # see the comment of https://github.com/NixOS/nixpkgs/pull/247678
+    "numba"
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/sparse/default.nix
+++ b/pkgs/development/python-modules/sparse/default.nix
@@ -2,10 +2,12 @@
 , buildPythonPackage
 , dask
 , fetchPypi
+, fetchpatch
 , numba
 , numpy
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 , scipy
 }:
 
@@ -20,6 +22,25 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-X1gno39s1vZzClQfmUyVxgo64jKeAfS6Ic7VM5rqAJg=";
   };
+
+  patches = [
+    # https://github.com/pydata/sparse/issues/594
+    (fetchpatch {
+      name = "fix-test.patch";
+      url = "https://github.com/pydata/sparse/commit/a55651d630efaea6fd2758d083c6d02333b0eebe.patch";
+      hash = "sha256-Vrx7MDlKtA8fOuFZenEkvgA70Hzm+p/4SPZuCvwtLuo=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    # the version of numba may not be set correctly until the next release, 0.58
+    # see the comment of https://github.com/NixOS/nixpkgs/pull/247678
+    "numba"
+  ];
 
   propagatedBuildInputs = [
     numba

--- a/pkgs/development/python-modules/umap-learn/default.nix
+++ b/pkgs/development/python-modules/umap-learn/default.nix
@@ -8,6 +8,7 @@
 , pynndescent
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 , scikit-learn
 , scipy
 , tensorflow
@@ -59,6 +60,16 @@ buildPythonPackage rec {
     })
   ];
 
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    # the version of numba may not be set correctly until the next release, 0.58
+    # see the comment of https://github.com/NixOS/nixpkgs/pull/247678
+    "numba"
+  ];
+
   propagatedBuildInputs = [
     numba
     numpy
@@ -90,6 +101,17 @@ buildPythonPackage rec {
 
     # tensorflow maybe incompatible? https://github.com/lmcinnes/umap/issues/821
     "test_save_load"
+
+    # incompatible with numpy 1.25
+    "test_tsw_spectral_init"
+    # incompatible with scipy 1.11
+    "test_kulsinski"
+    "test_sparse_kulsinski"
+    # incompatible with sklearn 1.3
+    "test_composite_trustworthiness"
+    "test_multi_component_layout"
+    "test_multi_component_layout_precomputed"
+    "test_precomputed_knn_on_iris"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

This is a follow up PR for #246727.

The version of numba is currently not set. As a result, packages that require numba with the lower limit failed to build because they could not find the appropriate numba.
This is a temporary fix until numba is updated to a newer version.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
