### PR TITLE
dotnet: adding runtimeId to hooks for fsproj

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-build-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-build-hook.sh
@@ -51,7 +51,7 @@ dotnetBuildHook() {
 
         for runtimeId in "${dotnetRuntimeIdsArray[@]}"; do
             local runtimeIdFlagsArray=()
-            if [[ $projectFile == *.csproj || -n ${dotnetSelfContainedBuild-} ]]; then
+            if [[ "$projectFile" =~ *.(cs|fs)proj || -n ${dotnetSelfContainedBuild-} || (-d "$projectFile" && -n "$(@findutils@/bin/find "$projectFile" -maxdepth 1 -type f -name "*.csproj" -o -name "*.fsproj" )" ) ]]; then
                 runtimeIdFlagsArray+=("--runtime" "$runtimeId")
             fi
 

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-check-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-check-hook.sh
@@ -52,10 +52,9 @@ dotnetCheckHook() {
     for projectFile in "${dotnetTestProjectFilesArray[@]-${dotnetProjectFilesArray[@]}}"; do
         for runtimeId in "${dotnetRuntimeIdsArray[@]}"; do
             local runtimeIdFlagsArray=()
-            if [[ $projectFile == *.csproj ]]; then
+             if [[ "$projectFile" =~ *.(cs|fs)proj || (-d "$projectFile" && -n "$(@findutils@/bin/find "$projectFile" -maxdepth 1 -type f -name "*.csproj" -o -name "*.fsproj" )" ) ]]; then
                 runtimeIdFlagsArray=("--runtime" "$runtimeId")
             fi
-
             LD_LIBRARY_PATH=$libraryPath \
                 dotnet test "$projectFile" \
                 -maxcpucount:"$maxCpuFlag" \

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-install-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-install-hook.sh
@@ -44,7 +44,7 @@ dotnetInstallHook() {
 
         for runtimeId in "${dotnetRuntimeIdsArray[@]}"; do
             runtimeIdFlagsArray=()
-            if [[ $projectFile == *.csproj || -n ${dotnetSelfContainedBuild-} ]]; then
+            if [[ "$projectFile" =~ *.(cs|fs)proj || -n ${dotnetSelfContainedBuild-} || (-d "$projectFile" && -n "$(@findutils@/bin/find "$projectFile" -maxdepth 1 -type f -name "*.csproj" -o -name "*.fsproj" )" ) ]]; then
                 runtimeIdFlagsArray+=("--runtime" "$runtimeId")
             fi
 


### PR DESCRIPTION
## Description of changes

fix for https://github.com/NixOS/nixpkgs/issues/248553

currently dotnet test fails for  fsharp test project files due to missing runtime id paratmeter, this commit fixes that 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
