### PR TITLE
pdf-sign: init at unstable-2022-08-08

### DIFF
--- a/pkgs/tools/graphics/pdf-sign/default.nix
+++ b/pkgs/tools/graphics/pdf-sign/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, substituteAll
+
+, python3
+, ghostscript
+, coreutils
+, pdftk
+, poppler_utils
+}:
+
+let
+  python-env = python3.withPackages (ps: with ps; [ tkinter ]);
+in
+stdenv.mkDerivation {
+  pname = "pdf-sign";
+  version = "unstable-2023-08-08";
+
+  src = fetchFromGitHub {
+    owner = "svenssonaxel";
+    repo = "pdf-sign";
+    rev = "98742c6b12ebe2ca3ba375c695f43b52fe38b362";
+    hash = "sha256-5GRk0T1iLqmvWI8zvZE3OWEHPS0/zN/Ie9brjZiFpqc=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./use-nix-paths.patch;
+      gs = "${ghostscript}/bin/gs";
+      mv = "${coreutils}/bin/mv";
+      pdftk = "${pdftk}/bin/pdftk";
+      pdfinfo = "${poppler_utils}/bin/pdfinfo";
+    })
+  ];
+
+  buildInputs = [ python-env ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp pdf-sign pdf-create-empty $out/bin
+    patchShebangs $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A tool to visually sign PDF files";
+    homepage = "https://github.com/svenssonaxel/pdf-sign";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.unix;
+  };
+}
+

--- a/pkgs/tools/graphics/pdf-sign/use-nix-paths.patch
+++ b/pkgs/tools/graphics/pdf-sign/use-nix-paths.patch
@@ -1,0 +1,93 @@
+diff --git a/pdf-create-empty b/pdf-create-empty
+index e4768af..5caf34c 100755
+--- a/pdf-create-empty
++++ b/pdf-create-empty
+@@ -20,7 +20,7 @@ def main(args):
+     except:
+         die('Invalid dimensions')
+     subprocess.run([
+-        'gs', '-dBATCH', '-dNOPAUSE', '-dSAFER', '-dQUIET',
++        '@gs@', '-dBATCH', '-dNOPAUSE', '-dSAFER', '-dQUIET',
+         f'-sOutputFile={o}',
+         '-sDEVICE=pdfwrite',
+         f'-dDEVICEWIDTHPOINTS={w}', f'-dDEVICEHEIGHTPOINTS={h}',
+diff --git a/pdf-sign b/pdf-sign
+index 64be231..37d508d 100755
+--- a/pdf-sign
++++ b/pdf-sign
+@@ -17,7 +17,7 @@ def main(args):
+             if args.flatten:
+                 outFile=intmp('input.pdf')
+                 subprocess.run([
+-                    'pdftk', filePath,
++                    '@pdftk@', filePath,
+                     'output', outFile,
+                     'flatten'
+                 ], check=True)
+@@ -28,7 +28,7 @@ def main(args):
+         if args.page < -pageCount or args.page==0 or pageCount < args.page:
+             die('Page number out of range')
+         pageNumber=Cell(args.page if 0 < args.page else pageCount+args.page+1)
+-        pagePDF=Cell(lambda: subprocess.run(['pdftk', inputPDF(), 'cat', str(pageNumber()), 'output', intmp('page.pdf')], check=True) and intmp('page.pdf'))
++        pagePDF=Cell(lambda: subprocess.run(['@pdftk@', inputPDF(), 'cat', str(pageNumber()), 'output', intmp('page.pdf')], check=True) and intmp('page.pdf'))
+         pageSize=Cell(lambda: pdfGetSize(pagePDF()))
+         # The chosen signature
+         if not args.signature and args.batch:
+@@ -52,7 +52,7 @@ def main(args):
+             dy=h*(1-signaturePositionY())/resize - sh/2
+             outFile=intmp('signature-positioned.pdf')
+             subprocess.run([
+-                'gs', '-dBATCH', '-dNOPAUSE', '-dSAFER', '-dQUIET',
++                '@gs@', '-dBATCH', '-dNOPAUSE', '-dSAFER', '-dQUIET',
+                 f'-sOutputFile={outFile}',
+                 '-sDEVICE=pdfwrite',
+                 f'-dDEVICEWIDTHPOINTS={w}', f'-dDEVICEHEIGHTPOINTS={h}', '-dFIXEDMEDIA',
+@@ -62,7 +62,7 @@ def main(args):
+             return outFile
+         # The signed page
+         signedPagePDF=Cell(lambda: subprocess.run([
+-            'pdftk',
++            '@pdftk@',
+             pagePDF(),
+             'stamp', signaturePositionedPDF(),
+             'output', intmp('signed-page.pdf'),
+@@ -80,7 +80,7 @@ def main(args):
+             (w, h)=displaySize()
+             outFile=intmp('display.png')
+             subprocess.run([
+-                'gs', '-dBATCH', '-dNOPAUSE', '-dSAFER', '-dQUIET',
++                '@gs@', '-dBATCH', '-dNOPAUSE', '-dSAFER', '-dQUIET',
+                 f'-sOutputFile={outFile}',
+                 '-sDEVICE=pngalpha',
+                 '-dMaxBitmap=2147483647',
+@@ -258,7 +258,7 @@ def main(args):
+                 if args.existing=='backup':
+                     backupFilePath=f'{signedFilePath}.backup{time.strftime("%Y%m%d_%H%M%S")}'
+                     subprocess.run([
+-                        'mv',
++                        '@mv@',
+                         signedFilePath,
+                         backupFilePath,
+                     ], check=True)
+@@ -269,7 +269,7 @@ def main(args):
+                     assert args.existing=='overwrite'
+             pnr=pageNumber()
+             subprocess.run([
+-                'pdftk',
++                '@pdftk@',
+                 f'A={inputPDF()}',
+                 f'B={signedPagePDF()}',
+                 'cat',
+@@ -352,10 +352,10 @@ def tkthrottle(frequency, root):
+     return decorator
+ 
+ def pdfCountPages(filePath):
+-    return int(fromCmdOutput(["pdfinfo", filePath], "^.*\nPages: +([0-9]+)\n.*$")[1])
++    return int(fromCmdOutput(["@pdfinfo@", filePath], "^.*\nPages: +([0-9]+)\n.*$")[1])
+ 
+ def pdfGetSize(filePath):
+-    [ignored, w, h, *ignored2]=fromCmdOutput(['pdfinfo', filePath], '^.*\nPage size: +([0-9.]+) x ([0-9.]+) pts( \([A-Za-z0-9]+\))?\n.*$')
++    [ignored, w, h, *ignored2]=fromCmdOutput(['@pdfinfo@', filePath], '^.*\nPage size: +([0-9.]+) x ([0-9.]+) pts( \([A-Za-z0-9]+\))?\n.*$')
+     return (float(w), float(h))
+ 
+ def m(pattern, string):

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11736,6 +11736,8 @@ with pkgs;
 
   pdf-quench = callPackage ../applications/misc/pdf-quench { };
 
+  pdf-sign = callPackage ../tools/graphics/pdf-sign { };
+
   pdfarranger = callPackage ../applications/misc/pdfarranger { };
 
   briss = callPackage ../tools/graphics/briss { };


### PR DESCRIPTION
## Description of changes

This PR adds 1 package: pdf-sign


Closes https://github.com/NixOS/nixpkgs/issues/247987
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
