### PR TITLE
nixos/nextcloud: Add ensureUsers option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -144,6 +144,8 @@
   - If [`system.stateVersion`](#opt-system.stateVersion) is >=23.05, `pkgs.nextcloud26` will be installed by default.
   - Please note that an upgrade from v25 (or older) to v27 directly is not possible. Please upgrade to `nextcloud26` (or earlier) first. Nextcloud prohibits skipping major versions while upgrading. You can upgrade by declaring [`services.nextcloud.package = pkgs.nextcloud26;`](options.html#opt-services.nextcloud.package).
 
+- The Nextcloud module now provides the option to add and configure users decleratively using [`services.nextcloud.ensureUsers`](options.html#opt-services.nextcloud.ensureUsers).
+
 - New options were added to `services.searx` for better SearXNG support, including options for the built-in rate limiter and bot protection and automatically configuring a local redis server.
 
 - A new option was added to the virtualisation module that enables specifying explicitly named network interfaces in QEMU VMs. The existing `virtualisation.vlans` is still supported for cases where the name of the network interface is irrelevant.

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -702,6 +702,43 @@ in {
         '';
       };
     };
+
+    ensureUsers = mkOption {
+      default = {};
+      description = lib.mdDoc ''
+        List of user accounts which get automatically created if they don't
+        exist yet. This option does not delete accounts which are not listed
+        anymore.
+      '';
+      example = {
+        user1 = {
+          passwordFile = /secrets/user1-localhost;
+          email = "user1@localhost";
+        };
+        user2 = {
+          passwordFile = /secrets/user2-localhost;
+          email = "user2@localhost";
+        };
+      };
+      type = types.attrsOf (types.submodule {
+        options = {
+          passwordFile = mkOption {
+            type = types.path;
+            example = "/path/to/file";
+            default = null;
+            description = lib.mdDoc ''
+              Specifies the path to a file containing the
+              clear text password for the user.
+            '';
+          };
+          email = mkOption {
+            type = types.str;
+            example = "user1@localhost";
+            default = null;
+          };
+        };
+      });
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -1018,6 +1055,21 @@ in {
             ''}
 
             ${occSetTrustedDomainsCmd}
+
+            ${optionalString (cfg.ensureUsers != {}) ''
+              ${concatStringsSep "\n" (mapAttrsToList (name: cfg: ''
+                if ${occ}/bin/nextcloud-occ user:info "${name}" | grep "user not found"; then
+                  export OC_PASS="$(cat ${escapeShellArg cfg.passwordFile})"
+                  ${occ}/bin/nextcloud-occ user:add --password-from-env "${name}"
+                fi
+                if ! ${occ}/bin/nextcloud-occ user:info "${name}" | grep "user not found"; then
+                  ${optionalString (cfg.email != null) ''
+                    ${occ}/bin/nextcloud-occ user:setting "${name}" settings email "${cfg.email}"
+                  ''}
+                fi
+              '') cfg.ensureUsers)}
+            ''}
+
           '';
           serviceConfig.Type = "oneshot";
           serviceConfig.User = "nextcloud";


### PR DESCRIPTION
## Description of changes

Aiming to get rid of the <code>config</code> option in the Nextcloud module, having them all in the free form type <code>extraOptions</code> which can be renamed to <code>settings</code> in accordance to RFC42 in a later PR.

Instead of defining a single admin user with <code>config.adminuser</code> and <code>config.adminpassFile</code> switch to a more generic approach which is used by other modules, having a <code>ensureUsers</code> attribute set.

```
services.nextcloud = {
  enable = true;
  package = pkgs.nextcloud27;
  hostName = "localhost";
  config = {
    adminpassFile = "${pkgs.writeText "adminpass" "hunter2"}";
  };
  database.createLocally = true;
  ensureUsers = {
    user1 = {
      email = "user1@localhost";
      passwordFile = /secrets/user1.secret;
    };
    user2 = {
      email = "user1@localhost";
      passwordFile = /secrets/user1.secret;
    };
  };
};
```

For now I would like to only add the `ensureUsers` option to add additional users. In a later PR I would like to manage admin user configuration with this option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
