### PR TITLE
nuked-md: init at 1.2

### DIFF
--- a/pkgs/applications/emulators/nuked-md/default.nix
+++ b/pkgs/applications/emulators/nuked-md/default.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gitUpdater
+, cmake
+, SDL2
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nuked-md";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "nukeykt";
+    repo = "Nuked-MD";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Pe+TSu9FBUhxtACq+6jMbrUxiwKLOJgQbEcmUrcrjMs=";
+  };
+
+  # Interesting detail about our SDL2 packaging:
+  # Because we build it with the configure script instead of CMake, we ship sdl2-config.cmake instead of SDL2Config.cmake
+  # The former doesn't set SDL2_FOUND while the latter does (like CMake config scripts should), which causes this issue:
+  #
+  # CMake Error at CMakeLists.txt:5 (find_package):
+  #   Found package configuration file:
+  #
+  #     <SDL2.dev>/lib/cmake/SDL2/sdl2-config.cmake
+  #
+  #   but it set SDL2_FOUND to FALSE so package "SDL2" is considered to be NOT
+  #   FOUND.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'SDL2 REQUIRED' 'SDL2'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    SDL2
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 Nuked-MD $out/bin/Nuked-MD
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+    };
+  };
+
+  meta = with lib; {
+    description = "Cycle accurate Mega Drive emulator";
+    longDescription = ''
+      Cycle accurate Mega Drive core. The goal of this project is to emulate Sega Mega Drive chipset as accurately as
+      possible using decapped chips photos.
+    '';
+    homepage = "https://github.com/nukeykt/Nuked-MD";
+    license = licenses.gpl2Plus;
+    mainProgram = "Nuked-MD";
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2613,6 +2613,8 @@ with pkgs;
 
   np2kai = callPackage ../applications/emulators/np2kai { };
 
+  nuked-md = callPackage ../applications/emulators/nuked-md { };
+
   oberon-risc-emu = callPackage ../applications/emulators/oberon-risc-emu { };
 
   openmsx = callPackage ../applications/emulators/openmsx { };


### PR DESCRIPTION
## Description of changes

Packages [Nuked-MD](https://github.com/nukeykt/Nuked-MD), a WIP cycle-accurate Sega Mega Drive / Genesis emulator based on decapped & reverse-engineered chip photos.

Currently more of a research & curiosity thing than usable for regular end-users, as it's 400x(!) slower than real hardware.

Showcase (massively sped-up, of course): https://www.youtube.com/watch?v=QaDBjkMXPw0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
I've sat around and waited 1h20m while it was slowly (but accurately!) displaying the first 9 seconds of a Genesis demo.
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
