### PR TITLE
CoreFoundation: specify the tbd explicitly

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/cf-setup-hook.sh
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/cf-setup-hook.sh
@@ -1,6 +1,6 @@
 forceLinkCoreFoundationFramework() {
   NIX_CFLAGS_COMPILE="-F@out@/Library/Frameworks${NIX_CFLAGS_COMPILE:+ }${NIX_CFLAGS_COMPILE-}"
-  NIX_LDFLAGS+=" @out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+  NIX_LDFLAGS+=" @out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation.tbd"
 }
 
 preConfigureHooks+=(forceLinkCoreFoundationFramework)

--- a/pkgs/os-specific/darwin/apple-sdk/cf-setup-hook.sh
+++ b/pkgs/os-specific/darwin/apple-sdk/cf-setup-hook.sh
@@ -3,7 +3,7 @@ linkSystemCoreFoundationFramework() {
   # gross! many symbols (such as _OBJC_CLASS_$_NSArray) are defined in system CF, but not
   # in the opensource release
   # if the package needs private headers, we assume they also want to link with system CF
-  NIX_LDFLAGS+=" @out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+  NIX_LDFLAGS+=" @out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation.tbd"
 }
 
 preConfigureHooks+=(linkSystemCoreFoundationFramework)


### PR DESCRIPTION
## Description of changes

The current hook specifies the path to the framework library, but nixpkgs does not actually provide the library when linking against the system framework. It provides a text-based stub (`.tbd`) instead. ld64 will find the stub and use it, but lld will not when the full path is specified. Both linkers work if the extension is included, so do that for compatibility with both. This fixes using lld with CoreFoundation (e.g., to support LTO on Darwin).

This was tested building both x86_64-darwin and aarch64-darwin stdenvs using clang 16 with ld64 and lld. In particular, Bash in the stdenv is linked against the system CoreFoundation (to avoid a dependency cycle). It was able to link with both linkers with this patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
