### PR TITLE
musescore: re-add USE_SYSTEM_FREETYPE functionality

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -64,6 +64,18 @@ in stdenv'.mkDerivation rec {
       url = "https://github.com/doronbehar/MuseScore/commit/f48448a3ede46f5a7ef470940072fbfb6742487c.patch";
       hash = "sha256-UEc7auscnW0KMfWkLKQtm+UstuTNsuFeoNJYIidIlwM=";
     })
+    # Upstream removed the option to use system freetype library in v4.1.0,
+    # causing the app to crash on systems when the outdated bundled freetype
+    # tries to load the Noto Sans font. For more info on the crash itself,
+    # see #244409 and https://github.com/musescore/MuseScore/issues/18795.
+    # For now, re-add the option ourselves. The fix has been merged upstream,
+    # so we can remove this patch with the next version. In the future, we
+    # may replace the other bundled thirdparty libs with system libs, see
+    # https://github.com/musescore/MuseScore/issues/11572.
+    (fetchpatch {
+      url = "https://github.com/musescore/MuseScore/commit/9ab6b32b1c3b990cfa7bb172ee8112521dc2269c.patch";
+      hash = "sha256-5GA29Z+o3I/uDTTDbkauZ8/xSdCE6yY93phMSY0ea7s=";
+    })
   ];
 
   cmakeFlags = [
@@ -73,7 +85,7 @@ in stdenv'.mkDerivation rec {
     # https://github.com/musescore/MuseScore/issues/15571
     "-DMUE_BUILD_CRASHPAD_CLIENT=OFF"
     # Use our freetype
-    "-DUSE_SYSTEM_FREETYPE=ON"
+    "-DMUE_COMPILE_USE_SYSTEM_FREETYPE=ON"
     # From some reason, in $src/build/cmake/SetupBuildEnvironment.cmake,
     # upstream defaults to compiling to x86_64 only, unless this cmake flag is
     # set

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -153,6 +153,9 @@ in stdenv'.mkDerivation rec {
     ln -s $out/Applications/mscore.app/Contents/MacOS/mscore $out/bin/mscore.
   '';
 
+  # Don't run bundled upstreams tests, as they require a running X window system.
+  doCheck = false;
+
   passthru.tests = nixosTests.musescore;
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes
Fixes #244409.

Upstream removed the option to use system freetype library in v4.1.0, causing the app to crash on systems when the outdated bundled freetype tries to load the Noto Sans font. For more info on the crash itself, see #244409 and https://github.com/musescore/MuseScore/issues/18795.

For now, re-add the option ourselves. The fix has been merged upstream, so we can remove this patch with the next version. In the future, we may replace the other bundled thirdparty libs with system libs, see https://github.com/musescore/MuseScore/issues/11572.

@doronbehar @turion 


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
