### PR TITLE
wipeout-rewrite: init at unstable-2023-08-13

### DIFF
--- a/pkgs/games/wipeout-rewrite/default.nix
+++ b/pkgs/games/wipeout-rewrite/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, Foundation
+, glew
+, SDL2
+, writeShellScript
+}:
+
+let
+  datadir = "\"\${XDG_DATA_HOME:-$HOME/.local/share}\"/wipeout-rewrite";
+  datadirCheck = writeShellScript "wipeout-rewrite-check-datadir.sh" ''
+    datadir=${datadir}
+
+    if [ ! -d "$datadir" ]; then
+      echo "[Wrapper] Creating data directory $datadir"
+      mkdir -p "$datadir"
+    fi
+
+    echo "[Wrapper] Remember to put your game assets into $datadir/wipeout if you haven't done so yet!"
+    echo "[Wrapper] Check https://github.com/phoboslab/wipeout-rewrite#running for the required format."
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wipeout-rewrite";
+  version = "unstable-2023-08-13";
+
+  src = fetchFromGitHub {
+    owner = "phoboslab";
+    repo = "wipeout-rewrite";
+    rev = "7a9f757a79d5c6806252cc1268bda5cdef463e23";
+    hash = "sha256-21IG9mZPGgRhVkT087G+Bz/zLkknkHKGmWjSpcLw8vE=";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    glew
+    SDL2
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    Foundation
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 wipegame $out/bin/wipegame
+
+    # I can't get --chdir to not expand the bash variables in datadir at build time (so they point to /homeless-shelter)
+    # or put them inside single quotes (breaking the expansion at runtime)
+    wrapProgram $out/bin/wipegame \
+      --run '${datadirCheck}' \
+      --run 'cd ${datadir}'
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    mainProgram = "wipegame";
+    description = "A re-implementation of the 1995 PSX game wipEout";
+    homepage = "https://github.com/phoboslab/wipeout-rewrite";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37113,6 +37113,10 @@ with pkgs;
 
   shipwright = callPackage ../games/shipwright { };
 
+  wipeout-rewrite = callPackage ../games/wipeout-rewrite {
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  };
+
   ### GAMES/DOOM-PORTS
 
   dhewm3 = callPackage ../games/doom-ports/dhewm3 { };


### PR DESCRIPTION
## Description of changes

https://phoboslab.org/log/2023/08/rewriting-wipeout
https://github.com/phoboslab/wipeout-rewrite

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
