### PR TITLE
libraw: add patch for CVE-2023-1729

### DIFF
--- a/pkgs/development/libraries/libraw/default.nix
+++ b/pkgs/development/libraries/libraw/default.nix
@@ -5,6 +5,13 @@
 , autoreconfHook
 , lcms2
 , pkg-config
+
+# for passthru.tests
+, deepin
+, freeimage
+, hdrmerge
+, imagemagick
+, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -33,6 +40,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   enableParallelBuilding = true;
+
+  passthru.tests = {
+    inherit imagemagick hdrmerge freeimage;
+    inherit (deepin) deepin-image-viewer;
+    inherit (python3.pkgs) rawkit;
+  };
 
   meta = with lib; {
     description = "Library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)";

--- a/pkgs/development/libraries/libraw/default.nix
+++ b/pkgs/development/libraries/libraw/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, lcms2, pkg-config }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, lcms2
+, pkg-config
+}:
 
 stdenv.mkDerivation rec {
   pname = "libraw";
@@ -10,6 +17,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-K9mULf6V/TCl5Vu4iuIdSGF9HzQlgNQLRFHIpNbmAlY";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2023-1729.patch";
+      url = "https://github.com/LibRaw/LibRaw/commit/9ab70f6dca19229cb5caad7cc31af4e7501bac93.patch";
+      hash = "sha256-OAyqphxvtSM15NI77HwtGTmTmP9YNu3xhZ6D1CceJ7I=";
+    })
+  ];
 
   outputs = [ "out" "lib" "dev" "doc" ];
 


### PR DESCRIPTION
## Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2023-1729

(testing was done against master, also tested `pkgsStatic` and `pkgsCross.aarch64-multiplatform` variants)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
