### PR TITLE
openrazer-daemon: do not install twice

### DIFF
--- a/pkgs/development/python-modules/openrazer/common.nix
+++ b/pkgs/development/python-modules/openrazer/common.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 }: rec {
   version = "3.5.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "openrazer";

--- a/pkgs/development/python-modules/openrazer/daemon.nix
+++ b/pkgs/development/python-modules/openrazer/daemon.nix
@@ -17,15 +17,13 @@ let
   common = import ./common.nix { inherit lib fetchFromGitHub; };
 in
 buildPythonPackage (common // {
-  pname = "openrazer_daemon";
+  pname = "openrazer-daemon";
 
   disabled = !isPy3k;
 
   outputs = [ "out" "man" ];
 
-  prePatch = ''
-    cd daemon
-  '';
+  sourceRoot = "${common.src.name}/daemon";
 
   postPatch = ''
     substituteInPlace openrazer_daemon/daemon.py --replace "plugdev" "openrazer"
@@ -43,8 +41,8 @@ buildPythonPackage (common // {
     setproctitle
   ];
 
-  postBuild = ''
-    DESTDIR="$out" PREFIX="" make install manpages
+  postInstall = ''
+    DESTDIR="$out" PREFIX="" make manpages install-resources install-systemd
   '';
 
   # no tests run


### PR DESCRIPTION
## Description of changes

While working on switching the Python package installer from pip to [installer](https://installer.pypa.io/en/stable/), discovered that this package was installing the same files twice. Its postBuild phase runs "make install", which calls "setup.py install". Then, in installPhase, pip is used to install again. This begins to break with installer, which notices that files it is writing to already exist. This PR fixes that by only calling the Makefile targets that do not install the Python wheel. In addition:

1. Add format = "setuptools" as best practice.
2. Change the pname so that it is normalized.
3. Change "cd" in prePatch to sourceRoot.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
