### PR TITLE
ncdu: 2.2.2 -> 2.3

### DIFF
--- a/pkgs/tools/misc/ncdu/default.nix
+++ b/pkgs/tools/misc/ncdu/default.nix
@@ -2,25 +2,31 @@
 , stdenv
 , fetchurl
 , ncurses
-, zig_0_10
+, zig_0_11
+, installShellFiles
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ncdu";
-  version = "2.2.2";
+  version = "2.3";
 
   src = fetchurl {
     url = "https://dev.yorhel.nl/download/ncdu-${finalAttrs.version}.tar.gz";
-    hash = "sha256-kNkgAk51Ixi0aXds5X4Ds8cC1JMprZglruqzbDur+ZM=";
+    hash = "sha256-u84dHHDxJHZxvk6iE12MUs0ppwivXtYs7Np9xqgACjw=";
   };
 
   nativeBuildInputs = [
-    zig_0_10.hook
+    zig_0_11.hook
+    installShellFiles
   ];
 
   buildInputs = [
     ncurses
   ];
+
+  postInstall = ''
+    installManPage ncdu.1
+  '';
 
   meta = {
     homepage = "https://dev.yorhel.nl/ncdu";
@@ -28,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://dev.yorhel.nl/ncdu/changes2";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pSub rodrgz ];
-    inherit (zig_0_10.meta) platforms;
+    inherit (zig_0_11.meta) platforms;
+    mainProgram = "ncdu";
   };
 })


### PR DESCRIPTION
###### Description of changes

Changelog: https://dev.yorhel.nl/ncdu/changes2

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes (or backporting 23.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).