### PR TITLE
texlive.combine: add paperSize parameter for setting paper sizes

### DIFF
--- a/doc/languages-frameworks/texlive.section.md
+++ b/doc/languages-frameworks/texlive.section.md
@@ -28,6 +28,29 @@ Since release 15.09 there is a new TeX Live packaging that lives entirely under 
   }
   ```
 
+- To configure the default page size, pass `paperSize`:
+
+  ```nix
+  texlive.combine {
+    # inherit (texlive) whatever-you-want;
+    paperSize = "letter"; # a4 or letter
+  }
+  ```
+
+  The argument `paperSize` can also be an attribute set, specifying different page sizes for different programs:
+
+  ```nix
+  texlive.combine {
+    # inherit (texlive) whatever-you-want;
+    paperSize = {
+      "dvipdfmx" = "legal";
+      "psutils" = "letter";
+    };
+  }
+  ```
+
+  The full list of supported programs and paper sizes can be found in `$TEXMFROOT/tlpkg/TeXLive/TLPaper.pm`.
+
 - You can list packages e.g. by `nix repl`.
 
   ```ShellSession


### PR DESCRIPTION
## Description of changes
Add a new parameter `paperSize` to `texlive.combine` with for setting the default paper size, either for all programs at once (with a string), or with different values per program (with an attribute set).

We should probably come up with a test for this.

PS: I hope that calling a single function in the module `TeXLive::TLPaper` does not make Nixpkgs GPL2!

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).