### PR TITLE
play-with-mpv: unstable-2020-05-18 -> unstable-2021-04-02

### DIFF
--- a/pkgs/tools/video/play-with-mpv/default.nix
+++ b/pkgs/tools/video/play-with-mpv/default.nix
@@ -1,30 +1,56 @@
-{ lib, python3Packages, fetchFromGitHub, fetchurl, youtube-dl, git }:
+{ lib
+, python3Packages
+, fetchFromGitHub
+, fetchurl
+, youtube-dl
+}:
 
 let
-  install_freedesktop = fetchurl {
-    url = "https://github.com/thann/install_freedesktop/tarball/2673e8da4a67bee0ffc52a0ea381a541b4becdd4";
-    sha256 = "0j8d5jdcyqbl5p6sc1ags86v3hr2sghmqqi99d1mvc064g90ckrv";
+  install-freedesktop = python3Packages.buildPythonPackage rec {
+    pname = "install-freedesktop";
+    version = "0.1.2-1-g2673e8d";
+    format = "setuptools";
+
+    src = fetchurl {
+      name = "Thann-install_freedesktop-${version}.tar.gz";
+      url = "https://github.com/thann/install_freedesktop/tarball/2673e8da4a67bee0ffc52a0ea381a541b4becdd4";
+      hash = "sha256-O08G0iMGsF1DSyliXOHTIsOxDdJPBabNLXRhz5osDUk=";
+    };
+
+    # package has no tests
+    doCheck = false;
   };
 in
 python3Packages.buildPythonApplication rec {
   pname = "play-with-mpv";
-  version = "unstable-2020-05-18";
+  version = "unstable-2021-04-02";
+  format = "setuptools";
 
   src = fetchFromGitHub {
-      owner = "thann";
-      repo = "play-with-mpv";
-      rev = "656448e03fe9de9e8bd21959f2a3b47c4acb8c3e";
-      sha256 = "1qma8b3lnkdhxdjsnrq7n9zgy53q62j4naaqqs07kjxbn72zb4p4";
+    owner = "thann";
+    repo = "play-with-mpv";
+    rev = "07a9c1dd57d9e16538991b13fd3e2ed54d6e3a2d";
+    hash = "sha256-ZtUFzgYGNa9+g2xDONW8B5bbsbXmyY3IeT1GQH0AVIw=";
   };
-
-  nativeBuildInputs = [ git ];
-  propagatedBuildInputs = [ youtube-dl ];
 
   postPatch = ''
     substituteInPlace setup.py --replace \
-    '"https://github.com/thann/install_freedesktop/tarball/master#egg=install_freedesktop-0.2.0"' \
-    '"file://${install_freedesktop}#egg=install_freedesktop-0.2.0"'
+      '"https://github.com/thann/install_freedesktop/tarball/master#egg=install_freedesktop-0.2.0"' \
+      '"file://${install-freedesktop}#egg=install_freedesktop-0.2.0"' \
+      --replace 'version = get_version()' 'version = "0.1.0.post9"'
   '';
+
+  nativeBuildInputs = with python3Packages; [
+    install-freedesktop
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    youtube-dl
+  ];
+
+  # package has no tests
+  doCheck = false;
 
   meta = with lib; {
     description = "Chrome extension and python server that allows you to play videos in webpages with MPV instead";


### PR DESCRIPTION
## Description of changes

I took the opportunity to update this package a few more commits:

https://github.com/Thann/play-with-mpv/commits/master

But the main motivation is that some changes I am making to Python bootstrapping are revealing missing dependencies that were being silently ignored before. (I think pip was being used to attempt to download them, and then the build continued afterward when that download fails.)

Here, the main change is that the custom build of install-freedesktop needs to be an actual Python package in order for setuptools to recognize that it's a fulfilled dependency.

We can also get rid of the `git` dependency if we replace the version in setup.py with a valid version string.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
