### PR TITLE
trivial-builders: add meta.mainProgram to writeShellScriptBin

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -304,6 +304,7 @@ rec {
       checkPhase = ''
         ${stdenv.shellDryRun} "$target"
       '';
+      meta.mainProgram = name;
     };
 
   /*


### PR DESCRIPTION
## Description of changes

Derivations built with `writeShellScriptBin`
should always be runnable with `nix run`. At present, the derivation is missing both `meta.mainProgram`
and `pname`– this means that `nix run` falls back
to inferring the bin path from `name`. This is
unreliable and depends on faulty heuristics.

For context, reference the following snippet from
`nix run --help`:

    If installable evaluates to a derivation, it will try to execute the
    program <out>/bin/<name>, where out is the primary output store path
    of the derivation, and name is the first of the following that exists:

      · The meta.mainProgram attribute of the derivation.
      · The pname attribute of the derivation.
      · The name part of the value of the name attribute of the derivation.