### PR TITLE
texlive.bin.pygmentex: use new bin container instead of buildPythonApplication

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -648,46 +648,6 @@ rec {
     enableParallelBuilding = true;
   };
 
-  pygmentex = python3Packages.buildPythonApplication rec {
-    pname = "pygmentex";
-    inherit (src) version;
-    pyproject = false;
-
-    src = assertFixedHash pname texlive.pkgs.pygmentex.tex;
-
-    propagatedBuildInputs = with python3Packages; [
-      pygments
-      chardet
-    ];
-
-    dontBuild = true;
-
-    doCheck = false;
-
-    installPhase = ''
-      runHook preInstall
-
-      install -D ./scripts/pygmentex/pygmentex.py "$out"/bin/pygmentex
-
-      runHook postInstall
-    '';
-
-    meta = {
-      homepage = "https://www.ctan.org/pkg/pygmentex";
-      description = "Auxiliary tool for typesetting code listings in LaTeX documents using Pygments";
-      longDescription = ''
-        PygmenTeX is a Python-based LaTeX package that can be used for
-        typesetting code listings in a LaTeX document using Pygments.
-
-        Pygments is a generic syntax highlighter for general use in all kinds of
-        software such as forum systems, wikis or other applications that need to
-        prettify source code.
-      '';
-      license = lib.licenses.lppl13c;
-      maintainers = with lib.maintainers; [ romildo ];
-    };
-  };
-
   asymptote =
     let
       version = "3.09";

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -671,6 +671,7 @@ allPkgLists
     // {
       # for backward compatibility
       latexindent = texlive.pkgs.latexindent;
+      pygmentex = texlive.pkgs.pigmentex;
     };
 
   combine =

--- a/pkgs/tools/typesetting/tex/texlive/patch-scripts.sed
+++ b/pkgs/tools/typesetting/tex/texlive/patch-scripts.sed
@@ -3,7 +3,9 @@
     N;
     # add script folder to path, unless we interfere with a docstring
     /\nr"""/b skip-python-path-patch
-    s!\n!\nimport sys; sys.path.insert(0,'@scriptsFolder@')\n!
+    # skip encoding declarations
+    /\n\s*#.*coding[=:]\s*[-a-zA-Z0-9_.]/N
+    s!\n\([^\n]*\)$!\nimport sys; sys.path.insert(0,'@scriptsFolder@')\n\1!
     :skip-python-path-patch
   }
 

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -146,6 +146,14 @@ lib.recursiveUpdate orig rec {
   ulqda.extraBuildInputs = [ (perl.withPackages (ps: with ps; [ DigestSHA1 ])) ];
 
   #### python packages
+  pygmentex.extraBuildInputs = [
+    (python3.withPackages (
+      ps: with ps; [
+        pygments
+        chardet
+      ]
+    ))
+  ];
   pythontex.extraBuildInputs = [ (python3.withPackages (ps: with ps; [ pygments ])) ];
 
   #### other runtime PATH dependencies


### PR DESCRIPTION
## Description of changes
Use the new lightweight bin container infrastructure to build pygmentex. This includes a small refinement to the bin containers (detect and skip the python encoding declaration) so it will rebuild all bin containers.

@romildo does it look ok to you?

Unfortunately this removes the metadata, but we can easily improve the infrastructure to accommodate for it if necessary.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).