### PR TITLE
python310Packages.dask: 2023.7.1 -> 2023.8.0; python310Packages.distributed: 2023.4.1 -> 2023.8.0

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -38,7 +38,7 @@
 
 buildPythonPackage rec {
   pname = "dask";
-  version = "2023.7.1";
+  version = "2023.8.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     owner = "dask";
     repo = "dask";
     rev = "refs/tags/${version}";
-    hash = "sha256-1KnvIMEWT1MwlvkdgH10xk+lGSsGWJMLBonTtWwKjog=";
+    hash = "sha256-ZKjfxTJCu3EUOKz16+VP8+cPqQliFNc7AU1FPC1gOXw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -25,16 +25,16 @@
 
 buildPythonPackage rec {
   pname = "distributed";
-  version = "2023.4.1";
+  version = "2023.8.0";
   format = "pyproject";
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-KCgftu3i8N0WSelHiqWqa1vLN5gUtleftSUx1Zu4nZg=";
+    hash = "sha256-FvNh7gfxUR1iIUY3kMolhzcbWupQL39E9JXWip8bdrQ=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

- python310Packages.dask: 2023.7.1 -> 2023.8.0 
Diff: https://github.com/dask/dask/compare/refs/tags/2023.7.1...2023.8.0
Changelog: https://docs.dask.org/en/latest/changelog.html

- python310Packages.distributed: 2023.4.1 -> 2023.8.0
Diff: https://github.com/dask/distributed/compare/refs/tags/2023.4.1...2023.8.0
Changelog: https://github.com/dask/distributed/blob/2023.8.0/docs/source/changelog.rst

This PR will also fix the currently broken `distributed`.
The results of nixpkgs-review are not good, but this fix should improve the current situation.

We may need #248483 first.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
