### PR TITLE
rizin, cutter: wrapper fixes, set meta.mainProgram

### DIFF
--- a/pkgs/development/tools/analysis/rizin/cutter.nix
+++ b/pkgs/development/tools/analysis/rizin/cutter.nix
@@ -57,6 +57,7 @@ let cutter = mkDerivation rec {
     description = "Free and Open Source Reverse Engineering Platform powered by rizin";
     homepage = src.meta.homepage;
     license = licenses.gpl3;
+    mainProgram = "cutter";
     maintainers = with maintainers; [ mic92 dtzWill ];
   };
 }; in cutter

--- a/pkgs/development/tools/analysis/rizin/cutter.nix
+++ b/pkgs/development/tools/analysis/rizin/cutter.nix
@@ -47,8 +47,8 @@ let cutter = mkDerivation rec {
       };
     };
     withPlugins = filter: pkgs.callPackage ./wrapper.nix {
-      unwrapped = cutter;
-      inherit rizin;
+      inherit rizin cutter;
+      isCutter = true;
       plugins = filter plugins;
     };
   };

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -118,7 +118,7 @@ let rizin = stdenv.mkDerivation rec {
       sigdb = pkgs.callPackage ./sigdb.nix { };
     };
     withPlugins = filter: pkgs.callPackage ./wrapper.nix {
-      unwrapped = rizin;
+      inherit rizin;
       plugins = filter plugins;
     };
   };

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -127,6 +127,7 @@ let rizin = stdenv.mkDerivation rec {
     description = "UNIX-like reverse engineering framework and command-line toolset.";
     homepage = "https://rizin.re/";
     license = lib.licenses.gpl3Plus;
+    mainProgram = "rizin";
     maintainers = with lib.maintainers; [ raskin makefu mic92 ];
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19792,7 +19792,7 @@ with pkgs;
 
   cutter = libsForQt5.callPackage ../development/tools/analysis/rizin/cutter.nix { };
 
-  cutterPlugins = recurseIntoAttrs rizin.plugins;
+  cutterPlugins = recurseIntoAttrs cutter.plugins;
 
   ragel = ragelStable;
 


### PR DESCRIPTION
## Description of changes

1. Set cutterPlugins to cutter.plugins rather than rizin.plugins which it was set to by mistake. This adds Cutter plugins to the binary cache.
2. Remove Rizin binaries from Cutter wrapper, because they aren't actually used by Cutter and if the user needs those binaries they should install Rizin separately. This allows us to remove the weird wrapper priority thing that I actually got wrong in the PR that adds it (it should've been the opposite - prefer Rizin wrapper over Cutter wrapper)
3. Set `meta.mainProgram` since `lib.getExe` doesn't fall back to package name anymore: #246386

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
