### PR TITLE
zotero-translation-server: init at unstable-2023-07-13

### DIFF
--- a/pkgs/tools/misc/zotero-translation-server/default.nix
+++ b/pkgs/tools/misc/zotero-translation-server/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildNpmPackage, fetchFromGitHub, nodejs }:
+
+buildNpmPackage rec {
+  pname = "zotero-translation-server";
+  version = "unstable-2023-07-13";
+
+  src = fetchFromGitHub {
+    owner = "zotero";
+    repo = "translation-server";
+    rev = "cf96d57f4e2af66fee7df9bad00681b3f4ac7d77";
+    hash = "sha256-GJn7UAl0raVGzplvFzo4A0RUjNbyGt/YI2mt1UZIJv0=";
+    fetchSubmodules = true;
+  };
+
+  npmDepsHash = "sha256-JHoBxUybs1GGRxEVG5GgX2mOCplTgR5dcPjnR42SEbY=";
+
+  makeCacheWritable = true;
+
+  dontNpmBuild = true;
+
+  postInstall = ''
+    mkdir -p $out/bin/ $out/share/zotero-translation-server/
+    makeWrapper ${nodejs}/bin/node $out/bin/translation-server \
+      --add-flags "$out/lib/node_modules/translation-server/src/server.js"
+    ln -s $out/lib/node_modules/translation-server/config $out/share/zotero-translation-server/config
+    ln -s $out/lib/node_modules/translation-server/modules $out/share/zotero-translation-server/modules
+  '';
+
+  meta = with lib; {
+    description = "A Node.js-based server to run Zotero translators";
+    homepage = "https://github.com/zotero/translation-server";
+    license = licenses.agpl3Only;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7713,6 +7713,8 @@ with pkgs;
 
   zonemaster-cli = perlPackages.ZonemasterCLI;
 
+  zotero-translation-server = callPackage ../tools/misc/zotero-translation-server { };
+
   zoxide = callPackage ../tools/misc/zoxide { };
 
   zzuf = callPackage ../tools/security/zzuf { };


### PR DESCRIPTION
## Description of changes

Add https://github.com/zotero/translation-server
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
