### PR TITLE
liburing: backport upstream parallel build fix

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit }:
+{ lib, stdenv, fetchgit, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "liburing";
@@ -9,6 +9,16 @@ stdenv.mkDerivation rec {
     rev    = "liburing-${version}";
     sha256 = "sha256-vbe9uh9AqXyPkzwD6zHoHH3JMeAJEl2FSGzny1T7diM=";
   };
+
+  patches = [
+    # Pull upstream fix for parallel build failures:
+    #   https://github.com/axboe/liburing/pull/891
+    (fetchpatch {
+      name = "parallel.patch";
+      url = "https://github.com/axboe/liburing/commit/c34dca74854cb6e7f2b09affa2a4ab0145e62371.patch";
+      hash = "sha256-RZSgHdQy5d7mXtMvkMyr+/kMhp1w+S5v9cqk5NSii5o=";
+    })
+  ];
 
   separateDebugInfo = true;
   enableParallelBuilding = true;


### PR DESCRIPTION
Without the change parallel build fails for me occasionally as:

       >      CC liburing-ffi.so.2.4
       > /nix/store/44xr71vsjfg2kz1hsxsq975day2fm12q-binutils-2.41/bin/ld: cannot find queue.os: No such file or directory
       > collect2: error: ld returned 1 exit status
       > make[1]: *** [Makefile:85: liburing-ffi.so.2.4] Error 1 shuffle=3560684383
       > make[1]: *** Waiting for unfinished jobs....
       > make[1]: Leaving directory '/build/liburing/src'
       > make: *** [Makefile:10: all] Error 2 shuffle=3560684383

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
