### PR TITLE
ablog: 0.10.33.post1 -> 0.11.14.post1

### DIFF
--- a/pkgs/applications/misc/ablog/default.nix
+++ b/pkgs/applications/misc/ablog/default.nix
@@ -3,30 +3,39 @@
 , fetchPypi
 }:
 
-with python3.pkgs;
-
-buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "ablog";
-  version = "0.10.33.post1";
+  version = "0.11.4.post1";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-+vrVQ4sItCXrSCzNXyKk6/6oDBOyfyD7iNWzmcbE/BQ=";
+    hash = "sha256-Zyvx7lVUQtjoGsSpFmH8pFrgTGgsFd4GMsL3fXKtUpU=";
   };
 
-  propagatedBuildInputs = [
-    feedgen
-    sphinx
-    invoke
-    watchdog
-    python-dateutil
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+    setuptools-scm
+    wheel
   ];
 
-  nativeCheckInputs = [
+  propagatedBuildInputs = with python3.pkgs; [
+    docutils
+    feedgen
+    invoke
+    packaging
+    python-dateutil
+    sphinx
+    watchdog
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
     pytestCheckHook
   ];
 
-  nativeBuildInputs = [ setuptools-scm ];
+  pytestFlagsArray = [
+    "--rootdir" "src/ablog"
+  ];
 
   meta = with lib; {
     description = "ABlog for blogging with Sphinx";


### PR DESCRIPTION
## Description of changes

There have been a few releases, which you can browse at https://github.com/sunpy/ablog/releases.

What I would like to pick up from this update is:

1. Removal of pkg_resources, which removes a deprecation message failing tests after updating setuptools to v68.
2. A switch to using pyproject.toml to bundle the project.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
