### PR TITLE
python3.pkgs.seaborn: patch tests using new matplotlib and numpy

### DIFF
--- a/pkgs/development/python-modules/seaborn/default.nix
+++ b/pkgs/development/python-modules/seaborn/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
 , flit-core
 , matplotlib
@@ -24,6 +25,24 @@ buildPythonPackage rec {
     hash = "sha256-N0ZF82UJ0NyriVy6W0fa8Fhvd7/js2yXxgfbfaW+ATk=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "fix-test-using-matplotlib-3.7.patch";
+      url = "https://github.com/mwaskom/seaborn/commit/db7ae11750fc2dfb695457239708448d54e9b8cd.patch";
+      hash = "sha256-LbieI0GeC/0NpFVxV/NRQweFjP/lj/TR2D/SLMPYqJg=";
+    })
+    (fetchpatch {
+      name = "fix-pandas-deprecation.patch";
+      url = "https://github.com/mwaskom/seaborn/commit/a48601d6bbf8381f9435be48624f1a77d6fbfced.patch";
+      hash = "sha256-LuN8jn6Jo9Fvdl5iGZ2LgINYujSDvvs+hSclnadV1F4=";
+    })
+    (fetchpatch {
+      name = "fix-tests-using-numpy-1.25.patch";
+      url = "https://github.com/mwaskom/seaborn/commit/b6737d5aec9a91bb8840cdda896a7970e1830d56.patch";
+      hash = "sha256-Xj82yyB5Vy2xKRl0ideDmJ5Zr4Xc+8cEHU/liVwMSvE=";
+    })
+  ];
+
   nativeBuildInputs = [
     flit-core
   ];
@@ -41,12 +60,12 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # incompatible with matplotlib 3.7
-    # https://github.com/mwaskom/seaborn/issues/3288
-    "test_subplot_kws"
-
     # requires internet connection
     "test_load_dataset_string_error"
+
+    # per https://github.com/mwaskom/seaborn/issues/3431, we can enable this
+    # once matplotlib releases version > 3.7.2
+    "test_share_xy"
   ] ++ lib.optionals (!stdenv.hostPlatform.isx86) [
     # overly strict float tolerances
     "TestDendrogram"
@@ -54,7 +73,7 @@ buildPythonPackage rec {
 
   # All platforms should use Agg. Let's set it explicitly to avoid probing GUI
   # backends (leads to crashes on macOS).
-  MPLBACKEND="Agg";
+  env.MPLBACKEND="Agg";
 
   pythonImportsCheck = [
     "seaborn"


### PR DESCRIPTION
## Description of changes

I think these tests started failing after updating matplotlib to 3.7.2 and numpy to 1.25.

This should close https://github.com/NixOS/nixpkgs/issues/248181.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
