### PR TITLE
pluginupdate: don't rely on NIX_PATH

### DIFF
--- a/maintainers/scripts/pluginupdate.py
+++ b/maintainers/scripts/pluginupdate.py
@@ -4,20 +4,20 @@
 # - maintainers/scripts/update-luarocks-packages
 
 # format:
-# $ nix run nixpkgs.python3Packages.black -c black update.py
+# $ nix run nixpkgs#black maintainers/scripts/pluginupdate.py
 # type-check:
-# $ nix run nixpkgs.python3Packages.mypy -c mypy update.py
+# $ nix run nixpkgs#python3.pkgs.mypy maintainers/scripts/pluginupdate.py
 # linted:
-# $ nix run nixpkgs.python3Packages.flake8 -c flake8 --ignore E501,E265 update.py
+# $ nix run nixpkgs#python3.pkgs.flake8 -- --ignore E501,E265 maintainers/scripts/pluginupdate.py
 
 import argparse
 import csv
 import functools
 import http
 import json
+import logging
 import os
 import subprocess
-import logging
 import sys
 import time
 import traceback
@@ -25,14 +25,14 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from functools import wraps
 from multiprocessing.dummy import Pool
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union, Any, Callable
-from urllib.parse import urljoin, urlparse
 from tempfile import NamedTemporaryFile
-from dataclasses import dataclass, asdict
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from urllib.parse import urljoin, urlparse
 
 import git
 
@@ -41,11 +41,12 @@ ATOM_LINK = "{http://www.w3.org/2005/Atom}link"  # "
 ATOM_UPDATED = "{http://www.w3.org/2005/Atom}updated"  # "
 
 LOG_LEVELS = {
-    logging.getLevelName(level): level for level in [
-        logging.DEBUG, logging.INFO, logging.WARN, logging.ERROR ]
+    logging.getLevelName(level): level
+    for level in [logging.DEBUG, logging.INFO, logging.WARN, logging.ERROR]
 }
 
 log = logging.getLogger()
+
 
 def retry(ExceptionToCheck: Any, tries: int = 4, delay: float = 3, backoff: float = 2):
     """Retry calling the decorated function using an exponential backoff.
@@ -77,6 +78,7 @@ def retry(ExceptionToCheck: Any, tries: int = 4, delay: float = 3, backoff: floa
 
     return deco_retry
 
+
 @dataclass
 class FetchConfig:
     proc: int
@@ -91,22 +93,21 @@ def make_request(url: str, token=None) -> urllib.request.Request:
 
 
 # a dictionary of plugins and their new repositories
-Redirects = Dict['PluginDesc', 'Repo']
+Redirects = Dict["PluginDesc", "Repo"]
+
 
 class Repo:
-    def __init__(
-        self, uri: str, branch: str
-    ) -> None:
+    def __init__(self, uri: str, branch: str) -> None:
         self.uri = uri
-        '''Url to the repo'''
+        """Url to the repo"""
         self._branch = branch
         # Redirect is the new Repo to use
-        self.redirect: Optional['Repo'] = None
+        self.redirect: Optional["Repo"] = None
         self.token = "dummy_token"
 
     @property
     def name(self):
-        return self.uri.split('/')[-1]
+        return self.uri.split("/")[-1]
 
     @property
     def branch(self):
@@ -114,6 +115,7 @@ class Repo:
 
     def __str__(self) -> str:
         return f"{self.uri}"
+
     def __repr__(self) -> str:
         return f"Repo({self.name}, {self.uri})"
 
@@ -125,9 +127,9 @@ class Repo:
     def latest_commit(self) -> Tuple[str, datetime]:
         log.debug("Latest commit")
         loaded = self._prefetch(None)
-        updated = datetime.strptime(loaded['date'], "%Y-%m-%dT%H:%M:%S%z")
+        updated = datetime.strptime(loaded["date"], "%Y-%m-%dT%H:%M:%S%z")
 
-        return loaded['rev'], updated
+        return loaded["rev"], updated
 
     def _prefetch(self, ref: Optional[str]):
         cmd = ["nix-prefetch-git", "--quiet", "--fetch-submodules", self.uri]
@@ -144,23 +146,23 @@ class Repo:
         return loaded["sha256"]
 
     def as_nix(self, plugin: "Plugin") -> str:
-        return f'''fetchgit {{
+        return f"""fetchgit {{
       url = "{self.uri}";
       rev = "{plugin.commit}";
       sha256 = "{plugin.sha256}";
-    }}'''
+    }}"""
 
 
 class RepoGitHub(Repo):
-    def __init__(
-        self, owner: str, repo: str, branch: str
-    ) -> None:
+    def __init__(self, owner: str, repo: str, branch: str) -> None:
         self.owner = owner
         self.repo = repo
         self.token = None
-        '''Url to the repo'''
+        """Url to the repo"""
         super().__init__(self.url(""), branch)
-        log.debug("Instantiating github repo owner=%s and repo=%s", self.owner, self.repo)
+        log.debug(
+            "Instantiating github repo owner=%s and repo=%s", self.owner, self.repo
+        )
 
     @property
     def name(self):
@@ -213,7 +215,6 @@ class RepoGitHub(Repo):
             new_repo = RepoGitHub(owner=new_owner, repo=new_name, branch=self.branch)
             self.redirect = new_repo
 
-
     def prefetch(self, commit: str) -> str:
         if self.has_submodules():
             sha256 = super().prefetch(commit)
@@ -233,12 +234,12 @@ class RepoGitHub(Repo):
         else:
             submodule_attr = ""
 
-        return f'''fetchFromGitHub {{
+        return f"""fetchFromGitHub {{
       owner = "{self.owner}";
       repo = "{self.repo}";
       rev = "{plugin.commit}";
       sha256 = "{plugin.sha256}";{submodule_attr}
-    }}'''
+    }}"""
 
 
 @dataclass(frozen=True)
@@ -258,15 +259,14 @@ class PluginDesc:
         return self.repo.name < other.repo.name
 
     @staticmethod
-    def load_from_csv(config: FetchConfig, row: Dict[str, str]) -> 'PluginDesc':
+    def load_from_csv(config: FetchConfig, row: Dict[str, str]) -> "PluginDesc":
         branch = row["branch"]
-        repo = make_repo(row['repo'], branch.strip())
+        repo = make_repo(row["repo"], branch.strip())
         repo.token = config.github_token
         return PluginDesc(repo, branch.strip(), row["alias"])
 
-
     @staticmethod
-    def load_from_string(config: FetchConfig, line: str) -> 'PluginDesc':
+    def load_from_string(config: FetchConfig, line: str) -> "PluginDesc":
         branch = "HEAD"
         alias = None
         uri = line
@@ -278,6 +278,7 @@ class PluginDesc:
         repo = make_repo(uri.strip(), branch.strip())
         repo.token = config.github_token
         return PluginDesc(repo, branch.strip(), alias)
+
 
 @dataclass
 class Plugin:
@@ -302,23 +303,38 @@ class Plugin:
         return copy
 
 
-def load_plugins_from_csv(config: FetchConfig, input_file: Path,) -> List[PluginDesc]:
+def load_plugins_from_csv(
+    config: FetchConfig,
+    input_file: Path,
+) -> List[PluginDesc]:
     log.debug("Load plugins from csv %s", input_file)
     plugins = []
-    with open(input_file, newline='') as csvfile:
+    with open(input_file, newline="") as csvfile:
         log.debug("Writing into %s", input_file)
-        reader = csv.DictReader(csvfile,)
+        reader = csv.DictReader(
+            csvfile,
+        )
         for line in reader:
             plugin = PluginDesc.load_from_csv(config, line)
             plugins.append(plugin)
 
     return plugins
 
+
 def run_nix_expr(expr):
     with CleanEnvironment() as nix_path:
-        cmd = ["nix", "eval", "--extra-experimental-features",
-                "nix-command", "--impure", "--json", "--expr", expr,
-                "--nix-path", nix_path]
+        cmd = [
+            "nix",
+            "eval",
+            "--extra-experimental-features",
+            "nix-command",
+            "--impure",
+            "--json",
+            "--expr",
+            expr,
+            "--nix-path",
+            nix_path,
+        ]
         log.debug("Running command %s", " ".join(cmd))
         out = subprocess.check_output(cmd)
         data = json.loads(out)
@@ -349,7 +365,7 @@ class Editor:
         self.nixpkgs_repo = None
 
     def add(self, args):
-        '''CSV spec'''
+        """CSV spec"""
         log.debug("called the 'add' command")
         fetch_config = FetchConfig(args.proc, args.github_token)
         editor = self
@@ -357,23 +373,27 @@ class Editor:
             log.debug("using plugin_line", plugin_line)
             pdesc = PluginDesc.load_from_string(fetch_config, plugin_line)
             log.debug("loaded as pdesc", pdesc)
-            append = [ pdesc ]
-            editor.rewrite_input(fetch_config, args.input_file, editor.deprecated, append=append)
-            plugin, _ = prefetch_plugin(pdesc, )
+            append = [pdesc]
+            editor.rewrite_input(
+                fetch_config, args.input_file, editor.deprecated, append=append
+            )
+            plugin, _ = prefetch_plugin(
+                pdesc,
+            )
             autocommit = not args.no_commit
             if autocommit:
                 commit(
                     editor.nixpkgs_repo,
                     "{drv_name}: init at {version}".format(
                         drv_name=editor.get_drv_name(plugin.normalized_name),
-                        version=plugin.version
+                        version=plugin.version,
                     ),
                     [args.outfile, args.input_file],
                 )
 
     # Expects arguments generated by 'update' subparser
-    def update(self, args ):
-        '''CSV spec'''
+    def update(self, args):
+        """CSV spec"""
         print("the update member function should be overriden in subclasses")
 
     def get_current_plugins(self) -> List[Plugin]:
@@ -386,11 +406,11 @@ class Editor:
         return plugins
 
     def load_plugin_spec(self, config: FetchConfig, plugin_file) -> List[PluginDesc]:
-        '''CSV spec'''
+        """CSV spec"""
         return load_plugins_from_csv(config, plugin_file)
 
     def generate_nix(self, _plugins, _outfile: str):
-        '''Returns nothing for now, writes directly to outfile'''
+        """Returns nothing for now, writes directly to outfile"""
         raise NotImplementedError()
 
     def get_update(self, input_file: str, outfile: str, config: FetchConfig):
@@ -414,7 +434,6 @@ class Editor:
 
         return update
 
-
     @property
     def attr_path(self):
         return self.name + "Plugins"
@@ -428,10 +447,11 @@ class Editor:
     def create_parser(self):
         common = argparse.ArgumentParser(
             add_help=False,
-            description=(f"""
+            description=(
+                f"""
                 Updates nix derivations for {self.name} plugins.\n
                 By default from {self.default_in} to {self.default_out}"""
-            )
+            ),
         )
         common.add_argument(
             "--input-names",
@@ -464,26 +484,33 @@ class Editor:
             Uses GITHUB_API_TOKEN environment variables as the default value.""",
         )
         common.add_argument(
-            "--no-commit", "-n", action="store_true", default=False,
-            help="Whether to autocommit changes"
+            "--no-commit",
+            "-n",
+            action="store_true",
+            default=False,
+            help="Whether to autocommit changes",
         )
         common.add_argument(
-            "--debug", "-d", choices=LOG_LEVELS.keys(),
+            "--debug",
+            "-d",
+            choices=LOG_LEVELS.keys(),
             default=logging.getLevelName(logging.WARN),
-            help="Adjust log level"
+            help="Adjust log level",
         )
 
         main = argparse.ArgumentParser(
             parents=[common],
-            description=(f"""
+            description=(
+                f"""
                 Updates nix derivations for {self.name} plugins.\n
                 By default from {self.default_in} to {self.default_out}"""
-            )
+            ),
         )
 
         subparsers = main.add_subparsers(dest="command", required=False)
         padd = subparsers.add_parser(
-            "add", parents=[],
+            "add",
+            parents=[],
             description="Add new plugin",
             add_help=False,
         )
@@ -503,10 +530,12 @@ class Editor:
         pupdate.set_defaults(func=self.update)
         return main
 
-    def run(self,):
-        '''
+    def run(
+        self,
+    ):
+        """
         Convenience function
-        '''
+        """
         parser = self.create_parser()
         args = parser.parse_args()
         command = args.command or "update"
@@ -517,8 +546,6 @@ class Editor:
             self.nixpkgs_repo = git.Repo(self.root, search_parent_directories=True)
 
         getattr(self, command)(args)
-
-
 
 
 class CleanEnvironment(object):
@@ -571,14 +598,15 @@ def print_download_error(plugin: PluginDesc, ex: Exception):
     ]
     print("\n".join(tb_lines))
 
+
 def check_results(
     results: List[Tuple[PluginDesc, Union[Exception, Plugin], Optional[Repo]]]
 ) -> Tuple[List[Tuple[PluginDesc, Plugin]], Redirects]:
-    ''' '''
+    """ """
     failures: List[Tuple[PluginDesc, Exception]] = []
     plugins = []
     redirects: Redirects = {}
-    for (pdesc, result, redirect) in results:
+    for pdesc, result, redirect in results:
         if isinstance(result, Exception):
             failures.append((pdesc, result))
         else:
@@ -595,17 +623,18 @@ def check_results(
     else:
         print(f", {len(failures)} plugin(s) could not be downloaded:\n")
 
-        for (plugin, exception) in failures:
+        for plugin, exception in failures:
             print_download_error(plugin, exception)
 
         sys.exit(1)
 
+
 def make_repo(uri: str, branch) -> Repo:
-    '''Instantiate a Repo with the correct specialization depending on server (gitub spec)'''
+    """Instantiate a Repo with the correct specialization depending on server (gitub spec)"""
     # dumb check to see if it's of the form owner/repo (=> github) or https://...
     res = urlparse(uri)
-    if res.netloc in [ "github.com", ""]:
-        res = res.path.strip('/').split('/')
+    if res.netloc in ["github.com", ""]:
+        res = res.path.strip("/").split("/")
         repo = RepoGitHub(res[0], res[1], branch)
     else:
         repo = Repo(uri.strip(), branch)
@@ -676,7 +705,6 @@ def prefetch(
         return (pluginDesc, e, None)
 
 
-
 def rewrite_input(
     config: FetchConfig,
     input_file: Path,
@@ -685,12 +713,14 @@ def rewrite_input(
     redirects: Redirects = {},
     append: List[PluginDesc] = [],
 ):
-    plugins = load_plugins_from_csv(config, input_file,)
+    plugins = load_plugins_from_csv(
+        config,
+        input_file,
+    )
 
     plugins.extend(append)
 
     if redirects:
-
         cur_date_iso = datetime.now().strftime("%Y-%m-%d")
         with open(deprecated, "r") as f:
             deprecations = json.load(f)
@@ -710,8 +740,8 @@ def rewrite_input(
     with open(input_file, "w") as f:
         log.debug("Writing into %s", input_file)
         # fields = dataclasses.fields(PluginDesc)
-        fieldnames = ['repo', 'branch', 'alias']
-        writer = csv.DictWriter(f, fieldnames, dialect='unix', quoting=csv.QUOTE_NONE)
+        fieldnames = ["repo", "branch", "alias"]
+        writer = csv.DictWriter(f, fieldnames, dialect="unix", quoting=csv.QUOTE_NONE)
         writer.writeheader()
         for plugin in sorted(plugins):
             writer.writerow(asdict(plugin))
@@ -725,7 +755,6 @@ def commit(repo: git.Repo, message: str, files: List[Path]) -> None:
         repo.index.commit(message)
     else:
         print("no changes in working tree to commit")
-
 
 
 def update_plugins(editor: Editor, args):
@@ -752,4 +781,3 @@ def update_plugins(editor: Editor, args):
                 f"{editor.attr_path}: resolve github repository redirects",
                 [args.outfile, args.input_file, editor.deprecated],
             )
-


### PR DESCRIPTION
## Description of changes

Nix does not respect `NIX_PATH` when the `nix-path` setting in nix.conf is set

Without this change (with `nix-path` set):

```
error:
       … <borked>

         at «none»:0: (source not available)

       … while calling the 'import' builtin

         at «string»:2:6:

            1|
            2| with import <localpkgs> {};
             |      ^
            3| lib.attrNames lua51Packages

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: file 'localpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)

       at «none»:0: (source not available)
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
