### PR TITLE
More efficient `formats.toml` using Rust and execline

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -210,12 +210,12 @@ rec {
       };
     in valueType;
 
-    generate = name: value: pkgs.callPackage ({ runCommand, remarshal }: runCommand name {
-      nativeBuildInputs = [ remarshal ];
+    generate = name: value: pkgs.callPackage ({ runCommand, json2toml }: runCommand name {
+      nativeBuildInputs = [ json2toml ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];
     } ''
-      json2toml "$valuePath" "$out"
+      json2toml "$valuePath" --print-output > "$out"
     '') {};
 
   };

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -213,9 +213,9 @@ in runBuildTests {
 
       [attrs]
       foo = "foo"
-
       [level1.level2.level3]
       level4 = "deep"
+
     '';
   };
 

--- a/pkgs/tools/misc/json2toml/default.nix
+++ b/pkgs/tools/misc/json2toml/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, rustPlatform
+, fetchCrate
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "json2toml";
+  version = "0.1.1";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-Zmb3Z5n+qUPMUXXntiXweQKjk2TeZIvcFr6yGuC2AX4=";
+  };
+
+  patches = [
+    ./no-unstable-features.patch
+  ];
+
+  cargoHash = "sha256-x1al3IsYOn4PGYA70CgqypwxF5QiX6+zgURaD9Z7CEw=";
+
+  meta = with lib; {
+    homepage = "https://github.com/voidei/json2toml";
+    description = "A simple CLI tool that converts json files to toml files.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ infinisil ];
+  };
+}

--- a/pkgs/tools/misc/json2toml/no-unstable-features.patch
+++ b/pkgs/tools/misc/json2toml/no-unstable-features.patch
@@ -1,0 +1,18 @@
+diff --git a/src/main.rs b/src/main.rs
+index 050f5c43ae68..afeaac27d63b 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,4 +1,3 @@
+-#![feature(file_create_new)]
+ use std::{
+     fs::{self, File},
+     io::{prelude::*, BufRead, BufReader},
+@@ -48,7 +47,7 @@ fn main() -> Result<()> {
+         std::process::exit(0);
+     }
+ 
+-    let mut file = match File::create_new(&output_file) {
++    let mut file = match File::options().write(true).create_new(true).open(&output_file) {
+         Ok(file) => file,
+         Err(e) => {
+             println!("Error creating {output_file:?}! Exiting program!");

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22096,6 +22096,8 @@ with pkgs;
 
   json2hcl = callPackage ../development/tools/json2hcl { };
 
+  json2toml = callPackage ../tools/misc/json2toml { };
+
   json2tsv = callPackage ../development/tools/json2tsv { };
 
   json2yaml = haskell.lib.compose.justStaticExecutables haskellPackages.json2yaml;


### PR DESCRIPTION
## Description of changes

This improves the efficiency of `pkgs.formats.toml`:
- Faster by about 90%, from 143ms to 14ms on my machine
- Smaller closure by about 72%, from 141.5MB to 40.0MB

This is achieved by:
- Packaging and using the Rust-based [json2toml](https://crates.io/crates/json2toml) instead of the Python-based [remarshal](https://github.com/remarshal-project/remarshal)
- Using [execline](https://www.skarnet.org/software/execline) (I learned about it from @alyssais some years ago!) instead of Bash, there's really no reason we need to use bash for such a simple derivation

I'm not saying that we _should_ do it like this, but I was motivated to at least demonstrate that builds can be faster by @oxalica's comment in https://github.com/NixOS/nixpkgs/pull/243390#issuecomment-1674211230.

I measured the performance using
```
./measure.sh "$(nix-instantiate test.nix)"
```

<details>
<summary>measure.sh</summary>

```bash
#!/usr/bin/env nix-shell
#!nix-shell -i bash -p ripgrep moreutils sta
set -euo pipefail

drv=$1
tmp=$(mktemp -d)
trap 'rm -rf "$tmp"' EXIT

nix-store -r "$drv" >/dev/null

for f in $(seq 10); do
    nix-store -r "$drv" --check -vvv 2>&1 | \
        rg --line-buffered \
            -e "building of '$drv!\*' from .drv file: created" \
            -e "building of '$drv!\*' from .drv file: done" \
        | ts '%.S' -i \
        | tail -1 \
        | cut -d' ' -f1 \
        >> "$tmp/times"
done

sta --transpose -n --mean --sd <"$tmp/times"
```
</details>

<details>
<summary>test.nix</summary>

```nix
with import ./. {};
(pkgs.formats.toml {}).generate "test2.toml" { }
```

</details>

## Things done
- [x] Ran `nix-build pkgs/pkgs-lib/tests` successfully on x86_64-linux