### PR TITLE
frozen: init at unstable-2021-02-23

### DIFF
--- a/pkgs/development/libraries/frozen/default.nix
+++ b/pkgs/development/libraries/frozen/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  pname = "frozen";
+  # pin to a newer release if frozen releases again, see cesanta/frozen#72
+  version = "unstable-2021-02-23";
+
+  src = fetchFromGitHub {
+    owner = "cesanta";
+    repo = "frozen";
+    rev = "21f051e3abc2240d9a25b2add6629b38e963e102";
+    hash = "sha256-BpuYK9fbWSpeF8iPT8ImrV3CKKaA5RQ2W0ZQ03TciR0=";
+  };
+
+  nativeBuildInputs = [ meson ninja ];
+
+  # frozen has a simple Makefile and a GN BUILD file as building scripts.
+  # Since it has only two source files, the best course of action to support
+  # cross compilation is to create a small meson.build file.
+  # Relevant upstream issue: https://github.com/cesanta/frozen/pull/71
+  preConfigure = ''
+    cp ${./meson.build} meson.build
+  '';
+
+  meta = {
+    homepage = "https://github.com/cesanta/frozen";
+    description = "Minimal JSON parser for C, targeted for embedded systems";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ thillux ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/frozen/meson.build
+++ b/pkgs/development/libraries/frozen/meson.build
@@ -1,0 +1,19 @@
+project(
+    'frozen',
+    'c',
+    default_options: [
+        'c_args=-Wextra -fno-builtin -pedantic',
+        'c_std=c99',
+        'werror=true'
+    ],
+    license: 'Apache-2.0',
+    version: '20210223'
+)
+
+library(
+    'frozen',
+    'frozen.c',
+    install: true
+)
+
+install_headers('frozen.h')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21178,6 +21178,8 @@ with pkgs;
 
   fribidi = callPackage ../development/libraries/fribidi { };
 
+  frozen = callPackage ../development/libraries/frozen { };
+
   funambol = callPackage ../development/libraries/funambol { };
 
   function-runner = callPackage ../development/web/function-runner { };


### PR DESCRIPTION
frozen is a small JSON parser and generator library, targeted at embedded use-cases. As it only uses two source files, add meson.build on the fly to enable cross compilation.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
