### PR TITLE
deepin.image-editor: 1.0.24 -> 1.0.32

### DIFF
--- a/pkgs/desktops/deepin/library/image-editor/default.nix
+++ b/pkgs/desktops/deepin/library/image-editor/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , dtkwidget
 , cmake
 , qttools
@@ -16,27 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "image-editor";
-  version = "1.0.24";
+  version = "1.0.32";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "sha256-0p/aicuBfaEyvfZomnz49IJLospWIdl23ZreDe+Bzqc=";
+    hash = "sha256-mA2pqWXa3i19jCymvUXnG6YUVezDSfRkHx2EoxAhnqU=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "feat_check_PREFIX_value_before_set.patch";
-      url = "https://github.com/linuxdeepin/image-editor/commit/dae86e848cf53ba0ece879d81e8d5335d61a7473.patch";
-      sha256 = "sha256-lxmR+nIrMWVyhl1jpA17x2yqJ40h5vnpqKKcjd8j9RY=";
-    })
-    (fetchpatch {
-      name = "feat_use_FULL_install_path.patch";
-      url = "https://github.com/linuxdeepin/image-editor/commit/855ae53a0444ac628aa0fe893932df6263b82e2e.patch";
-      sha256 = "sha256-3Dynlwl/l/b6k6hOHjTdoDQ/VGBDfyRz9b8QY8FEsCc=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace libimageviewer/service/ffmpegvideothumbnailer.cpp \
@@ -57,7 +43,9 @@ stdenv.mkDerivation rec {
     pcre
   ];
 
-  cmakeFlags = [ "-DVERSION=${version}" ];
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
 
   meta = with lib; {
     description = "Image editor lib for dtk";


### PR DESCRIPTION
## Description of changes
https://github.com/linuxdeepin/image-editor/compare/1.0.24...1.0.32

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
