### PR TITLE
liberation_ttf_v2: 2.1.0 -> 2.1.5

### DIFF
--- a/pkgs/data/fonts/liberation-fonts/default.nix
+++ b/pkgs/data/fonts/liberation-fonts/default.nix
@@ -4,7 +4,7 @@ let
 
   commonNativeBuildInputs = [ fontforge python3 ];
   common =
-    { version, repo, sha256, nativeBuildInputs, postPatch ? null }:
+    { version, repo, sha256, docsToInstall, nativeBuildInputs, postPatch ? null }:
       stdenv.mkDerivation rec {
         pname = "liberation-fonts";
         inherit version;
@@ -20,11 +20,7 @@ let
         installPhase = ''
           find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
 
-          install -m444 -Dt $out/share/doc/${pname}-${version} AUTHORS     || true
-          install -m444 -Dt $out/share/doc/${pname}-${version} ChangeLog   || true
-          install -m444 -Dt $out/share/doc/${pname}-${version} COPYING     || true
-          install -m444 -Dt $out/share/doc/${pname}-${version} License.txt || true
-          install -m444 -Dt $out/share/doc/${pname}-${version} README      || true
+          install -m444 -Dt $out/share/doc/${pname}-${version} ${lib.concatStringsSep " " docsToInstall}
         '';
 
         meta = with lib; {
@@ -51,18 +47,20 @@ in
   liberation_ttf_v1 = common {
     repo = "liberation-1.7-fonts";
     version = "1.07.5";
-    nativeBuildInputs = commonNativeBuildInputs ;
+    docsToInstall = [ "AUTHORS" "ChangeLog" "COPYING" "License.txt" "README" ];
+    nativeBuildInputs = commonNativeBuildInputs;
     sha256 = "1ffl10mf78hx598sy9qr5m6q2b8n3mpnsj73bwixnd4985gsz56v";
   };
   liberation_ttf_v2 = common {
     repo = "liberation-fonts";
-    version = "2.1.0";
+    version = "2.1.5";
+    docsToInstall = [ "AUTHORS" "ChangeLog" "LICENSE" "README.md" ];
     nativeBuildInputs = commonNativeBuildInputs ++ [ fonttools ];
     postPatch = ''
       substituteInPlace scripts/setisFixedPitch-fonttools.py --replace \
         'font = ttLib.TTFont(fontfile)' \
         'font = ttLib.TTFont(fontfile, recalcTimestamp=False)'
     '';
-    sha256 = "03xpzaas264x5n6qisxkhc68pkpn32m7y78qdm3rdkxdwi8mv8mz";
+    sha256 = "Wg1uoD2k/69Wn6XU+7wHqf2KO/bt4y7pwgmG7+IUh4Q=";
   };
 }


### PR DESCRIPTION
## Description of changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
