### PR TITLE
fteqw: unstable-2022-08-09 -> unstable-2023-08-03

### DIFF
--- a/pkgs/games/fteqw/default.nix
+++ b/pkgs/games/fteqw/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchsvn
+, fetchFromGitHub
 , gzip
 , libvorbis
 , libmad

--- a/pkgs/games/fteqw/generic.nix
+++ b/pkgs/games/fteqw/generic.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchsvn
+, fetchFromGitHub
 , stdenv
 , libopus
 , xorg
@@ -14,12 +14,13 @@
 
 stdenv.mkDerivation {
   inherit pname buildFlags buildInputs nativeBuildInputs postFixup;
-  version = "unstable-2022-08-09";
+  version = "unstable-2023-08-03";
 
-  src = fetchsvn {
-    url = "https://svn.code.sf.net/p/fteqw/code/trunk";
-    rev = "6303";
-    sha256 = "sha256-tSTFX59iVUvndPRdREayKpkQ+YCYKCMQe2PXZfnTgPQ=";
+  src = fetchFromGitHub {
+    owner = "fte-team";
+    repo = "fteqw";
+    rev = "3adec5d0a53ba9ae32a92fc0a805cf6d5ec107fb";
+    hash = "sha256-p/U02hwKI+YqlVXIS/7+gujknNDLr5L53unjvG5qLJU=";
   };
 
   makeFlags = [
@@ -45,7 +46,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     inherit description;
-    homepage = "https://fte.triptohell.info";
+    homepage = "https://fteqw.org";
     longDescription = ''
       FTE is a game engine baed on QuakeWorld able to
       play games such as Quake 1, 2, 3, and Hexen 2.


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/eukara/freecs/issues/31
It turns out that the old upstream, a SVN repo at https://sourceforge.net/p/fteqw/code/HEAD/tree, is actually abandoned in favor of the new upstream at https://www.github.com/fte-team/fteqw. Thus I changed the upstream.

Since the website at https://fte.triptohell.info links to the old SVN repo, I thought it would be appropriate to also change the homepage to https://fteqw.org. Need your advice for this one.

I tested the binaries as follows: `fteqw` running on FreeHL and FreeCS, and `fteqcc` to compile FreeHL and FreeCS. It all worked well.

The point of this update is for me to later package FreeHL and FreeCS.

cc @necrophcodr

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
