### PR TITLE
glibc: implement `LD_FALLBACK_PATH` environment variable

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -35,6 +35,7 @@
 { pname
 , withLinuxHeaders ? false
 , profilingLibraries ? false
+, withLdFallbackPatch ? false
 , withGd ? false
 , enableCET ? false
 , extraBuildInputs ? []
@@ -81,9 +82,6 @@ stdenv.mkDerivation ({
       /* Don't use /etc/ld.so.preload, but /etc/ld-nix.so.preload.  */
       ./dont-use-system-ld-so-preload.patch
 
-      /* Implement LD_FALLBACK_PATH */
-      ./ld-fallback.patch
-
       /* The command "getconf CS_PATH" returns the default search path
          "/bin:/usr/bin", which is inappropriate on NixOS machines. This
          patch extends the search path by "/run/current-system/sw/bin". */
@@ -104,6 +102,7 @@ stdenv.mkDerivation ({
       */
       ./reenable_DT_HASH.patch
     ]
+    ++ lib.optional withLdFallbackPatch ./ld-fallback.patch
     /* NVCC does not support ARM intrinsics. Since <math.h> is pulled in by almost
        every HPC piece of software, without this patch CUDA compilation on ARM
        is effectively broken. See
@@ -216,7 +215,7 @@ stdenv.mkDerivation ({
   passthru = { inherit version; minorRelease = version; };
 }
 
-// (removeAttrs args [ "withLinuxHeaders" "withGd" "enableCET" "postInstall" "makeFlags" ]) //
+// (removeAttrs args [ "withLinuxHeaders" "withLdFallbackPatch" "withGd" "enableCET" "postInstall" "makeFlags" ]) //
 
 {
   src = fetchurl {

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -81,6 +81,9 @@ stdenv.mkDerivation ({
       /* Don't use /etc/ld.so.preload, but /etc/ld-nix.so.preload.  */
       ./dont-use-system-ld-so-preload.patch
 
+      /* Implement LD_FALLBACK_PATH */
+      ./ld-fallback.patch
+
       /* The command "getconf CS_PATH" returns the default search path
          "/bin:/usr/bin", which is inappropriate on NixOS machines. This
          patch extends the search path by "/run/current-system/sw/bin". */

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -1,6 +1,8 @@
-{ lib, stdenv, callPackage
+{ lib, config
+, stdenv, callPackage
 , withLinuxHeaders ? true
 , profilingLibraries ? false
+, withLdFallbackPatch ? config.glibc.withLdFallbackPatch
 , withGd ? false
 , enableCET ? if stdenv.hostPlatform.isx86_64 then "permissive" else false
 , pkgsBuildBuild
@@ -16,8 +18,11 @@ let
 in
 
 (callPackage ./common.nix { inherit stdenv; } {
-  inherit withLinuxHeaders withGd profilingLibraries enableCET;
-  pname = "glibc" + lib.optionalString withGd "-gd" + lib.optionalString (stdenv.cc.isGNU && libgcc==null) "-nolibgcc";
+  inherit withLinuxHeaders withLdFallbackPatch withGd profilingLibraries enableCET;
+  pname = "glibc"
+    + lib.optionalString withLdFallbackPatch "-ldfallback"
+    + lib.optionalString withGd "-gd"
+    + lib.optionalString (stdenv.cc.isGNU && libgcc==null) "-nolibgcc";
 }).overrideAttrs(previousAttrs: {
 
     # Note:

--- a/pkgs/development/libraries/glibc/ld-fallback.patch
+++ b/pkgs/development/libraries/glibc/ld-fallback.patch
@@ -1,8 +1,55 @@
+From 5956982e611afe46f2aa6a1e241262379fdbcbb6 Mon Sep 17 00:00:00 2001
+From: Jan Malakhovski <oxij@oxij.org>
+Date: Wed, 9 Aug 2023 08:53:06 +0000
+Subject: [PATCH] Implement support for LD_FALLBACK_PATH env variable and
+ related command line options
+
+LD_FALLBACK_PATH has the same semantics as LD_LIBRARY_PATH but unlike
+LD_LIBRARY_PATH, instead of having the highest priority, it has the second-lowest
+(it gets used just before the default system directories).
+
+Thus, LD_FALLBACK_PATH provides a way to specify fallback library paths.
+
+Consider the following use cases:
+
+- Running a closed-source program (like Steam and its games) on an unsupported
+  distribution: closed-source programs commonly override LD_LIBRARY_PATH to
+  override system libraries with their own bundled versions, but they
+  frequently do it the wrong way by overriding it while ignoring the current
+  value of LD_LIBRARY_PATH, thus failing to pick up any non-system libraries
+  they don't bundle but require specific versions of.
+
+  LD_FALLBACK_PATH, being the low-priority option, can't be used to achieve
+  the same effect as LD_LIBRARY_PATH from the perspective of the closed-source
+  program's vendor, thus making it unlikely they would ever touch
+  LD_FALLBACK_PATH. But it can be used by other tools to supply needed default
+  libraries to the closed-source program in question.
+
+- Similarly, sometimes you just want to change the underlying library for a
+  set of programs without changing the system default. For instance, if you
+  have different GPUs requiring different libGL's (though, specifically for
+  libGL there are several less ad-hoc solutions than this).
+
+In general, before LD_FALLBACK_PATH there was no good way to solve these
+problems without generating a whole chroot. Now you can collect those
+libraries you want to override system defaults but not override those found
+via LD_LIBRARY_PATH in a directory somewhere and put its path into
+LD_FALLBACK_PATH.
+---
+ elf/dl-load.c               | 60 +++++++++++++++++++++++++++++++++++--
+ elf/dl-main.h               |  7 +++++
+ elf/dl-support.c            |  1 +
+ elf/dl-usage.c              |  2 ++
+ elf/rtld.c                  | 22 ++++++++++++++
+ sysdeps/generic/ldsodefs.h  |  1 +
+ sysdeps/generic/unsecvars.h |  1 +
+ 7 files changed, 92 insertions(+), 2 deletions(-)
+
 diff --git a/elf/dl-load.c b/elf/dl-load.c
-index 9e2089cfaa..e560b09932 100644
+index 9a87fda9c9..a8fd639238 100644
 --- a/elf/dl-load.c
 +++ b/elf/dl-load.c
-@@ -99,6 +99,8 @@ int __stack_prot attribute_hidden attribute_relro
+@@ -101,6 +101,8 @@ int __stack_prot attribute_hidden attribute_relro
  
  /* This is the decomposed LD_LIBRARY_PATH search path.  */
  struct r_search_path_struct __rtld_env_path_list attribute_relro;
@@ -11,7 +58,7 @@ index 9e2089cfaa..e560b09932 100644
  
  /* List of the hardware capabilities we might end up using.  */
  #ifdef SHARED
-@@ -683,6 +685,7 @@ cache_rpath (struct link_map *l,
+@@ -701,6 +703,7 @@ cache_rpath (struct link_map *l,
  
  void
  _dl_init_paths (const char *llp, const char *source,
@@ -19,7 +66,7 @@ index 9e2089cfaa..e560b09932 100644
  		const char *glibc_hwcaps_prepend,
  		const char *glibc_hwcaps_mask)
  {
-@@ -835,6 +838,45 @@ _dl_init_paths (const char *llp, const char *source,
+@@ -854,6 +857,45 @@ _dl_init_paths (const char *llp, const char *source,
      }
    else
      __rtld_env_path_list.dirs = (void *) -1;
@@ -65,7 +112,7 @@ index 9e2089cfaa..e560b09932 100644
  }
  
  
-@@ -1997,9 +2039,10 @@ open_path (const char *name, size_t namelen, int mode,
+@@ -1928,9 +1970,10 @@ open_path (const char *name, size_t namelen, int mode,
        if (sps->malloced)
  	free (sps->dirs);
  
@@ -78,7 +125,7 @@ index 9e2089cfaa..e560b09932 100644
  	sps->dirs = (void *) -1;
      }
  
-@@ -2233,6 +2276,17 @@ _dl_map_object (struct link_map *loader, const char *name,
+@@ -2160,6 +2203,17 @@ _dl_map_object (struct link_map *loader, const char *name,
  	}
  #endif
  
@@ -96,7 +143,7 @@ index 9e2089cfaa..e560b09932 100644
        /* Finally, try the default path.  */
        if (fd == -1
  	  && ((l = loader ?: GL(dl_ns)[nsid]._ns_loaded) == NULL
-@@ -2416,6 +2470,8 @@ _dl_rtld_di_serinfo (struct link_map *loader, Dl_serinfo *si, bool counting)
+@@ -2342,6 +2396,8 @@ _dl_rtld_di_serinfo (struct link_map *loader, Dl_serinfo *si, bool counting)
       Here is where ld.so.cache gets checked, but we don't have
       a way to indicate that in the results for Dl_serinfo.  */
  
@@ -106,7 +153,7 @@ index 9e2089cfaa..e560b09932 100644
    if (!(loader->l_flags_1 & DF_1_NODEFLIB))
      add_path (&p, &__rtld_search_dirs, XXX_default);
 diff --git a/elf/dl-main.h b/elf/dl-main.h
-index 3a5e13c739..24742b14cf 100644
+index 92766d06b4..c9d85f4dcc 100644
 --- a/elf/dl-main.h
 +++ b/elf/dl-main.h
 @@ -78,6 +78,12 @@ struct dl_main_state
@@ -122,7 +169,7 @@ index 3a5e13c739..24742b14cf 100644
    /* The list preloaded objects from LD_PRELOAD.  */
    const char *preloadlist;
  
-@@ -107,6 +113,7 @@ static inline void
+@@ -110,6 +116,7 @@ static inline void
  call_init_paths (const struct dl_main_state *state)
  {
    _dl_init_paths (state->library_path, state->library_path_source,
@@ -131,10 +178,10 @@ index 3a5e13c739..24742b14cf 100644
  }
  
 diff --git a/elf/dl-support.c b/elf/dl-support.c
-index 7abb65d8e3..b76975d663 100644
+index 44a54dea07..3b402d53a6 100644
 --- a/elf/dl-support.c
 +++ b/elf/dl-support.c
-@@ -337,6 +337,7 @@ _dl_non_dynamic_init (void)
+@@ -288,6 +288,7 @@ _dl_non_dynamic_init (void)
    /* Initialize the data structures for the search paths for shared
       objects.  */
    _dl_init_paths (getenv ("LD_LIBRARY_PATH"), "LD_LIBRARY_PATH",
@@ -143,10 +190,10 @@ index 7abb65d8e3..b76975d663 100644
  		     linked binaries.  */
  		  NULL, NULL);
 diff --git a/elf/dl-usage.c b/elf/dl-usage.c
-index 6e26818bd7..2cec74b4ad 100644
+index 98f0b0d027..98b9da57aa 100644
 --- a/elf/dl-usage.c
 +++ b/elf/dl-usage.c
-@@ -247,6 +247,8 @@ setting environment variables (which would be inherited by subprocesses).\n\
+@@ -187,6 +187,8 @@ setting environment variables (which would be inherited by subprocesses).\n\
    --inhibit-cache       Do not use " LD_SO_CACHE "\n\
    --library-path PATH   use given PATH instead of content of the environment\n\
                          variable LD_LIBRARY_PATH\n\
@@ -156,10 +203,10 @@ index 6e26818bd7..2cec74b4ad 100644
                          search glibc-hwcaps subdirectories in LIST\n\
    --glibc-hwcaps-mask LIST\n\
 diff --git a/elf/rtld.c b/elf/rtld.c
-index 596b6ac3d9..85a152195e 100644
+index a91e2a4471..d03ccbe077 100644
 --- a/elf/rtld.c
 +++ b/elf/rtld.c
-@@ -290,6 +290,8 @@ dl_main_state_init (struct dl_main_state *state)
+@@ -295,6 +295,8 @@ dl_main_state_init (struct dl_main_state *state)
    audit_list_init (&state->audit_list);
    state->library_path = NULL;
    state->library_path_source = NULL;
@@ -168,7 +215,7 @@ index 596b6ac3d9..85a152195e 100644
    state->preloadlist = NULL;
    state->preloadarg = NULL;
    state->glibc_hwcaps_prepend = NULL;
-@@ -1229,6 +1231,17 @@ dl_main (const ElfW(Phdr) *phdr,
+@@ -1438,6 +1440,16 @@ dl_main (const ElfW(Phdr) *phdr,
  	    _dl_argc -= 2;
  	    _dl_argv += 2;
  	  }
@@ -178,7 +225,6 @@ index 596b6ac3d9..85a152195e 100644
 +	    state.fallback_path = _dl_argv[2];
 +	    state.fallback_path_source = "--fallback-path";
 +
-+	    _dl_skip_args += 2;
 +	    _dl_argc -= 2;
 +	    _dl_argv += 2;
 +	    // this line is to force git produce the correct diff
@@ -186,11 +232,11 @@ index 596b6ac3d9..85a152195e 100644
  	else if (! strcmp (_dl_argv[1], "--inhibit-rpath")
  		 && _dl_argc > 2)
  	  {
-@@ -2781,6 +2794,16 @@ process_envvars (struct dl_main_state *state)
- #ifdef EXTRA_LD_ENVVARS_13
- 	  EXTRA_LD_ENVVARS_13
- #endif
-+
+@@ -2644,6 +2656,16 @@ process_envvars (struct dl_main_state *state)
+ 	    GLRO(dl_dynamic_weak) = 1;
+ 	  break;
+ 
++	case 13:
 +	  /* The library fallback search path.  */
 +	  if (!__libc_enable_secure
 +	      && memcmp (envline, "FALLBACK_PATH", 13) == 0)
@@ -200,14 +246,14 @@ index 596b6ac3d9..85a152195e 100644
 +	      break;
 +	    }
 +
+ 	case 14:
+ 	  /* Where to place the profiling data file.  */
  	  if (!__libc_enable_secure
- 	      && memcmp (envline, "USE_LOAD_BIAS", 13) == 0)
- 	    {
 diff --git a/sysdeps/generic/ldsodefs.h b/sysdeps/generic/ldsodefs.h
-index aab7245e93..aced9be1fd 100644
+index e8b7359b04..1ff1b2cec1 100644
 --- a/sysdeps/generic/ldsodefs.h
 +++ b/sysdeps/generic/ldsodefs.h
-@@ -1061,6 +1061,7 @@ extern struct r_debug *_dl_debug_initialize (ElfW(Addr) ldbase, Lmid_t ns)
+@@ -1075,6 +1075,7 @@ extern struct r_debug *_dl_debug_update (Lmid_t ns) attribute_hidden;
     search.  GLIBC_HWCAPS_MASK is used to filter the built-in
     subdirectories if not NULL.  */
  extern void _dl_init_paths (const char *library_path, const char *source,
@@ -216,10 +262,10 @@ index aab7245e93..aced9be1fd 100644
  			    const char *glibc_hwcaps_mask)
    attribute_hidden;
 diff --git a/sysdeps/generic/unsecvars.h b/sysdeps/generic/unsecvars.h
-index 5ea8a4a259..0d01562bee 100644
+index 81397fb90b..8a47ca9284 100644
 --- a/sysdeps/generic/unsecvars.h
 +++ b/sysdeps/generic/unsecvars.h
-@@ -18,6 +18,7 @@
+@@ -12,6 +12,7 @@
    "LD_DYNAMIC_WEAK\0"							      \
    "LD_HWCAP_MASK\0"							      \
    "LD_LIBRARY_PATH\0"							      \

--- a/pkgs/development/libraries/glibc/ld-fallback.patch
+++ b/pkgs/development/libraries/glibc/ld-fallback.patch
@@ -1,52 +1,70 @@
-From 5956982e611afe46f2aa6a1e241262379fdbcbb6 Mon Sep 17 00:00:00 2001
+From 9d7cc3850df04c15d9c82e51c9e9198ead7bf847 Mon Sep 17 00:00:00 2001
 From: Jan Malakhovski <oxij@oxij.org>
-Date: Wed, 9 Aug 2023 08:53:06 +0000
-Subject: [PATCH] Implement support for LD_FALLBACK_PATH env variable and
- related command line options
+Date: Mon, 14 Aug 2023 13:00:00 +0000
+Subject: [PATCH] Implement support for LD_FALLBACK_PATH envvar and related
+ command line options
 
 LD_FALLBACK_PATH has the same semantics as LD_LIBRARY_PATH but unlike
-LD_LIBRARY_PATH, instead of having the highest priority, it has the second-lowest
-(it gets used just before the default system directories).
+LD_LIBRARY_PATH, instead of having the highest priority, it has the
+second-lowest (it gets used just before the default system directories).
 
 Thus, LD_FALLBACK_PATH provides a way to specify fallback library paths.
 
+In other words, LD_FALLBACK_PATH provides a way to override system libraries
+without creating a chroot.
+
 Consider the following use cases:
 
-- Running a closed-source program (like Steam and its games) on an unsupported
-  distribution: closed-source programs commonly override LD_LIBRARY_PATH to
-  override system libraries with their own bundled versions, but they
-  frequently do it the wrong way by overriding it while ignoring the current
-  value of LD_LIBRARY_PATH, thus failing to pick up any non-system libraries
-  they don't bundle but require specific versions of.
+* Sometimes you just want to change a set of system libraries for a set of
+  programs without changing the system default. For instance, if you have
+  different GPUs requiring different libGL, CUDA, and/or OpenCL
+  implementations. (Though, specifically for libGL there are better solutions
+  for per-screen routing of OpenGL calls.)
 
-  LD_FALLBACK_PATH, being the low-priority option, can't be used to achieve
-  the same effect as LD_LIBRARY_PATH from the perspective of the closed-source
-  program's vendor, thus making it unlikely they would ever touch
-  LD_FALLBACK_PATH. But it can be used by other tools to supply needed default
-  libraries to the closed-source program in question.
+  LD_FALLBACK_PATH is especially useful in a developer setting given that
+  maintaining multiple (e.g. for each GPU type) per-project chroot
+  environments is pretty hard.
 
-- Similarly, sometimes you just want to change the underlying library for a
-  set of programs without changing the system default. For instance, if you
-  have different GPUs requiring different libGL's (though, specifically for
-  libGL there are several less ad-hoc solutions than this).
+* Running a closed-source program (like Steam and its games) on an unsupported
+  distribution (this patch was originally created for SLNOS, a distribution
+  based on NixOS): closed-source programs commonly override LD_LIBRARY_PATH to
+  replace system libraries with their own bundled versions, but they
+  frequently do it the wrong way by simply assigning LD_LIBRARY_PATH to point
+  at their own /lib directory instead of prepending that /lib path to the
+  current value of LD_LIBRARY_PATH, thus failing to pick up any non-system
+  libraries they don't bundle but require specific versions of.
 
-In general, before LD_FALLBACK_PATH there was no good way to solve these
-problems without generating a whole chroot. Now you can collect those
-libraries you want to override system defaults but not override those found
-via LD_LIBRARY_PATH in a directory somewhere and put its path into
-LD_FALLBACK_PATH.
+  From the perspective of a closed-source program's vendor, LD_FALLBACK_PATH
+  --- being the low-priority option --- can't really be used to consistently
+  achieve the same effect to as overriding LD_LIBRARY_PATH, thus making it
+  unlikely they would ever touch it. But it can be used by other tools to
+  supply needed default libraries to the closed-source program in question.
+
+With LD_FALLBACK_PATH, you can just drop all those libraries you want to
+replace your defaults into a directory and put its path into LD_FALLBACK_PATH,
+or use Nix or a similar package manager to do that for you.
 ---
- elf/dl-load.c               | 60 +++++++++++++++++++++++++++++++++++--
- elf/dl-main.h               |  7 +++++
- elf/dl-support.c            |  1 +
- elf/dl-usage.c              |  2 ++
- elf/rtld.c                  | 22 ++++++++++++++
- sysdeps/generic/ldsodefs.h  |  1 +
- sysdeps/generic/unsecvars.h |  1 +
- 7 files changed, 92 insertions(+), 2 deletions(-)
+ elf/dl-load.c                    | 100 ++++++++++++++++++++-----------
+ elf/dl-main.h                    |   7 +++
+ elf/dl-support.c                 |   1 +
+ elf/dl-usage.c                   |   2 +
+ elf/link.h                       |   1 +
+ elf/rtld.c                       |  22 +++++++
+ elf/tst-auditmod1.c              |   2 +
+ sysdeps/generic/ldsodefs.h       |   1 +
+ sysdeps/generic/unsecvars.h      |   1 +
+ sysdeps/i386/tst-auditmod3b.c    |   3 +
+ sysdeps/x86_64/tst-auditmod10b.c |   2 +
+ sysdeps/x86_64/tst-auditmod3b.c  |   2 +
+ sysdeps/x86_64/tst-auditmod4b.c  |   2 +
+ sysdeps/x86_64/tst-auditmod5b.c  |   2 +
+ sysdeps/x86_64/tst-auditmod6b.c  |   2 +
+ sysdeps/x86_64/tst-auditmod6c.c  |   2 +
+ sysdeps/x86_64/tst-auditmod7b.c  |   2 +
+ 17 files changed, 120 insertions(+), 34 deletions(-)
 
 diff --git a/elf/dl-load.c b/elf/dl-load.c
-index 9a87fda9c9..a8fd639238 100644
+index 9a87fda9c9..26291dc261 100644
 --- a/elf/dl-load.c
 +++ b/elf/dl-load.c
 @@ -101,6 +101,8 @@ int __stack_prot attribute_hidden attribute_relro
@@ -58,61 +76,102 @@ index 9a87fda9c9..a8fd639238 100644
  
  /* List of the hardware capabilities we might end up using.  */
  #ifdef SHARED
-@@ -701,6 +703,7 @@ cache_rpath (struct link_map *l,
+@@ -699,8 +701,53 @@ cache_rpath (struct link_map *l,
+ }
  
+ 
++static void
++_decompose_dl_path(const char* link_path,
++                   struct r_search_path_struct* env_path_list,
++                   const char* source,
++                   struct link_map *l)
++{
++  const char *errstring = NULL;
++
++  /* Decompose the LD_LIBRARY_PATH/LD_FALLBACK_PATH contents.  */
++
++  if (link_path != NULL && *link_path != '\0')
++    {
++      char *link_path_tmp = strdupa (link_path);
++
++      /* First determine how many elements it has.  */
++      size_t nlink_path = 1;
++      for (const char *cp = link_path_tmp; *cp != '\0'; ++cp)
++	if (*cp == ':' || *cp == ';')
++	  ++nlink_path;
++
++      env_path_list->dirs = (struct r_search_path_elem **)
++	malloc ((nlink_path + 1) * sizeof (struct r_search_path_elem *));
++      if (env_path_list->dirs == NULL)
++	{
++	  errstring = N_("cannot create cache for search path");
++	  _dl_signal_error (ENOMEM, NULL, NULL, errstring);
++	}
++
++      (void) fillin_rpath (link_path_tmp, env_path_list->dirs, ":;",
++			   source, NULL, l);
++
++      if (env_path_list->dirs[0] == NULL)
++	{
++	  free (env_path_list->dirs);
++	  env_path_list->dirs = (void *) -1;
++	}
++
++      env_path_list->malloced = 0;
++    }
++  else
++    env_path_list->dirs = (void *) -1;
++}
++
++
  void
  _dl_init_paths (const char *llp, const char *source,
 +		const char *lfp, const char *fsource,
  		const char *glibc_hwcaps_prepend,
  		const char *glibc_hwcaps_mask)
  {
-@@ -854,6 +857,45 @@ _dl_init_paths (const char *llp, const char *source,
+@@ -822,38 +869,8 @@ _dl_init_paths (const char *llp, const char *source,
+ 	l->l_rpath_dirs.dirs = (void *) -1;
      }
-   else
-     __rtld_env_path_list.dirs = (void *) -1;
-+
-+  /* Made by copying the above followed by
-+      %s/llp/lfp/g
-+      %s/env_path_list/fallback_path_list/g
-+      %s/source/fsource/g
-+   */
-+  if (lfp != NULL && *lfp != '\0')
-+    {
-+      char *lfp_tmp = strdupa (lfp);
-+
-+      /* Decompose the LD_LIBRARY_PATH contents.  First determine how many
-+	 elements it has.  */
-+      size_t nlfp = 1;
-+      for (const char *cp = lfp_tmp; *cp != '\0'; ++cp)
-+	if (*cp == ':' || *cp == ';')
-+	  ++nlfp;
-+
-+      __rtld_fallback_path_list.dirs = (struct r_search_path_elem **)
-+	malloc ((nlfp + 1) * sizeof (struct r_search_path_elem *));
-+      if (__rtld_fallback_path_list.dirs == NULL)
-+	{
-+	  errstring = N_("cannot create cache for search path");
-+	  goto signal_error;
-+	}
-+
-+      (void) fillin_rpath (lfp_tmp, __rtld_fallback_path_list.dirs, ":;",
-+			   fsource, NULL, l);
-+
-+      if (__rtld_fallback_path_list.dirs[0] == NULL)
-+	{
-+	  free (__rtld_fallback_path_list.dirs);
-+	  __rtld_fallback_path_list.dirs = (void *) -1;
-+	}
-+
-+      __rtld_fallback_path_list.malloced = 0;
-+    }
-+  else
-+    __rtld_fallback_path_list.dirs = (void *) -1;
-+
+ 
+-  if (llp != NULL && *llp != '\0')
+-    {
+-      char *llp_tmp = strdupa (llp);
+-
+-      /* Decompose the LD_LIBRARY_PATH contents.  First determine how many
+-	 elements it has.  */
+-      size_t nllp = 1;
+-      for (const char *cp = llp_tmp; *cp != '\0'; ++cp)
+-	if (*cp == ':' || *cp == ';')
+-	  ++nllp;
+-
+-      __rtld_env_path_list.dirs = (struct r_search_path_elem **)
+-	malloc ((nllp + 1) * sizeof (struct r_search_path_elem *));
+-      if (__rtld_env_path_list.dirs == NULL)
+-	{
+-	  errstring = N_("cannot create cache for search path");
+-	  goto signal_error;
+-	}
+-
+-      (void) fillin_rpath (llp_tmp, __rtld_env_path_list.dirs, ":;",
+-			   source, NULL, l);
+-
+-      if (__rtld_env_path_list.dirs[0] == NULL)
+-	{
+-	  free (__rtld_env_path_list.dirs);
+-	  __rtld_env_path_list.dirs = (void *) -1;
+-	}
+-
+-      __rtld_env_path_list.malloced = 0;
+-    }
+-  else
+-    __rtld_env_path_list.dirs = (void *) -1;
++  _decompose_dl_path(llp, &__rtld_env_path_list, source, l);
++  _decompose_dl_path(lfp, &__rtld_fallback_path_list, fsource, l);
  }
  
  
-@@ -1928,9 +1970,10 @@ open_path (const char *name, size_t namelen, int mode,
+@@ -1928,9 +1945,10 @@ open_path (const char *name, size_t namelen, int mode,
        if (sps->malloced)
  	free (sps->dirs);
  
@@ -125,29 +184,30 @@ index 9a87fda9c9..a8fd639238 100644
  	sps->dirs = (void *) -1;
      }
  
-@@ -2160,6 +2203,17 @@ _dl_map_object (struct link_map *loader, const char *name,
+@@ -2160,6 +2178,17 @@ _dl_map_object (struct link_map *loader, const char *name,
  	}
  #endif
  
 +      /* Try the LD_FALLBACK_PATH environment variable.  */
 +      /* Made by copying LD_LIBRARY_PATH snippet above followed by
 +          %s/env_path_list/fallback_path_list/g
-+          %s/LA_SER_LIBPATH/LA_SER_DEFAULT/g
++          %s/LA_SER_LIBPATH/LA_SER_FALLBACK/g
 +       */
 +      if (fd == -1 && __rtld_fallback_path_list.dirs != (void *) -1)
 +	fd = open_path (name, namelen, mode, &__rtld_fallback_path_list,
 +			&realname, &fb,
 +			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
-+			LA_SER_DEFAULT, &found_other_class);
++			LA_SER_FALLBACK, &found_other_class);
 +
        /* Finally, try the default path.  */
        if (fd == -1
  	  && ((l = loader ?: GL(dl_ns)[nsid]._ns_loaded) == NULL
-@@ -2342,6 +2396,8 @@ _dl_rtld_di_serinfo (struct link_map *loader, Dl_serinfo *si, bool counting)
+@@ -2342,6 +2371,9 @@ _dl_rtld_di_serinfo (struct link_map *loader, Dl_serinfo *si, bool counting)
       Here is where ld.so.cache gets checked, but we don't have
       a way to indicate that in the results for Dl_serinfo.  */
  
-+  add_path (&p, &__rtld_fallback_path_list, XXX_default);
++  /* Try the LD_FALLBACK_PATH environment variable.  */
++  add_path (&p, &__rtld_fallback_path_list, XXX_FALLBACK);
 +
    /* Finally, try the default path.  */
    if (!(loader->l_flags_1 & DF_1_NODEFLIB))
@@ -202,6 +262,18 @@ index 98f0b0d027..98b9da57aa 100644
    --glibc-hwcaps-prepend LIST\n\
                          search glibc-hwcaps subdirectories in LIST\n\
    --glibc-hwcaps-mask LIST\n\
+diff --git a/elf/link.h b/elf/link.h
+index 3b5954d981..9b227530ed 100644
+--- a/elf/link.h
++++ b/elf/link.h
+@@ -130,6 +130,7 @@ enum
+     LA_SER_LIBPATH = 0x02,	/* Directory from LD_LIBRARY_PATH.  */
+     LA_SER_RUNPATH = 0x04,	/* Directory from RPATH/RUNPATH.  */
+     LA_SER_CONFIG = 0x08,	/* Found through ldconfig.  */
++    LA_SER_FALLBACK = 0x20,	/* Directory from LD_FALLBACK_PATH.  */
+     LA_SER_DEFAULT = 0x40,	/* Default directory.  */
+     LA_SER_SECURE = 0x80	/* Unused.  */
+   };
 diff --git a/elf/rtld.c b/elf/rtld.c
 index a91e2a4471..d03ccbe077 100644
 --- a/elf/rtld.c
@@ -249,6 +321,19 @@ index a91e2a4471..d03ccbe077 100644
  	case 14:
  	  /* Where to place the profiling data file.  */
  	  if (!__libc_enable_secure
+diff --git a/elf/tst-auditmod1.c b/elf/tst-auditmod1.c
+index 573e37abd6..fb3a01e8bb 100644
+--- a/elf/tst-auditmod1.c
++++ b/elf/tst-auditmod1.c
+@@ -49,6 +49,8 @@ la_objsearch (const char *name, uintptr_t *cookie, unsigned int flag)
+     flagstr = "LA_SER_RUNPATH";
+   else if (flag == LA_SER_CONFIG)
+     flagstr = "LA_SER_CONFIG";
++  else if (flag == LA_SER_FALLBACK)
++    flagstr = "LA_SER_FALLBACK";
+   else if (flag == LA_SER_DEFAULT)
+     flagstr = "LA_SER_DEFAULT";
+   else if (flag == LA_SER_SECURE)
 diff --git a/sysdeps/generic/ldsodefs.h b/sysdeps/generic/ldsodefs.h
 index e8b7359b04..1ff1b2cec1 100644
 --- a/sysdeps/generic/ldsodefs.h
@@ -262,10 +347,10 @@ index e8b7359b04..1ff1b2cec1 100644
  			    const char *glibc_hwcaps_mask)
    attribute_hidden;
 diff --git a/sysdeps/generic/unsecvars.h b/sysdeps/generic/unsecvars.h
-index 81397fb90b..8a47ca9284 100644
+index 8278c50a84..6fc015a2d5 100644
 --- a/sysdeps/generic/unsecvars.h
 +++ b/sysdeps/generic/unsecvars.h
-@@ -12,6 +12,7 @@
+@@ -11,6 +11,7 @@
    "LD_DYNAMIC_WEAK\0"							      \
    "LD_HWCAP_MASK\0"							      \
    "LD_LIBRARY_PATH\0"							      \
@@ -273,3 +358,108 @@ index 81397fb90b..8a47ca9284 100644
    "LD_ORIGIN_PATH\0"							      \
    "LD_PRELOAD\0"							      \
    "LD_PROFILE\0"							      \
+diff --git a/sysdeps/i386/tst-auditmod3b.c b/sysdeps/i386/tst-auditmod3b.c
+index 21c95fd711..5da63e790d 100644
+--- a/sysdeps/i386/tst-auditmod3b.c
++++ b/sysdeps/i386/tst-auditmod3b.c
+@@ -80,6 +80,9 @@ la_objsearch (const char *name, uintptr_t *cookie, unsigned int flag)
+     case LA_SER_CONFIG:
+       flagstr = "LA_SER_CONFIG";
+       break;
++    case LA_SER_FALLBACK:
++      flagstr = "LA_SER_FALLBACK";
++      break;
+     case LA_SER_DEFAULT:
+       flagstr = "LA_SER_DEFAULT";
+       break;
+diff --git a/sysdeps/x86_64/tst-auditmod10b.c b/sysdeps/x86_64/tst-auditmod10b.c
+index b62537adf0..d0abbd8fa1 100644
+--- a/sysdeps/x86_64/tst-auditmod10b.c
++++ b/sysdeps/x86_64/tst-auditmod10b.c
+@@ -68,6 +68,8 @@ la_objsearch (const char *name, uintptr_t *cookie, unsigned int flag)
+     flagstr = "LA_SER_RUNPATH";
+   else if (flag == LA_SER_CONFIG)
+     flagstr = "LA_SER_CONFIG";
++  else if (flag == LA_SER_FALLBACK)
++    flagstr = "LA_SER_FALLBACK";
+   else if (flag == LA_SER_DEFAULT)
+     flagstr = "LA_SER_DEFAULT";
+   else if (flag == LA_SER_SECURE)
+diff --git a/sysdeps/x86_64/tst-auditmod3b.c b/sysdeps/x86_64/tst-auditmod3b.c
+index 7aad92382e..72a0fb0bdf 100644
+--- a/sysdeps/x86_64/tst-auditmod3b.c
++++ b/sysdeps/x86_64/tst-auditmod3b.c
+@@ -52,6 +52,8 @@ la_objsearch (const char *name, uintptr_t *cookie, unsigned int flag)
+     flagstr = "LA_SER_RUNPATH";
+   else if (flag == LA_SER_CONFIG)
+     flagstr = "LA_SER_CONFIG";
++  else if (flag == LA_SER_FALLBACK)
++    flagstr = "LA_SER_FALLBACK";
+   else if (flag == LA_SER_DEFAULT)
+     flagstr = "LA_SER_DEFAULT";
+   else if (flag == LA_SER_SECURE)
+diff --git a/sysdeps/x86_64/tst-auditmod4b.c b/sysdeps/x86_64/tst-auditmod4b.c
+index 1153ea442c..39e2338965 100644
+--- a/sysdeps/x86_64/tst-auditmod4b.c
++++ b/sysdeps/x86_64/tst-auditmod4b.c
+@@ -51,6 +51,8 @@ la_objsearch (const char *name, uintptr_t *cookie, unsigned int flag)
+     flagstr = "LA_SER_RUNPATH";
+   else if (flag == LA_SER_CONFIG)
+     flagstr = "LA_SER_CONFIG";
++  else if (flag == LA_SER_FALLBACK)
++    flagstr = "LA_SER_FALLBACK";
+   else if (flag == LA_SER_DEFAULT)
+     flagstr = "LA_SER_DEFAULT";
+   else if (flag == LA_SER_SECURE)
+diff --git a/sysdeps/x86_64/tst-auditmod5b.c b/sysdeps/x86_64/tst-auditmod5b.c
+index 6a280fd61b..21de890f58 100644
+--- a/sysdeps/x86_64/tst-auditmod5b.c
++++ b/sysdeps/x86_64/tst-auditmod5b.c
+@@ -52,6 +52,8 @@ la_objsearch (const char *name, uintptr_t *cookie, unsigned int flag)
+     flagstr = "LA_SER_RUNPATH";
+   else if (flag == LA_SER_CONFIG)
+     flagstr = "LA_SER_CONFIG";
++  else if (flag == LA_SER_FALLBACK)
++    flagstr = "LA_SER_FALLBACK";
+   else if (flag == LA_SER_DEFAULT)
+     flagstr = "LA_SER_DEFAULT";
+   else if (flag == LA_SER_SECURE)
+diff --git a/sysdeps/x86_64/tst-auditmod6b.c b/sysdeps/x86_64/tst-auditmod6b.c
+index 3533602c07..911109649d 100644
+--- a/sysdeps/x86_64/tst-auditmod6b.c
++++ b/sysdeps/x86_64/tst-auditmod6b.c
+@@ -51,6 +51,8 @@ la_objsearch (const char *name, uintptr_t *cookie, unsigned int flag)
+     flagstr = "LA_SER_RUNPATH";
+   else if (flag == LA_SER_CONFIG)
+     flagstr = "LA_SER_CONFIG";
++  else if (flag == LA_SER_FALLBACK)
++    flagstr = "LA_SER_FALLBACK";
+   else if (flag == LA_SER_DEFAULT)
+     flagstr = "LA_SER_DEFAULT";
+   else if (flag == LA_SER_SECURE)
+diff --git a/sysdeps/x86_64/tst-auditmod6c.c b/sysdeps/x86_64/tst-auditmod6c.c
+index 8000e89224..e310b5a74d 100644
+--- a/sysdeps/x86_64/tst-auditmod6c.c
++++ b/sysdeps/x86_64/tst-auditmod6c.c
+@@ -51,6 +51,8 @@ la_objsearch (const char *name, uintptr_t *cookie, unsigned int flag)
+     flagstr = "LA_SER_RUNPATH";
+   else if (flag == LA_SER_CONFIG)
+     flagstr = "LA_SER_CONFIG";
++  else if (flag == LA_SER_FALLBACK)
++    flagstr = "LA_SER_FALLBACK";
+   else if (flag == LA_SER_DEFAULT)
+     flagstr = "LA_SER_DEFAULT";
+   else if (flag == LA_SER_SECURE)
+diff --git a/sysdeps/x86_64/tst-auditmod7b.c b/sysdeps/x86_64/tst-auditmod7b.c
+index 5abe6d1bc9..4405fda1bd 100644
+--- a/sysdeps/x86_64/tst-auditmod7b.c
++++ b/sysdeps/x86_64/tst-auditmod7b.c
+@@ -51,6 +51,8 @@ la_objsearch (const char *name, uintptr_t *cookie, unsigned int flag)
+     flagstr = "LA_SER_RUNPATH";
+   else if (flag == LA_SER_CONFIG)
+     flagstr = "LA_SER_CONFIG";
++  else if (flag == LA_SER_FALLBACK)
++    flagstr = "LA_SER_FALLBACK";
+   else if (flag == LA_SER_DEFAULT)
+     flagstr = "LA_SER_DEFAULT";
+   else if (flag == LA_SER_SECURE)

--- a/pkgs/development/libraries/glibc/ld-fallback.patch
+++ b/pkgs/development/libraries/glibc/ld-fallback.patch
@@ -1,153 +1,94 @@
 diff --git a/elf/dl-load.c b/elf/dl-load.c
-index aaaaaaa..bbbbbbb 100644
+index 9e2089cfaa..e560b09932 100644
 --- a/elf/dl-load.c
 +++ b/elf/dl-load.c
-@@ -90,20 +90,22 @@ struct filebuf
- #if __WORDSIZE == 32
- # define FILEBUF_SIZE 512
- #else
- # define FILEBUF_SIZE 832
- #endif
-   char buf[FILEBUF_SIZE] __attribute__ ((aligned (__alignof (ElfW(Ehdr)))));
- };
+@@ -99,6 +99,8 @@ int __stack_prot attribute_hidden attribute_relro
  
  /* This is the decomposed LD_LIBRARY_PATH search path.  */
- static struct r_search_path_struct env_path_list attribute_relro;
+ struct r_search_path_struct __rtld_env_path_list attribute_relro;
 +/* This is the decomposed LD_FALLBACK_PATH search path.  */
-+static struct r_search_path_struct fallback_path_list attribute_relro;
++struct r_search_path_struct __rtld_fallback_path_list attribute_relro;
  
  /* List of the hardware capabilities we might end up using.  */
- static const struct r_strlenpair *capstr attribute_relro;
- static size_t ncapstr attribute_relro;
- static size_t max_capstrlen attribute_relro;
- 
- 
- /* Get the generated information about the trusted directories.  Use
-    an array of concatenated strings to avoid relocations.  See
-    gen-trusted-dirs.awk.  */
-@@ -612,21 +614,21 @@ cache_rpath (struct link_map *l,
-     }
- 
-   /* Make sure the cache information is available.  */
-   return decompose_rpath (sp, (const char *) (D_PTR (l, l_info[DT_STRTAB])
- 					      + l->l_info[tag]->d_un.d_val),
- 			  l, what);
- }
- 
+ #ifdef SHARED
+@@ -683,6 +685,7 @@ cache_rpath (struct link_map *l,
  
  void
--_dl_init_paths (const char *llp)
-+_dl_init_paths (const char *llp, const char *lfp)
+ _dl_init_paths (const char *llp, const char *source,
++		const char *lfp, const char *fsource,
+ 		const char *glibc_hwcaps_prepend,
+ 		const char *glibc_hwcaps_mask)
  {
-   size_t idx;
-   const char *strp;
-   struct r_search_path_elem *pelem, **aelem;
-   size_t round_size;
-   struct link_map __attribute__ ((unused)) *l = NULL;
-   /* Initialize to please the compiler.  */
-   const char *errstring = NULL;
- 
-   /* Fill in the information about the application's RPATH and the
-@@ -760,20 +762,59 @@ _dl_init_paths (const char *llp)
-       if (env_path_list.dirs[0] == NULL)
- 	{
- 	  free (env_path_list.dirs);
- 	  env_path_list.dirs = (void *) -1;
- 	}
- 
-       env_path_list.malloced = 0;
+@@ -835,6 +838,45 @@ _dl_init_paths (const char *llp, const char *source,
      }
    else
-     env_path_list.dirs = (void *) -1;
+     __rtld_env_path_list.dirs = (void *) -1;
 +
 +  /* Made by copying the above followed by
 +      %s/llp/lfp/g
 +      %s/env_path_list/fallback_path_list/g
-+      %s/LIBRARY_PATH/FALLBACK_PATH/g
++      %s/source/fsource/g
 +   */
 +  if (lfp != NULL && *lfp != '\0')
 +    {
 +      char *lfp_tmp = strdupa (lfp);
 +
-+      /* Decompose the LD_FALLBACK_PATH contents.  First determine how many
++      /* Decompose the LD_LIBRARY_PATH contents.  First determine how many
 +	 elements it has.  */
 +      size_t nlfp = 1;
 +      for (const char *cp = lfp_tmp; *cp != '\0'; ++cp)
 +	if (*cp == ':' || *cp == ';')
 +	  ++nlfp;
 +
-+      fallback_path_list.dirs = (struct r_search_path_elem **)
++      __rtld_fallback_path_list.dirs = (struct r_search_path_elem **)
 +	malloc ((nlfp + 1) * sizeof (struct r_search_path_elem *));
-+      if (fallback_path_list.dirs == NULL)
++      if (__rtld_fallback_path_list.dirs == NULL)
 +	{
 +	  errstring = N_("cannot create cache for search path");
 +	  goto signal_error;
 +	}
 +
-+      (void) fillin_rpath (lfp_tmp, fallback_path_list.dirs, ":;",
-+			   "LD_FALLBACK_PATH", NULL, l);
++      (void) fillin_rpath (lfp_tmp, __rtld_fallback_path_list.dirs, ":;",
++			   fsource, NULL, l);
 +
-+      if (fallback_path_list.dirs[0] == NULL)
++      if (__rtld_fallback_path_list.dirs[0] == NULL)
 +	{
-+	  free (fallback_path_list.dirs);
-+	  fallback_path_list.dirs = (void *) -1;
++	  free (__rtld_fallback_path_list.dirs);
++	  __rtld_fallback_path_list.dirs = (void *) -1;
 +	}
 +
-+      fallback_path_list.malloced = 0;
++      __rtld_fallback_path_list.malloced = 0;
 +    }
 +  else
-+    fallback_path_list.dirs = (void *) -1;
++    __rtld_fallback_path_list.dirs = (void *) -1;
 +
  }
  
  
- static void
- __attribute__ ((noreturn, noinline))
- lose (int code, int fd, const char *name, char *realname, struct link_map *l,
-       const char *msg, struct r_debug *r, Lmid_t nsid)
- {
-   /* The file might already be closed.  */
-   if (fd != -1)
-@@ -1822,23 +1863,23 @@ open_path (const char *name, size_t namelen, int mode,
-   while (*++dirs != NULL);
- 
-   /* Remove the whole path if none of the directories exists.  */
-   if (__glibc_unlikely (! any))
-     {
-       /* Paths which were allocated using the minimal malloc() in ld.so
- 	 must not be freed using the general free() in libc.  */
+@@ -1997,9 +2039,10 @@ open_path (const char *name, size_t namelen, int mode,
        if (sps->malloced)
  	free (sps->dirs);
  
--      /* rtld_search_dirs and env_path_list are attribute_relro, therefore
-+      /* rtld_search_dirs, env_path_list, and fallback_path_list are attribute_relro, therefore
- 	 avoid writing into it.  */
--      if (sps != &rtld_search_dirs && sps != &env_path_list)
-+      if (sps != &rtld_search_dirs && sps != &env_path_list && sps != &fallback_path_list)
+-      /* __rtld_search_dirs and __rtld_env_path_list are
++      /* __rtld_search_dirs, __rtld_env_path_list,
++	 and __rtld_fallback_path_list are
+ 	 attribute_relro, therefore avoid writing to them.  */
+-      if (sps != &__rtld_search_dirs && sps != &__rtld_env_path_list)
++      if (sps != &__rtld_search_dirs && sps != &__rtld_env_path_list && sps != &__rtld_fallback_path_list)
  	sps->dirs = (void *) -1;
      }
  
-   return -1;
- }
- 
- /* Map in the shared object file NAME.  */
- 
- struct link_map *
- _dl_map_object (struct link_map *loader, const char *name,
-@@ -2058,20 +2099,27 @@ _dl_map_object (struct link_map *loader, const char *name,
- 				    false);
- 		  if (__glibc_likely (fd != -1))
- 		    realname = cached;
- 		  else
- 		    free (cached);
- 		}
- 	    }
+@@ -2233,6 +2276,17 @@ _dl_map_object (struct link_map *loader, const char *name,
  	}
  #endif
  
-+      /* Try the LD_FALLBACK_PATH environment variable. */
-+      if (fd == -1 && fallback_path_list.dirs != (void *) -1)
-+	fd = open_path (name, namelen, mode, &fallback_path_list,
++      /* Try the LD_FALLBACK_PATH environment variable.  */
++      /* Made by copying LD_LIBRARY_PATH snippet above followed by
++          %s/env_path_list/fallback_path_list/g
++          %s/LA_SER_LIBPATH/LA_SER_DEFAULT/g
++       */
++      if (fd == -1 && __rtld_fallback_path_list.dirs != (void *) -1)
++	fd = open_path (name, namelen, mode, &__rtld_fallback_path_list,
 +			&realname, &fb,
 +			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
 +			LA_SER_DEFAULT, &found_other_class);
@@ -155,121 +96,97 @@ index aaaaaaa..bbbbbbb 100644
        /* Finally, try the default path.  */
        if (fd == -1
  	  && ((l = loader ?: GL(dl_ns)[nsid]._ns_loaded) == NULL
- 	      || __glibc_likely (!(l->l_flags_1 & DF_1_NODEFLIB)))
- 	  && rtld_search_dirs.dirs != (void *) -1)
- 	fd = open_path (name, namelen, mode, &rtld_search_dirs,
- 			&realname, &fb, l, LA_SER_DEFAULT, &found_other_class);
- 
-       /* Add another newline when we are tracing the library loading.  */
-       if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-@@ -2241,19 +2289,22 @@ _dl_rtld_di_serinfo (struct link_map *loader, Dl_serinfo *si, bool counting)
-   add_path (&p, &env_path_list, XXX_ENV);
- 
-   /* Look at the RUNPATH information for this binary.  */
-   if (cache_rpath (loader, &loader->l_runpath_dirs, DT_RUNPATH, "RUNPATH"))
-     add_path (&p, &loader->l_runpath_dirs, XXX_RUNPATH);
- 
-   /* XXX
+@@ -2416,6 +2470,8 @@ _dl_rtld_di_serinfo (struct link_map *loader, Dl_serinfo *si, bool counting)
       Here is where ld.so.cache gets checked, but we don't have
       a way to indicate that in the results for Dl_serinfo.  */
  
-+  /* Try the LD_FALLBACK_PATH environment variable.  */
-+  add_path (&p, &fallback_path_list, XXX_default);
++  add_path (&p, &__rtld_fallback_path_list, XXX_default);
 +
    /* Finally, try the default path.  */
    if (!(loader->l_flags_1 & DF_1_NODEFLIB))
-     add_path (&p, &rtld_search_dirs, XXX_default);
+     add_path (&p, &__rtld_search_dirs, XXX_default);
+diff --git a/elf/dl-main.h b/elf/dl-main.h
+index 3a5e13c739..24742b14cf 100644
+--- a/elf/dl-main.h
++++ b/elf/dl-main.h
+@@ -78,6 +78,12 @@ struct dl_main_state
+   /* Where library_path comes from.  LD_LIBRARY_PATH or --library-path.  */
+   const char *library_path_source;
  
-   if (counting)
-     /* Count the struct size before the string area, which we didn't
-        know before we completed dls_cnt.  */
-     si->dls_size += (char *) &si->dls_serpath[si->dls_cnt] - (char *) si;
++  /* The fallback search path.  */
++  const char *fallback_path;
++
++  /* Where fallback_path comes from.  LD_FALLBACK_PATH or --fallback-path.  */
++  const char *fallback_path_source;
++
+   /* The list preloaded objects from LD_PRELOAD.  */
+   const char *preloadlist;
+ 
+@@ -107,6 +113,7 @@ static inline void
+ call_init_paths (const struct dl_main_state *state)
+ {
+   _dl_init_paths (state->library_path, state->library_path_source,
++                  state->fallback_path, state->fallback_path_source,
+                   state->glibc_hwcaps_prepend, state->glibc_hwcaps_mask);
  }
+ 
 diff --git a/elf/dl-support.c b/elf/dl-support.c
-index 114f77a..ad67d48 100644
+index 7abb65d8e3..b76975d663 100644
 --- a/elf/dl-support.c
 +++ b/elf/dl-support.c
-@@ -315,21 +315,21 @@ _dl_non_dynamic_init (void)
-     HP_TIMING_NOW (_dl_cpuclock_offset);
- 
-   _dl_verbose = *(getenv ("LD_WARN") ?: "") == '\0' ? 0 : 1;
- 
-   /* Set up the data structures for the system-supplied DSO early,
-      so they can influence _dl_init_paths.  */
-   setup_vdso (NULL, NULL);
- 
+@@ -337,6 +337,7 @@ _dl_non_dynamic_init (void)
    /* Initialize the data structures for the search paths for shared
       objects.  */
--  _dl_init_paths (getenv ("LD_LIBRARY_PATH"));
-+  _dl_init_paths (getenv ("LD_LIBRARY_PATH"), getenv ("LD_FALLBACK_PATH"));
- 
-   /* Remember the last search directory added at startup.  */
-   _dl_init_all_dirs = GL(dl_all_dirs);
- 
-   _dl_lazy = *(getenv ("LD_BIND_NOW") ?: "") == '\0';
- 
-   _dl_bind_not = *(getenv ("LD_BIND_NOT") ?: "") != '\0';
- 
-   _dl_dynamic_weak = *(getenv ("LD_DYNAMIC_WEAK") ?: "") == '\0';
- 
+   _dl_init_paths (getenv ("LD_LIBRARY_PATH"), "LD_LIBRARY_PATH",
++		  getenv ("LD_FALLBACK_PATH"), "LD_FALLBACK_PATH",
+ 		  /* No glibc-hwcaps selection support in statically
+ 		     linked binaries.  */
+ 		  NULL, NULL);
+diff --git a/elf/dl-usage.c b/elf/dl-usage.c
+index 6e26818bd7..2cec74b4ad 100644
+--- a/elf/dl-usage.c
++++ b/elf/dl-usage.c
+@@ -247,6 +247,8 @@ setting environment variables (which would be inherited by subprocesses).\n\
+   --inhibit-cache       Do not use " LD_SO_CACHE "\n\
+   --library-path PATH   use given PATH instead of content of the environment\n\
+                         variable LD_LIBRARY_PATH\n\
++  --fallback-path PATH  use given PATH instead of content of the environment\n\
++                        variable LD_FALLBACK_PATH\n\
+   --glibc-hwcaps-prepend LIST\n\
+                         search glibc-hwcaps subdirectories in LIST\n\
+   --glibc-hwcaps-mask LIST\n\
 diff --git a/elf/rtld.c b/elf/rtld.c
-index 453f56e..48b319e 100644
+index 596b6ac3d9..85a152195e 100644
 --- a/elf/rtld.c
 +++ b/elf/rtld.c
-@@ -814,20 +814,22 @@ security_init (void)
-   /* We do not need the _dl_random value anymore.  The less
-      information we leave behind, the better, so clear the
-      variable.  */
-   _dl_random = NULL;
- }
- 
- #include "setup-vdso.h"
- 
- /* The library search path.  */
- static const char *library_path attribute_relro;
-+/* The fallback library search path.  */
-+static const char *fallback_path attribute_relro;
- /* The list preloaded objects.  */
- static const char *preloadlist attribute_relro;
- /* Nonzero if information about versions has to be printed.  */
- static int version_info attribute_relro;
- 
- /* The LD_PRELOAD environment variable gives list of libraries
-    separated by white space or colons that are loaded before the
-    executable's dependencies and prepended to the global scope list.
-    (If the binary is running setuid all elements containing a '/' are
-    ignored since it is insecure.)  Return the number of preloads
-@@ -1311,21 +1313,21 @@ of this helper program; chances are you did not intend to run this program.\n\
-   /* Set up the data structures for the system-supplied DSO early,
-      so they can influence _dl_init_paths.  */
-   setup_vdso (main_map, &first_preload);
- 
- #ifdef DL_SYSDEP_OSCHECK
-   DL_SYSDEP_OSCHECK (_dl_fatal_printf);
- #endif
- 
-   /* Initialize the data structures for the search paths for shared
-      objects.  */
--  _dl_init_paths (library_path);
-+  _dl_init_paths (library_path, fallback_path);
- 
-   /* Initialize _r_debug.  */
-   struct r_debug *r = _dl_debug_initialize (GL(dl_rtld_map).l_addr,
- 					    LM_ID_BASE);
-   r->r_state = RT_CONSISTENT;
- 
-   /* Put the link_map for ourselves on the chain so it can be found by
-      name.  Note that at this point the global chain of link maps contains
-      exactly one element, which is pointed to by dl_loaded.  */
-   if (! GL(dl_rtld_map).l_name)
-@@ -2575,20 +2577,29 @@ process_envvars (enum mode *modep)
- 	      && memcmp (envline, "DYNAMIC_WEAK", 12) == 0)
- 	    GLRO(dl_dynamic_weak) = 1;
- 	  break;
- 
- 	case 13:
- 	  /* We might have some extra environment variable with length 13
- 	     to handle.  */
+@@ -290,6 +290,8 @@ dl_main_state_init (struct dl_main_state *state)
+   audit_list_init (&state->audit_list);
+   state->library_path = NULL;
+   state->library_path_source = NULL;
++  state->fallback_path = NULL;
++  state->fallback_path_source = NULL;
+   state->preloadlist = NULL;
+   state->preloadarg = NULL;
+   state->glibc_hwcaps_prepend = NULL;
+@@ -1229,6 +1231,17 @@ dl_main (const ElfW(Phdr) *phdr,
+ 	    _dl_argc -= 2;
+ 	    _dl_argv += 2;
+ 	  }
++	else if (! strcmp (_dl_argv[1], "--fallback-path")
++		 && _dl_argc > 2)
++	  {
++	    state.fallback_path = _dl_argv[2];
++	    state.fallback_path_source = "--fallback-path";
++
++	    _dl_skip_args += 2;
++	    _dl_argc -= 2;
++	    _dl_argv += 2;
++	    // this line is to force git produce the correct diff
++	  }
+ 	else if (! strcmp (_dl_argv[1], "--inhibit-rpath")
+ 		 && _dl_argc > 2)
+ 	  {
+@@ -2781,6 +2794,16 @@ process_envvars (struct dl_main_state *state)
  #ifdef EXTRA_LD_ENVVARS_13
  	  EXTRA_LD_ENVVARS_13
  #endif
@@ -278,59 +195,31 @@ index 453f56e..48b319e 100644
 +	  if (!__libc_enable_secure
 +	      && memcmp (envline, "FALLBACK_PATH", 13) == 0)
 +	    {
-+	      fallback_path = &envline[14];
++	      state->fallback_path = &envline[14];
++	      state->fallback_path_source = "LD_FALLBACK_PATH";
 +	      break;
 +	    }
 +
  	  if (!__libc_enable_secure
  	      && memcmp (envline, "USE_LOAD_BIAS", 13) == 0)
  	    {
- 	      GLRO(dl_use_load_bias) = envline[14] == '1' ? -1 : 0;
- 	      break;
- 	    }
- 	  break;
- 
- 	case 14:
- 	  /* Where to place the profiling data file.  */
 diff --git a/sysdeps/generic/ldsodefs.h b/sysdeps/generic/ldsodefs.h
-index 0ea2786..7786212 100644
+index aab7245e93..aced9be1fd 100644
 --- a/sysdeps/generic/ldsodefs.h
 +++ b/sysdeps/generic/ldsodefs.h
-@@ -974,21 +974,21 @@ extern void _dl_sort_maps (struct link_map **maps, unsigned int nmaps,
- extern void _dl_debug_state (void);
- rtld_hidden_proto (_dl_debug_state)
- 
- /* Initialize `struct r_debug' if it has not already been done.  The
-    argument is the run-time load address of the dynamic linker, to be put
-    in the `r_ldbase' member.  Returns the address of the structure.  */
- extern struct r_debug *_dl_debug_initialize (ElfW(Addr) ldbase, Lmid_t ns)
-      attribute_hidden;
- 
- /* Initialize the basic data structure for the search paths.  */
--extern void _dl_init_paths (const char *library_path) attribute_hidden;
-+extern void _dl_init_paths (const char *library_path, const char *fallback_path) attribute_hidden;
- 
- /* Gather the information needed to install the profiling tables and start
-    the timers.  */
- extern void _dl_start_profile (void) attribute_hidden;
- 
- /* The actual functions used to keep book on the calls.  */
- extern void _dl_mcount (ElfW(Addr) frompc, ElfW(Addr) selfpc);
- rtld_hidden_proto (_dl_mcount)
- 
- /* This function is simply a wrapper around the _dl_mcount function
+@@ -1061,6 +1061,7 @@ extern struct r_debug *_dl_debug_initialize (ElfW(Addr) ldbase, Lmid_t ns)
+    search.  GLIBC_HWCAPS_MASK is used to filter the built-in
+    subdirectories if not NULL.  */
+ extern void _dl_init_paths (const char *library_path, const char *source,
++			    const char *fallback_path, const char *fallback_source,
+ 			    const char *glibc_hwcaps_prepend,
+ 			    const char *glibc_hwcaps_mask)
+   attribute_hidden;
 diff --git a/sysdeps/generic/unsecvars.h b/sysdeps/generic/unsecvars.h
-index 5ea8a4a..0d01562 100644
+index 5ea8a4a259..0d01562bee 100644
 --- a/sysdeps/generic/unsecvars.h
 +++ b/sysdeps/generic/unsecvars.h
-@@ -11,20 +11,21 @@
-   "GCONV_PATH\0"							      \
-   "GETCONF_DIR\0"							      \
-   GLIBC_TUNABLES_ENVVAR							      \
-   "HOSTALIASES\0"							      \
-   "LD_AUDIT\0"								      \
-   "LD_DEBUG\0"								      \
-   "LD_DEBUG_OUTPUT\0"							      \
+@@ -18,6 +18,7 @@
    "LD_DYNAMIC_WEAK\0"							      \
    "LD_HWCAP_MASK\0"							      \
    "LD_LIBRARY_PATH\0"							      \
@@ -338,10 +227,3 @@ index 5ea8a4a..0d01562 100644
    "LD_ORIGIN_PATH\0"							      \
    "LD_PRELOAD\0"							      \
    "LD_PROFILE\0"							      \
-   "LD_SHOW_AUXV\0"							      \
-   "LD_USE_LOAD_BIAS\0"							      \
-   "LOCALDOMAIN\0"							      \
-   "LOCPATH\0"								      \
-   "MALLOC_TRACE\0"							      \
-   "NIS_PATH\0"								      \
-   "NLSPATH\0"								      \

--- a/pkgs/development/libraries/glibc/ld-fallback.patch
+++ b/pkgs/development/libraries/glibc/ld-fallback.patch
@@ -1,0 +1,347 @@
+diff --git a/elf/dl-load.c b/elf/dl-load.c
+index aaaaaaa..bbbbbbb 100644
+--- a/elf/dl-load.c
++++ b/elf/dl-load.c
+@@ -90,20 +90,22 @@ struct filebuf
+ #if __WORDSIZE == 32
+ # define FILEBUF_SIZE 512
+ #else
+ # define FILEBUF_SIZE 832
+ #endif
+   char buf[FILEBUF_SIZE] __attribute__ ((aligned (__alignof (ElfW(Ehdr)))));
+ };
+ 
+ /* This is the decomposed LD_LIBRARY_PATH search path.  */
+ static struct r_search_path_struct env_path_list attribute_relro;
++/* This is the decomposed LD_FALLBACK_PATH search path.  */
++static struct r_search_path_struct fallback_path_list attribute_relro;
+ 
+ /* List of the hardware capabilities we might end up using.  */
+ static const struct r_strlenpair *capstr attribute_relro;
+ static size_t ncapstr attribute_relro;
+ static size_t max_capstrlen attribute_relro;
+ 
+ 
+ /* Get the generated information about the trusted directories.  Use
+    an array of concatenated strings to avoid relocations.  See
+    gen-trusted-dirs.awk.  */
+@@ -612,21 +614,21 @@ cache_rpath (struct link_map *l,
+     }
+ 
+   /* Make sure the cache information is available.  */
+   return decompose_rpath (sp, (const char *) (D_PTR (l, l_info[DT_STRTAB])
+ 					      + l->l_info[tag]->d_un.d_val),
+ 			  l, what);
+ }
+ 
+ 
+ void
+-_dl_init_paths (const char *llp)
++_dl_init_paths (const char *llp, const char *lfp)
+ {
+   size_t idx;
+   const char *strp;
+   struct r_search_path_elem *pelem, **aelem;
+   size_t round_size;
+   struct link_map __attribute__ ((unused)) *l = NULL;
+   /* Initialize to please the compiler.  */
+   const char *errstring = NULL;
+ 
+   /* Fill in the information about the application's RPATH and the
+@@ -760,20 +762,59 @@ _dl_init_paths (const char *llp)
+       if (env_path_list.dirs[0] == NULL)
+ 	{
+ 	  free (env_path_list.dirs);
+ 	  env_path_list.dirs = (void *) -1;
+ 	}
+ 
+       env_path_list.malloced = 0;
+     }
+   else
+     env_path_list.dirs = (void *) -1;
++
++  /* Made by copying the above followed by
++      %s/llp/lfp/g
++      %s/env_path_list/fallback_path_list/g
++      %s/LIBRARY_PATH/FALLBACK_PATH/g
++   */
++  if (lfp != NULL && *lfp != '\0')
++    {
++      char *lfp_tmp = strdupa (lfp);
++
++      /* Decompose the LD_FALLBACK_PATH contents.  First determine how many
++	 elements it has.  */
++      size_t nlfp = 1;
++      for (const char *cp = lfp_tmp; *cp != '\0'; ++cp)
++	if (*cp == ':' || *cp == ';')
++	  ++nlfp;
++
++      fallback_path_list.dirs = (struct r_search_path_elem **)
++	malloc ((nlfp + 1) * sizeof (struct r_search_path_elem *));
++      if (fallback_path_list.dirs == NULL)
++	{
++	  errstring = N_("cannot create cache for search path");
++	  goto signal_error;
++	}
++
++      (void) fillin_rpath (lfp_tmp, fallback_path_list.dirs, ":;",
++			   "LD_FALLBACK_PATH", NULL, l);
++
++      if (fallback_path_list.dirs[0] == NULL)
++	{
++	  free (fallback_path_list.dirs);
++	  fallback_path_list.dirs = (void *) -1;
++	}
++
++      fallback_path_list.malloced = 0;
++    }
++  else
++    fallback_path_list.dirs = (void *) -1;
++
+ }
+ 
+ 
+ static void
+ __attribute__ ((noreturn, noinline))
+ lose (int code, int fd, const char *name, char *realname, struct link_map *l,
+       const char *msg, struct r_debug *r, Lmid_t nsid)
+ {
+   /* The file might already be closed.  */
+   if (fd != -1)
+@@ -1822,23 +1863,23 @@ open_path (const char *name, size_t namelen, int mode,
+   while (*++dirs != NULL);
+ 
+   /* Remove the whole path if none of the directories exists.  */
+   if (__glibc_unlikely (! any))
+     {
+       /* Paths which were allocated using the minimal malloc() in ld.so
+ 	 must not be freed using the general free() in libc.  */
+       if (sps->malloced)
+ 	free (sps->dirs);
+ 
+-      /* rtld_search_dirs and env_path_list are attribute_relro, therefore
++      /* rtld_search_dirs, env_path_list, and fallback_path_list are attribute_relro, therefore
+ 	 avoid writing into it.  */
+-      if (sps != &rtld_search_dirs && sps != &env_path_list)
++      if (sps != &rtld_search_dirs && sps != &env_path_list && sps != &fallback_path_list)
+ 	sps->dirs = (void *) -1;
+     }
+ 
+   return -1;
+ }
+ 
+ /* Map in the shared object file NAME.  */
+ 
+ struct link_map *
+ _dl_map_object (struct link_map *loader, const char *name,
+@@ -2058,20 +2099,27 @@ _dl_map_object (struct link_map *loader, const char *name,
+ 				    false);
+ 		  if (__glibc_likely (fd != -1))
+ 		    realname = cached;
+ 		  else
+ 		    free (cached);
+ 		}
+ 	    }
+ 	}
+ #endif
+ 
++      /* Try the LD_FALLBACK_PATH environment variable. */
++      if (fd == -1 && fallback_path_list.dirs != (void *) -1)
++	fd = open_path (name, namelen, mode, &fallback_path_list,
++			&realname, &fb,
++			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
++			LA_SER_DEFAULT, &found_other_class);
++
+       /* Finally, try the default path.  */
+       if (fd == -1
+ 	  && ((l = loader ?: GL(dl_ns)[nsid]._ns_loaded) == NULL
+ 	      || __glibc_likely (!(l->l_flags_1 & DF_1_NODEFLIB)))
+ 	  && rtld_search_dirs.dirs != (void *) -1)
+ 	fd = open_path (name, namelen, mode, &rtld_search_dirs,
+ 			&realname, &fb, l, LA_SER_DEFAULT, &found_other_class);
+ 
+       /* Add another newline when we are tracing the library loading.  */
+       if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
+@@ -2241,19 +2289,22 @@ _dl_rtld_di_serinfo (struct link_map *loader, Dl_serinfo *si, bool counting)
+   add_path (&p, &env_path_list, XXX_ENV);
+ 
+   /* Look at the RUNPATH information for this binary.  */
+   if (cache_rpath (loader, &loader->l_runpath_dirs, DT_RUNPATH, "RUNPATH"))
+     add_path (&p, &loader->l_runpath_dirs, XXX_RUNPATH);
+ 
+   /* XXX
+      Here is where ld.so.cache gets checked, but we don't have
+      a way to indicate that in the results for Dl_serinfo.  */
+ 
++  /* Try the LD_FALLBACK_PATH environment variable.  */
++  add_path (&p, &fallback_path_list, XXX_default);
++
+   /* Finally, try the default path.  */
+   if (!(loader->l_flags_1 & DF_1_NODEFLIB))
+     add_path (&p, &rtld_search_dirs, XXX_default);
+ 
+   if (counting)
+     /* Count the struct size before the string area, which we didn't
+        know before we completed dls_cnt.  */
+     si->dls_size += (char *) &si->dls_serpath[si->dls_cnt] - (char *) si;
+ }
+diff --git a/elf/dl-support.c b/elf/dl-support.c
+index 114f77a..ad67d48 100644
+--- a/elf/dl-support.c
++++ b/elf/dl-support.c
+@@ -315,21 +315,21 @@ _dl_non_dynamic_init (void)
+     HP_TIMING_NOW (_dl_cpuclock_offset);
+ 
+   _dl_verbose = *(getenv ("LD_WARN") ?: "") == '\0' ? 0 : 1;
+ 
+   /* Set up the data structures for the system-supplied DSO early,
+      so they can influence _dl_init_paths.  */
+   setup_vdso (NULL, NULL);
+ 
+   /* Initialize the data structures for the search paths for shared
+      objects.  */
+-  _dl_init_paths (getenv ("LD_LIBRARY_PATH"));
++  _dl_init_paths (getenv ("LD_LIBRARY_PATH"), getenv ("LD_FALLBACK_PATH"));
+ 
+   /* Remember the last search directory added at startup.  */
+   _dl_init_all_dirs = GL(dl_all_dirs);
+ 
+   _dl_lazy = *(getenv ("LD_BIND_NOW") ?: "") == '\0';
+ 
+   _dl_bind_not = *(getenv ("LD_BIND_NOT") ?: "") != '\0';
+ 
+   _dl_dynamic_weak = *(getenv ("LD_DYNAMIC_WEAK") ?: "") == '\0';
+ 
+diff --git a/elf/rtld.c b/elf/rtld.c
+index 453f56e..48b319e 100644
+--- a/elf/rtld.c
++++ b/elf/rtld.c
+@@ -814,20 +814,22 @@ security_init (void)
+   /* We do not need the _dl_random value anymore.  The less
+      information we leave behind, the better, so clear the
+      variable.  */
+   _dl_random = NULL;
+ }
+ 
+ #include "setup-vdso.h"
+ 
+ /* The library search path.  */
+ static const char *library_path attribute_relro;
++/* The fallback library search path.  */
++static const char *fallback_path attribute_relro;
+ /* The list preloaded objects.  */
+ static const char *preloadlist attribute_relro;
+ /* Nonzero if information about versions has to be printed.  */
+ static int version_info attribute_relro;
+ 
+ /* The LD_PRELOAD environment variable gives list of libraries
+    separated by white space or colons that are loaded before the
+    executable's dependencies and prepended to the global scope list.
+    (If the binary is running setuid all elements containing a '/' are
+    ignored since it is insecure.)  Return the number of preloads
+@@ -1311,21 +1313,21 @@ of this helper program; chances are you did not intend to run this program.\n\
+   /* Set up the data structures for the system-supplied DSO early,
+      so they can influence _dl_init_paths.  */
+   setup_vdso (main_map, &first_preload);
+ 
+ #ifdef DL_SYSDEP_OSCHECK
+   DL_SYSDEP_OSCHECK (_dl_fatal_printf);
+ #endif
+ 
+   /* Initialize the data structures for the search paths for shared
+      objects.  */
+-  _dl_init_paths (library_path);
++  _dl_init_paths (library_path, fallback_path);
+ 
+   /* Initialize _r_debug.  */
+   struct r_debug *r = _dl_debug_initialize (GL(dl_rtld_map).l_addr,
+ 					    LM_ID_BASE);
+   r->r_state = RT_CONSISTENT;
+ 
+   /* Put the link_map for ourselves on the chain so it can be found by
+      name.  Note that at this point the global chain of link maps contains
+      exactly one element, which is pointed to by dl_loaded.  */
+   if (! GL(dl_rtld_map).l_name)
+@@ -2575,20 +2577,29 @@ process_envvars (enum mode *modep)
+ 	      && memcmp (envline, "DYNAMIC_WEAK", 12) == 0)
+ 	    GLRO(dl_dynamic_weak) = 1;
+ 	  break;
+ 
+ 	case 13:
+ 	  /* We might have some extra environment variable with length 13
+ 	     to handle.  */
+ #ifdef EXTRA_LD_ENVVARS_13
+ 	  EXTRA_LD_ENVVARS_13
+ #endif
++
++	  /* The library fallback search path.  */
++	  if (!__libc_enable_secure
++	      && memcmp (envline, "FALLBACK_PATH", 13) == 0)
++	    {
++	      fallback_path = &envline[14];
++	      break;
++	    }
++
+ 	  if (!__libc_enable_secure
+ 	      && memcmp (envline, "USE_LOAD_BIAS", 13) == 0)
+ 	    {
+ 	      GLRO(dl_use_load_bias) = envline[14] == '1' ? -1 : 0;
+ 	      break;
+ 	    }
+ 	  break;
+ 
+ 	case 14:
+ 	  /* Where to place the profiling data file.  */
+diff --git a/sysdeps/generic/ldsodefs.h b/sysdeps/generic/ldsodefs.h
+index 0ea2786..7786212 100644
+--- a/sysdeps/generic/ldsodefs.h
++++ b/sysdeps/generic/ldsodefs.h
+@@ -974,21 +974,21 @@ extern void _dl_sort_maps (struct link_map **maps, unsigned int nmaps,
+ extern void _dl_debug_state (void);
+ rtld_hidden_proto (_dl_debug_state)
+ 
+ /* Initialize `struct r_debug' if it has not already been done.  The
+    argument is the run-time load address of the dynamic linker, to be put
+    in the `r_ldbase' member.  Returns the address of the structure.  */
+ extern struct r_debug *_dl_debug_initialize (ElfW(Addr) ldbase, Lmid_t ns)
+      attribute_hidden;
+ 
+ /* Initialize the basic data structure for the search paths.  */
+-extern void _dl_init_paths (const char *library_path) attribute_hidden;
++extern void _dl_init_paths (const char *library_path, const char *fallback_path) attribute_hidden;
+ 
+ /* Gather the information needed to install the profiling tables and start
+    the timers.  */
+ extern void _dl_start_profile (void) attribute_hidden;
+ 
+ /* The actual functions used to keep book on the calls.  */
+ extern void _dl_mcount (ElfW(Addr) frompc, ElfW(Addr) selfpc);
+ rtld_hidden_proto (_dl_mcount)
+ 
+ /* This function is simply a wrapper around the _dl_mcount function
+diff --git a/sysdeps/generic/unsecvars.h b/sysdeps/generic/unsecvars.h
+index 5ea8a4a..0d01562 100644
+--- a/sysdeps/generic/unsecvars.h
++++ b/sysdeps/generic/unsecvars.h
+@@ -11,20 +11,21 @@
+   "GCONV_PATH\0"							      \
+   "GETCONF_DIR\0"							      \
+   GLIBC_TUNABLES_ENVVAR							      \
+   "HOSTALIASES\0"							      \
+   "LD_AUDIT\0"								      \
+   "LD_DEBUG\0"								      \
+   "LD_DEBUG_OUTPUT\0"							      \
+   "LD_DYNAMIC_WEAK\0"							      \
+   "LD_HWCAP_MASK\0"							      \
+   "LD_LIBRARY_PATH\0"							      \
++  "LD_FALLBACK_PATH\0"							      \
+   "LD_ORIGIN_PATH\0"							      \
+   "LD_PRELOAD\0"							      \
+   "LD_PROFILE\0"							      \
+   "LD_SHOW_AUXV\0"							      \
+   "LD_USE_LOAD_BIAS\0"							      \
+   "LOCALDOMAIN\0"							      \
+   "LOCPATH\0"								      \
+   "MALLOC_TRACE\0"							      \
+   "NIS_PATH\0"								      \
+   "NLSPATH\0"								      \

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -128,6 +128,27 @@ let
       '';
     };
 
+    glibc.withLdFallbackPatch = mkMassRebuild {
+      description = lib.mdDoc ''
+        Whether to build `glibc` with LD_FALLBACK_PATH patch enabled by
+        default.
+
+        In short: the patch implements LD_FALLBACK_PATH environment variable
+        that provides a way to override system libraries without the need for
+        any `chroot`s. This is very useful for overriding CUDA, OpenCL, libGL,
+        and similar vendor-specific libraries per-application (especially
+        while doing development of said application) or for running
+        closed-source programs (like games) requiring specific versions of
+        system libraries.
+
+        See `pkgs/development/libraries/glibc/ld-fallback.patch` for more
+        info.
+
+        Changing the default will cause a mass rebuild.
+      '';
+      # I.e., see ../development/libraries/glibc/ld-fallback.patch
+    };
+
     cudaSupport = mkMassRebuild {
       feature = "build packages with CUDA support by default";
     };

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -129,14 +129,10 @@ let
     };
 
     cudaSupport = mkMassRebuild {
-      type = types.bool;
-      default = false;
       feature = "build packages with CUDA support by default";
     };
 
     rocmSupport = mkMassRebuild {
-      type = types.bool;
-      default = false;
       feature = "build packages with ROCm support by default";
     };
 


### PR DESCRIPTION
## Description of changes

This adds LD_FALLBACK_PATH environment variable support to `glibc`. From the commit message:

```
Subject: [PATCH] Implement support for LD_FALLBACK_PATH envvar and related
 command line options

LD_FALLBACK_PATH has the same semantics as LD_LIBRARY_PATH but unlike
LD_LIBRARY_PATH, instead of having the highest priority, it has the
second-lowest (it gets used just before the default system directories).

Thus, LD_FALLBACK_PATH provides a way to specify fallback library paths.

In other words, LD_FALLBACK_PATH provides a way to override system libraries
without creating a chroot.

Consider the following use cases:

* Sometimes you just want to change a set of system libraries for a set of
  programs without changing the system default. For instance, if you have
  different GPUs requiring different libGL, CUDA, and/or OpenCL
  implementations. (Though, specifically for libGL there are better solutions
  for per-screen routing of OpenGL calls.)

  LD_FALLBACK_PATH is especially useful in a developer setting given that
  maintaining multiple (e.g. for each GPU type) per-project chroot
  environments is pretty hard.

* Running a closed-source program (like Steam and its games) on an unsupported
  distribution (this patch was originally created for SLNOS, a distribution
  based on NixOS): closed-source programs commonly override LD_LIBRARY_PATH to
  replace system libraries with their own bundled versions, but they
  frequently do it the wrong way by simply assigning LD_LIBRARY_PATH to point
  at their own /lib directory instead of prepending that /lib path to the
  current value of LD_LIBRARY_PATH, thus failing to pick up any non-system
  libraries they don't bundle but require specific versions of.

  From the perspective of a closed-source program's vendor, LD_FALLBACK_PATH
  --- being the low-priority option --- can't really be used to consistently
  achieve the same effect to as overriding LD_LIBRARY_PATH, thus making it
  unlikely they would ever touch it. But it can be used by other tools to
  supply needed default libraries to the closed-source program in question.

With LD_FALLBACK_PATH, you can just drop all those libraries you want to
replace your defaults into a directory and put its path into LD_FALLBACK_PATH,
or use Nix or a similar package manager to do that for you.
```

## Why?

Basically, `LD_FALLBACK_PATH` provides a cheap ad-hoc alternative to generating app-specific chroots for making wrappers that want to change default libraries.

I made it as a better alternative to #31263 in https://github.com/NixOS/nixpkgs/pull/31263#issuecomment-373294811, and kept it updated since. If you look through that issue, you'll see that neither the original problem, nor any of the related ones mentioned there are solved, even though most of the issues are closed as stale.

I've been using this thing since Spring 2018 without issues.

# Pings

ping @domenkozar and @Ericson2314 who wanted me to PR this and @timokau who also reported happily using my patch in https://github.com/NixOS/nixpkgs/pull/59595#issuecomment-485072071