### PR TITLE
gdal: introduce a gdalMinimal variant with a smaller closure size

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -3,6 +3,9 @@
 , callPackage
 , fetchFromGitHub
 
+, useMinimalFeatures ? false
+, useTiledb ? (!useMinimalFeatures) && !(stdenv.isDarwin && stdenv.isx86_64)
+
 , bison
 , cmake
 , gtest
@@ -55,7 +58,6 @@
 , libspatialite
 , sqlite
 , libtiff
-, useTiledb ? !(stdenv.isDarwin && stdenv.isx86_64)
 , tiledb
 , libwebp
 , xercesc
@@ -101,63 +103,68 @@ stdenv.mkDerivation (finalAttrs: {
     "-DGDAL_USE_TILEDB=OFF"
   ];
 
-  buildInputs = [
-    armadillo
-    c-blosc
-    brunsli
-    cfitsio
-    crunch
-    curl
-    cryptopp
-    libdeflate
-    expat
-    libgeotiff
-    geos
-    giflib
-    libheif
-    dav1d  # required by libheif
-    libaom  # required by libheif
-    libde265  # required by libheif
-    rav1e  # required by libheif
-    x265  # required by libheif
-    hdf4
-    hdf5-cpp
-    libjpeg
-    json_c
-    libjxl
-    libhwy  # required by libjxl
-    lerc
-    xz
-    libxml2
-    lz4
-    libmysqlclient
-    netcdf
-    openjpeg
-    openssl
-    pcre2
-    libpng
-    poppler
-    postgresql
-    proj
-    qhull
-    libspatialite
-    sqlite
-    libtiff
-    gtest
-  ] ++ lib.optionals useTiledb [
-    tiledb
-  ] ++ [
-    libwebp
-    zlib
-    zstd
-    python3
-    python3.pkgs.numpy
-  ] ++ lib.optionals (!stdenv.isDarwin) [
-    # tests for formats enabled by these packages fail on macos
-    arrow-cpp
-    openexr
-    xercesc
-  ] ++ lib.optional stdenv.isDarwin libiconv;
+  buildInputs =
+    let
+      tileDbDeps = lib.optionals useTiledb [ tiledb ];
+
+      darwinDeps = lib.optionals stdenv.isDarwin [ libiconv ];
+      nonDarwinDeps = lib.optionals (!stdenv.isDarwin) [
+        # tests for formats enabled by these packages fail on macos
+        arrow-cpp
+        openexr
+        xercesc
+      ];
+    in [
+      armadillo
+      c-blosc
+      brunsli
+      cfitsio
+      crunch
+      curl
+      cryptopp
+      libdeflate
+      expat
+      libgeotiff
+      geos
+      giflib
+      libheif
+      dav1d  # required by libheif
+      libaom  # required by libheif
+      libde265  # required by libheif
+      rav1e  # required by libheif
+      x265  # required by libheif
+      hdf4
+      hdf5-cpp
+      libjpeg
+      json_c
+      libjxl
+      libhwy  # required by libjxl
+      lerc
+      xz
+      libxml2
+      lz4
+      libmysqlclient
+      netcdf
+      openjpeg
+      openssl
+      pcre2
+      libpng
+      poppler
+      postgresql
+      proj
+      qhull
+      libspatialite
+      sqlite
+      libtiff
+      gtest
+      libwebp
+      zlib
+      zstd
+      python3
+      python3.pkgs.numpy
+    ] ++ tileDbDeps
+      ++ darwinDeps
+      ++ nonDarwinDeps;
 
   postInstall = ''
     wrapPythonPrograms

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -12,6 +12,8 @@
 , usePoppler ? (!useMinimalFeatures)
 , useArrow ? (!useMinimalFeatures)
 , useHDF ? (!useMinimalFeatures)
+, useNetCDF ? (!useMinimalFeatures)
+, useArmadillo ? (!useMinimalFeatures)
 
 , bison
 , cmake
@@ -133,6 +135,8 @@ stdenv.mkDerivation (finalAttrs: {
         hdf4
         hdf5-cpp
       ];
+      netCdfDeps = lib.optionals useNetCDF [ netcdf ];
+      armadilloDeps = lib.optionals useArmadillo [ armadillo ];
 
       darwinDeps = lib.optionals stdenv.isDarwin [ libiconv ];
       nonDarwinDeps = lib.optionals (!stdenv.isDarwin) ([
@@ -141,7 +145,6 @@ stdenv.mkDerivation (finalAttrs: {
         xercesc
       ] ++ arrowDeps);
     in [
-      armadillo
       c-blosc
       brunsli
       cfitsio
@@ -159,7 +162,6 @@ stdenv.mkDerivation (finalAttrs: {
       xz
       libxml2
       lz4
-      netcdf
       openjpeg
       openssl
       pcre2
@@ -183,6 +185,8 @@ stdenv.mkDerivation (finalAttrs: {
       ++ popplerDeps
       ++ arrowDeps
       ++ hdfDeps
+      ++ netCdfDeps
+      ++ armadilloDeps
       ++ darwinDeps
       ++ nonDarwinDeps;
 

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -6,6 +6,9 @@
 , useMinimalFeatures ? false
 , useTiledb ? (!useMinimalFeatures) && !(stdenv.isDarwin && stdenv.isx86_64)
 , useLibHEIF ? (!useMinimalFeatures)
+, useLibJXL ? (!useMinimalFeatures)
+, useMysql ? (!useMinimalFeatures)
+, usePostgres ? (!useMinimalFeatures)
 
 , bison
 , cmake
@@ -115,6 +118,12 @@ stdenv.mkDerivation (finalAttrs: {
         rav1e
         x265
       ];
+      libJxlDeps = lib.optionals useLibJXL [
+        libjxl
+        libhwy
+      ];
+      mysqlDeps = lib.optionals useMysql [ libmysqlclient ];
+      postgresDeps = lib.optionals usePostgres [ postgresql ];
 
       darwinDeps = lib.optionals stdenv.isDarwin [ libiconv ];
       nonDarwinDeps = lib.optionals (!stdenv.isDarwin) [
@@ -140,20 +149,16 @@ stdenv.mkDerivation (finalAttrs: {
       hdf5-cpp
       libjpeg
       json_c
-      libjxl
-      libhwy  # required by libjxl
       lerc
       xz
       libxml2
       lz4
-      libmysqlclient
       netcdf
       openjpeg
       openssl
       pcre2
       libpng
       poppler
-      postgresql
       proj
       qhull
       libspatialite
@@ -167,6 +172,9 @@ stdenv.mkDerivation (finalAttrs: {
       python3.pkgs.numpy
     ] ++ tileDbDeps
       ++ libHeifDeps
+      ++ libJxlDeps
+      ++ mysqlDeps
+      ++ postgresDeps
       ++ darwinDeps
       ++ nonDarwinDeps;
 

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -5,6 +5,7 @@
 
 , useMinimalFeatures ? false
 , useTiledb ? (!useMinimalFeatures) && !(stdenv.isDarwin && stdenv.isx86_64)
+, useLibHEIF ? (!useMinimalFeatures)
 
 , bison
 , cmake
@@ -106,6 +107,14 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     let
       tileDbDeps = lib.optionals useTiledb [ tiledb ];
+      libHeifDeps = lib.optionals useLibHEIF [
+        libheif
+        dav1d
+        libaom
+        libde265
+        rav1e
+        x265
+      ];
 
       darwinDeps = lib.optionals stdenv.isDarwin [ libiconv ];
       nonDarwinDeps = lib.optionals (!stdenv.isDarwin) [
@@ -127,12 +136,6 @@ stdenv.mkDerivation (finalAttrs: {
       libgeotiff
       geos
       giflib
-      libheif
-      dav1d  # required by libheif
-      libaom  # required by libheif
-      libde265  # required by libheif
-      rav1e  # required by libheif
-      x265  # required by libheif
       hdf4
       hdf5-cpp
       libjpeg
@@ -163,6 +166,7 @@ stdenv.mkDerivation (finalAttrs: {
       python3
       python3.pkgs.numpy
     ] ++ tileDbDeps
+      ++ libHeifDeps
       ++ darwinDeps
       ++ nonDarwinDeps;
 

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -9,6 +9,9 @@
 , useLibJXL ? (!useMinimalFeatures)
 , useMysql ? (!useMinimalFeatures)
 , usePostgres ? (!useMinimalFeatures)
+, usePoppler ? (!useMinimalFeatures)
+, useArrow ? (!useMinimalFeatures)
+, useHDF ? (!useMinimalFeatures)
 
 , bison
 , cmake
@@ -124,14 +127,19 @@ stdenv.mkDerivation (finalAttrs: {
       ];
       mysqlDeps = lib.optionals useMysql [ libmysqlclient ];
       postgresDeps = lib.optionals usePostgres [ postgresql ];
+      popplerDeps = lib.optionals usePoppler [ poppler ];
+      arrowDeps = lib.optionals useArrow [ arrow-cpp ];
+      hdfDeps = lib.optionals useHDF [
+        hdf4
+        hdf5-cpp
+      ];
 
       darwinDeps = lib.optionals stdenv.isDarwin [ libiconv ];
-      nonDarwinDeps = lib.optionals (!stdenv.isDarwin) [
+      nonDarwinDeps = lib.optionals (!stdenv.isDarwin) ([
         # tests for formats enabled by these packages fail on macos
-        arrow-cpp
         openexr
         xercesc
-      ];
+      ] ++ arrowDeps);
     in [
       armadillo
       c-blosc
@@ -145,8 +153,6 @@ stdenv.mkDerivation (finalAttrs: {
       libgeotiff
       geos
       giflib
-      hdf4
-      hdf5-cpp
       libjpeg
       json_c
       lerc
@@ -158,7 +164,6 @@ stdenv.mkDerivation (finalAttrs: {
       openssl
       pcre2
       libpng
-      poppler
       proj
       qhull
       libspatialite
@@ -175,6 +180,9 @@ stdenv.mkDerivation (finalAttrs: {
       ++ libJxlDeps
       ++ mysqlDeps
       ++ postgresDeps
+      ++ popplerDeps
+      ++ arrowDeps
+      ++ hdfDeps
       ++ darwinDeps
       ++ nonDarwinDeps;
 
@@ -229,6 +237,8 @@ stdenv.mkDerivation (finalAttrs: {
     "test_rda_download_queue"
   ] ++ lib.optionals (lib.versionOlder proj.version "8") [
     "test_ogr_parquet_write_crs_without_id_in_datum_ensemble_members"
+  ] ++ lib.optionals (!usePoppler) [
+    "test_pdf_jpx_compression"
   ];
   postCheck = ''
     popd # autotest

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21315,6 +21315,10 @@ with pkgs;
 
   gdal = callPackage ../development/libraries/gdal { };
 
+  gdalMinimal = callPackage ../development/libraries/gdal {
+    useMinimalFeatures = true;
+  };
+
   gdcm = callPackage ../development/libraries/gdcm {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices Cocoa;
   };


### PR DESCRIPTION
## Description of changes

This is intended to reduce the support burden and closure size of using `gdal`; in contexts like PostGIS, it's possible to expose GDAL (and the one quadrillion lines of code it pulls in) through PostgreSQL. This isn't always desireable; an overlay may want to make some features optional. And even ignoring that, `gdal` is currently incredibly bloated and depends on nearly everything under the sun.

`gdal` versus `gdalMinimal` yields a closure size reduction from 1.1GiB to 430MiB:

```
austin@GANON:~/src/nixpkgs$ nix path-info -Srh ./result | tail -1
/nix/store/g6yblqa0gb1n3s5ndm628fndd0acn4dd-gdal-3.7.1                     1.1G
austin@GANON:~/src/nixpkgs$ nix path-info -Srh ./result-2 | tail -1
/nix/store/81i50vd3i5hs8jkkwqyp257y98jjkjqp-gdal-3.7.1                   434.1M
austin@GANON:~/src/nixpkgs$ 
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
