### PR TITLE
immer: init at 0.8.0

### DIFF
--- a/pkgs/development/libraries/immer/default.nix
+++ b/pkgs/development/libraries/immer/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "immer";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "arximboldi";
+    repo = "immer";
+    rev = "v${version}";
+    hash = "sha256-R0C6hN50eyFSv10L/Q0tRdnUrRvze+eRXPrlAQsddYY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  dontBuild = true;
+  dontUseCmakeBuildDir = true;
+
+  meta = with lib; {
+    description = "Postmodern immutable and persistent data structures for C++ — value semantics at scale";
+    homepage = "https://sinusoid.es/immer";
+    changelog = "https://github.com/arximboldi/immer/releases/tag/v${version}";
+    license = licenses.boost;
+    maintainers = with maintainers; [ sifmelcara ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21873,6 +21873,8 @@ with pkgs;
 
   imtui = callPackage ../development/libraries/imtui { };
 
+  immer = callPackage ../development/libraries/immer { };
+
   imv = callPackage ../applications/graphics/imv { };
 
   iml = callPackage ../development/libraries/iml { };


### PR DESCRIPTION
## Description of changes

Part of #246247

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
