### PR TITLE
python311Packages.aioquic: 0.9.20 -> 0.9.21

### DIFF
--- a/pkgs/development/python-modules/aioquic/default.nix
+++ b/pkgs/development/python-modules/aioquic/default.nix
@@ -1,40 +1,25 @@
 { lib
-, fetchPypi
-, fetchpatch
 , buildPythonPackage
+, certifi
+, fetchPypi
 , openssl
 , pylsqpack
-, certifi
-, pytestCheckHook
 , pyopenssl
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aioquic";
-  version = "0.9.20";
+  version = "0.9.21";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-7ENqqs6Ze4RrAeUgDtv34+VrkYJqFE77l0j9jd0zK74=";
+    hash = "sha256-ecfsBjGOeFYnZlyk6HI63zR7ciW30AbjMtJXWh9RbvU=";
   };
-
-  patches = [
-    # This patch is here because it's required by the next patch.
-    (fetchpatch {
-      url = "https://github.com/aiortc/aioquic/commit/3930580b50831a034d21ee4689362188b21a4d6a.patch";
-      hash = "sha256-XjhyajDawN/G1nPtkMbNe66iJCo76UpdA7PqwtxO5ag=";
-    })
-    # https://github.com/aiortc/aioquic/pull/349, fixes test failure due pyopenssl==22
-    (fetchpatch {
-      url = "https://github.com/aiortc/aioquic/commit/c3b72be85868d67ee32d49ab9bd98a4357cbcde9.patch";
-      hash = "sha256-AjW+U9DpNXgA5yqKkWnx0OYpY2sZR9KIdQ3pSzxU+uY=";
-    })
-    # AssertionError: 'self-signed certificate' != 'self signed certificate'
-    (fetchpatch {
-      url = "https://github.com/aiortc/aioquic/commit/cfcd3ce12fb27f5b26deb011a82f66b5d68d521a.patch";
-      hash = "sha256-bCW817Z7jCxYySfUukNR4cibURH3qZWEQjeeyvRIqZY=";
-    })
-  ];
 
   propagatedBuildInputs = [
     certifi
@@ -42,11 +27,17 @@ buildPythonPackage rec {
     pyopenssl
   ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [
+    openssl
+  ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
-  pythonImportsCheck = [ "aioquic" ];
+  pythonImportsCheck = [
+    "aioquic"
+  ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
