### PR TITLE
treewide: cleanup `sourceRoot` and `setSourceRoot` usage

### DIFF
--- a/pkgs/applications/audio/losslessaudiochecker/default.nix
+++ b/pkgs/applications/audio/losslessaudiochecker/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoPatchelfHook ];
 
-  setSourceRoot = "sourceRoot=$PWD";
+  sourceRoot = ".";
 
   dontBuild = true;
 

--- a/pkgs/applications/audio/sony-headphones-client/default.nix
+++ b/pkgs/applications/audio/sony-headphones-client/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config copyDesktopItems ];
   buildInputs = [ bluez dbus glew glfw imgui ];
 
-  sourceRoot = "./${src.name}/Client";
+  sourceRoot = "${src.name}/Client";
 
   cmakeFlags = [ "-Wno-dev" ];
 

--- a/pkgs/applications/editors/howl/default.nix
+++ b/pkgs/applications/editors/howl/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1qc58l3rkr37cj6vhf8c7bnwbz93nscyraz7jxqwjq6k4gj0cjw3";
   };
 
-  sourceRoot = "./howl-${version}/src";
+  sourceRoot = "howl-${version}/src";
 
   # The Makefile uses "/usr/local" if not explicitly overridden
   installFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libmediainfo wxGTK32 desktop-file-utils libSM imagemagick ]
     ++ lib.optionals stdenv.isDarwin [ Cocoa ];
 
-  sourceRoot = "./MediaInfo/Project/GNU/GUI/";
+  sourceRoot = "MediaInfo/Project/GNU/GUI";
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ libzen libmediainfo zlib ];
 
-  sourceRoot = "./MediaInfo/Project/GNU/CLI/";
+  sourceRoot = "MediaInfo/Project/GNU/CLI";
 
   configureFlags = [ "--with-libmediainfo=${libmediainfo}" ];
 

--- a/pkgs/applications/radio/rscw/default.nix
+++ b/pkgs/applications/radio/rscw/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "1hxwxmqc5jinr14ya1idigqigc8qhy1vimzcwy2vmwdjay2sqik2";
   };
 
-  setSourceRoot = "sourceRoot=`pwd`";
+  sourceRoot = ".";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ gtk2 fftw ];

--- a/pkgs/applications/science/biology/sratoolkit/default.nix
+++ b/pkgs/applications/science/biology/sratoolkit/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     stdenv.cc.cc.lib
   ];
 
-  sourceRoot = "./sratoolkit.${version}-ubuntu64/bin";
+  sourceRoot = "sratoolkit.${version}-ubuntu64/bin";
 
   installPhase = ''
     find -L . -executable -type f -! -name "*remote-fuser*" -exec install -m755 -D {} $out/bin/{} \;

--- a/pkgs/applications/science/electronics/xyce/default.nix
+++ b/pkgs/applications/science/electronics/xyce/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
 
   srcs = [ xyce_src regression_src ];
 
-  sourceRoot = "./${xyce_src.name}";
+  sourceRoot = xyce_src.name;
 
   preConfigure = "./bootstrap";
 

--- a/pkgs/applications/science/logic/ekrhyper/default.nix
+++ b/pkgs/applications/science/logic/ekrhyper/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ ocaml perl ];
-  setSourceRoot = "export sourceRoot=$(echo */ekrh/src/)";
+  setSourceRoot = "export sourceRoot=$(echo */ekrh/src)";
   preInstall = "export INSTALLDIR=$out";
   postInstall = ''for i in "$out/casc"/*; do ln -s "$i" "$out/bin/ekrh-casc-$(basename $i)"; done '';
 

--- a/pkgs/applications/science/misc/golly/default.nix
+++ b/pkgs/applications/science/misc/golly/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   ];
 
   setSourceRoot = ''
-    sourceRoot=$(echo */gui-wx/)
+    sourceRoot=$(echo */gui-wx)
   '';
 
   postPatch = ''

--- a/pkgs/applications/video/davinci-resolve/default.nix
+++ b/pkgs/applications/video/davinci-resolve/default.nix
@@ -109,9 +109,7 @@ let
       '';
 
       # The unpack phase won't generate a directory
-      setSourceRoot = ''
-        sourceRoot=$PWD
-      '';
+      sourceRoot = ".";
 
       installPhase = ''
         runHook preInstall

--- a/pkgs/data/fonts/maple-font/default.nix
+++ b/pkgs/data/fonts/maple-font/default.nix
@@ -5,10 +5,9 @@
 }:
 
 let
-  maple-font = { pname, sha256, desc }: stdenv.mkDerivation
-    rec{
-
-      inherit pname desc;
+  maple-font = { pname, sha256, desc }:
+    stdenv.mkDerivation rec{
+      inherit pname;
       version = "6.4";
       src = fetchurl {
         url = "https://github.com/subframe7536/Maple-font/releases/download/v${version}/${pname}.zip";
@@ -17,7 +16,7 @@ let
 
       # Work around the "unpacker appears to have produced no directories"
       # case that happens when the archive doesn't have a subdirectory.
-      setSourceRoot = "sourceRoot=`pwd`";
+      sourceRoot = ".";
       nativeBuildInputs = [ unzip ];
       installPhase = ''
         find . -name '*.ttf'    -exec install -Dt $out/share/fonts/truetype {} \;

--- a/pkgs/data/fonts/roboto-mono/default.nix
+++ b/pkgs/data/fonts/roboto-mono/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     })
   ];
 
-  sourceRoot = "./";
+  sourceRoot = ".";
 
   unpackCmd = ''
     ttfName=$(basename $(stripHash $curSrc))

--- a/pkgs/data/fonts/rubik/default.nix
+++ b/pkgs/data/fonts/rubik/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation {
     })
   ];
 
-  sourceRoot = "./";
+  sourceRoot = ".";
 
   unpackCmd = ''
     ttfName=$(basename $(stripHash $curSrc))

--- a/pkgs/data/misc/unicode-character-database/default.nix
+++ b/pkgs/data/misc/unicode-character-database/default.nix
@@ -16,9 +16,7 @@ stdenv.mkDerivation rec {
     unzip
   ];
 
-  setSourceRoot = ''
-    sourceRoot=$PWD
-  '';
+  sourceRoot = ".";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/data/misc/unihan-database/default.nix
+++ b/pkgs/data/misc/unihan-database/default.nix
@@ -16,9 +16,7 @@ stdenv.mkDerivation rec {
     unzip
   ];
 
-  setSourceRoot = ''
-    sourceRoot=$PWD
-  '';
+  sourceRoot = ".";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/desktops/rox/rox-filer/default.nix
+++ b/pkgs/desktops/rox/rox-filer/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   # go to the source directory after unpacking the sources
-  setSourceRoot = "export sourceRoot=rox-filer-${version}/ROX-Filer/";
+  sourceRoot = "rox-filer-${version}/ROX-Filer";
 
   # account for 'setSourceRoot' offset
   patchFlags = [ "-p2" ];

--- a/pkgs/development/compilers/flutter/engine-artifacts/default.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/default.nix
@@ -187,7 +187,7 @@ let
             hash = (if artifactDirectory == null then hashes else hashes.${artifactDirectory}).${archive};
           });
 
-      setSourceRoot = if overrideUnpackCmd then "sourceRoot=`pwd`" else null;
+      sourceRoot = if overrideUnpackCmd then "." else null;
       unpackCmd = if overrideUnpackCmd then "unzip -o $src -d $out" else null;
 
       installPhase =

--- a/pkgs/development/libraries/dab_lib/default.nix
+++ b/pkgs/development/libraries/dab_lib/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-KSkOg0a5iq+13kClQqj+TaEP/PsLUrm8bMmiJEAZ+C4=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/library/";
+  sourceRoot = "${finalAttrs.src.name}/library";
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ faad2 fftwFloat zlib ];

--- a/pkgs/development/libraries/java/mockobjects/default.nix
+++ b/pkgs/development/libraries/java/mockobjects/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   # Work around the "unpacker appears to have produced no directories"
-  setSourceRoot = "sourceRoot=`pwd`";
+  sourceRoot = ".";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/libraries/libzen/default.nix
+++ b/pkgs/development/libraries/libzen/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   configureFlags = [ "--enable-shared" ];
 
-  sourceRoot = "./ZenLib/Project/GNU/Library/";
+  sourceRoot = "ZenLib/Project/GNU/Library";
 
   preConfigure = "sh autogen.sh";
 

--- a/pkgs/development/libraries/liquidfun/default.nix
+++ b/pkgs/development/libraries/liquidfun/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libGLU libGL libX11 libXi ];
 
-  sourceRoot = "liquidfun/Box2D/";
+  sourceRoot = "liquidfun/Box2D";
 
   preConfigurePhases = "preConfigure";
 

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -524,9 +524,7 @@ with prev;
       tar xf *.tar.gz
     '';
     # Without this, source root is wrongly set to ./readline-2.6/doc
-    setSourceRoot = ''
-      sourceRoot=./readline-${lib.versions.majorMinor oa.version}
-    '';
+    sourceRoot = "readline-${lib.versions.majorMinor oa.version}";
   });
 
   sqlite = prev.sqlite.overrideAttrs (drv: {

--- a/pkgs/development/tools/misc/blackfire/php-probe.nix
+++ b/pkgs/development/tools/misc/blackfire/php-probe.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     autoPatchelfHook
   ];
 
-  setSourceRoot = "sourceRoot=`pwd`";
+  sourceRoot = ".";
 
   dontUnpack = true;
 

--- a/pkgs/development/tools/tabnine/default.nix
+++ b/pkgs/development/tools/tabnine/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   # Work around the "unpacker appears to have produced no directories"
   # case that happens when the archive doesn't have a subdirectory.
-  setSourceRoot = "sourceRoot=`pwd`";
+  sourceRoot = ".";
 
   nativeBuildInputs = [ unzip ];
 

--- a/pkgs/os-specific/linux/firmware/xow_dongle-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/xow_dongle-firmware/default.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ cabextract ];
 
-  sourceRoot = "./.";
+  sourceRoot = ".";
 
   unpackCmd = ''
     cabextract -F FW_ACC_00U.bin ${src}

--- a/pkgs/os-specific/linux/xone/default.nix
+++ b/pkgs/os-specific/linux/xone/default.nix
@@ -20,9 +20,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  setSourceRoot = ''
-    export sourceRoot=$(pwd)/source
-  '';
+  sourceRoot = src.name;
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -17,9 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-rT2Mq40fE055FemDG7PBjt+cxgIHJG9tTjtw2nW6B98=";
   };
 
-  setSourceRoot = ''
-    export sourceRoot=$(pwd)/source/hid-xpadneo/src
-  '';
+  sourceRoot = "${finalAttrs.src.name}/hid-xpadneo/src";
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
   buildInputs = [ bluez ];

--- a/pkgs/servers/matrix-synapse/plugins/mjolnir-antispam.nix
+++ b/pkgs/servers/matrix-synapse/plugins/mjolnir-antispam.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "sha256-/vnojWLpu/fktqPUhAdL1QTESxDwFrBVYAkyF79Fj9w=";
   };
 
-  sourceRoot = "./${src.name}/synapse_antispam";
+  sourceRoot = "${src.name}/synapse_antispam";
 
   buildInputs = [ matrix-synapse ];
 

--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -21,7 +21,7 @@ let
       dontUnpack = true;
       # Work around the "unpacker appears to have produced no directories"
       # case that happens when the archive doesn't have a subdirectory.
-      setSourceRoot = "sourceRoot=$(pwd)";
+      sourceRoot = ".";
       nativeBuildInputs = [ unzip ];
       meta = a.meta // {
         platforms = elasticsearch.meta.platforms;

--- a/pkgs/tools/archivers/unar/default.nix
+++ b/pkgs/tools/archivers/unar/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
 
   dontConfigure = true;
 
-  sourceRoot = "./${src.name}/XADMaster";
+  sourceRoot = "${src.name}/XADMaster";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/audio/stt/default.nix
+++ b/pkgs/tools/audio/stt/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://github.com/coqui-ai/STT/releases/download/v${version}/native_client.tflite.Linux.tar.xz";
     hash = "sha256-RVYc64pLYumQoVUEFZdxfUUaBMozaqgD0h/yiMaWN90=";
   };
-  setSourceRoot = "sourceRoot=`pwd`";
+
+  sourceRoot = ".";
 
   nativeBuildInputs = [
     autoPatchelfHook

--- a/pkgs/tools/misc/ent/default.nix
+++ b/pkgs/tools/misc/ent/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   # Work around the "unpacker appears to have produced no directories"
   # case that happens when the archive doesn't have a subdirectory.
-  setSourceRoot = "sourceRoot=`pwd`";
+  sourceRoot = ".";
 
   nativeBuildInputs = [ unzip ];
 

--- a/pkgs/tools/misc/usbimager/default.nix
+++ b/pkgs/tools/misc/usbimager/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-CEGUXJXqXmD8uT93T9dg49Lf5vTpAzQjdnhYmbR5zTI=";
   };
 
-  sourceRoot = "${src.name}/src/";
+  sourceRoot = "${src.name}/src";
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook ];
   buildInputs = lib.optionals withUdisks [ udisks glib ]

--- a/pkgs/tools/networking/bully/default.nix
+++ b/pkgs/tools/networking/bully/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  sourceRoot = "./${src.name}/src";
+  sourceRoot = "${src.name}/src";
 
   installPhase = ''
     install -Dm555 -t $out/bin bully

--- a/pkgs/tools/networking/ookla-speedtest/default.nix
+++ b/pkgs/tools/networking/ookla-speedtest/default.nix
@@ -34,9 +34,7 @@ stdenv.mkDerivation rec {
 
   src = srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  setSourceRoot = ''
-    sourceRoot=$PWD
-  '';
+  sourceRoot = ".";
 
   dontBuild = true;
   dontConfigure = true;

--- a/pkgs/tools/security/mpw/default.nix
+++ b/pkgs/tools/security/mpw/default.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
     inherit rev;
   };
 
-  sourceRoot = "./${src.name}/platform-independent/c/cli";
+  sourceRoot = "${src.name}/platform-independent/c/cli";
 
   postPatch = ''
     rm build

--- a/pkgs/tools/typesetting/xmlroff/default.nix
+++ b/pkgs/tools/typesetting/xmlroff/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     popt
   ];
 
-  sourceRoot = "${src.name}/xmlroff/";
+  sourceRoot = "${src.name}/xmlroff";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Finishing touches after #245388, #247977, and #248528 (at least for now). This one is kind of a mass-rebuild, though.

This replaces `setSourceRoot = "sourceRoot=$PWD"` with just `sourceRoot = "."`, removes unneeded dots and slashes from all of them, and fixes any leftover references to "source" instead of `src.name`.