### PR TITLE
geos: update meta.description and meta.homepage

### DIFF
--- a/pkgs/development/libraries/geos/default.nix
+++ b/pkgs/development/libraries/geos/default.nix
@@ -21,10 +21,11 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
   meta = with lib; {
-    description = "C++ port of the Java Topology Suite (JTS)";
-    homepage = "https://trac.osgeo.org/geos";
+    description = "C/C++ library for computational geometry with a focus on algorithms used in geographic information systems (GIS) software";
+    homepage = "https://libgeos.org";
     license = licenses.lgpl21Only;
     maintainers = teams.geospatial.members;
     pkgConfigModules = [ "geos" ];
+    mainProgram = "geosop";
   };
 })


### PR DESCRIPTION
The primary change in this PR is to use the updated homepage.

Hopefully this is an improved description for geos too.

This was originally from #245468