### PR TITLE
python3.pkgs.pycups: 1.9.73 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/pycups/default.nix
+++ b/pkgs/development/python-modules/pycups/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, lib, buildPythonPackage, fetchurl, cups, libiconv }:
+{ stdenv, lib, buildPythonPackage, fetchPypi, cups, libiconv }:
 
 buildPythonPackage rec {
   pname = "pycups";
-  version = "1.9.73";
+  version = "2.0.1";
 
-  src = fetchurl {
-    url = "http://cyberelk.net/tim/data/pycups/pycups-${version}.tar.bz2";
-    sha256 = "c381be011889ca6f728598578c89c8ac9f7ab1e95b614474df9f2fa831ae5335";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-V0NM5fYlSOsSlJyoIX8Gb07rIaXWq4sTRx3ONQ44DJA=";
   };
 
   buildInputs = [ cups ] ++ lib.optional stdenv.isDarwin libiconv;


### PR DESCRIPTION

## Description of changes
Changes: https://github.com/OpenPrinting/pycups/blob/v2.0.1/NEWS

Most notably, this fixes for me a segfault in `destroy_TLS()`[1] that got fixed upstream in 2.0.0.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1816107

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
