### PR TITLE
python310Packages.chex: 0.1.6 -> 0.1.82; unbreak

### DIFF
--- a/pkgs/development/python-modules/chex/default.nix
+++ b/pkgs/development/python-modules/chex/default.nix
@@ -1,35 +1,39 @@
-{ absl-py
+{ lib
 , buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, absl-py
 , cloudpickle
 , dm-tree
-, fetchFromGitHub
 , jax
 , jaxlib
-, lib
 , numpy
 , pytestCheckHook
 , toolz
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "chex";
-  version = "0.1.6";
+  version = "0.1.82";
   format = "setuptools";
+
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "deepmind";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-VolRlLLgKga9S17ByVrYya9VPtu9yiOnvt/WmlE1DOc=";
+    hash = "sha256-xBq22AaR2Tp1NSPefEyvCDeUYqRZlAf5LVHWo0luiXk=";
   };
 
   propagatedBuildInputs = [
     absl-py
-    cloudpickle
-    dm-tree
+    jaxlib
     jax
     numpy
     toolz
+    typing-extensions
   ];
 
   pythonImportsCheck = [
@@ -37,19 +41,9 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    jaxlib
+    cloudpickle
+    dm-tree
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # See https://github.com/deepmind/chex/issues/204.
-    "test_uninspected_checks"
-
-    # These tests started failing at some point after upgrading to 0.1.5
-    "test_useful_failure"
-    "TreeAssertionsTest"
-    "PmapFakeTest"
-    "WithDeviceTest"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Update and fix dependencies of python310Packages.chex.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).