### PR TITLE
treewide: noop: refer to `src.name` or similar in `sourceRoot` where appropriate, part 4: leftovers

### DIFF
--- a/pkgs/development/python-modules/dbt-core/default.nix
+++ b/pkgs/development/python-modules/dbt-core/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     hash = "sha256-ZgP11fVMtXpzo9QaTkejvKl0LzCAkIyGBMcOquBirxQ=";
   };
 
-  sourceRoot = "source/core";
+  sourceRoot = "${src.name}/core";
 
   nativeBuildInputs = [
     pythonRelaxDepsHook

--- a/pkgs/development/python-modules/dbt-postgres/default.nix
+++ b/pkgs/development/python-modules/dbt-postgres/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage {
 
   inherit (dbt-core) version src;
 
-  sourceRoot = "source/plugins/postgres";
+  sourceRoot = "${dbt-core.src.name}/plugins/postgres";
 
   env.DBT_PSYCOPG2_NAME = "psycopg2";
 

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -97,7 +97,7 @@ buildPythonPackage rec {
     hash = "sha256-YQFIF1tA/CjvmD6xGgVre2lbcHR+UYx/sy1dOfpvkPY=";
   };
 
-  sourceRoot = "source/libs/langchain";
+  sourceRoot = "${src.name}/libs/langchain";
 
   postPatch = ''
     substituteInPlace langchain/utilities/bash.py \

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -8,7 +8,7 @@
 , pytest-asyncio
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "langsmith";
   version = "0.0.14";
   format = "pyproject";
@@ -22,7 +22,7 @@ buildPythonPackage {
     hash = "sha256-U8fs16Uq80EB7Ey5YuQhUKKI9DOXJWlabM5JdoDnWP0=";
   };
 
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -12,7 +12,7 @@
 }:
 
 let
-  self = buildPythonPackage {
+  self = buildPythonPackage rec {
     pname = "opentelemetry-api";
     version = "1.18.0";
     disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ let
       hash = "sha256-8xf4TqEkBeueejQBckFGwBNN4Gyo+/7/my6Z1Mnei5Q=";
     };
 
-    sourceRoot = "source/opentelemetry-api";
+    sourceRoot = "${src.name}/opentelemetry-api";
 
     format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-common/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-common/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage {
   pname = "opentelemetry-exporter-otlp-proto-common";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/exporter/opentelemetry-exporter-otlp-proto-common";
+  sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-otlp-proto-common";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage {
   pname = "opentelemetry-exporter-otlp-proto-grpc";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/exporter/opentelemetry-exporter-otlp-proto-grpc";
+  sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-otlp-proto-grpc";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-http/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-http/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage {
   pname = "opentelemetry-exporter-otlp-proto-http";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/exporter/opentelemetry-exporter-otlp-proto-http";
+  sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-otlp-proto-http";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage {
   pname = "opentelemetry-exporter-otlp";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/exporter/opentelemetry-exporter-otlp";
+  sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-otlp";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage {
   pname = "opentelemetry-exporter-prometheus";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/exporter/opentelemetry-exporter-prometheus";
+  sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-prometheus";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-aiohttp-client/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-aiohttp-client/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage {
   pname = "opentelemetry-instrumentation-aiohttp-client";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-aiohttp-client";
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-aiohttp-client";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-asgi/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-asgi/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage {
   pname = "opentelemetry-instrumentation-asgi";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-asgi";
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-asgi";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage {
   pname = "opentelemetry-instrumentation-django";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-django";
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-django";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage {
   pname = "opentelemetry-instrumentation-grpc";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-grpc";
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-grpc";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-wsgi/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-wsgi/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage {
   pname = "opentelemetry-instrumentation-wsgi";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/instrumentation/opentelemetry-instrumentation-wsgi";
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-wsgi";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     hash = "sha256-MPBOdurEQhA9BPRgVftejjtkvN/zRQEJDjQcS2QW3xc=";
   };
 
-  sourceRoot = "source/opentelemetry-instrumentation";
+  sourceRoot = "${src.name}/opentelemetry-instrumentation";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-proto/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-proto/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage {
   pname = "opentelemetry-proto";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/opentelemetry-proto";
+  sourceRoot = "${opentelemetry-api.src.name}/opentelemetry-proto";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-sdk/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-sdk/default.nix
@@ -17,7 +17,7 @@ let
     pname = "opentelemetry-sdk";
     disabled = pythonOlder "3.7";
 
-    sourceRoot = "source/opentelemetry-sdk";
+    sourceRoot = "${opentelemetry-api.src.name}/opentelemetry-sdk";
 
     format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage {
   pname = "opentelemetry-semantic-conventions";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/opentelemetry-semantic-conventions";
+  sourceRoot = "${opentelemetry-api.src.name}/opentelemetry-semantic-conventions";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage {
   pname = "opentelemetry-test-utils";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/tests/opentelemetry-test-utils";
+  sourceRoot = "${opentelemetry-api.src.name}/tests/opentelemetry-test-utils";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/opentelemetry-util-http/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-util-http/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage {
   pname = "opentelemetry-util-http";
   disabled = pythonOlder "3.7";
 
-  sourceRoot = "source/util/opentelemetry-util-http";
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/util/opentelemetry-util-http";
 
   format = "pyproject";
 

--- a/pkgs/development/python-modules/prophet/default.nix
+++ b/pkgs/development/python-modules/prophet/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     })
   ];
 
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   env.PROPHET_REPACKAGE_CMDSTAN = "false";
 

--- a/pkgs/misc/moonfire-nvr/default.nix
+++ b/pkgs/misc/moonfire-nvr/default.nix
@@ -21,7 +21,7 @@ let
   ui = buildNpmPackage {
     inherit version src;
     pname = "${pname}-ui";
-    sourceRoot = "source/ui";
+    sourceRoot = "${src.name}/ui";
     npmDepsHash = "sha256-IpZWgMo6Y3vRn9h495ifMB3tQxobLeTLC0xXS1vrKLA=";
     installPhase = ''
       runHook preInstall
@@ -34,7 +34,7 @@ let
 in rustPlatform.buildRustPackage {
   inherit pname version src;
 
-  sourceRoot = "source/server";
+  sourceRoot = "${src.name}/server";
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/tools/misc/fx-cast-bridge/default.nix
+++ b/pkgs/tools/misc/fx-cast-bridge/default.nix
@@ -10,7 +10,7 @@ buildNpmPackage rec {
     rev = "v${version}";
     hash = "sha256-hB4NVJW2exHoKsMp0CKzHerYgj8aR77rV+ZsCoWA1Dg=";
   };
-  sourceRoot = "source/app";
+  sourceRoot = "${src.name}/app";
   npmDepsHash = "sha256-GLrDRZqKcX1PDGREx+MLZ1TEjr88r9nz4TvZ9nvo40g=";
 
   nativeBuildInputs = [ python3 ];


### PR DESCRIPTION
Continues where #245388 and #247977 left off.

This replaces all the leftover references to `fetchzip`'s "source" in `sourceRoot` package attribute with `src.name` and similar.

A noop, build-wise.