### PR TITLE
pythonRelaxDepsHook: remove version from pkg_name

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
@@ -78,24 +78,25 @@ pythonRelaxDepsHook() {
     pushd dist
 
     # See https://peps.python.org/pep-0491/#escaping-and-unicode
-    local -r pkg_name="${pname//[^[:alnum:].]/_}-$version"
+    local -r pkg_name="${pname//[^[:alnum:].]/_}"
     local -r unpack_dir="unpacked"
-    local -r metadata_file="$unpack_dir/$pkg_name/$pkg_name.dist-info/METADATA"
+    local -r metadata_file="$unpack_dir/$pkg_name*/$pkg_name*.dist-info/METADATA"
 
     # We generally shouldn't have multiple wheel files, but let's be safer here
     for wheel in "$pkg_name"*".whl"; do
         @pythonInterpreter@ -m wheel unpack --dest "$unpack_dir" "$wheel"
         rm -rf "$wheel"
 
-        _pythonRelaxDeps "$metadata_file"
-        _pythonRemoveDeps "$metadata_file"
+        # Using no quotes on purpose since we need to expand the glob from `$metadata_file`
+        _pythonRelaxDeps $metadata_file
+        _pythonRemoveDeps $metadata_file
 
         if (( "${NIX_DEBUG:-0}" >= 1 )); then
             echo "pythonRelaxDepsHook: resulting METADATA for '$wheel':"
-            cat "$unpack_dir/$pkg_name/$pkg_name.dist-info/METADATA"
+            cat $metadata_file
         fi
 
-        @pythonInterpreter@ -m wheel pack "$unpack_dir/$pkg_name"
+        @pythonInterpreter@ -m wheel pack "$unpack_dir/$pkg_name"*
     done
 
     # Remove the folder since it will otherwise be in the dist output.


### PR DESCRIPTION
## Description of changes

Since the wheel file name is based on the package metadata instead of what we set in the derivation, if you set the version as `unstable-YYYYMMDD`, for example, the hook would silently fail. We will ignore the version now and just use a glob instead to match anything that has the package name in its path.

Fixes #248185.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
