### PR TITLE
nuclear: 0.6.27 -> 0.6.30

### DIFF
--- a/pkgs/applications/audio/nuclear/default.nix
+++ b/pkgs/applications/audio/nuclear/default.nix
@@ -1,33 +1,38 @@
-{
-  appimageTools,
-  lib,
-  fetchurl,
-}: let
+{ appimageTools
+, lib
+, fetchurl
+}:
+let
   pname = "nuclear";
-  version = "0.6.27";
+  version = "0.6.30";
 
   src = fetchurl {
     url = "https://github.com/nukeop/nuclear/releases/download/v${version}/${pname}-v${version}.AppImage";
-    hash = "sha256-vCtGuId2yMVIQrMZcjN1i2buV4sah2qKupbr4LhqMbA=";
+    hash = "sha256-he1uGC1M/nFcKpMM9JKY4oeexJcnzV0ZRxhTjtJz6xw=";
   };
 
-  appimageContents = appimageTools.extract {inherit pname version src;};
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
-  appimageTools.wrapType2 {
-    inherit pname version src;
+appimageTools.wrapType2 {
+  inherit pname version src;
 
-    extraInstallCommands = ''
-      install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
-      substituteInPlace $out/share/applications/${pname}.desktop \
-        --replace 'Exec=AppRun' 'Exec=${pname}'
-      cp -r ${appimageContents}/usr/share/icons $out/share
-    '';
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+    cp -r ${appimageContents}/usr/share/icons $out/share
 
-    meta = with lib; {
-      description = "Streaming music player that finds free music for you";
-      homepage = "https://nuclear.js.org/";
-      license = licenses.agpl3Plus;
-      maintainers = with maintainers; [NotAShelf ivar];
-      platforms = ["x86_64-linux"];
-    };
-  }
+    # unless linked, the binary is placed in $out/bin/nuclear-someVersion
+    # link it to $out/bin/nuclear
+    ln -s $out/bin/${pname}-${version} $out/bin/${pname}
+  '';
+
+  meta = with lib; {
+    description = "Streaming music player that finds free music for you";
+    homepage = "https://nuclear.js.org/";
+    license = licenses.agpl3Plus;
+    maintainers = [ maintainers.NotAShelf ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "nuclear";
+  };
+}


### PR DESCRIPTION
## Description of changes

- Bump nuclear version
- Add missing mainProgram
- remove `@IvarWithoutBones` as a maintainer as they seem to be no longer interested in maintaining this package. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
