### PR TITLE
python3Packages.astropy: Fix cross compilation

### DIFF
--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -7,7 +7,6 @@
 , astropy-extension-helpers
 , cython
 , jinja2
-, oldest-supported-numpy
 , setuptools-scm
 , wheel
 
@@ -42,7 +41,7 @@ buildPythonPackage {
     astropy-extension-helpers
     cython
     jinja2
-    oldest-supported-numpy
+    numpy
     setuptools-scm
     wheel
   ];

--- a/pkgs/development/python-modules/pyerfa/default.nix
+++ b/pkgs/development/python-modules/pyerfa/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , jinja2
-, oldest-supported-numpy
 , setuptools-scm
 , wheel
 , liberfa
@@ -24,7 +23,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     jinja2
-    oldest-supported-numpy
+    numpy
     packaging
     setuptools-scm
     wheel


### PR DESCRIPTION
Fixes the build time error:
`ModuleNotFoundError: No module named 'numpy.core._multiarray_umath'`.

Depends on #249111

## Description of changes

Added `numpy` on `nativeBuildInputs`, so that it's available at build time when cross compiling.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross compiled from x86_64-linux)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
