### PR TITLE
python3Packages.streamdeck: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/development/python-modules/streamdeck/default.nix
+++ b/pkgs/development/python-modules/streamdeck/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "streamdeck";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-9bNWsNEW5Di2EZ3z+p8y4Q7GTfIG66b05pTiQcff7HE=";
+    hash = "sha256-aVmWbrBhZ49NfwOp23FD1dxZF+w/q26fIOVs7iQXUxo=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/streamdeck/hardcode-libusb.patch
+++ b/pkgs/development/python-modules/streamdeck/hardcode-libusb.patch
@@ -5,7 +5,7 @@ index 824c59c..f13754e 100644
 @@ -110,7 +110,7 @@ class LibUSBHIDAPI(Transport):
  
              search_library_names = {
-                 "Windows": ["hidapi.dll", "libhidapi-0.dll"],
+                 "Windows": ["hidapi.dll", "libhidapi-0.dll", "./hidapi.dll"],
 -                "Linux": ["libhidapi-libusb.so", "libhidapi-libusb.so.0"],
 +                "Linux": ["@libusb@"],
                  "Darwin": ["libhidapi.dylib"],


### PR DESCRIPTION
## Description of changes

[Changelog](https://github.com/abcminiuser/python-elgato-streamdeck/blob/master/CHANGELOG#L1-L3):

```
Version 0.9.4:
	- Updated Windows HIDAPI backend to attempt to load from the local working directory.
	- Added detection for MacOS Homebrew installations of the libhidapi back-end library.
```

Tested in conjunction with https://github.com/NixOS/nixpkgs/pull/247618 because `streamdeck-ui` doesn't build on nixpkgs `master`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
