### PR TITLE
anki: switch to using qt5

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -13,7 +13,7 @@
 , nodejs-slim
 , protobuf
 , python3
-, qt6
+, qt5
 , rsync
 , rustPlatform
 , writeShellScriptBin
@@ -139,19 +139,19 @@ python3.pkgs.buildPythonApplication {
     cargo
     rustPlatform.cargoSetupHook
     ninja
-    qt6.wrapQtAppsHook
+    qt5.wrapQtAppsHook
     rsync
   ] ++ lib.optional stdenv.isDarwin swift;
   nativeCheckInputs = with python3.pkgs; [ pytest mock astroid  ];
 
   buildInputs = [
-    qt6.qtbase
-  ] ++ lib.optional stdenv.isLinux qt6.qtwayland;
+    qt5.qtbase
+  ] ++ lib.optional stdenv.isLinux qt5.qtwayland;
   propagatedBuildInputs = with python3.pkgs; [
     # This rather long list came from running:
-    #    grep --no-filename -oE "^[^ =]*" python/{requirements.base.txt,requirements.bundle.txt,requirements.qt6_4.txt} | \
-    #      sort | uniq | grep -v "^#$"
-    # in their repo at the git tag for this version
+    # grep --no-filename -oE "^[^ =]*" python/requirements.base.txt python/requirements.bundle.txt python/requirements.qt5_15.txt | \
+    #    sort | uniq | grep -v "^#$"
+    # in their repo at anki git tag 2.1.61
     # There's probably a more elegant way, but the above extracted all the
     # names, without version numbers, of their python dependencies. The hope is
     # that nixpkgs versions are "close enough"
@@ -176,15 +176,16 @@ python3.pkgs.buildPythonApplication {
     pep517
     python3.pkgs.protobuf
     pyparsing
-    pyqt6
-    pyqt6-sip
-    pyqt6-webengine
+    pyqt5
+    pyqt5_sip
+    pyqtwebengine
     pyrsistent
     pysocks
     requests
     send2trash
     six
     soupsieve
+    tomli
     urllib3
     waitress
     werkzeug


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/248357

I'm unsure if the issue is with nixpkgs pyqt6 packaging, or if the issue is an upstream one.

Either way, we're able to get working preferences by switching back to qt5, and upstream supports both qt5 and qt6 still, so this seems like a reasonable path to take.

We can tackle getting qt6 working if it's still broken whenever upstream or nixpkgs drops qt5 support.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).