### PR TITLE
{rofi-bluetooth,i3lock}: add meta.mainProgram

### DIFF
--- a/pkgs/applications/misc/rofi-bluetooth/default.nix
+++ b/pkgs/applications/misc/rofi-bluetooth/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/nickclyde/rofi-bluetooth";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ MoritzBoehme ];
+    mainProgram = "rofi-bluetooth";
     platforms = platforms.linux;
   };
 })

--- a/pkgs/applications/window-managers/i3/lock.nix
+++ b/pkgs/applications/window-managers/i3/lock.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://i3wm.org/i3lock/";
     maintainers = with maintainers; [ malyn domenkozar ];
+    mainProgram = "i3lock";
     license = licenses.bsd3;
     platforms = platforms.all;
   };


### PR DESCRIPTION
Related PR: NixOS#246386

## Description of changes

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
