### PR TITLE
sbcl.pkgs.{…}: add missing native dependencies

### DIFF
--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -223,7 +223,43 @@ let
       lispLibs = o.lispLibs ++ [
         self.mcclim
       ];
-});
+    });
+    cl-charms = super.cl-charms.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.ncurses ];
+    });
+    libusb-ffi = super.libusb-ffi.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.libusb-compat-0_1 ];
+    });
+    cl-fam = super.cl-fam.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.fam ];
+    });
+    jpeg-turbo = super.jpeg-turbo.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.libjpeg_turbo ];
+    });
+    vorbisfile-ffi = super.vorbisfile-ffi.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.libvorbis ];
+    });
+    png = super.png.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.libpng ];
+    });
+    zmq = super.zmq.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.czmq ];
+    });
+    consfigurator = super.consfigurator.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.acl pkgs.libcap ];
+    });
+    cl-gss = super.cl-gss.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.libkrb5 ];
+    });
+    magicffi = super.magicffi.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.file ];
+    });
+    keystone = super.keystone.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.keystone ];
+    });
+    capstone = super.capstone.overrideLispAttrs (o: {
+      nativeLibs = [ pkgs.capstone ];
+    });
   });
 
   qlpkgs =


### PR DESCRIPTION
Full list of packages going from failure to build to build:

cl-charms libusb-ffi cl-fam jpeg-turbo vorbisfile-ffi png zmq consfigurator cl-gss magicffi keystone capstone

## Description of changes

Fixes: #248317 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
