### PR TITLE
dumpasn1: init at 20230207.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8671,6 +8671,11 @@
     githubId = 1927188;
     name = "karolchmist";
   };
+  katexochen = {
+    github = "katexochen";
+    githubId = 49727155;
+    name = "Paul Meyer";
+  };
   kayhide = {
     email = "kayhide@gmail.com";
     github = "kayhide";

--- a/pkgs/tools/security/dumpasn1/configpath.patch
+++ b/pkgs/tools/security/dumpasn1/configpath.patch
@@ -1,0 +1,28 @@
+From ab8bd63b32b963ddc7346a2dabfd39fba8bfba72 Mon Sep 17 00:00:00 2001
+From: Paul Meyer <49727155+katexochen@users.noreply.github.com>
+Date: Sun, 13 Aug 2023 14:13:21 +0200
+Subject: [PATCH] make config path injectable during build
+
+This way a config path can be added to the list during build by
+defining the makro.
+
+Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>
+---
+ dumpasn1.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/dumpasn1.c b/dumpasn1.c
+index e7bf268..94f1582 100644
+--- a/dumpasn1.c
++++ b/dumpasn1.c
+@@ -451,6 +451,10 @@ static const char *configPaths[] = {
+ 	/* General environment-based paths */
+ 	"$DUMPASN1_PATH/",
+ 
++  #ifdef DUMPASN1_CONFIG_PATH
++	DUMPASN1_CONFIG_PATH,
++  #endif /* DUMPASN1_CONFIG_PATH */
++
+ 	NULL
+ 	};
+ #endif /* OS-specific search paths */

--- a/pkgs/tools/security/dumpasn1/default.nix
+++ b/pkgs/tools/security/dumpasn1/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dumpasn1";
+  version = "20230207.0.0";
+
+  src = fetchFromGitHub {
+    owner = "katexochen";
+    repo = "dumpasn1";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-r40czSLdjCYbt73zK7exCoP/kMq6+pyJfz9LKJLLaXM=";
+  };
+
+  CFLAGS = ''-DDUMPASN1_CONFIG_PATH='"$(out)/etc/"' '';
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  patches = [
+    # Allow adding a config file path during build via makro.
+    # Used to add the store path of the included config file through CFLAGS.
+    # This won't be merged upstream.
+    ./configpath.patch
+  ];
+
+  meta = with lib; {
+    description = "Display and debug ASN.1 data";
+    homepage = "https://github.com/katexochen/dumpasn1";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ katexochen ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7438,6 +7438,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  dumpasn1 = callPackage ../tools/security/dumpasn1 { };
+
   dumptorrent = callPackage ../tools/misc/dumptorrent { };
 
   duo-unix = callPackage ../tools/security/duo-unix { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
