### PR TITLE
python3.pkgs.tensorboardx: 2.5.1 -> 2.6.2

### DIFF
--- a/pkgs/development/python-modules/tensorboardx/default.nix
+++ b/pkgs/development/python-modules/tensorboardx/default.nix
@@ -2,88 +2,55 @@
 , buildPythonPackage
 , crc32c
 , fetchFromGitHub
-, fetchpatch
 , lib
 , matplotlib
 , moto
 , numpy
-, pillow
 , protobuf
 , pytestCheckHook
 , torch
-, six
+, setuptools-scm
 , soundfile
 , stdenv
 , tensorboard
 , torchvision
-, which
 }:
 
 buildPythonPackage rec {
   pname = "tensorboardx";
-  version = "2.5.1";
+  version = "2.6.2";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "lanpa";
     repo = "tensorboardX";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Np0Ibn51qL0ORwq1IY8lUle05MQDdb5XkI1uzGOKJno=";
+    hash = "sha256-m7RLDOMuRNLacnIudptBGjhcTlMk8+v/onz6Amqxb90=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "fix-test-multiprocess-fork-on-darwin.patch";
-      url = "https://github.com/lanpa/tensorboardX/commit/246a867237ff12893351b9275a1e297ee2861319.patch";
-      hash = "sha256-ObUaIi1gFcGZAvDOEtZFd9TjZZUp3k89tYwmDQ5yOWg=";
-    })
-    # https://github.com/lanpa/tensorboardX/pull/706
-    (fetchpatch {
-      name = "fix-test-use-matplotlib-agg-backend.patch";
-      url = "https://github.com/lanpa/tensorboardX/commit/751821c7af7f7f2cb724938e36fa04e814c0e4de.patch";
-      hash = "sha256-Tu76ZRTh8fGj+/CzpqJO65hKrDFASbmzoLVIZ0kyLQA=";
-    })
-    # https://github.com/lanpa/tensorboardX/pull/707
-    (fetchpatch {
-      name = "fix-test-handle-numpy-float128-missing.patch";
-      url = "https://github.com/lanpa/tensorboardX/commit/38f57ffc3b3dd91e76b13ec97404278065fbc782.patch";
-      hash = "sha256-5Po41lHiO5hKi4ZtWR98/wwDe9HKZdADNTv40mgIEvk=";
-    })
-    # https://github.com/lanpa/tensorboardX/pull/708
-    (fetchpatch {
-      name = "fix-test-respect-tmpdir.patch";
-      url = "https://github.com/lanpa/tensorboardX/commit/b0191d1cfb8a23def76e465d20fd59302c894f32.patch";
-      hash = "sha256-6rSncJ16P1u70Cz9nObo8lMD7Go50BR3DZLgP4bODk4=";
-    })
-  ];
-
-  postPatch = ''
-    # Version detection seems broken here, the version reported by python is
-    # newer than the protobuf package itself.
-    sed -i -e "s/'protobuf[^']*'/'protobuf'/" setup.py
-  '';
-
   nativeBuildInputs = [
-    which
     protobuf
+    setuptools-scm
   ];
 
   # required to make tests deterministic
-  PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";
+  env.PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   propagatedBuildInputs = [
     crc32c
     numpy
-    six
-    soundfile
   ];
+
+  pythonImportsCheck = [ "tensorboardX" ];
 
   nativeCheckInputs = [
     boto3
     matplotlib
     moto
-    pillow
     pytestCheckHook
+    soundfile
     torch
     tensorboard
     torchvision
@@ -107,7 +74,9 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Library for writing tensorboard-compatible logs";
-    homepage = "https://github.com/lanpa/tensorboardX";
+    homepage = "https://tensorboardx.readthedocs.io";
+    downloadPage = "https://github.com/lanpa/tensorboardX";
+    changelog = "https://github.com/lanpa/tensorboardX/blob/${src.rev}/HISTORY.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ lebastr akamaus ];
     platforms = platforms.all;


### PR DESCRIPTION
## Description of changes

https://pypi.org/project/tensorboardX/

Cleans up a number of patches I added that have now been accepted upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
