### PR TITLE
Fix useDotnetFromEnv's DOTNET_ROOT detection

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
@@ -83,6 +83,7 @@ in
         shell = stdenv.shell;
         which = "${which}/bin/which";
         dirname = "${coreutils}/bin/dirname";
+        realpath = "${coreutils}/bin/realpath";
       };
     } ./dotnet-fixup-hook.sh) { };
 }

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh
@@ -10,7 +10,7 @@ wrapDotnetProgram() {
     if [ ! "${selfContainedBuild-}" ]; then
         if [ "${useDotnetFromEnv-}" ]; then
             # if dotnet CLI is available, set DOTNET_ROOT based on it. Otherwise set to default .NET runtime
-            dotnetRootFlags+=("--run" 'command -v dotnet &>/dev/null && export DOTNET_ROOT="$(@dirname@ "$(@dirname@ "$(@which@ dotnet)")")" || export DOTNET_ROOT="@dotnetRuntime@"')
+            dotnetRootFlags+=("--run" 'command -v dotnet &>/dev/null && export DOTNET_ROOT="$(@dirname@ "$(@realpath@ "$(@which@ dotnet)")")" || export DOTNET_ROOT="@dotnetRuntime@"')
             dotnetRootFlags+=("--suffix" "PATH" ":" "@dotnetRuntime@/bin")
         else
             dotnetRootFlags+=("--set" "DOTNET_ROOT" "@dotnetRuntime@")

--- a/pkgs/development/compilers/dotnet/combine-packages.nix
+++ b/pkgs/development/compilers/dotnet/combine-packages.nix
@@ -17,16 +17,11 @@ assert lib.assertMsg ((builtins.length dotnetPackages) > 0)
     paths = dotnetPackages;
     pathsToLink = [ "/host" "/packs" "/sdk" "/sdk-manifests" "/shared" "/templates" ];
     ignoreCollisions = true;
-    nativeBuildInputs = [
-      makeWrapper
-    ];
     postBuild = ''
       cp -R ${cli}/{dotnet,share,nix-support} $out/
 
       mkdir $out/bin
       ln -s $out/dotnet $out/bin/dotnet
-      wrapProgram $out/bin/dotnet \
-        --prefix LD_LIBRARY_PATH : ${cli.icu}/lib
     '';
     passthru = {
       inherit (cli) icu;


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/249075

This PR tries to fix the detection of locally installed dotnet versions, when using a package built with `useDotnetFromEnv = true;`

(Original PR introducing this feature: https://github.com/NixOS/nixpkgs/pull/235041)

The issue is that the original PR's detection was trying to find the correct `DOTNET_ROOT` from the currently installed binary, by running `which dotnet` and going up some levels in the parent directories.

I found that doing that is not correct because `which dotnet` will result in the symlink's path (`/run/current-system/sw/bin/dotnet` or `/etc/profiles/per-user/<user>/bin/dotnet`)

Using `realpath`, however, we can reach the `/nix/store` location of the program.

In `dotnetCorePackages.sdk_6_0` (aka. `dotnet-sdk`) the actual binary is located at `$out/dotnet`. There is also `$out/bin/dotnet` which is just a symlink to the actual.

So running `realpath $(which dotnet)` will result in `$out/dotnet` which is great.
(`realpath` will follow a symlink chain until it reaches a normal file).

However when using `dotnetCorePackages.combinePackages` to have multiple sdks installed, `realpath $(which dotnet)` will result in `$out/bin/dotnet`, because `$out/bin/dotnet` is not actually a symlink, but the result of running `wrapProgram`. The wrapper adds `dotnet-sdk.icu` to the `LD_LIBRARY_PATH`.
(PR where this was added: https://github.com/NixOS/nixpkgs/pull/187118)

My fix was to remove this wrapper, so `realpath` can find the actual binary.

---

I am not yet sure why the wrapping with `icu` was needed if the non-combined binary didn't have it in the `LD_LIBRARY_PATH`.

@GGG-KILLER, as the original author of the commit with the wrapper, can you tell us why the wrapping was needed?

I will look for any packages where this removal would cause an issue.

---

If this PR is merged, we will need to make sure that for every installable dotnet there is an uninterrupted symlink-chain to `$out/dotnet`.

AFAIK, `sdk_x_0` `runtime_x_0`, `aspnetcore_x_0`, and their combinations with `combinePackages` now all conform to this pattern.

---

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
