### PR TITLE
tokio-console: 0.1.7 -> 0.1.9

### DIFF
--- a/pkgs/development/tools/tokio-console/cargo-lock.patch
+++ b/pkgs/development/tools/tokio-console/cargo-lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index fcbe50c..27d4c30 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1390,7 +1390,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-console"
+-version = "0.1.8"
++version = "0.1.9"
+ dependencies = [
+  "atty",
+  "clap",

--- a/pkgs/development/tools/tokio-console/default.nix
+++ b/pkgs/development/tools/tokio-console/default.nix
@@ -6,18 +6,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tokio-console";
-  version = "0.1.7";
+  version = "0.1.9";
 
   src = fetchFromGitHub {
     owner = "tokio-rs";
     repo = "console";
     rev = "tokio-console-v${version}";
-    sha256 = "sha256-yTNLKpBkzzN0X73CjN/UXRGjAGOnCCgJa6A6loA6baM=";
+    hash = "sha256-zISgEhUmAfHErq4AelbnSwtKjtxYH//pbLUAlPKxQYk=";
   };
 
-  cargoSha256 = "sha256-K/auhqlL/K6RYE0lHyvSUqK1cOwJBBZD3QTUevZzLXQ=";
+  cargoHash = "sha256-qK8U6BZN7sdBP8CbzsDeewsGulNA/KFVS9vscBxysRg=";
 
   nativeBuildInputs = [ protobuf ];
+
+  cargoPatches = [ ./cargo-lock.patch ];
 
   # uses currently unstable tokio features
   RUSTFLAGS = "--cfg tokio_unstable";
@@ -32,6 +34,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "A debugger for asynchronous Rust code";
     homepage = "https://github.com/tokio-rs/console";
+    mainProgram = "tokio-console";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ max-niederman ];
   };


### PR DESCRIPTION
## Description of changes

Upgrade tokio-console to 0.1.9

cc @max-niederman 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
