### PR TITLE
ladybird: unstable-2023-01-17 -> unstable-2024-03-16

### DIFF
--- a/nixos/tests/ladybird.nix
+++ b/nixos/tests/ladybird.nix
@@ -21,7 +21,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ''
       machine.wait_for_x()
       machine.succeed("echo '<!DOCTYPE html><html><body><h1>Hello world</h1></body></html>' > page.html")
-      machine.execute("ladybird file://$(pwd)/page.html >&2 &")
+      machine.execute("Ladybird file://$(pwd)/page.html >&2 &")
       machine.wait_for_window("Ladybird")
       machine.sleep(5)
       machine.wait_for_text("Hello world")

--- a/pkgs/applications/networking/browsers/ladybird/default.nix
+++ b/pkgs/applications/networking/browsers/ladybird/default.nix
@@ -1,73 +1,157 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchzip
+, fetchurl
+, cacert
+, tzdata
+, unicode-emoji
+, unicode-character-database
+, darwin
 , cmake
 , ninja
-, unzip
-, wrapQtAppsHook
 , libxcrypt
-, qtbase
+, qt6Packages
 , nixosTests
+, AppKit
+, Cocoa
+, Foundation
+, OpenGL
 }:
 
+let
+  inherit (builtins) elemAt;
+  cldr_version = "44.1.0";
+  cldr-json = fetchzip {
+    url = "https://github.com/unicode-org/cldr-json/releases/download/${cldr_version}/cldr-${cldr_version}-json-modern.zip";
+    stripRoot = false;
+    hash = "sha256-EbbzaaspKgRT/dsJV3Kf0Dfj8LN9zT+Pl4gk5kiOXWk=";
+    postFetch = ''
+      echo -n ${cldr_version} > $out/version.txt
+    '';
+  };
+  unicode-idna = fetchurl {
+    url = "https://www.unicode.org/Public/idna/${unicode-character-database.version}/IdnaMappingTable.txt";
+    hash = "sha256-QCy9KF8flS/NCDS2NUHVT2nT2PG4+Fmb9xoaFJNfgsQ=";
+  };
+  adobe-icc-profiles = fetchurl {
+    url = "https://download.adobe.com/pub/adobe/iccprofiles/win/AdobeICCProfilesCS4Win_end-user.zip";
+    hash = "sha256-kgQ7fDyloloPaXXQzcV9tgpn3Lnr37FbFiZzEb61j5Q=";
+    name = "adobe-icc-profiles.zip";
+  };
+  public_suffix_commit = "9094af5c6cb260e69137c043c01be18fee01a540";
+  public-suffix-list = fetchurl {
+    url = "https://raw.githubusercontent.com/publicsuffix/list/${public_suffix_commit}/public_suffix_list.dat";
+    hash = "sha256-0szHUz1T0MXOQ9tcXoKY2F/bI3s7hsYCjURqywZsf1w=";
+  };
+  # Note: The cacert version is synthetic and must match the version in the package's CMake
+  cacert_version = "2023-12-12";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ladybird";
-  version = "unstable-2023-01-17";
+  version = "0-unstable-2024-03-16";
 
   src = fetchFromGitHub {
     owner = "SerenityOS";
     repo = "serenity";
-    rev = "45e85d20b64862df119f643f24e2d500c76c58f3";
-    hash = "sha256-n2mLg9wNfdMGsJuGj+ukjto9qYjGOIz4cZjgvMGQUrY=";
+    rev = "3a8bde9ef24dace600484b38992fdc7d17bf92c3";
+    hash = "sha256-r8HYcexrOjDYsXuCtROiNY7Rl60pVQBvVQf190gqNuY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/Ladybird";
 
   postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "MACOSX_BUNDLE TRUE" "MACOSX_BUNDLE FALSE"
-    # https://github.com/SerenityOS/serenity/issues/17062
-    substituteInPlace main.cpp \
-      --replace "./SQLServer/SQLServer" "$out/bin/SQLServer"
-    # https://github.com/SerenityOS/serenity/issues/10055
-    substituteInPlace ../Meta/Lagom/CMakeLists.txt \
-      --replace "@rpath" "$out/lib"
+    sed -i '/iconutil/d' CMakeLists.txt
+
+    # Don't set absolute paths in RPATH
+    substituteInPlace ../Meta/CMake/lagom_install_options.cmake \
+      --replace-fail "\''${CMAKE_INSTALL_BINDIR}" "bin" \
+      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}" "lib"
   '';
 
-  nativeBuildInputs = [
+  preConfigure = ''
+    # Setup caches for LibLocale, LibUnicode, LibTimezone, LibTLS and LibGfx
+    # Note that the versions of the input data packages must match the
+    # expected version in the package's CMake.
+    mkdir -p build/Caches
+
+    ln -s ${cldr-json} build/Caches/CLDR
+
+    cp -r ${unicode-character-database}/share/unicode build/Caches/UCD
+    chmod +w build/Caches/UCD
+    cp ${unicode-emoji}/share/unicode/emoji/emoji-test.txt build/Caches/UCD
+    cp ${unicode-idna} build/Caches/UCD/IdnaMappingTable.txt
+    echo -n ${unicode-character-database.version} > build/Caches/UCD/version.txt
+    chmod -w build/Caches/UCD
+
+    mkdir build/Caches/TZDB
+    tar -xzf ${elemAt tzdata.srcs 0} -C build/Caches/TZDB
+    echo -n ${tzdata.version} > build/Caches/TZDB/version.txt
+
+    mkdir build/Caches/CACERT
+    cp ${cacert}/etc/ssl/certs/ca-bundle.crt build/Caches/CACERT/cacert-${cacert_version}.pem
+    echo -n ${cacert_version} > build/Caches/CACERT/version.txt
+
+    mkdir build/Caches/PublicSuffix
+    cp ${public-suffix-list} build/Caches/PublicSuffix/public_suffix_list.dat
+
+    mkdir build/Caches/AdobeICCProfiles
+    cp ${adobe-icc-profiles} build/Caches/AdobeICCProfiles/adobe-icc-profiles.zip
+    chmod +w build/Caches/AdobeICCProfiles
+  '';
+
+  nativeBuildInputs = with qt6Packages; [
     cmake
     ninja
-    unzip
     wrapQtAppsHook
   ];
 
-  buildInputs = [
+  buildInputs = with qt6Packages; [
     libxcrypt
     qtbase
+    qtmultimedia
+  ] ++ lib.optionals stdenv.isDarwin [
+    AppKit
+    Cocoa
+    Foundation
+    OpenGL
   ];
 
   cmakeFlags = [
     # Disable network operations
-    "-DENABLE_TIME_ZONE_DATABASE_DOWNLOAD=false"
-    "-DENABLE_UNICODE_DATABASE_DOWNLOAD=false"
+    "-DSERENITY_CACHE_DIR=Caches"
+    "-DENABLE_NETWORK_DOWNLOADS=OFF"
+    "-DENABLE_COMMONMARK_SPEC_DOWNLOAD=OFF"
+  ] ++ lib.optionals stdenv.isLinux [
+    "-DCMAKE_INSTALL_LIBEXECDIR=libexec"
+    # FIXME: Enable this when launching with the commandline flag --enable-gpu-painting doesn't fail calling eglBindAPI on GNU/Linux
+    "-DENABLE_ACCELERATED_GRAPHICS=OFF"
   ];
+
+  # FIXME: Add an option to -DENABLE_QT=ON on macOS to use Qt rather than Cocoa for the GUI
+  # FIXME: Add an option to enable PulseAudio rather than using Qt multimedia on non-macOS
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
-  # https://github.com/SerenityOS/serenity/issues/10055
   postInstall = lib.optionalString stdenv.isDarwin ''
-    install_name_tool -add_rpath $out/lib $out/bin/ladybird
+    mkdir -p $out/Applications $out/bin
+    mv $out/bundle/Ladybird.app $out/Applications
   '';
+
+  # Only Ladybird and WebContent need wrapped, if Qt is enabled.
+  # On linux we end up wraping some non-Qt apps, like headless-browser.
+  dontWrapQtApps = stdenv.isDarwin;
 
   passthru.tests = {
     nixosTest = nixosTests.ladybird;
   };
 
   meta = with lib; {
-    description = "A browser using the SerenityOS LibWeb engine with a Qt GUI";
-    homepage = "https://github.com/awesomekling/ladybird";
+    description = "A browser using the SerenityOS LibWeb engine with a Qt or Cocoa GUI";
+    homepage = "https://ladybird.dev";
     license = licenses.bsd2;
     maintainers = with maintainers; [ fgaz ];
-    platforms = platforms.unix;
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+    mainProgram = "Ladybird";
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32856,8 +32856,9 @@ with pkgs;
 
   ladspa-sdk = callPackage ../applications/audio/ladspa-sdk { };
 
-  ladybird = qt6Packages.callPackage ../applications/networking/browsers/ladybird {
+  ladybird = darwin.apple_sdk_11_0.callPackage ../applications/networking/browsers/ladybird {
     stdenv = if stdenv.isDarwin then overrideLibcxx darwin.apple_sdk_11_0.llvmPackages_16.stdenv else stdenv;
+    inherit (darwin.apple_sdk_11_0.frameworks) AppKit Cocoa Foundation OpenGL;
   };
 
   lazpaint = callPackage ../applications/graphics/lazpaint { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update to current master.

- Pre-Download required Unicode, Common Locale Database, Timezone database and Root CA certificates, and ICC profiles to build with the new option -DENABLE_NETWORK_DOWNLOADS=OFF
- Copy required downloaded files to the expected SERENITY_CACHE_DIR layout
- Remove workarounds for resolved upstream issues.
- Add new missing qtmultimedia package
- Remove unused unzip package
- Point homepage at https://ladybird.dev
- Set mainProgram to "ladybird"
- Enable the macOS bundle on Darwin platforms


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @emilytrau @networkException @fgaz 
