### PR TITLE
nixos/lxd-agent: init module from distrobuilder generator

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1464,6 +1464,7 @@
   ./virtualisation/lxc.nix
   ./virtualisation/lxcfs.nix
   ./virtualisation/lxd.nix
+  ./virtualisation/lxd-agent.nix
   ./virtualisation/multipass.nix
   ./virtualisation/nixos-containers.nix
   ./virtualisation/oci-containers.nix

--- a/nixos/modules/virtualisation/lxd-agent.nix
+++ b/nixos/modules/virtualisation/lxd-agent.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.virtualisation.lxd.agent;
+
+  # the lxd agent is provided by the lxd daemon through a virtiofs or 9p mount
+  # this is a port of the distrobuilder lxd-agent generator
+  # https://github.com/lxc/distrobuilder/blob/f77300bf7d7d5707b08eaf8a434d647d1ba81b5d/generators/lxd-agent.go#L18-L55
+  preStartScript = ''
+    PREFIX="/run/lxd_agent"
+
+    mount_virtiofs() {
+        mount -t virtiofs config "$PREFIX/.mnt" >/dev/null 2>&1
+    }
+
+    mount_9p() {
+        modprobe 9pnet_virtio >/dev/null 2>&1 || true
+        mount -t 9p config "$PREFIX/.mnt" -o access=0,trans=virtio,size=1048576 >/dev/null 2>&1
+    }
+
+    fail() {
+        umount -l "$PREFIX" >/dev/null 2>&1 || true
+        rmdir "$PREFIX" >/dev/null 2>&1 || true
+        echo "$1"
+        exit 1
+    }
+
+    # Setup the mount target.
+    umount -l "$PREFIX" >/dev/null 2>&1 || true
+    mkdir -p "$PREFIX"
+    mount -t tmpfs tmpfs "$PREFIX" -o mode=0700,size=50M
+    mkdir -p "$PREFIX/.mnt"
+
+    # Try virtiofs first.
+    mount_virtiofs || mount_9p || fail "Couldn't mount virtiofs or 9p, failing."
+
+    # Copy the data.
+    cp -Ra "$PREFIX/.mnt/"* "$PREFIX"
+
+    # Unmount the temporary mount.
+    umount "$PREFIX/.mnt"
+    rmdir "$PREFIX/.mnt"
+
+    # Fix up permissions.
+    chown -R root:root "$PREFIX"
+  '';
+in {
+  meta.maintainers = with lib.maintainers; [ adamcstephens ];
+
+  options = {
+    virtualisation.lxd.agent.enable = lib.mkEnableOption (lib.mdDoc "Enable LXD agent");
+  };
+
+  config = lib.mkIf cfg.enable {
+    # https://github.com/lxc/distrobuilder/blob/f77300bf7d7d5707b08eaf8a434d647d1ba81b5d/generators/lxd-agent.go#L108-L125
+    systemd.services.lxd-agent = {
+      enable = true;
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.kmod pkgs.util-linux ];
+
+      preStart = preStartScript;
+
+      # avoid killing nixos-rebuild switch when executed through lxc exec
+      stopIfChanged = false;
+
+      unitConfig = {
+        Description = "LXD - agent";
+        Documentation = "https://documentation.ubuntu.com/lxd/en/latest";
+        ConditionPathExists = "/dev/virtio-ports/org.linuxcontainers.lxd";
+        Before = lib.optionals config.services.cloud-init.enable [ "cloud-init.target" "cloud-init.service" "cloud-init-local.service" ];
+        DefaultDependencies = "no";
+        StartLimitInterval = "60";
+        StartLimitBurst = "10";
+      };
+
+      serviceConfig = {
+        Type = "notify";
+        WorkingDirectory = "-/run/lxd_agent";
+        ExecStart = "/run/lxd_agent/lxd-agent";
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+
+    systemd.paths.lxd-agent = {
+      enable = true;
+      wantedBy = [ "multi-user.target" ];
+      pathConfig.PathExists = "/dev/virtio-ports/org.linuxcontainers.lxd";
+    };
+  };
+}


### PR DESCRIPTION
## Description of changes

LXD configures VMs to run an agent, the `lxd-agent`. The agent is provided to the VM through a virtiofs or 9p shared folder so that it matches the LXD server version.

This module is a port of the configuration done by distrobuilder (an LXC/LXD image builder). 

Part of and prep for #244093

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
