### PR TITLE
androidenv fix cmdline beta versions' problem

### DIFF
--- a/pkgs/development/mobile/androidenv/cmdline-tools.nix
+++ b/pkgs/development/mobile/androidenv/cmdline-tools.nix
@@ -1,4 +1,4 @@
-{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, stdenv, cmdLineToolsVersion, postInstall}:
+{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, stdenv, postInstall}:
 
 deployAndroidPackage {
   name = "androidsdk";
@@ -16,7 +16,7 @@ deployAndroidPackage {
     export ANDROID_SDK_ROOT="$out/libexec/android-sdk"
 
     # Wrap all scripts that require JAVA_HOME
-    find $ANDROID_SDK_ROOT/cmdline-tools/${cmdLineToolsVersion}/bin -maxdepth 1 -type f -executable | while read program; do
+    find $ANDROID_SDK_ROOT/${package.path}/bin -maxdepth 1 -type f -executable | while read program; do
       if grep -q "JAVA_HOME" $program; then
         wrapProgram $program  --prefix PATH : ${pkgs.jdk11}/bin \
           --prefix ANDROID_SDK_ROOT : $ANDROID_SDK_ROOT
@@ -24,12 +24,12 @@ deployAndroidPackage {
     done
 
     # Wrap sdkmanager script
-    wrapProgram $ANDROID_SDK_ROOT/cmdline-tools/${cmdLineToolsVersion}/bin/sdkmanager \
+    wrapProgram $ANDROID_SDK_ROOT/${package.path}/bin/sdkmanager \
       --prefix PATH : ${lib.makeBinPath [ pkgs.jdk11 ]} \
       --add-flags "--sdk_root=$ANDROID_SDK_ROOT"
 
     # Patch all script shebangs
-    patchShebangs $ANDROID_SDK_ROOT/cmdline-tools/${cmdLineToolsVersion}/bin
+    patchShebangs $ANDROID_SDK_ROOT/${package.path}/bin
 
     cd $ANDROID_SDK_ROOT
     ${postInstall}

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -314,6 +314,8 @@ rec {
       '') plugins}
     ''; # */
 
+  cmdline-tools-package = check-version packages "cmdline-tools" cmdLineToolsVersion;
+
   # This derivation deploys the tools package and symlinks all the desired
   # plugins that we want to use. If the license isn't accepted, prints all the licenses
   # requested and throws.
@@ -329,9 +331,9 @@ rec {
       by an environment variable for a single invocation of the nix tools.
         $ export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
   '' else callPackage ./cmdline-tools.nix {
-    inherit deployAndroidPackage os cmdLineToolsVersion;
+    inherit deployAndroidPackage os;
 
-    package = check-version packages "cmdline-tools" cmdLineToolsVersion;
+    package = cmdline-tools-package;
 
     postInstall = ''
       # Symlink all requested plugins
@@ -375,7 +377,7 @@ rec {
           ln -s $i $out/bin
       done
 
-      find $ANDROID_SDK_ROOT/cmdline-tools/${cmdLineToolsVersion}/bin -type f -executable | while read i; do
+      find $ANDROID_SDK_ROOT/${cmdline-tools-package.path}/bin -type f -executable | while read i; do
           ln -s $i $out/bin
       done
 


### PR DESCRIPTION
## Description of changes

This PR will fix the `cmdline` beta versions' problem that is raised in https://github.com/NixOS/nixpkgs/issues/247436.
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
