### PR TITLE
jetbrains.rider : added udev to extraLdPath

### DIFF
--- a/pkgs/applications/editors/jetbrains/linux.nix
+++ b/pkgs/applications/editors/jetbrains/linux.nix
@@ -11,6 +11,7 @@
 , unzip
 , libsecret
 , libnotify
+, udev
 , e2fsprogs
 , python3
 , vmopts ? null
@@ -109,6 +110,9 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
         # Some internals want libstdc++.so.6
         stdenv.cc.cc.lib libsecret e2fsprogs
         libnotify
+        # Required for Help -> Collect Logs
+        # in at least rider and goland
+        udev
       ] ++ extraLdPath)}" \
       ${lib.concatStringsSep " " extraWrapperArgs} \
       --set-default JDK_HOME "$jdk" \


### PR DESCRIPTION
## Description of changes

This commit adds udev to extraLdPath in order to fix following error in Rider 
```

2023-08-14 14:38:31,611 [1313369] SEVERE - #c.i.o.p.Task - Could not initialize class com.sun.jna.platform.linux.Udev
java.lang.NoClassDefFoundError: Could not initialize class com.sun.jna.platform.linux.Udev
	at oshi.hardware.platform.linux.LinuxCentralProcessor.queryCurrentFreq(LinuxCentralProcessor.java:294)
	at oshi.util.Memoizer$1.get(Memoizer.java:87)
	at oshi.hardware.common.AbstractCentralProcessor.getCurrentFreq(AbstractCentralProcessor.java:140)
	at oshi.hardware.platform.linux.LinuxCentralProcessor.queryMaxFreq(LinuxCentralProcessor.java:343)
	at oshi.util.Memoizer$1.get(Memoizer.java:87)
	at oshi.hardware.common.AbstractCentralProcessor.getMaxFreq(AbstractCentralProcessor.java:128)
	at com.jetbrains.performancePlugin.utils.HardwareCollector.printCpu(HardwareCollector.java:157)
	at com.jetbrains.performancePlugin.utils.HardwareCollector.collectInfo(HardwareCollector.java:57)
	at com.intellij.ide.actions.CollectZippedLogsAction.packLogs(CollectZippedLogsAction.java:123)
	at com.intellij.ide.actions.CollectZippedLogsAction.packLogs(CollectZippedLogsAction.java:93)
	at com.intellij.ide.actions.CollectZippedLogsAction.lambda$actionPerformed$0(CollectZippedLogsAction.java:74)
	at com.intellij.openapi.progress.impl.CoreProgressManager$2.run(CoreProgressManager.java:281)
	at com.intellij.openapi.progress.impl.CoreProgressManager.startTask(CoreProgressManager.java:429)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.startTask(ProgressManagerImpl.java:114)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressSynchronously$9(CoreProgressManager.java:513)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$new$0(ProgressRunner.java:84)
	at com.intellij.codeWithMe.ClientId$Companion.decorateFunction$lambda$10(ClientId.kt:329)
	at com.intellij.codeWithMe.ClientId$Companion.decorateFunction$lambda$10(ClientId.kt:329)
	at com.intellij.codeWithMe.ClientId$Companion.decorateFunction$lambda$10(ClientId.kt:329)
	at com.intellij.codeWithMe.ClientId$Companion.decorateFunction$lambda$10(ClientId.kt:329)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:252)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:186)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$13(CoreProgressManager.java:604)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:679)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:635)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:603)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:173)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:252)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:702)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:699)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:699)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: Unable to load library 'udev':
libudev.so: cannot open shared object file: No such file or directory
libudev.so: cannot open shared object file: No such file or directory
Native library (linux-x86-64/libudev.so) not found in resource path (/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/app.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/3rd-party-rt.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/util.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/util_rt.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/util-8.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/jps-model.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/stats.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/protobuf.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/external-system-rt.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/intellij-test-discovery.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/forms_rt.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/rd.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/externalProcess-rt.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/annotations-java5.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/async-profiler-windows.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/async-profiler.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/byte-buddy-agent.jar:/nix/store/vynv7x3vawc8a7cw4290sm5rdig7fp1c-rider-with-plugins-2023.1.4/rider/lib/error-
	at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:307)
	at com.sun.jna.NativeLibrary.getInstance(NativeLibrary.java:467)
	at com.sun.jna.Library$Handler.<init>(Library.java:192)
	at com.sun.jna.Native.load(Native.java:622)
	at com.sun.jna.Native.load(Native.java:596)
	at com.sun.jna.platform.linux.Udev.<clinit>(Udev.java:37)
	at oshi.software.os.linux.LinuxOperatingSystem.<clinit>(LinuxOperatingSystem.java:93)
	at oshi.SystemInfo.createOperatingSystem(SystemInfo.java:106)
	at oshi.util.Memoizer$1.get(Memoizer.java:87)
	at oshi.SystemInfo.getOperatingSystem(SystemInfo.java:98)
	at com.jetbrains.performancePlugin.utils.HardwareCollector.collectInfo(HardwareCollector.java:49)
	... 29 more
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).