### PR TITLE
treewide: Amend hacks of removing $(pwd)

### DIFF
--- a/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
@@ -46,8 +46,8 @@ mkOpenModelicaDerivation ({
 
   preFixup = ''
     for entry in $(find $out -name libipopt.so); do
-      patchelf --shrink-rpath --allowed-rpath-prefixes /nix/store $entry
-      patchelf --set-rpath '$ORIGIN':"$(patchelf --print-rpath $entry)" $entry
+      patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" "$entry"
+      patchelf --set-rpath '$ORIGIN':"$(patchelf --print-rpath $entry)" "$entry"
     done
   '';
 

--- a/pkgs/development/libraries/hipfft/default.nix
+++ b/pkgs/development/libraries/hipfft/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
   '' + lib.optionalString buildSamples ''
     mkdir -p $sample/bin
     mv clients/staging/hipfft_* $sample/bin
-    patchelf $sample/bin/hipfft_* --shrink-rpath --allowed-rpath-prefixes /nix/store
+    patchelf $sample/bin/hipfft_* --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE"
   '' + lib.optionalString (buildTests || buildBenchmarks) ''
     rmdir $out/bin
   '';

--- a/pkgs/development/libraries/hipsolver/default.nix
+++ b/pkgs/development/libraries/hipsolver/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
   '' + lib.optionalString buildSamples ''
     mkdir -p $sample/bin
     mv clients/staging/example-* $sample/bin
-    patchelf $sample/bin/example-* --shrink-rpath --allowed-rpath-prefixes /nix/store
+    patchelf $sample/bin/example-* --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE"
   '' + lib.optionalString (buildTests || buildBenchmarks) ''
     rmdir $out/bin
   '';

--- a/pkgs/development/libraries/migraphx/default.nix
+++ b/pkgs/development/libraries/migraphx/default.nix
@@ -140,7 +140,7 @@ in stdenv.mkDerivation (finalAttrs: {
   '' + lib.optionalString buildTests ''
     mkdir -p $test/bin
     mv bin/test_* $test/bin
-    patchelf $test/bin/test_* --shrink-rpath --allowed-rpath-prefixes /nix/store
+    patchelf $test/bin/test_* --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE"
   '';
 
   passthru.updateScript = rocmUpdateScript {

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -47,11 +47,12 @@ qtModule {
 
   doCheck = false; # fails 13 out of 13 tests (ctest)
 
-  # Hack to avoid TMPDIR in RPATHs.
-  preFixup = ''
-    rm -rf "$(pwd)"
-    mkdir "$(pwd)"
+  # remove forbidden references to $TMPDIR
+  preFixup = lib.optionalString stdenv.isLinux ''
+    patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" "$out"/libexec/*
   '';
+
+  enableParallelBuilding = true;
 
   meta = {
     maintainers = with lib.maintainers; [ abbradar periklis ];

--- a/pkgs/development/pharo/default.nix
+++ b/pkgs/development/pharo/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation {
     mkdir "$out/bin"
     cp build/vm/*.so* "$out/lib/"
     cp build/vm/pharo "$out/bin/pharo"
-    patchelf --allowed-rpath-prefixes /nix/store --shrink-rpath "$out/bin/pharo"
+    patchelf --allowed-rpath-prefixes "$NIX_STORE" --shrink-rpath "$out/bin/pharo"
     wrapProgram "$out/bin/pharo" --set LD_LIBRARY_PATH "${library_path}"
 
     runHook postInstall

--- a/pkgs/development/tools/misc/rdc/default.nix
+++ b/pkgs/development/tools/misc/rdc/default.nix
@@ -102,7 +102,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     find $out/bin -executable -type f -exec \
-      patchelf {} --shrink-rpath --allowed-rpath-prefixes /nix/store \;
+      patchelf {} --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" \;
   '' + lib.optionalString buildTests ''
     mkdir -p $test
     mv $out/bin/rdctst_tests $test/bin

--- a/pkgs/development/tools/simavr/default.nix
+++ b/pkgs/development/tools/simavr/default.nix
@@ -35,8 +35,10 @@ in stdenv.mkDerivation rec {
   buildInputs = [ libelf freeglut libGLU libGL ]
     ++ lib.optional stdenv.isDarwin GLUT;
 
-  # Hack to avoid TMPDIR in RPATHs.
-  preFixup = ''rm -rf "$(pwd)" && mkdir "$(pwd)" '';
+  # remove forbidden references to $TMPDIR
+  preFixup = lib.optionalString stdenv.isLinux ''
+    patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" "$out"/bin/*
+  '';
 
   doCheck = true;
   checkTarget = "-C tests run_tests";

--- a/pkgs/os-specific/linux/libsmbios/default.nix
+++ b/pkgs/os-specific/linux/libsmbios/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   # remove forbidden reference to $TMPDIR
   preFixup = ''
-    patchelf --shrink-rpath --allowed-rpath-prefixes "/nix/store" "$out/sbin/smbios-sys-info-lite"
+    patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" "$out/sbin/smbios-sys-info-lite"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
The strip phase is using $TMPDIR now, so it would fail with:
`mktemp: failed to create file via template 'striperr.XXXXXX': No such file or directory`

Closes https://github.com/NixOS/nixpkgs/pull/248817

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
