### PR TITLE
itch: 25.6.2 -> 26.1.2

### DIFF
--- a/pkgs/games/itch/default.nix
+++ b/pkgs/games/itch/default.nix
@@ -3,7 +3,7 @@
 , fetchzip
 , fetchFromGitHub
 , butler
-, electron_11
+, electron
 , steam-run
 , makeWrapper
 , copyDesktopItems
@@ -11,12 +11,13 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "itch";
-  version = "25.6.2";
+  version = "26.1.2";
 
+  # TODO: Using kitch instead of itch, revert when possible
   src = fetchzip {
-    url = "https://broth.itch.ovh/${pname}/linux-amd64/${version}/itch.zip";
+    url = "https://broth.itch.ovh/k${pname}/linux-amd64/${version}/archive/default#.zip";
     stripRoot = false;
-    sha256 = "sha256-F/vaYBHCygseiKNMJ+jBy31YDIFqYToAETGUl/pkHII=";
+    sha256 = "sha256-thXe+glpltSiKNGIRgvOZQZPJWfDHWo3dLdziyp2BM4=";
   };
 
   itch-setup = fetchzip {
@@ -29,8 +30,8 @@ stdenvNoCC.mkDerivation rec {
     fetchFromGitHub {
         owner = "itchio";
         repo = pname;
-        rev = "v25.6.1-canary"; # Use ${version} if possible
-        hash = "sha256-iBp7K7AW97SOlRa8N8TW2LcVtmUi9JU00fYUuPwKORc=";
+        rev = "v${version}-canary";
+        sha256 = "sha256-veZiKs9qHge+gCEpJ119bAT56ssXJAH3HBcYkEHqBFg=";
         sparseCheckout = [ sparseCheckout ];
       } + sparseCheckout;
 
@@ -53,6 +54,10 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
+    # TODO: Remove when the next stable Itch is stabilized
+    substituteInPlace ./resources/app/package.json \
+      --replace "kitch" "itch"
+
     mkdir -p $out/bin $out/share/${pname}/resources/app
     cp -r resources/app "$out/share/${pname}/resources/"
 
@@ -72,7 +77,7 @@ stdenvNoCC.mkDerivation rec {
 
   postFixup = ''
     makeWrapper ${steam-run}/bin/steam-run $out/bin/${pname} \
-      --add-flags ${electron_11}/bin/electron \
+      --add-flags ${electron}/bin/electron \
       --add-flags $out/share/${pname}/resources/app \
       --set BROTH_USE_LOCAL butler,itch-setup \
       --prefix PATH : ${butler}/bin/:${itch-setup}


### PR DESCRIPTION
## Description of changes

While this new version is still a beta (some of the icons will be blue), the Electron version is not insecure anymore, with the number literally doubled (from 11 to 22).
Closes #220844 for real.
Closes #252457.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
