### PR TITLE
beetsPackages.copyartifacts: unstable-2020-02-15 -> 0.1.5

### DIFF
--- a/pkgs/tools/audio/beets/plugins/copyartifacts.nix
+++ b/pkgs/tools/audio/beets/plugins/copyartifacts.nix
@@ -1,14 +1,14 @@
 { lib, fetchFromGitHub, beets, python3Packages }:
 
-python3Packages.buildPythonApplication {
+python3Packages.buildPythonApplication rec {
   pname = "beets-copyartifacts";
-  version = "unstable-2020-02-15";
+  version = "0.1.5";
 
   src = fetchFromGitHub {
     repo = "beets-copyartifacts";
     owner = "adammillerio";
-    rev = "85eefaebf893cb673fa98bfde48406ec99fd1e4b";
-    sha256 = "sha256-bkT2BZZ2gdcacgvyrVe2vMrOMV8iMAm8Q5xyrZzyqU0=";
+    rev = "v${version}";
+    sha256 = "sha256-UTZh7T6Z288PjxFgyFxHnPt0xpAH3cnr8/jIrlJhtyU=";
   };
 
   postPatch = ''
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication {
 
   meta = {
     description = "Beets plugin to move non-music files during the import process";
-    homepage = "https://github.com/sbarakat/beets-copyartifacts";
+    homepage = "https://github.com/adammillerio/beets-copyartifacts";
     license = lib.licenses.mit;
     inherit (beets.meta) platforms;
   };


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/adammillerio/beets-copyartifacts/releases

This is a fork of the original [copyartifacts](https://github.com/sbarakat/beets-copyartifacts), which is now unmaintained. The beets documentation [recommends its use](https://beets.readthedocs.io/en/stable/plugins/index.html#other-plugins).

It'd also be nice to have a maintainer. I don't have much knowledge of Python, but can help if needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
