### PR TITLE
nix-doc: 0.5.9 -> 0.5.10

### DIFF
--- a/pkgs/tools/package-management/nix-doc/default.nix
+++ b/pkgs/tools/package-management/nix-doc/default.nix
@@ -1,14 +1,14 @@
-{ lib, rustPlatform, fetchFromGitHub, boost, nix, pkg-config }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub, boost, nix, pkg-config }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-doc";
-  version = "0.5.9";
+  version = "0.5.10";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "lf-";
     repo = "nix-doc";
-    sha256 = "sha256-uilVJz1MnMF3i/ZXY0bIoSK3uAzfxWuHfhoOSmQgY/I=";
+    sha256 = "sha256-+T4Bz26roTFiXTM8P8FnJLSdFY2hP26X4nChWWUACN8=";
   };
 
   doCheck = true;
@@ -16,7 +16,20 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config nix ];
 
-  cargoSha256 = "sha256-02noJcbtml4MxRCjaWtjOWLTUNOQnKy3GCsil31J6F8=";
+  # Packaging support for making the nix-doc plugin load cleanly as a no-op on
+  # the wrong Nix version (disabling bindnow permits loading libraries
+  # requiring unavailable symbols if they are unreached)
+  hardeningDisable = [ "bindnow" ];
+  # Due to a Rust bug, setting -Z relro-level to anything including "off" on
+  # macOS will cause link errors
+  env = lib.optionalAttrs stdenv.isLinux {
+    # nix-doc does not use nightly features, however, there is no other way to
+    # set relro-level
+    RUSTC_BOOTSTRAP = 1;
+    RUSTFLAGS = "-Z relro-level=partial";
+  };
+
+  cargoSha256 = "sha256-GylSWo4LIsjKnJE9H6iJHZ99UI6UPhAOnAGXk+v8bko=";
 
   meta = with lib; {
     description = "An interactive Nix documentation tool";


### PR DESCRIPTION

## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/237637 and its entire
class of problems by making nix-doc save the version it was built for in
the library and then bail harmlessly if it is mismatched.

```
dev/nixpkgs2 » nix-build -A nix-doc
/nix/store/wv9nm47lplyz4b0pa4549zwrnsp3zvaf-nix-doc-0.5.10
dev/nixpkgs2 » nix-build -A nixVersions.nix_2_14 -o result2
/nix/store/ka0ygdzl9jd0j77y7ls6shngdz9vvqpn-nix-2.14.1
dev/nixpkgs2 » ./result2/bin/nix --plugin-files ./result/lib/libnix_doc_plugin.so repl
nix-doc warning: mismatched nix version, not loading
Welcome to Nix 2.14.1. Type :? for help.

nix-repl>
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
