### PR TITLE
python3.pkgs.gyp: patch shebang in mac_tool.py

### DIFF
--- a/pkgs/development/python-modules/gyp/default.nix
+++ b/pkgs/development/python-modules/gyp/default.nix
@@ -27,6 +27,12 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "gyp" "gyp.generator" ];
 
+  # Make mac_tool.py executable so that patchShebangs hook processes it. This
+  # file is copied and run by builds using gyp on macOS
+  preFixup = ''
+    chmod +x "$out/${python.sitePackages}/gyp/mac_tool.py"
+  '';
+
   meta = with lib; {
     description = "A tool to generate native build files";
     homepage = "https://gyp.gsrc.io";


### PR DESCRIPTION
## Description of changes

When building `nss` on my macOS machine with the sandbox enabled, it would fail with the following error:
```
FAILED: libdbm.a
rm -f libdbm.a && ./gyp-mac-tool filter-libtool libtool  -static -o libdbm.a obj/lib/dbm/src/dbm.db.o obj/lib/dbm/src/dbm.dirent.o obj/lib/dbm/src/dbm.h_bigkey.o obj/lib/dbm/src/dbm.h_func.o obj/lib/dbm/src/dbm.h_log2.o obj/lib/dbm/src/dbm.h_page.o obj/lib/dbm/src/dbm.hash.o obj/lib/dbm/src/dbm.hash_buf.o obj/lib/dbm/src/dbm.mktemp.o
/bin/sh: ./gyp-mac-tool: /usr/bin/env: bad interpreter: Operation not permitted
```

This is because the `mac_tool.py` file produced by `gyp` does not have its shebang patched. This PR fixes that by marking that file executable so that the patchShebangs hook processes it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
