### PR TITLE
python310Packages.pydicom: 2.3.1 -> 2.4.2

### DIFF
--- a/pkgs/development/python-modules/deid/default.nix
+++ b/pkgs/development/python-modules/deid/default.nix
@@ -36,7 +36,7 @@ let
 in
 buildPythonPackage rec {
   pname = "deid";
-  version = "0.3.21";
+  version = "0.3.22";
 
   format = "pyproject";
   disabled = pythonOlder "3.7";
@@ -46,8 +46,8 @@ buildPythonPackage rec {
     owner = "pydicom";
     repo = pname;
     # the github repo does not contain Pypi version tags:
-    rev = "38717b8cbfd69566ba489dd0c9858bb93101e26d";
-    hash = "sha256-QqofxNjshbNfu8vZ37rB6pxj5R8q0wlUhJRhrpkKySk=";
+    rev = "40dc96125daeb65856d643e12c3d6dfec756be0d";
+    hash = "sha256-OtxQPF29eqt8I1Q12ga8a1IjBVO+VBk6y0DQmRtCNoU=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -11,13 +11,13 @@
 
 let
   pname = "pydicom";
-  version = "2.3.1";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "pydicom";
     repo = "pydicom";
     rev = "refs/tags/v${version}";
-    hash = "sha256-xt0aK908lLgNlpcI86OSxy96Z/PZnQh7+GXzJ0VMQGA=";
+    hash = "sha256-FNZVu2/7kBGeP4iTH53bsApfHzHFxr5bxqbqkI4T95E=";
   };
 
   # Pydicom needs pydicom-data to run some tests. If these files aren't downloaded
@@ -25,8 +25,8 @@ let
   test_data = fetchFromGitHub {
     owner = "pydicom";
     repo = "pydicom-data";
-    rev = "bbb723879690bb77e077a6d57657930998e92bd5";
-    hash = "sha256-dCI1temvpNWiWJYVfQZKy/YJ4ad5B0e9hEKHJnEeqzk=";
+    rev = "cbb9b2148bccf0f550e3758c07aca3d0e328e768";
+    hash = "sha256-nF/j7pfcEpWHjjsqqTtIkW8hCEbuQ3J4IxpRk0qc1CQ=";
   };
 
 in


### PR DESCRIPTION
python310Packages.deid: 0.3.21 -> 0.3.22

## Description of changes

Routine update.

Results of `nixpkgs-review` on x86-64_NixOS:
```
6 packages failed to build:
intensity-normalization intensity-normalization.dist python311Packages.intensity-normalization python311Packages.intensity-normalization.dist python311Packages.pynetdicom python311Packages.pynetdicom.dist

84 packages built:
expliot expliot.dist python310Packages.dcmstack python310Packages.dcmstack.dist python310Packages.deid python310Packages.deid.dist python310Packages.dicom-numpy python310Packages.dicom-numpy.dist python310Packages.dicom2nifti python310Packages.dicom2nifti.dist python310Packages.dicomweb-client python310Packages.dicomweb-client.dist python310Packages.dipy python310Packages.dipy.dist python310Packages.heudiconv python310Packages.heudiconv.dist python310Packages.nibabel python310Packages.nibabel.dist python310Packages.nilearn python310Packages.nilearn.dist python310Packages.nipy python310Packages.nipy.dist python310Packages.nipype python310Packages.nipype.dist python310Packages.nitime python310Packages.nitime.dist python310Packages.nitransforms python310Packages.nitransforms.dist python310Packages.pybids python310Packages.pybids.dist python310Packages.pydicom python310Packages.pydicom-seg python310Packages.pydicom-seg.dist python310Packages.pydicom.dist python310Packages.pymedio python310Packages.pymedio.dist python310Packages.pynetdicom python310Packages.pynetdicom.dist python310Packages.pyorthanc python310Packages.pyorthanc.dist python310Packages.torchio python310Packages.torchio.dist python310Packages.xnatpy python310Packages.xnatpy.dist python311Packages.dcmstack python311Packages.dcmstack.dist python311Packages.deid python311Packages.deid.dist python311Packages.dicom-numpy python311Packages.dicom-numpy.dist python311Packages.dicom2nifti python311Packages.dicom2nifti.dist python311Packages.dicomweb-client python311Packages.dicomweb-client.dist python311Packages.dipy python311Packages.dipy.dist python311Packages.heudiconv python311Packages.heudiconv.dist python311Packages.nibabel python311Packages.nibabel.dist python311Packages.nilearn python311Packages.nilearn.dist python311Packages.nipy python311Packages.nipy.dist python311Packages.nipype python311Packages.nipype.dist python311Packages.nitime python311Packages.nitime.dist python311Packages.nitransforms python311Packages.nitransforms.dist python311Packages.pybids python311Packages.pybids.dist python311Packages.pydicom python311Packages.pydicom-seg python311Packages.pydicom-seg.dist python311Packages.pydicom.dist python311Packages.pymedio python311Packages.pymedio.dist python311Packages.pyorthanc python311Packages.pyorthanc.dist python311Packages.torchio python311Packages.torchio.dist python311Packages.xnatpy python311Packages.xnatpy.dist
```

Looks like all the failures (`intensity-normaliztion` and `python311Packages.pynetdicom`) are pre-existing and unrelated.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).