### PR TITLE
clipbuzz: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/tools/misc/clipbuzz/default.nix
+++ b/pkgs/tools/misc/clipbuzz/default.nix
@@ -1,23 +1,21 @@
 { lib
 , stdenv
-, fetchFromSourcehut
+, fetchzip
 , libX11
 , libXfixes
-, zig_0_10
+, zig_0_11
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "clipbuzz";
-  version = "2.0.0";
+  version = "2.0.1";
 
-  src = fetchFromSourcehut {
-    owner = "~cnx";
-    repo = "clipbuzz";
-    rev = finalAttrs.version;
-    hash = "sha256-V5bAZHoScTzFZBPUhPd7xc/c32SXPLAJp+vsc/lCyeI=";
+  src = fetchzip {
+    url = "https://trong.loang.net/~cnx/clipbuzz/snapshot/clipbuzz-${finalAttrs.version}.tar.gz";
+    hash = "sha256-2//IwthAjGyVSZaXjgpM1pUJGYWZVkrJ6JyrVbzOtr8=";
   };
 
-  nativeBuildInputs = [ zig_0_10.hook ];
+  nativeBuildInputs = [ zig_0_11.hook ];
 
   buildInputs = [
     libX11
@@ -26,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta =  {
     description = "Buzz on new X11 clipboard events";
-    homepage = "https://git.sr.ht/~cnx/clipbuzz";
+    homepage = "https://trong.loang.net/~cnx/clipbuzz";
     license = lib.licenses.unlicense;
     maintainers = [ lib.maintainers.McSinyx ];
   };


### PR DESCRIPTION
## Description of changes

Port clipbuzz to Zig 0.11.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).