### PR TITLE
pkgs/misc/cups/drivers: add brother mfcj1205w 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14962,6 +14962,12 @@
     githubId = 1153271;
     name = "Sander van der Burg";
   };
+  saoriyuko = {
+    email = "saori.yuko@protonmail.ch";
+    github = "saori-yuko";
+    githubId = 102890314;
+    name = "Saori Yuko";
+  };
   sarcasticadmin = {
     email = "rob@sarcasticadmin.com";
     github = "sarcasticadmin";

--- a/pkgs/misc/cups/drivers/brother/mfcj1205w/default.nix
+++ b/pkgs/misc/cups/drivers/brother/mfcj1205w/default.nix
@@ -1,5 +1,4 @@
-{ pkgsi686Linux
-, stdenv
+{ stdenv
 , fetchurl
 , dpkg
 , makeWrapper
@@ -22,7 +21,7 @@ let
   reldir = "opt/brother/Printers/${model}/";
 
 in rec {
-  driver = pkgsi686Linux.stdenv.mkDerivation rec {
+  driver = stdenv.mkDerivation rec {
     inherit src version;
     name = "${model}drv-${version}";
 
@@ -40,9 +39,8 @@ in rec {
         --prefix PATH : ${lib.makeBinPath [
           coreutils ghostscript gnugrep gnused which
         ]}
-    # need to use i686 glibc here, these are 32bit proprietary binaries
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      $dir/lpd/i686/brmfcj1205wfilter
+      $dir/lpd/x86_64/brmfcj1205wfilter
     '';
 
     meta = {
@@ -50,8 +48,8 @@ in rec {
       homepage = "http://www.brother.com/";
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.unfree;
-      platforms = [ "x86_64-linux" "i686-linux" ];
-      maintainers = [ lib.maintainers.steveej ];
+      platforms = [ "x86_64-linux" ];
+      maintainers = [ lib.maintainers.saori-yuko ];
     };
   };
 
@@ -83,8 +81,8 @@ in rec {
       homepage = "http://www.brother.com/";
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.gpl2;
-      platforms = [ "x86_64-linux" "i686-linux" ];
-      maintainers = [ lib.maintainers.steveej ];
+      platforms = [ "x86_64-linux" ];
+      maintainers = [ lib.maintainers.saori-yuko ];
     };
   };
 }

--- a/pkgs/misc/cups/drivers/brother/mfcj1205w/default.nix
+++ b/pkgs/misc/cups/drivers/brother/mfcj1205w/default.nix
@@ -49,7 +49,7 @@ in rec {
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.unfree;
       platforms = [ "x86_64-linux" ];
-      maintainers = [ lib.maintainers.saori-yuko ];
+      maintainers = [ lib.maintainers.saoriyuko ];
     };
   };
 
@@ -82,7 +82,7 @@ in rec {
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.gpl2;
       platforms = [ "x86_64-linux" ];
-      maintainers = [ lib.maintainers.saori-yuko ];
+      maintainers = [ lib.maintainers.saoriyuko ];
     };
   };
 }

--- a/pkgs/misc/cups/drivers/brother/mfcj1205w/default.nix
+++ b/pkgs/misc/cups/drivers/brother/mfcj1205w/default.nix
@@ -1,0 +1,90 @@
+{ pkgsi686Linux
+, stdenv
+, fetchurl
+, dpkg
+, makeWrapper
+, coreutils
+, ghostscript
+, gnugrep
+, gnused
+, which
+, perl
+, lib
+}:
+
+let
+  model = "mfcj1205w";
+  version = "3.5.0-1";
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf105289/${model}pdrv-${version}.i386.deb";
+    sha256 = "0qkpnc5ijhr0dfbm8xvpvj2mqizqr79hnr8qbjr7v36fkym8gdiy";
+  };
+  reldir = "opt/brother/Printers/${model}/";
+
+in rec {
+  driver = pkgsi686Linux.stdenv.mkDerivation rec {
+    inherit src version;
+    name = "${model}drv-${version}";
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      dir="$out/${reldir}"
+      substituteInPlace $dir/lpd/filter_${model} \
+        --replace /usr/bin/perl ${perl}/bin/perl \
+        --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"${model}\"; #"
+      wrapProgram $dir/lpd/filter_${model} \
+        --prefix PATH : ${lib.makeBinPath [
+          coreutils ghostscript gnugrep gnused which
+        ]}
+    # need to use i686 glibc here, these are 32bit proprietary binaries
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      $dir/lpd/i686/brmfcj1205wfilter
+    '';
+
+    meta = {
+      description = "Brother ${lib.strings.toUpper model} driver";
+      homepage = "http://www.brother.com/";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      license = lib.licenses.unfree;
+      platforms = [ "x86_64-linux" "i686-linux" ];
+      maintainers = [ lib.maintainers.steveej ];
+    };
+  };
+
+  cupswrapper = stdenv.mkDerivation rec {
+    inherit version src;
+    name = "${model}cupswrapper-${version}";
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      basedir=${driver}/${reldir}
+      dir=$out/${reldir}
+      substituteInPlace $dir/cupswrapper/brother_lpdwrapper_${model} \
+        --replace /usr/bin/perl ${perl}/bin/perl \
+        --replace "basedir =~" "basedir = \"$basedir\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"${model}\"; #"
+      wrapProgram $dir/cupswrapper/brother_lpdwrapper_${model} \
+        --prefix PATH : ${lib.makeBinPath [ coreutils gnugrep gnused ]}
+      mkdir -p $out/lib/cups/filter
+      mkdir -p $out/share/cups/model
+      ln $dir/cupswrapper/brother_lpdwrapper_${model} $out/lib/cups/filter
+      ln $dir/cupswrapper/brother_${model}_printer_en.ppd $out/share/cups/model
+    '';
+
+    meta = {
+      description = "Brother ${lib.strings.toUpper model} CUPS wrapper driver";
+      homepage = "http://www.brother.com/";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      license = lib.licenses.gpl2;
+      platforms = [ "x86_64-linux" "i686-linux" ];
+      maintainers = [ lib.maintainers.steveej ];
+    };
+  };
+}

--- a/pkgs/misc/cups/drivers/brother/mfcj1205w/default.nix
+++ b/pkgs/misc/cups/drivers/brother/mfcj1205w/default.nix
@@ -45,7 +45,7 @@ in rec {
 
     meta = {
       description = "Brother ${lib.strings.toUpper model} driver";
-      homepage = "http://www.brother.com/";
+      homepage = "https://www.brother.com/";
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.unfree;
       platforms = [ "x86_64-linux" ];
@@ -78,7 +78,7 @@ in rec {
 
     meta = {
       description = "Brother ${lib.strings.toUpper model} CUPS wrapper driver";
-      homepage = "http://www.brother.com/";
+      homepage = "https://www.brother.com/";
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.gpl2;
       platforms = [ "x86_64-linux" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40747,7 +40747,6 @@ with pkgs;
   mfcl2740dwcupswrapper = callPackage ../misc/cups/drivers/mfcl2740dwcupswrapper { };
   mfcl2740dwlpr = callPackage ../misc/cups/drivers/mfcl2740dwlpr { };
 
-  # This driver is only available as a 32 bit proprietary binary driver
   mfcj1205wlpr = (callPackage ../misc/cups/drivers/brother/mfcj1205w { }).driver;
   mfcj1205wcupswrapper = (callPackage ../misc/cups/drivers/brother/mfcj1205w { }).cupswrapper;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40748,6 +40748,10 @@ with pkgs;
   mfcl2740dwlpr = callPackage ../misc/cups/drivers/mfcl2740dwlpr { };
 
   # This driver is only available as a 32 bit proprietary binary driver
+  mfcj1205wlpr = (callPackage ../misc/cups/drivers/brother/mfcj1205w { }).driver;
+  mfcj1205wcupswrapper = (callPackage ../misc/cups/drivers/brother/mfcj1205w { }).cupswrapper;
+
+  # This driver is only available as a 32 bit proprietary binary driver
   mfcl3770cdwlpr = (callPackage ../misc/cups/drivers/brother/mfcl3770cdw { }).driver;
   mfcl3770cdwcupswrapper = (callPackage ../misc/cups/drivers/brother/mfcl3770cdw { }).cupswrapper;
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds the printer driver for the Brother mfcj1205w.
It combines the cups-wrapper and the driver in one file which allows
sharing common variables and making it less error-prone than the other
Brother drivers in repository.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
