### PR TITLE
ledit: 2.04 → 2.06

### DIFF
--- a/pkgs/tools/misc/ledit/default.nix
+++ b/pkgs/tools/misc/ledit/default.nix
@@ -1,31 +1,38 @@
-{ lib, stdenv, fetchzip, ocaml, camlp5}:
+{ lib, stdenv, fetchFromGitHub, ocamlPackages }:
 
 stdenv.mkDerivation {
   pname = "ledit";
-  version = "2.04";
+  version = "2.06";
 
-  src = fetchzip {
-    url = "http://pauillac.inria.fr/~ddr/ledit/distrib/src/ledit-2.04.tgz";
-    sha512 = "16vlv6rcsddwrvsqqiwxdfv5rxvblhrx0k84g7pjibi0an241yx8aqf8cj4f4sgl5xfs3frqrdf12zqwjf2h4jvk8jyhyar8n0nj3g0";
+  src = fetchFromGitHub {
+    owner = "chetmurthy";
+    repo = "ledit";
+    rev = "3dbd668d9c69aab5ccd61f6b906c14122ae3271d";
+    hash = "sha256-9+isvwOw5Iw5OToztqZ5PiQPj6Pxl2ZqAC7UMF+tCM4=";
   };
 
   preBuild = ''
-    mkdir -p $out/bin
-    substituteInPlace Makefile --replace /bin/rm rm --replace BINDIR=/usr/local/bin BINDIR=$out/bin
+    substituteInPlace Makefile --replace /bin/rm rm --replace /usr/local/ $out/
   '';
 
   strictDeps = true;
 
-  nativeBuildInputs = [
+  nativeBuildInputs = with ocamlPackages; [
     ocaml
+    findlib
     camlp5
   ];
+
+  buildInputs = with ocamlPackages; [
+    camlp5
+    camlp-streams
+  ];
+
 
   meta = with lib; {
     homepage = "http://pauillac.inria.fr/~ddr/ledit/";
     description = "A line editor, allowing to use shell commands with control characters like in emacs";
     license = licenses.bsd3;
     maintainers = [ maintainers.delta ];
-    broken = lib.versionOlder ocaml.version "4.03";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10147,9 +10147,7 @@ with pkgs;
 
   lact = callPackage ../tools/system/lact { };
 
-  ledit = callPackage ../tools/misc/ledit {
-    inherit (ocaml-ng.ocamlPackages_4_11) ocaml camlp5;
-  };
+  ledit = callPackage ../tools/misc/ledit { };
 
   ledmon = callPackage ../tools/system/ledmon { };
 


### PR DESCRIPTION
## Description of changes

Port to Camlp5 ≥ 8.00

cc maintainer @D4Delta

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
