### PR TITLE
postgresql_beta: init at version 16beta3

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -98,7 +98,7 @@ let
       ++ lib.optionals jitSupport [ "--with-llvm" ];
 
     patches = [
-      ./patches/disable-resolve_symlinks.patch
+      (if atLeast "16" then ./patches/disable-normalize_exec_path.patch else ./patches/disable-resolve_symlinks.patch)
       ./patches/less-is-more.patch
       ./patches/hardcode-pgxs-path.patch
       ./patches/specify_pkglibdir_at_runtime.patch
@@ -349,6 +349,15 @@ let
       hash = "sha256-/8fUiR8A/79cP06rf7vO2EYLjA7mPFpRZxM7nmWZ2TI=";
       this = self.postgresql_15;
       thisAttr = "postgresql_15";
+      inherit self;
+    };
+
+    postgresql_beta = self.callPackage generic {
+      version = "16beta3";
+      psqlSchema = "16";
+      hash = "sha256-/89E4nJmL2rEUajW1v+VFxXbZRyNSQfsZZy95Gq9UtM=";
+      this = self.postgresql_beta;
+      thisAttr = "postgresql_beta";
       inherit self;
     };
   };

--- a/pkgs/servers/sql/postgresql/patches/disable-normalize_exec_path.patch
+++ b/pkgs/servers/sql/postgresql/patches/disable-normalize_exec_path.patch
@@ -1,0 +1,12 @@
+diff --git a/src/common/exec.c b/src/common/exec.c
+index f209b934df..30da457572 100644
+--- a/src/common/exec.c
++++ b/src/common/exec.c
+@@ -238,6 +238,7 @@ find_my_exec(const char *argv0, char *retpath)
+ static int
+ normalize_exec_path(char *path)
+ {
++	return 0;
+ 	/*
+ 	 * We used to do a lot of work ourselves here, but now we just let
+ 	 * realpath(3) do all the heavy lifting.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26917,12 +26917,14 @@ with pkgs;
     postgresql_13
     postgresql_14
     postgresql_15
+    postgresql_beta
 
     postgresql_11_jit
     postgresql_12_jit
     postgresql_13_jit
     postgresql_14_jit
     postgresql_15_jit
+    postgresql_beta_jit
   ;
   postgresql = postgresql_14.override { this = postgresql; };
   postgresql_jit = postgresql_14_jit.override { this = postgresql_jit; };
@@ -26931,13 +26933,15 @@ with pkgs;
   postgresql11Packages = recurseIntoAttrs postgresql_11.pkgs;
   postgresql12Packages = recurseIntoAttrs postgresql_12.pkgs;
   postgresql13Packages = recurseIntoAttrs postgresql_13.pkgs;
+  postgresql14Packages = postgresqlPackages;
   postgresql15Packages = recurseIntoAttrs postgresql_15.pkgs;
+  postgresqlBetaPackages = recurseIntoAttrs postgresql_beta.pkgs;
   postgresql11JitPackages = recurseIntoAttrs postgresql_11_jit.pkgs;
   postgresql12JitPackages = recurseIntoAttrs postgresql_12_jit.pkgs;
   postgresql13JitPackages = recurseIntoAttrs postgresql_13_jit.pkgs;
   postgresql14JitPackages = recurseIntoAttrs postgresql_14_jit.pkgs;
   postgresql15JitPackages = recurseIntoAttrs postgresql_15_jit.pkgs;
-  postgresql14Packages = postgresqlPackages;
+  postgresqlBetaJitPackages = recurseIntoAttrs postgresql_beta_jit.pkgs;
 
   postgresql_jdbc = callPackage ../development/java-modules/postgresql_jdbc { };
 


### PR DESCRIPTION
Summary: For integration and testing purposes, especially for downstream consumers (Flakes, etc) that rely on testing against various PostgreSQL versions, it's useful to have a beta version around. An example of this is PostgREST, which has several people using Nix in order to test the server against different versions. Testing against beta versions is currently awkward because there's no way to get them besides patching and forking Nixpkgs.

There's a related problem here, which is that the APIs needed to create your *own* postgresql package, with all extensions, are not exposed. That might be worth doing later on; but for now, it's easy to just track beta versions and nip the issue in the bud from there.

The intent is that this `beta` package follows the same basic rules as the Linux prerelease "beta" packages; that is:

- `postgresql_beta` *always* tracks a beta, even if the corresponding release is out.
   - That means that once PostgreSQL 16 is released, this expression will be out of date until PostgreSQL 17 Beta 1 is released.
- `postgresql_beta` is updated on a provisional basis i.e. it won't necessarily get prompt updates or security updates like the other expressions.
- It is primarily intended for advanced users to test and integrate against, so they might submit issues to various upstream maintainers.

Many thanks to Laurence Isla, who initially made this change as part of an effort to integrate PostgREST against PostgreSQL 16 Beta 2.

See also: postgrest/postgrest#2865

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
