### PR TITLE
bottles: fix GStreamer on 32 bit apps

### DIFF
--- a/pkgs/applications/misc/bottles/fhsenv.nix
+++ b/pkgs/applications/misc/bottles/fhsenv.nix
@@ -1,7 +1,6 @@
 { buildFHSEnv
 , symlinkJoin
 , bottles-unwrapped
-, gst_all_1
 , extraPkgs ? pkgs: [ ]
 , extraLibraries ? pkgs: [ ]
 }:
@@ -92,10 +91,6 @@ let fhsEnv = {
       zlib # Freetype
     ] ++ xorgDeps pkgs
     ++ extraLibraries pkgs;
-
-  profile = ''
-    export GST_PLUGIN_PATH=/usr/lib32/gstreamer-1.0:/usr/lib64/gstreamer-1.0
-  '';
 };
 in
 symlinkJoin {

--- a/pkgs/applications/misc/bottles/fhsenv.nix
+++ b/pkgs/applications/misc/bottles/fhsenv.nix
@@ -36,6 +36,14 @@ let fhsEnv = {
         libXv
         libXxf86vm
       ];
+      gstreamerDeps = pkgs: with pkgs.gst_all_1; [
+        gstreamer
+        gst-plugins-base
+        gst-plugins-good
+        gst-plugins-ugly
+        gst-plugins-bad
+        gst-libav
+      ];
     in
     pkgs: with pkgs; [
       # https://wiki.winehq.org/Building_Wine
@@ -48,12 +56,6 @@ let fhsEnv = {
       gnutls
       libglvnd
       gsm
-      gst_all_1.gstreamer
-      gst_all_1.gst-plugins-base
-      gst_all_1.gst-plugins-good
-      gst_all_1.gst-plugins-ugly
-      gst_all_1.gst-plugins-bad
-      gst_all_1.gst-libav
       libgphoto2
       libjpeg_turbo
       libkrb5
@@ -90,6 +92,7 @@ let fhsEnv = {
       p11-kit
       zlib # Freetype
     ] ++ xorgDeps pkgs
+    ++ gstreamerDeps pkgs
     ++ extraLibraries pkgs;
 };
 in


### PR DESCRIPTION
## Description of changes

Because of the gst_all_1 input, 64 bit GStreamer was sneaking into the 32 bit libs.

Basically:
```nix
{ buildFHSEnv
, gst_all_1 # Because of this input...
}:
buildFHSEnv {
  multiPkgs = pkgs: with pkgs; {
    # This is both 32 bit and 64 bit
    hello

    # ...this is target arch only (because the `with pkgs;` doesn't apply in this case)
    gst_all_1.gst-plugins-base
  };
}
```

This commit removes the `gst_all_1` input to correct that.

Also removes setting `GST_PLUGIN_PATH`, as it doesn't seem necessary anymore.
(That env is the reason why I added the `gst_all_1` input and accidentally causing the issue in the first place. Ugh...)

Closes #207641.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
