### PR TITLE
python310Packages.tensorboardx: 2.5.1 -> 2.6.2; unbreak

### DIFF
--- a/pkgs/development/python-modules/tensorboardx/default.nix
+++ b/pkgs/development/python-modules/tensorboardx/default.nix
@@ -1,9 +1,8 @@
-{ boto3
-, buildPythonPackage
-, crc32c
-, fetchFromGitHub
-, fetchpatch
+{ buildPythonPackage
 , lib
+, fetchFromGitHub
+, boto3
+, crc32c
 , matplotlib
 , moto
 , numpy
@@ -11,7 +10,7 @@
 , protobuf
 , pytestCheckHook
 , torch
-, six
+, setuptools-scm
 , soundfile
 , stdenv
 , tensorboard
@@ -21,51 +20,22 @@
 
 buildPythonPackage rec {
   pname = "tensorboardx";
-  version = "2.5.1";
+  version = "2.6.2";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "lanpa";
     repo = "tensorboardX";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Np0Ibn51qL0ORwq1IY8lUle05MQDdb5XkI1uzGOKJno=";
+    hash = "sha256-m7RLDOMuRNLacnIudptBGjhcTlMk8+v/onz6Amqxb90=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "fix-test-multiprocess-fork-on-darwin.patch";
-      url = "https://github.com/lanpa/tensorboardX/commit/246a867237ff12893351b9275a1e297ee2861319.patch";
-      hash = "sha256-ObUaIi1gFcGZAvDOEtZFd9TjZZUp3k89tYwmDQ5yOWg=";
-    })
-    # https://github.com/lanpa/tensorboardX/pull/706
-    (fetchpatch {
-      name = "fix-test-use-matplotlib-agg-backend.patch";
-      url = "https://github.com/lanpa/tensorboardX/commit/751821c7af7f7f2cb724938e36fa04e814c0e4de.patch";
-      hash = "sha256-Tu76ZRTh8fGj+/CzpqJO65hKrDFASbmzoLVIZ0kyLQA=";
-    })
-    # https://github.com/lanpa/tensorboardX/pull/707
-    (fetchpatch {
-      name = "fix-test-handle-numpy-float128-missing.patch";
-      url = "https://github.com/lanpa/tensorboardX/commit/38f57ffc3b3dd91e76b13ec97404278065fbc782.patch";
-      hash = "sha256-5Po41lHiO5hKi4ZtWR98/wwDe9HKZdADNTv40mgIEvk=";
-    })
-    # https://github.com/lanpa/tensorboardX/pull/708
-    (fetchpatch {
-      name = "fix-test-respect-tmpdir.patch";
-      url = "https://github.com/lanpa/tensorboardX/commit/b0191d1cfb8a23def76e465d20fd59302c894f32.patch";
-      hash = "sha256-6rSncJ16P1u70Cz9nObo8lMD7Go50BR3DZLgP4bODk4=";
-    })
-  ];
-
-  postPatch = ''
-    # Version detection seems broken here, the version reported by python is
-    # newer than the protobuf package itself.
-    sed -i -e "s/'protobuf[^']*'/'protobuf'/" setup.py
-  '';
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     which
     protobuf
+    setuptools-scm
   ];
 
   # required to make tests deterministic
@@ -74,7 +44,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     crc32c
     numpy
-    six
     soundfile
   ];
 
@@ -105,9 +74,13 @@ buildPythonPackage rec {
     "tests/test_lint.py"
   ];
 
+  pythonImportsCheck = [ "tensorboardX" ];
+
   meta = with lib; {
     description = "Library for writing tensorboard-compatible logs";
-    homepage = "https://github.com/lanpa/tensorboardX";
+    homepage = "https://tensorboardx.readthedocs.io";
+    downloadPage = "https://github.com/lanpa/tensorboardX";
+    changelog = "https://github.com/lanpa/tensorboardX/blob/${src.rev}/HISTORY.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ lebastr akamaus ];
     platforms = platforms.all;


### PR DESCRIPTION
2.5.1 was failing to build due to Pillow 10 API changes.

## Description of changes

Routine update; remove patches included in release; update build due to use of setuptool-scm; update homepage; add changelog; add pythonImportsCheck.

Results of `nixpkgs-review` on `x86_64-Linux`:

```
4 packages marked as broken and skipped:
piper-train piper-train.dist python311Packages.elegy python311Packages.elegy.dist

2 packages failed to build:
python310Packages.elegy python310Packages.elegy.dist

8 packages built:
python310Packages.pytorch-lightning python310Packages.pytorch-lightning.dist python310Packages.tensorboardx python310Packages.tensorboardx.dist python311Packages.pytorch-lightning python311Packages.pytorch-lightning.dist python311Packages.tensorboardx python311Packages.tensorboardx.dist
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).