### PR TITLE
python3.pkgs.diofant: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/development/python-modules/diofant/default.nix
+++ b/pkgs/development/python-modules/diofant/default.nix
@@ -1,38 +1,56 @@
 { lib
 , buildPythonPackage
+, cython
+, fetchpatch
 , fetchPypi
 , gmpy2
-, isort
 , mpmath
 , numpy
 , pythonOlder
 , scipy
 , setuptools-scm
+, wheel
 }:
 
 buildPythonPackage rec {
   pname = "diofant";
-  version = "0.13.0";
-  disabled = pythonOlder "3.9";
+  version = "0.14.0";
   format = "pyproject";
+  disabled = pythonOlder "3.10";
 
   src = fetchPypi {
     inherit version;
     pname = "Diofant";
-    sha256 = "bac9e086a7156b20f18e3291d6db34e305338039a3c782c585302d377b74dd3c";
+    hash = "sha256-c886y37xR+4TxZw9+3tb7nkTGxWcS+Ag/ruUUdpf7S4=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "remove-pip-from-build-dependencies.patch";
+      url = "https://github.com/diofant/diofant/commit/117e441808faa7c785ccb81bf211772d60ebdec3.patch";
+      hash = "sha256-MYk1Ku4F3hAv7+jJQLWhXd8qyKRX+QYuBzPfYWT0VbU=";
+    })
+  ];
+
   nativeBuildInputs = [
-    isort
     setuptools-scm
+    wheel
   ];
 
   propagatedBuildInputs = [
-    gmpy2
     mpmath
-    numpy
-    scipy
   ];
+
+  passthru.optional-dependencies = {
+    exports = [
+      cython
+      numpy
+      scipy
+    ];
+    gmpy = [
+      gmpy2
+    ];
+  };
 
   # tests take ~1h
   doCheck = false;


### PR DESCRIPTION
## Description of changes

https://github.com/diofant/diofant/releases/tag/v0.14.0

I also mimicked upstream by pulling some dependencies out of propagatedBuildInputs and into optional-dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
