### PR TITLE
 qt5.qtbase: backport patch to fix things crashing on exit 

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -46,6 +46,7 @@ let
       ./qtbase.patch.d/0009-qtbase-qtpluginpath.patch
       ./qtbase.patch.d/0010-qtbase-assert.patch
       ./qtbase.patch.d/0011-fix-header_module.patch
+      ./qtbase.patch.d/9999-backport-dbus-crash.patch
     ];
     qtdeclarative = [
       ./qtdeclarative.patch

--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/9999-backport-dbus-crash.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/9999-backport-dbus-crash.patch
@@ -1,0 +1,79 @@
+commit eb0c6846a5d05d686f0686f0f1ddddcad762ad26 (HEAD -> kde/5.15)
+Author: K900 <me@0upti.me>
+Date:   Mon Aug 14 22:44:02 2023 +0300
+
+    QLibraryPrivate: Actually merge load hints
+
+    Or old and new load hints in mergeLoadHints() instead of just storing
+    new ones. Andjust QLibraryPrivate::setLoadHints() to handle objects
+    with no file name differently and just set load hints directly.
+
+    Mention that load hints are merged once the file name is set
+    in the documentation for QLibrary::setLoadHints().
+
+    Add a regression test into tst_qfactoryloader.
+
+    Update and extend tst_QPluginLoader::loadHints() to take into account
+    load hints merging.
+
+    Fixes: QTBUG-114480
+    Change-Id: I3b9afaec7acde1f5ff992d913f8d7217392c7e00
+    Reviewed-by: Qt CI Bot <qt_ci_bot@qt-project.org>
+    Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+
+diff --git a/src/corelib/plugin/qlibrary.cpp b/src/corelib/plugin/qlibrary.cpp
+index 5d2f024267..45b5a3fe27 100644
+--- a/src/corelib/plugin/qlibrary.cpp
++++ b/src/corelib/plugin/qlibrary.cpp
+@@ -526,7 +526,7 @@ void QLibraryPrivate::mergeLoadHints(QLibrary::LoadHints lh)
+     if (pHnd.loadRelaxed())
+         return;
+
+-    loadHintsInt.storeRelaxed(lh);
++    loadHintsInt.fetchAndOrRelaxed(lh);
+ }
+
+ QFunctionPointer QLibraryPrivate::resolve(const char *symbol)
+@@ -538,6 +538,13 @@ QFunctionPointer QLibraryPrivate::resolve(const char *symbol)
+
+ void QLibraryPrivate::setLoadHints(QLibrary::LoadHints lh)
+ {
++    // Set the load hints directly for a dummy if this object is not associated
++    // with a file. Such object is not shared between multiple instances.
++    if (fileName.isEmpty()) {
++        loadHintsInt.storeRelaxed(lh);
++        return;
++    }
++
+     // this locks a global mutex
+     QMutexLocker lock(&qt_library_mutex);
+     mergeLoadHints(lh);
+@@ -1166,6 +1173,10 @@ QString QLibrary::errorString() const
+     lazy symbol resolution, and will not export external symbols for resolution
+     in other dynamically-loaded libraries.
+
++    \note Hints can only be cleared when this object is not associated with a
++    file. Hints can only be added once the file name is set (\a hints will
++    be or'ed with the old hints).
++
+     \note Setting this property after the library has been loaded has no effect
+     and loadHints() will not reflect those changes.
+
+diff --git a/src/corelib/plugin/qpluginloader.cpp b/src/corelib/plugin/qpluginloader.cpp
+index 0a63b93762..ceee5d6385 100644
+--- a/src/corelib/plugin/qpluginloader.cpp
++++ b/src/corelib/plugin/qpluginloader.cpp
+@@ -414,10 +414,11 @@ QString QPluginLoader::errorString() const
+ void QPluginLoader::setLoadHints(QLibrary::LoadHints loadHints)
+ {
+     if (!d) {
+-        d = QLibraryPrivate::findOrCreate(QString());   // ugly, but we need a d-ptr
++        d = QLibraryPrivate::findOrCreate({}, {}, loadHints); // ugly, but we need a d-ptr
+         d->errorString.clear();
++    } else {
++        d->setLoadHints(loadHints);
+     }
+-    d->setLoadHints(loadHints);
+ }
+
+ QLibrary::LoadHints QPluginLoader::loadHints() const


### PR DESCRIPTION
## Description of changes

This is kind of experimental, and we decided after a conversation with upstream to keep it vendored for a bit and then upstream if nothing explodes. 

Upstream commit: https://invent.kde.org/qt/qt/qtbase/-/commit/666ce51d4eb6b5dd312f98e2d7a18c54b59945e4

Upstream issues:
- https://bugreports.qt.io/browse/QTBUG-114480
- https://bugreports.qt.io/browse/QTBUG-112258

Possibly relevant Nixpkgs issue:
- https://github.com/NixOS/nixpkgs/issues/220168

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
