### PR TITLE
libiio: disable Python for static builds

### DIFF
--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -4,7 +4,7 @@
 , flex
 , bison
 , libxml2
-, python
+, pythonSupport ? stdenv.hostPlatform.hasSharedLibraries, python
 , libusb1
 , avahiSupport ? true, avahi
 , libaio
@@ -19,7 +19,8 @@ stdenv.mkDerivation rec {
   pname = "libiio";
   version = "0.24";
 
-  outputs = [ "out" "lib" "dev" "python" ];
+  outputs = [ "out" "lib" "dev" ]
+    ++ lib.optional pythonSupport "python";
 
   src = fetchFromGitHub {
     owner = "analogdevicesinc";
@@ -37,8 +38,9 @@ stdenv.mkDerivation rec {
     flex
     bison
     pkg-config
+  ] ++ lib.optionals pythonSupport ([
     python
-  ] ++ lib.optional python.isPy3k python.pkgs.setuptools;
+  ] ++ lib.optional python.isPy3k python.pkgs.setuptools);
 
   buildInputs = [
     libxml2
@@ -49,25 +51,26 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DUDEV_RULES_INSTALL_DIR=${placeholder "out"}/lib/udev/rules.d"
-    "-DPython_EXECUTABLE=${python.pythonForBuild.interpreter}"
-    "-DPYTHON_BINDINGS=on"
     # osx framework is disabled,
     # the linux-like directory structure is used for proper output splitting
     "-DOSX_PACKAGE=off"
     "-DOSX_FRAMEWORK=off"
+  ] ++ lib.optionals pythonSupport [
+    "-DPython_EXECUTABLE=${python.pythonForBuild.interpreter}"
+    "-DPYTHON_BINDINGS=on"
   ] ++ lib.optionals (!avahiSupport) [
     "-DHAVE_DNS_SD=OFF"
   ];
 
   postPatch = ''
-    # Hardcode path to the shared library into the bindings.
-    sed "s#@libiio@#$lib/lib/libiio${stdenv.hostPlatform.extensions.sharedLibrary}#g" ${./hardcode-library-path.patch} | patch -p1
-
     substituteInPlace libiio.rules.cmakein \
       --replace /bin/sh ${runtimeShell}
+  '' + lib.optionalString pythonSupport ''
+    # Hardcode path to the shared library into the bindings.
+    sed "s#@libiio@#$lib/lib/libiio${stdenv.hostPlatform.extensions.sharedLibrary}#g" ${./hardcode-library-path.patch} | patch -p1
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString pythonSupport ''
     # Move Python bindings into a separate output.
     moveToOutput ${python.sitePackages} "$python"
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5882,7 +5882,10 @@ self: super: with self; {
     inherit (pkgs.config) cudaSupport;
   };
 
-  libiio = (toPythonModule (pkgs.libiio.override { inherit python; })).python;
+  libiio = (toPythonModule (pkgs.libiio.override {
+    pythonSupport = true;
+    inherit python;
+  })).python;
 
   libkeepass = callPackage ../development/python-modules/libkeepass { };
 


### PR DESCRIPTION
## Description of changes

libiio's Python bindings use ctypes to load the shared library, which obviously can't work with a static build. Recent changes (#240575, #244118) have also started causing eval errors because the package uses `stdenv.hostPlatform.extensions.sharedLibrary`, which isn't available when building a static library:
```
 error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'ardupilot-copter-bebop-static-armv7l-unknown-linux-musleabihf-35da15d'
         whose name attribute is located at /nix/store/sralzj4w34v4mwr0sxq417b4ys202in3-source/pkgs/stdenv/generic/make-derivation.nix:300:7

       … while evaluating attribute 'propagatedBuildInputs' of derivation 'ardupilot-copter-bebop-static-armv7l-unknown-linux-musleabihf-35da15d'

         at /nix/store/sralzj4w34v4mwr0sxq417b4ys202in3-source/pkgs/stdenv/generic/make-derivation.nix:354:7:

          353|       depsHostHostPropagated      = lib.elemAt (lib.elemAt propagatedDependencies 1) 0;
          354|       propagatedBuildInputs       = lib.elemAt (lib.elemAt propagatedDependencies 1) 1;
             |       ^
          355|       depsTargetTargetPropagated  = lib.elemAt (lib.elemAt propagatedDependencies 2) 0;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attribute 'sharedLibrary' missing

       at /nix/store/sralzj4w34v4mwr0sxq417b4ys202in3-source/pkgs/development/libraries/libiio/default.nix:64:38:

           63|     # Hardcode path to the shared library into the bindings.
           64|     sed "s#@libiio@#$lib/lib/libiio${stdenv.hostPlatform.extensions.sharedLibrary}#g" ${./hardcode-library-path.patch} | patch -p1
             |                                      ^
           65|
```

This patch adds a flag to disable the Python bindings, and automatically disables them for static builds.

Note that even with this patch, static libiio doesn't build successfully by default. You have to disable avahi and manually disable libxml2 with custom CMake flags. I currently build a [custom stripped down static libiio](https://github.com/lopsided98/ardupilot-flake/blob/9b7bca24d2726e4c455e247ee6e8cc38ee3e33c6/default.nix#L60C6-L72C7) like this:
```
(pkgsStatic.libiio.override {
  avahiSupport = false;
  libxml2 = null;
  libusb1 = null;
}).overrideAttrs ({
  cmakeFlags ? [], ...
}: {
  cmakeFlags = cmakeFlags ++ [
    "-DWITH_NETWORK_BACKEND=OFF"
    "-DWITH_USB_BACKEND=OFF"
    "-DWITH_XML_BACKEND=OFF"
  ];
})
```

cc @thoughtpolice @amjoseph-nixpkgs 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
