### PR TITLE
darwin.linuxBuilder: Fix working directory in documentation

### DIFF
--- a/doc/packages/darwin-builder.section.md
+++ b/doc/packages/darwin-builder.section.md
@@ -94,7 +94,11 @@ $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
       system = linuxSystem;
       modules = [
         "${nixpkgs}/nixos/modules/profiles/macos-builder.nix"
-        { virtualisation.host.pkgs = pkgs; }
+        { virtualisation = {
+            host.pkgs = pkgs;
+            darwin-builder.workingDirectory = "/var/lib/darwin-builder";
+          };
+        };
       ];
     };
   in {


### PR DESCRIPTION
This fixes the working directory for the `launchctl` service configuration that is mentioned in the documentation, as caught by @MaxDaten in:

https://github.com/NixOS/nixpkgs/issues/229542#issuecomment-1674886874
