### PR TITLE
invoice2data: clean up some build and runtime dependencies

### DIFF
--- a/pkgs/tools/text/invoice2data/default.nix
+++ b/pkgs/tools/text/invoice2data/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , ghostscript
 , imagemagick
 , poppler_utils
@@ -16,25 +17,28 @@ python3.pkgs.buildPythonApplication rec {
     owner = "invoice-x";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ss2h8cg0sga+lzJyQHckrZB/Eb63Oj3FkqmGqWCzCQ8=";
+    hash = "sha256-ss2h8cg0sga+lzJyQHckrZB/Eb63Oj3FkqmGqWCzCQ8=";
   };
 
-  buildInputs = with python3.pkgs; [ setuptools-git ];
+  patches = [
+    # https://github.com/invoice-x/invoice2data/pull/522
+    (fetchpatch {
+      name = "clean-up-build-dependencies.patch";
+      url = "https://github.com/invoice-x/invoice2data/commit/ccea3857c7c8295ca51dc24de6cde78774ea7e64.patch";
+      hash = "sha256-BhqPW4hWG/EaR3qBv5a68dcvIMrCCT74GdDHr0Mss5Q=";
+    })
+  ];
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools-git
+  ];
 
   propagatedBuildInputs = with python3.pkgs; [
-    chardet
     dateparser
     pdfminer-six
     pillow
     pyyaml
-    setuptools
-    unidecode
   ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "pytest-runner" ""
-  '';
 
   makeWrapperArgs = ["--prefix" "PATH" ":" (lib.makeBinPath [
     ghostscript


### PR DESCRIPTION
## Description of changes

This change does the following:

1. Pull in a patch to remove unnecessary `pip` and `pytest-runner` dependencies in setup.cfg.
2. Move setuptools-git into nativeBuildInputs, where it belongs.
3. Remove `chardet`, which was removed in https://github.com/invoice-x/invoice2data/pull/449.
4. Remove `setuptools`, which is not needed at runtime.
5. Remove `unidecode`, which was removed in https://github.com/invoice-x/invoice2data/pull/436.

This package has an updated version (version 0.4.4), but I don't feel prepared to update it yet. It's also nontrivial to get the tests working again, so I've skipped doing that in this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
