### PR TITLE
python3.pkgs.certbot-dns-*: ignore warning in setuptools 67.5.0+

### DIFF
--- a/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
@@ -12,6 +12,8 @@ buildPythonPackage rec {
   inherit (certbot) src version;
   disabled = pythonOlder "3.6";
 
+  sourceRoot = "${src.name}/certbot-dns-cloudflare";
+
   propagatedBuildInputs = [
     acme
     certbot
@@ -22,9 +24,12 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
+  pytestFlagsArray = [
+    "-o cache_dir=$(mktemp -d)"
 
-  sourceRoot = "${src.name}/certbot-dns-cloudflare";
+    # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
+    "-W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"
+  ];
 
   meta = certbot.meta // {
     description = "Cloudflare DNS Authenticator plugin for Certbot";

--- a/pkgs/development/python-modules/certbot-dns-google/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-google/default.nix
@@ -13,6 +13,8 @@ buildPythonPackage rec {
   inherit (certbot) src version;
   disabled = pythonOlder "3.6";
 
+  sourceRoot = "${src.name}/certbot-dns-google";
+
   propagatedBuildInputs = [
     acme
     certbot
@@ -24,9 +26,12 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
+  pytestFlagsArray = [
+    "-o cache_dir=$(mktemp -d)"
 
-  sourceRoot = "${src.name}/certbot-dns-google";
+    # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
+    "-W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"
+  ];
 
   meta = certbot.meta // {
     description = "Google Cloud DNS Authenticator plugin for Certbot";

--- a/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
@@ -12,6 +12,8 @@ buildPythonPackage rec {
   inherit (certbot) src version;
   disabled = pythonOlder "3.6";
 
+  sourceRoot = "${src.name}/certbot-dns-rfc2136";
+
   propagatedBuildInputs = [
     acme
     certbot
@@ -22,9 +24,12 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
+  pytestFlagsArray = [
+    "-o cache_dir=$(mktemp -d)"
 
-  sourceRoot = "${src.name}/certbot-dns-rfc2136";
+    # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
+    "-W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"
+  ];
 
   meta = certbot.meta // {
     description = "RFC 2136 DNS Authenticator plugin for Certbot";

--- a/pkgs/development/python-modules/certbot-dns-route53/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-route53/default.nix
@@ -22,7 +22,12 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
+  pytestFlagsArray = [
+    "-o cache_dir=$(mktemp -d)"
+
+    # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
+    "-W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"
+  ];
 
   sourceRoot = "${src.name}/certbot-dns-route53";
 


### PR DESCRIPTION
## Description of changes

Prior to updating to the latest version of setuptools, need to ignore a new DeprecationWarning, pending a solution upstream in https://github.com/certbot/certbot/issues/9606.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
