### PR TITLE
WIP: Bump packages svtplay-dl and pytrainer

### DIFF
--- a/pkgs/applications/misc/pytrainer/default.nix
+++ b/pkgs/applications/misc/pytrainer/default.nix
@@ -23,33 +23,21 @@ let
       matplotlib = super.matplotlib.override {
         enableGtk3 = true;
       };
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (old: rec {
-        version = "1.4.46";
-        src = fetchPypi {
-          pname = "SQLAlchemy";
-          inherit version;
-          hash = "sha256-aRO4JH2KKS74MVFipRkx4rQM6RaB8bbxj2lwRSAMSjA=";
-        };
-        disabledTestPaths = [
-           "test/aaa_profiling"
-           "test/ext/mypy"
-        ];
-      });
     });
   };
 in python.pkgs.buildPythonApplication rec {
   pname = "pytrainer";
-  version = "2.1.0";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "pytrainer";
     repo = "pytrainer";
     rev = "v${version}";
-    sha256 = "sha256-U2SVQKkr5HF7LB0WuCZ1xc7TljISjCNO26QUDGR+W/4=";
+    hash = "sha256-t61vHVTKN5KsjrgbhzljB7UZdRask7qfYISd+++QbV0=";
   };
 
   propagatedBuildInputs = with python.pkgs; [
-    sqlalchemy-migrate
+    sqlalchemy
     python-dateutil
     matplotlib
     lxml
@@ -85,10 +73,17 @@ in python.pkgs.buildPythonApplication rec {
     psycopg2
   ]);
 
+  postPatch = ''
+    substituteInPlace pytrainer/platform.py \
+        --replace 'sys.prefix' "\"$out\""
+  '';
+
   checkPhase = ''
-    env HOME=$TEMPDIR TZDIR=${tzdata}/share/zoneinfo \
+    env \
+      HOME=$TEMPDIR \
+      TZDIR=${tzdata}/share/zoneinfo \
       TZ=Europe/Kaliningrad \
-      LC_ALL=en_US.UTF-8 \
+      LC_TIME=C \
       xvfb-run -s '-screen 0 800x600x24' \
       ${python.interpreter} setup.py test
   '';

--- a/pkgs/tools/misc/svtplay-dl/default.nix
+++ b/pkgs/tools/misc/svtplay-dl/default.nix
@@ -15,7 +15,7 @@ let
     python pytest nose cryptography pyyaml requests mock requests-mock
     python-dateutil setuptools;
 
-  version = "4.24";
+  version = "4.25";
 
 in
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "spaam";
     repo = "svtplay-dl";
     rev = version;
-    hash = "sha256-ZUQi0KWnzIlEbFNTouJkd7cE5KPdrKZQfzwo4OeQZU4=";
+    hash = "sha256-vYcBK7jgoBEC7dZ+5osJ/Q85wSNLXO02wcv9GHaa0Ds=";
   };
 
   pythonPaths = [ cryptography pyyaml requests ];


### PR DESCRIPTION
## Description of changes

Bump svtplay-dl and pytrainer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).