### PR TITLE
kicad.libraries.packages3d:  reduce size to allow caching

### DIFF
--- a/pkgs/applications/misc/stepreduce/default.nix
+++ b/pkgs/applications/misc/stepreduce/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+}:
+
+stdenv.mkDerivation rec {
+  pname = "stepreduce";
+  version = "unstable-2020-04-30";
+
+  src = fetchFromGitLab {
+    owner = "sethhillbrand";
+    repo = "stepreduce";
+    rev = "e89091c33b67e2a18584e1fe3560bfd48ae98773";
+    hash = "sha256-bCseBQ6J3sWFt0kzaRkV11lwzOGvNPebvQ6w4OJaMBs=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 stepreduce $out/bin/stepreduce
+
+    runHook prostInstall
+  '';
+
+  meta = with lib; {
+    description = "Reduces STEP file size by removing redundancy";
+    homepage = "https://gitlab.com/sethhillbrand/stepreduce";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -230,17 +230,8 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ evils ];
-    # kicad is cross platform
     platforms = lib.platforms.all;
     broken = stdenv.isDarwin;
-
-    hydraPlatforms = if (with3d) then [ ] else platforms;
-    # We can't download the 3d models on Hydra,
-    # they are a ~1 GiB download and they occupy ~5 GiB in store.
-    # as long as the base and libraries (minus 3d) are build,
-    # this wrapper does not need to get built
-    # the kicad-*small "packages" cause this to happen
-
     mainProgram = "kicad";
   };
 }

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -229,7 +229,7 @@ stdenv.mkDerivation rec {
       The Programs handle Schematic Capture, and PCB Layout with Gerber output.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ evils kiwi ];
+    maintainers = with lib.maintainers; [ evils ];
     # kicad is cross platform
     platforms = lib.platforms.all;
     broken = stdenv.isDarwin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39564,9 +39564,11 @@ with pkgs;
 
   # this is a wrapper for kicad.base and kicad.libraries
   kicad = callPackage ../applications/science/electronics/kicad { };
+  # this is the same but without the (sizable) 3D models library
   kicad-small = kicad.override { pname = "kicad-small"; with3d = false; };
+  # this is the master branch at whatever point update.sh last updated versions.nix
   kicad-unstable = kicad.override { pname = "kicad-unstable"; stable = false; };
-  # mostly here so the kicad-unstable components (except packages3d) get built
+  # and a small version of that
   kicad-unstable-small = kicad.override {
     pname = "kicad-unstable-small";
     stable = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40917,6 +40917,8 @@ with pkgs;
 
   steamcontroller = callPackage ../misc/drivers/steamcontroller { };
 
+  stepreduce = callPackage ../applications/misc/stepreduce { };
+
   stern = callPackage ../applications/networking/cluster/stern { };
 
   streamripper = callPackage ../applications/audio/streamripper { };


### PR DESCRIPTION
## Description of changes

add the `stepreduce` package and use it to reduce the size of the step files in the KiCad 3D models
and apply zip compression for .stpZ output

these bring the closure size bellow 2G allowing hydra to cache the output
(downloading the packages from gitlab directly sometimes fails, and it takes a while which leads some people to think something went wrong)

stepreduce brings down closure size from 5.4G to 3.3G
zip brings it down from 3.3G to 1.6G (or 5.4G to 1.9G without reduce)

xz compressed NAR sizes are:
plain: 373M
gzip: 712M
zip: 712M
stepreduce: 262M
stepreduce & gzip: 465M
(gzip only works here coincidentally because our KiCad was built with a library that has that support
[the quasi standard of stpZ is more universally supported](https://www.mbx-if.org/documents/rec_prac_file_compression_v13.pdf))
stepreduce & zip: 468M

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).