### PR TITLE
teensy-cmake-macros: init at unstable-2023-04-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11102,6 +11102,12 @@
     github = "michaelCTS";
     githubId = 132582212;
   };
+  michaeldonovan = {
+    email = "michael@mdonovan.dev";
+    name = "Michael Donovan";
+    github = "michaeldonovan";
+    githubId = 14077230;
+  };
   michaelgrahamevans = {
     email = "michaelgrahamevans@gmail.com";
     name = "Michael Evans";

--- a/pkgs/development/embedded/teensy-cmake-macros/default.nix
+++ b/pkgs/development/embedded/teensy-cmake-macros/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, callPackage
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "teensy-cmake-macros";
+  version = "unstable-2023-04-15";
+
+  src = fetchFromGitHub {
+    owner = "newdigate";
+    repo = "teensy-cmake-macros";
+    rev = "dc401ed23e6e13a9db3cd2a65f611a4738df3b0e";
+    hash = "sha256-E+BOlsCJtOScr3B5GSv1WM6rFv6cFYvm/iJ893fsmXM=";
+  };
+
+  propagatedBuildInputs = [ cmake pkg-config ];
+
+  passthru = {
+    hook = callPackage ./hook.nix {
+      teensy-cmake-macros = finalAttrs.finalPackage;
+    };
+  };
+
+  meta = with lib; {
+    description = "CMake macros for building teensy projects";
+    platforms = platforms.all;
+    homepage = "https://github.com/newdigate/teensy-cmake-macros";
+    license = licenses.mit;
+    maintainers = [ maintainers.michaeldonovan ];
+  };
+})

--- a/pkgs/development/embedded/teensy-cmake-macros/hook.nix
+++ b/pkgs/development/embedded/teensy-cmake-macros/hook.nix
@@ -1,0 +1,17 @@
+{ lib
+, makeSetupHook
+, teensy-cmake-macros
+}:
+
+makeSetupHook {
+  name = "teensy-cmake-macros-hook";
+
+  propagatedBuildInputs = [ teensy-cmake-macros ];
+
+  passthru = { inherit teensy-cmake-macros; };
+
+  meta = {
+    description = "A setup hook for teensy-cmake-macros";
+    inherit (teensy-cmake-macros.meta) maintainers platforms broken;
+  };
+} ./setup-hook.sh

--- a/pkgs/development/embedded/teensy-cmake-macros/setup-hook.sh
+++ b/pkgs/development/embedded/teensy-cmake-macros/setup-hook.sh
@@ -1,0 +1,5 @@
+teensyCMakeMacrosEnvHook() {
+  cmakeFlagsArray+=(-DCMAKE_MODULE_PATH=@out@/lib/cmake)
+}
+
+addEnvHooks "$targetOffset" teensyCMakeMacrosEnvHook

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20156,6 +20156,8 @@ with pkgs;
 
   tcptrack = callPackage ../development/tools/misc/tcptrack { };
 
+  teensy-cmake-macros = callPackage ../development/embedded/teensy-cmake-macros { };
+
   teensyduino = arduino-core.override { withGui = true; withTeensyduino = true; };
 
   teensy-loader-cli = callPackage ../development/embedded/teensy-loader-cli { };


### PR DESCRIPTION
## Description of changes

Init package for [newdigate/teensy-cmake-macros](https://github.com/newdigate/teensy-cmake-macros/), a set of CMake macros for building [Teensy](https://www.pjrc.com/teensy/) apps/libraries with gcc-arm-none-eabi.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
