### PR TITLE
python3Packages.torch: migrate to CUDA redist from CUDA Toolkit

### DIFF
--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, buildPythonPackage, python,
+{ stdenv, lib, fetchFromGitHub, fetchpatch, buildPythonPackage, python,
   config, cudaSupport ? config.cudaSupport, cudaPackages, magma,
   useSystemNccl ? true,
   MPISupport ? false, mpi,
@@ -52,17 +52,8 @@
 
 let
   inherit (lib) lists strings trivial;
-  inherit (cudaPackages) cudatoolkit cudaFlags cudnn nccl;
-in
+  inherit (cudaPackages) cudaFlags cudnn nccl;
 
-assert cudaSupport -> stdenv.isLinux;
-assert cudaSupport -> (cudaPackages.cudaMajorVersion == "11");
-
-# confirm that cudatoolkits are sync'd across dependencies
-assert !(MPISupport && cudaSupport) || mpi.cudatoolkit == cudatoolkit;
-assert !cudaSupport || magma.cudaPackages.cudatoolkit == cudatoolkit;
-
-let
   setBool = v: if v then "1" else "0";
 
   # https://github.com/pytorch/pytorch/blob/v2.0.1/torch/utils/cpp_extension.py#L1744
@@ -102,23 +93,6 @@ let
     else
       throw "No GPU targets specified"
   );
-
-  cudatoolkit_joined = symlinkJoin {
-    name = "${cudatoolkit.name}-unsplit";
-    # nccl is here purely for semantic grouping it could be moved to nativeBuildInputs
-    paths = [ cudatoolkit.out cudatoolkit.lib nccl.dev nccl.out ];
-  };
-
-  # Normally libcuda.so.1 is provided at runtime by nvidia-x11 via
-  # LD_LIBRARY_PATH=/run/opengl-driver/lib.  We only use the stub
-  # libcuda.so from cudatoolkit for running tests, so that we don’t have
-  # to recompile pytorch on every update to nvidia-x11 or the kernel.
-  cudaStub = linkFarm "cuda-stub" [{
-    name = "libcuda.so.1";
-    path = "${cudatoolkit}/lib/stubs/libcuda.so";
-  }];
-  cudaStubEnv = lib.optionalString cudaSupport
-    "LD_LIBRARY_PATH=${cudaStub}\${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH ";
 
   rocmtoolkit_joined = symlinkJoin {
     name = "rocm-merged";
@@ -160,6 +134,12 @@ in buildPythonPackage rec {
     # base is 10.12. Until we upgrade, we can fall back on the older
     # pthread support.
     ./pthreadpool-disable-gcd.diff
+  ] ++ lib.optionals stdenv.isLinux [
+    # Propagate CUPTI to Kineto by overriding the search path with environment variables.
+    (fetchpatch {
+      url = "https://github.com/pytorch/pytorch/pull/108847/commits/7ae4d7c0e2dec358b4fe81538efe9da5eb580ec9.patch";
+      hash = "sha256-skFaDg98xcJqJfzxWk+qhUxPLHDStqvd0mec3PgksIg=";
+    })
   ];
 
   postPatch = lib.optionalString rocmSupport ''
@@ -184,6 +164,13 @@ in buildPythonPackage rec {
       --replace "set(ROCM_PATH \$ENV{ROCM_PATH})" \
         "set(ROCM_PATH \$ENV{ROCM_PATH})''\nset(ROCM_VERSION ${lib.concatStrings (lib.intersperse "0" (lib.splitString "." hip.version))})"
   ''
+  # Detection of NCCL version doesn't work particularly well when using the static binary.
+  + lib.optionalString cudaSupport ''
+    substituteInPlace cmake/Modules/FindNCCL.cmake \
+      --replace \
+        'message(FATAL_ERROR "Found NCCL header version and library version' \
+        'message(WARNING "Found NCCL header version and library version'
+  ''
   # error: no member named 'aligned_alloc' in the global namespace; did you mean simply 'aligned_alloc'
   # This lib overrided aligned_alloc hence the error message. Tltr: his function is linkable but not in header.
   + lib.optionalString (stdenv.isDarwin && lib.versionOlder stdenv.targetPlatform.darwinSdkVersion "11.0") ''
@@ -192,12 +179,16 @@ in buildPythonPackage rec {
     inline void *aligned_alloc(size_t align, size_t size)'
   '';
 
+  # NOTE(@connorbaker): Though we do not disable Gloo or MPI when building with CUDA support, caution should be taken
+  # when using the different backends. Gloo's GPU support isn't great, and MPI and CUDA can't be used at the same time
+  # without extreme care to ensure they don't lock each other out of shared resources.
+  # For more, see https://github.com/open-mpi/ompi/issues/7733#issuecomment-629806195.
   preConfigure = lib.optionalString cudaSupport ''
     export TORCH_CUDA_ARCH_LIST="${gpuTargetString}"
-    export CC=${cudatoolkit.cc}/bin/gcc CXX=${cudatoolkit.cc}/bin/g++
-  '' + lib.optionalString (cudaSupport && cudnn != null) ''
     export CUDNN_INCLUDE_DIR=${cudnn.dev}/include
     export CUDNN_LIB_DIR=${cudnn.lib}/lib
+    export CUPTI_INCLUDE_DIR=${cudaPackages.cuda_cupti.dev}/include
+    export CUPTI_LIBRARY_DIR=${cudaPackages.cuda_cupti.lib}/lib
   '' + lib.optionalString rocmSupport ''
     export ROCM_PATH=${rocmtoolkit_joined}
     export ROCM_SOURCE_DIR=${rocmtoolkit_joined}
@@ -256,6 +247,7 @@ in buildPythonPackage rec {
   PYTORCH_BUILD_NUMBER = 0;
 
   USE_SYSTEM_NCCL = setBool useSystemNccl;                  # don't build pytorch's third_party NCCL
+  USE_STATIC_NCCL = setBool useSystemNccl;
 
   # Suppress a weird warning in mkl-dnn, part of ideep in pytorch
   # (upstream seems to have fixed this in the wrong place?)
@@ -286,12 +278,43 @@ in buildPythonPackage rec {
     pybind11
     pythonRelaxDepsHook
     removeReferencesTo
-  ] ++ lib.optionals cudaSupport [ cudatoolkit_joined ]
-    ++ lib.optionals rocmSupport [ rocmtoolkit_joined ];
+  ] ++ lib.optionals cudaSupport (with cudaPackages; [
+    autoAddOpenGLRunpathHook
+    cuda_nvcc
+  ])
+  ++ lib.optionals rocmSupport [ rocmtoolkit_joined ];
 
   buildInputs = [ blas blas.provider pybind11 ]
     ++ lib.optionals stdenv.isLinux [ linuxHeaders_5_19 ] # TMP: avoid "flexible array member" errors for now
-    ++ lib.optionals cudaSupport [ cudnn.dev cudnn.lib nccl ]
+    ++ lib.optionals cudaSupport (with cudaPackages; [
+      cuda_cccl.dev # <thrust/*>
+      cuda_cudart # cuda_runtime.h and libraries
+      cuda_cupti.dev # For kineto
+      cuda_cupti.lib # For kineto
+      cuda_nvcc.dev # crt/host_config.h; even though we include this in nativeBuildinputs, it's needed here too
+      cuda_nvml_dev.dev # <nvml.h>
+      cuda_nvrtc.dev
+      cuda_nvrtc.lib
+      cuda_nvtx.dev
+      cuda_nvtx.lib # -llibNVToolsExt
+      cudnn.dev
+      cudnn.lib
+      libcublas.dev
+      libcublas.lib
+      libcufft.dev
+      libcufft.lib
+      libcurand.dev
+      libcurand.lib
+      libcusolver.dev
+      libcusolver.lib
+      libcusparse.dev
+      libcusparse.lib
+      nccl.dev # Provides nccl.h AND a static copy of NCCL!
+    ] ++ lists.optionals (strings.versionOlder cudaVersion "11.8") [
+      cuda_nvprof.dev # <cuda_profiler_api.h>
+    ] ++ lists.optionals (strings.versionAtLeast cudaVersion "11.8") [
+      cuda_profiler_api.dev # <cuda_profiler_api.h>
+    ])
     ++ lib.optionals rocmSupport [ openmp ]
     ++ lib.optionals (cudaSupport || rocmSupport) [ magma ]
     ++ lib.optionals stdenv.isLinux [ numactl ]
@@ -335,7 +358,6 @@ in buildPythonPackage rec {
 
   checkPhase = with lib.versions; with lib.strings; concatStringsSep " " [
     "runHook preCheck"
-    cudaStubEnv
     "${python.interpreter} test/run_test.py"
     "--exclude"
     (concatStringsSep " " [
@@ -419,6 +441,17 @@ in buildPythonPackage rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ teh thoughtpolice tscholak ]; # tscholak esp. for darwin-related builds
     platforms = with platforms; linux ++ lib.optionals (!cudaSupport && !rocmSupport) darwin;
-    broken = rocmSupport && cudaSupport; # CUDA and ROCm are mutually exclusive
+    broken = builtins.any trivial.id [
+      # CUDA and ROCm are mutually exclusive
+      (cudaSupport && rocmSupport)
+      # CUDA is only supported on Linux
+      (cudaSupport && !stdenv.isLinux)
+      # Only CUDA 11 is currently supported
+      (cudaSupport && (cudaPackages.cudaMajorVersion != "11"))
+      # MPI cudatoolkit does not match cudaPackages.cudatoolkit
+      (MPISupport && cudaSupport && (mpi.cudatoolkit != cudaPackages.cudatoolkit))
+      # Magma cudaPackages does not match cudaPackages
+      (cudaSupport && (magma.cudaPackages != cudaPackages))
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Carrying on the torch lit by https://github.com/NixOS/nixpkgs/pull/168745.

#### Numbers!

See Full details for setup and full output of `nix path-info -rsSh`.

Before PR (baseline):

```console
$ nix build --impure github:nixos/nixpkgs/9a12fb6936d9d21f6bb602c68d1b41ec16bfc7d4#python3Packages.torch -o torch-pr-249259-baseline
$ nix path-info -sSh ./torch-pr-249259-baseline
/nix/store/2agqm11avdxkyqd378c87qzg3cdn9a3b-python3.10-torch-2.0.1	  88.3M	   9.1G
```

After PR:

```console
$ nix build --impure .#python3Packages.torch -o torch-pr-249259-applied
$ nix path-info -sSh ./torch-pr-249259-applied
/nix/store/kxrrpb3py0d5d443wy7bw1idjnk80sfb-python3.10-torch-2.0.1	  88.3M	   3.7G
```

<details><summary>Full numbers</summary>

Shared `~/.config/nixpkgs/config.nix` across both:

```nix
{
  allowUnfree = true;
  cudaSupport = true;
  cudaCapabilities = [ "8.9" ];
}
```

Baseline values:

```console
$ nix path-info -rsSh ./torch-pr-249259-baseline
/nix/store/gnzwqa9df994g01yw5x75qnbl1rhp9ds-libunistring-1.1                       	   1.8M	   1.8M
/nix/store/h3aw16j1c54jv8s39yvdhpfcx3538jwi-libidn2-2.3.4                          	 350.4K	   2.1M
/nix/store/kv0v4h5i911gj39m7n9q10k8r8gbn3sa-xgcc-12.3.0-libgcc                     	 139.1K	 139.1K
/nix/store/905gkx2q1pswixwmi1qfhfl6mik3f22l-glibc-2.37-8                           	  28.8M	  31.1M
/nix/store/jzd79aanwywnp3ak48gv8q75h5h2vmf8-keyutils-1.6.3-lib                     	  41.6K	  31.1M
/nix/store/m36d29gn5gm9bk0g7fcln1v8171hvn95-bash-5.2-p15                           	   1.6M	  32.7M
/nix/store/01qn4g83hjzqmd8yfbb3dz32dzp8zjvg-libkrb5-1.20.1                         	   2.2M	  35.0M
/nix/store/fcdkcrsrg289h6k33fwmfkhsdj55r6yr-libxcrypt-4.4.36                       	 128.0K	  31.2M
/nix/store/m1rszkm1s0d5z12r3pyg1rp0rns5hdm9-zlib-1.2.13                            	 125.6K	  31.2M
/nix/store/iy98w96czin7yn1m4g01bv8dy8rn14f4-attr-2.5.1                             	  78.8K	  31.2M
/nix/store/gy17d3psdvfxgkc0ds8dnl9c1yphhvf0-acl-2.3.1                              	 108.9K	  31.3M
/nix/store/s2pgr9iqj60mfnmabixnqacxl4bzb408-gcc-12.3.0-libgcc                      	 139.1K	 139.1K
/nix/store/gi26p79iq8jrw51irq5x82c2cqlgicxi-gcc-12.3.0-lib                         	   7.5M	  38.8M
/nix/store/z5l5pl36yzx2px99qyxiz3lhwaa9dkh4-gmp-with-cxx-6.3.0                     	 743.0K	  39.5M
/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3                          	   1.4M	  41.1M
/nix/store/04hllvrsxrw8krjgz0lydxfdy2gg2ndw-perl-5.38.0                            	  55.7M	  97.1M
/nix/store/05vjzaa5sqpbijhj80klmmb3g07szyk9-sqlite-3.42.0                          	   1.4M	  32.6M
/nix/store/p499d70p3j0pd5nglv6fih2b0wqa1lg7-perl5.38.0-URI-5.05                    	 147.6K	 147.6K
/nix/store/0p48bwydyyx2x5kvj7xvg2g7c1phs39y-perl5.38.0-Net-HTTP-6.19               	  37.5K	 185.2K
/nix/store/2w2kvximnrcfz64hrc1vm2mxnk1pshsn-perl5.38.0-WWW-RobotRules-6.02         	  18.5K	 166.2K
/nix/store/412xalqakavz4jca40g6i8ajjd9yi8rp-perl5.38.0-Try-Tiny-0.30               	  23.2K	  23.2K
/nix/store/445vs1m4ipq9j6fglyvhxccamz53biax-perl5.38.0-LWP-MediaTypes-6.04         	  58.8K	  58.8K
/nix/store/wmy31bs7qc644pcm27s7kqhvdizb7db2-perl5.38.0-TimeDate-2.33               	  88.1K	  88.1K
/nix/store/6micrqpph8n1x2k27lb4a24mbc736705-perl5.38.0-HTTP-Date-6.05              	  15.0K	 103.2K
/nix/store/7c7m4iykqdlw14ng6h86m1rpbhfm28p8-perl5.38.0-Test-RequiresInternet-0.05  	   6.0K	   6.0K
/nix/store/9020xcc9202sfdxzypqgi577vipaw8yl-perl5.38.0-Encode-Locale-1.05          	  15.1K	  15.1K
/nix/store/fpcmbfrwqi8wgmxv2zpqlcdyf6bpwpca-perl5.38.0-Test-Fatal-0.016            	  18.0K	  41.2K
/nix/store/i38mkz11rg0qh9gbr903bskgfwdwi94j-perl5.38.0-IO-HTML-1.004               	  22.2K	  22.2K
/nix/store/jii79jq75zz7d51iwkla6ic2mxplvb9w-perl5.38.0-HTTP-Message-6.26           	 137.6K	 484.5K
/nix/store/g4mgf488zs0nmldaqiwc318zyppz0aa5-perl5.38.0-HTTP-Negotiate-6.01         	  19.2K	 503.7K
/nix/store/j3dxv879x1jcdsq8fhcfvyvvxhmbgr7c-perl5.38.0-HTML-Tagset-3.20            	  15.7K	  15.7K
/nix/store/kd9zkl0vmy4lkxkr1kggmgdp101f8kqq-perl5.38.0-HTML-Parser-3.75            	 149.8K	  31.7M
/nix/store/sa5gnhd3jqrjz8fyi57d67cm1k5qdjah-perl5.38.0-File-Listing-6.14           	  17.0K	 120.2K
/nix/store/vhhfald23ll714hrpryhydl09j4jchvm-perl5.38.0-HTTP-Cookies-6.09           	  40.3K	 524.8K
/nix/store/x7b15w080ra90kdhdfxv8jvzwwi6lhv6-perl5.38.0-Test-Needs-0.002006         	  11.1K	  11.1K
/nix/store/z86kai40yhhw2ny9wph2nv8xin0hhvqa-perl5.38.0-HTTP-Daemon-6.14            	  33.5K	 518.0K
/nix/store/0i9rpczim8vhiy79hpbgms5cyc8kyq85-perl5.38.0-libwww-perl-6.67            	 289.5K	  98.2M
/nix/store/3dmavjv0mj5h014i90bj9gsa9vddhnjb-expat-2.5.0                            	 253.0K	  31.3M
/nix/store/0dl2jr3hd7wjdpdvsya6pvxk1z239r5f-perl5.38.0-XML-Parser-2.46             	 428.7K	  98.9M
/nix/store/3cg1n66ln0l5frnk4lydjajrbf9pavv9-gawk-5.2.2                             	   2.6M	  33.7M
/nix/store/b686rq3liv9m60ck3r2rg8klk6bkarr5-util-linux-minimal-2.39.1-lib          	   1.8M	  32.9M
/nix/store/df10ppbxbsc5xnyc1bsh4xra2vxq5dbb-libffi-3.4.4                           	  55.2K	  31.1M
/nix/store/13lky39i5y7yh3dafjf788l04k5lv5a3-pcre-8.45                              	 513.3K	  31.6M
/nix/store/lpg2kfi54w421sg8ky7vz6ni8rzwiigb-libselinux-3.3                         	   1.1M	  32.7M
/nix/store/n0rn1f5n7v1j7xh3i4jmq5hd3ibdyvvp-pcre2-10.42                            	   1.8M	  32.9M
/nix/store/xq4s68bfp0hbx68fc1dlvv43a8mv0a1k-glib-2.76.4                            	  13.2M	  49.6M
/nix/store/4z85925nggvjiqj8p8vkib5wrzs5r1pp-glib-2.76.4-bin                        	 247.3K	  49.9M
/nix/store/53dwh9ai5sj8sfyzq00vxxamaxsif0y0-perl5.38.0-XML-Twig-3.52               	 502.5K	  99.4M
/nix/store/7ipff5ik2h3v2hf7v9mycp1k52hlmkz8-perl5.38.0-X11-Protocol-0.56           	 244.4K	  97.3M
/nix/store/m5iyqfxb2xzn277m5nfri9vf2wd9mma7-perl5.38.0-IPC-System-Simple-1.30      	  36.5K	  36.5K
/nix/store/ss0kag2cmjdp5i2wq748vgdhx085rmzq-perl5.38.0-File-BaseDir-0.08           	  16.5K	  53.0K
/nix/store/9nv3sfxd5zya67qpw6icfqx1lgv90zff-perl5.38.0-File-DesktopEntry-0.22      	  27.2K	 227.8K
/nix/store/8j20m37v4w1bv66zlwhdirhy427y3ikd-perl5.38.0-File-MimeInfo-0.30          	  78.7K	  97.4M
/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11                           	 923.2K	  33.8M
/nix/store/dllid2s0v445dfnqfapshm48aarnbcdl-file-5.45                              	   8.3M	  39.5M
/nix/store/76xssy04mbjrjvccfkn43d4x0x2xp5ic-xz-5.4.4                               	 795.6K	  31.9M
/nix/store/lg451mdjcnszbbxikdd75v1c4p8gw28y-zstd-1.5.5                             	   1.1M	  39.9M
/nix/store/1a36nlxkzxp8g4mfamv8d20vxfm2r0g2-kmod-30-lib                            	 120.5K	  40.8M
/nix/store/32dbr9m9insn4jylldydfngfddi233s4-util-linux-minimal-2.39.1-swap         	  92.2K	  32.9M
/nix/store/3m3x06nxqkd7623b2md4071bp4wlk0b8-kexec-tools-2.0.26                     	 237.1K	  31.4M
/nix/store/6j441sca7vaqxw717rkidc1rgvinx895-kmod-30                                	 210.3K	  40.8M
/nix/store/afnipzq5w9ggwb4pn7s17id8hfd87hwi-bzip2-1.0.8                            	  79.5K	  31.2M
/nix/store/7284vinlwkp93151h6r3jcmdp5463rq9-bzip2-1.0.8-bin                        	  68.4K	  31.2M
/nix/store/9yzfj1sj5af85vbgmd33rpwpn0yg0fil-zstd-1.5.5-bin                         	 343.9K	  44.5M
/nix/store/mbvy50fhspgwanw0fpns41afchll75br-gzip-1.12                              	 153.1K	  32.8M
/nix/store/xm6vmd1fq87mh70b793xzs39wnc084sw-xz-5.4.4-bin                           	 174.6K	  32.0M
/nix/store/7pifsqk6vjl31da81nlf1ylx3f6r7x17-kbd-2.6.1                              	   2.6M	  50.6M
/nix/store/7spv90rkbaf394hh1fzx0p8a1xzx3jhs-libcap-2.69-lib                        	  78.0K	  31.2M
/nix/store/akmp8y3308y45fi55vdn10pxgbr8m0v2-util-linux-minimal-2.39.1-mount        	 112.2K	  33.0M
/nix/store/g7q44sdl9m0bnvbq76cx6nwrpbmdivy5-util-linux-minimal-2.39.1-login        	  85.7K	  31.3M
/nix/store/58zvgaag2sh39iqd0i78wis9npj676cb-ncurses-6.4                            	   3.5M	  34.6M
/nix/store/i9gbgjzfvfpphb4yxjca71lakvwsixj4-readline-8.2p1                         	 455.5K	  35.1M
/nix/store/g882vp4i2mgypn751jbainhnj7q84my7-bash-interactive-5.2-p15               	   6.9M	  42.0M
/nix/store/b33y3zkl0g8l92cll64js1p8s703q9zw-glibc-2.37-8-getent                    	  42.2K	  31.1M
/nix/store/jl59kw9mg2rbi7a8bk2vzfpx072sq2zb-getent-glibc-2.37-8                    	 528.0 	  31.1M
/nix/store/w0sjpqah99hjn4g1h104x9p9p41w3833-libseccomp-2.5.4-lib                   	 138.9K	  31.2M
/nix/store/d9kbs3l63q8s0i20aqm4d8nba67wsjh8-systemd-minimal-253.6                  	  12.4M	  77.0M
/nix/store/pilkni313ds2nzv6pc6ifi8m3s7rkg7x-libXdmcp-1.1.4                         	  31.4K	  31.1M
/nix/store/y03kj0yh1p8dlw2fk05dq8ksjnv35wly-libXau-1.0.11                          	  23.4K	  31.1M
/nix/store/n93df5q2nkcfkg1gn8yc4x31dzrsamxs-libxcb-1.15                            	   1.3M	  32.5M
/nix/store/pgdp4mwzyyhsyn41vh4kj68rvvsfp6nn-libX11-1.8.6                           	   2.5M	  35.0M
/nix/store/n3gqczwmv85566q3xq19w5i1y3p9935x-dbus-1.14.8-lib                        	 449.9K	  81.4M
/nix/store/mddajb8igp48gv0cx08z787dsxa7rjz7-perl5.38.0-Net-DBus-1.2.0              	 465.3K	 139.9M
/nix/store/dxs75ddpkqb6kz0fjvbmznpsj7mwvc93-libXext-1.3.5                          	  94.2K	  35.1M
/nix/store/k9v7rqld577d521fja8wfdq39r8plnsz-libICE-1.1.1                           	 118.9K	  31.2M
/nix/store/0qi9h7r991hfydh1584401da2mzl6jm0-libSM-1.2.4                            	  44.9K	  33.0M
/nix/store/133fhh338fpglm4kkv81w9rz5vw8aw1h-libXt-1.3.0                            	 475.1K	  37.4M
/nix/store/ighhj08vrw8g2zrv79mj7ydw8siw8m2c-libXmu-1.1.4                           	 153.7K	  37.6M
/nix/store/ps7nsbxklhkyv3vvipj0z6a5cb3adyzj-xset-1.2.5                             	  45.2K	  37.7M
/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9                             	 714.7K	  31.8M
/nix/store/07sk98jk0h3abhs2nmwiqihvf6m79hnv-xdg-utils-unstable-2022-11-06          	 293.8K	 168.2M
/nix/store/1qq748gdkykzykkxmi1kgpajnv27r92r-gmp-with-cxx-6.3.0                     	 741.8K	  39.5M
/nix/store/0a3la5zksq8zlnc3z27mcb8fay8firz6-isl-0.20                               	   2.5M	  41.9M
/nix/store/0jhjw06iipmnz6nm8r94zzvqsvlfs5w9-libevent-2.1.12                        	 845.8K	  31.9M
/nix/store/gsb6wnh4iqj9cl9n1jdg1w3ph2nmwg09-nettle-3.9.1                           	 698.0K	  40.2M
/nix/store/2bibqz0hdxj12h20r26n79czb05p1cjg-unbound-1.17.1-lib                     	   1.0M	  42.0M
/nix/store/7g8cyxwalrncay14rx3b3milbsln7vd1-libtasn1-4.19.0                        	  91.7K	  31.2M
/nix/store/6782lsv710y3i1j0akckf2sh6yklpvjl-p11-kit-0.25.0                         	   4.8M	  36.0M
/nix/store/zb8w1ic4inxgxchlnwvwxg9vkbx08xz6-dns-root-data-2019-01-11               	   4.4K	   4.4K
/nix/store/0c7pj47zzhlgklm4v8jlykkiq3a92lm0-gnutls-3.8.1                           	   3.1M	  50.2M
/nix/store/0vgy4c2c80zv7xsq9v0adcr2rjl18wss-openresolv-3.13.2                      	  66.8K	  42.8M
/nix/store/21qsjzqjwjyfmbh5gy1b9g5dmhy35w1f-libXi-1.8.1                            	  84.2K	  35.2M
/nix/store/18c36dcl8hhwaf79izrarw89n7gqr4lw-libmnl-1.0.5                           	  42.2K	  31.1M
/nix/store/7va19r92k2p6d0sq0qnvnikqrwlh50m8-libnfnetlink-1.0.2                     	  55.2K	  31.1M
/nix/store/c7nbl568ki44yai3j3zb9mxxm2gg095z-libnl-3.7.0                            	   1.4M	  32.5M
/nix/store/b3wdn9yijsw65y6rwqgh9wn5cb72b5sz-libpcap-1.10.4                         	   1.1M	  35.2M
/nix/store/hz00dab547ny9m1z4ryb2jm3447hci82-libnetfilter_conntrack-1.0.9           	 191.7K	  31.4M
/nix/store/q52w7qz97hjyw14swcs6fll1r89bav7h-libnftnl-1.2.6                         	 300.6K	  31.4M
/nix/store/1hrxvmasj9bsd0vd1pbp9hl31rh4flaw-iptables-1.8.9                         	   2.6M	  38.4M
/nix/store/gzwwz0j5k2q0qn3bdphay75ahv9iiw5j-brotli-1.0.9-lib                       	   1.7M	  32.8M
/nix/store/yr3k99szpnyzpha9g8qi0ap5skrsvh59-openssl-3.0.10                         	   6.2M	  37.3M
/nix/store/px7p1kxw6ygk716q4y6sf7pplm9paylp-libssh2-1.11.0                         	 309.8K	  37.7M
/nix/store/s7gv3m679skgfnd2mrbgbibz11c6yk03-nghttp2-1.54.0-lib                     	 217.3K	  31.3M
/nix/store/m3z2c4a8mvlvqmrsx5jp4qa41p48fjq4-curl-8.2.1                             	 837.1K	  53.1M
/nix/store/s39n4kcc48ks8jixgsk2izi9h7lrxgqa-elfutils-0.189                         	   3.6M	  57.5M
/nix/store/1qh77c75bllww1v0n9kfzn7cgd9833pj-libbpf-1.2.2                           	   1.7M	  59.2M
/nix/store/6pfmrp789c8x6fwiiqnixyh6i1q1gd62-libgpg-error-1.47                      	 815.0K	  31.9M
/nix/store/4dlp1q8qy779w8bjfcxw4qmvl3kvkx7w-npth-1.6                               	  52.0K	  32.7M
/nix/store/4hi5ypfqzbmvjz3m6za8hspvzwd7zsjn-libassuan-2.5.6                        	  97.3K	  32.0M
/nix/store/qqq73sq0vyvrzqgdd2vvmnxl40l2b6fi-libgcrypt-1.10.2                       	   1.4M	  33.3M
/nix/store/7532iq3clbwp4qd7nqdayc9bsb0hfd9j-gnupg-2.4.1                            	   1.1M	  36.1M
/nix/store/jxksa9lnz3nv459frzp3pqnaxx1nh7kw-json-c-0.16                            	 219.6K	  31.3M
/nix/store/7p0bi40ay1gfgdaf6r6wbbn0h3p73kjb-tpm2-tss-4.0.1                         	   3.3M	  58.3M
/nix/store/blfxv4rg251xvfjx6xrcgayi8kp230xw-lz4-1.9.4                              	 231.5K	  31.3M
/nix/store/251l0zk73sfsias4qfnf1xcd7qcrd00r-pcsclite-1.9.5                         	  87.9K	  31.2M
/nix/store/ska7h7plz9xkig5s1l59jmlmnr36i7m9-libcbor-unstable-2023-01-29            	 161.7K	  31.3M
/nix/store/f5xmwnaim57695zyh1rmv10wjp0h16p2-libfido2-1.13.0                        	 981.3K	  84.4M
/nix/store/h9bjwhv47s1zpl1gij269zpda65cpf1l-libmicrohttpd-0.9.71                   	 159.4K	  50.3M
/nix/store/j6yvs1q9lsshiwhgq3g4abwm7c5pq1gd-libapparmor-3.1.6                      	 431.6K	  31.5M
/nix/store/j5nj1yh6b0sgqi9cb21jcr83qnvi9sys-lvm2-2.03.22-lib                       	 408.4K	  77.4M
/nix/store/vgivlw1g3ndiiv160ilajcrizrwzzv87-libargon2-20190702                     	 137.0K	  31.2M
/nix/store/mwfa6k7pfj1qjcjjn8s4x7ckx884b4ac-cryptsetup-2.6.1                       	   2.1M	  86.0M
/nix/store/2k111sb2cjzq9phi6la5kw7z7sc1gbrg-db-4.8.30                              	   3.4M	  42.2M
/nix/store/pf39x2qbcv6ii8dd5i3dd34pqfnfkmja-audit-3.1.2                            	 786.5K	  33.5M
/nix/store/ny5rqva39sy2bqkgmvq8djhy2wd8hmbr-linux-pam-1.5.2                        	   1.8M	  46.5M
/nix/store/q5lvjrl7b12vqmsd93h013z9dqkbva0p-gnutar-1.35                            	   2.7M	  34.0M
/nix/store/i0lc8fswlqfh59bf3480n5rgjhqnpdvr-systemd-253.6                          	  31.6M	 162.5M
/nix/store/q67xa2v6b30q9lqvj577fml5bzpp6vpr-gsettings-desktop-schemas-44.0         	   5.0M	   5.0M
/nix/store/qacmq3399l9ncy3fjlp0kl6sir1wk0ih-dconf-0.40.0-lib                       	 303.8K	  49.9M
/nix/store/r9z8h9dqmk4j62pwx7r0fygcbnk4qlqg-libXtst-1.2.4                          	 121.8K	  35.3M
/nix/store/1bi8v58yq39z30q1szpqawzx0p5lhzcl-at-spi2-core-2.48.3                    	   2.1M	 189.4M
/nix/store/dw932dvfv8vaa617g2kdg3hwnh5sr92y-libjpeg-turbo-2.1.5.1                  	   1.6M	  32.7M
/nix/store/x3316w897l06h7ds8mb4xbqjd4bksc3n-libdeflate-1.18                        	 391.9K	  31.5M
/nix/store/18cx0dv1alh3p4fm62pyp1pzlkra0z42-libtiff-4.5.1                          	 597.8K	  42.2M
/nix/store/pzrr4vw5cx2p8229vw71fffq7kixfdf5-libpng-apng-1.6.39                     	 249.3K	  31.5M
/nix/store/6828n61l9rnhss1ykp7hz5vnwmgpnany-gdk-pixbuf-2.42.10                     	   2.8M	  63.6M
/nix/store/82z4lkdiicc07krfbhj6byyryf00kvml-libxml2-2.11.4                         	   1.5M	  32.7M
/nix/store/9vj3dzx2cq80c9v51c8080mayq8y83mh-libXrender-0.9.11                      	  53.5K	  35.1M
/nix/store/18har2a1sc7bh1fzd616is2byvdrgk58-libXrandr-1.5.3                        	  63.0K	  35.2M
/nix/store/36p280pv1rv1a1zq997bjdrg9l5l9444-iso-codes-4.15.0                       	  18.7M	  18.7M
/nix/store/3bp79vdcgvs02dqm1jz7v110jy9m3kyk-wayland-1.22.0                         	 385.7K	  31.5M
/nix/store/kyl7p46llvz9arc4732rr24wbwd8snij-libdaemon-0.14                         	  36.9K	  31.1M
/nix/store/mnd23b8pb12mkc4fzvh3pdh23b5blxij-avahi-0.8                              	   1.5M	  98.9M
/nix/store/4a60431549mzjgcf9k3rh93zq3f19cpc-cups-2.4.6-lib                         	   4.6M	 113.9M
/nix/store/s2fik099wsc90c416h1p8nykjj4hibz0-publicsuffix-list-unstable-2023-02-16  	 245.3K	 245.3K
/nix/store/db2zfwmfjdppi77h5biv6f0q9pgxfzif-libpsl-0.21.2                          	 118.9K	  31.4M
/nix/store/3cmhgilizgvyz1r5di91wiwl33k9ac9j-libsoup-3.4.2                          	   1.1M	  54.4M
/nix/store/4c998w5xzfsllg9ql512d79awgch7prj-freetype-2.13.1                        	   2.0M	  35.2M
/nix/store/bkp6kqv0yy0zqfxrnd467mwc2g96kdn2-dejavu-fonts-minimal-2.37              	 742.6K	 742.6K
/nix/store/agig39clzgzf9bgc9x6bs8dwjz38bqjk-fontconfig-2.14.2                      	   1.6M	   2.3M
/nix/store/9a0px23rsi9ylxpvwi5qy3mkfvrxpbaq-fontconfig-2.14.2-lib                  	 390.0K	  38.2M
/nix/store/as57ja6jw950q57lk3l24dx5zgvys5vx-libglvnd-1.6.0                         	   2.5M	  37.6M
/nix/store/x1czqd7hrrx7brwv5sgp244d86jwiy48-pixman-0.42.2                          	 787.3K	  31.9M
/nix/store/xzj3caxycdqz6ghpj5mi99pnzm7d4if0-cairo-1.16.0                           	   1.8M	  65.8M
/nix/store/5dg50lpz358zl6f3jya9jx7mqiihggyd-gobject-introspection-1.76.1           	   1.7M	  67.4M
/nix/store/knv3la8wvmvifcfsvf7qa012ydw2l439-libsoup-2.74.3                         	   1.2M	  55.8M
/nix/store/pqgpr997150234a99v7zhilrd8wl8w0b-json-glib-1.6.6                        	 604.0K	  50.2M
/nix/store/zswmb1194y2qi67afq992jcj4rpqcdqg-icu4c-73.2                             	  37.7M	  78.0M
/nix/store/5if236sw6zi9pb0yv7q7l8smwvw771nq-tracker-3.5.3                          	   4.2M	 125.3M
/nix/store/70jz0la256zc7vim1q9p7gs26rvi601g-libXfixes-6.0.1                        	  38.2K	  35.0M
/nix/store/7l2ljrlaz2isza2z32l8lr5gqdclqj52-fribidi-1.0.13                         	 154.3K	  31.2M
/nix/store/9p46zfnwkvl1zi8ghrs5qj5i839f9rwy-libXinerama-1.1.5                      	  21.9K	  35.1M
/nix/store/ajaj7rfd4pjsjr045rd5d2lq1pz3683v-libXcomposite-0.4.6                    	  25.2K	  35.0M
/nix/store/nwkjj3vaaiv7gy835wmjnx244md90sgb-libGL-1.6.0                            	 520.0 	  37.6M
/nix/store/dgzf7fkgpmmqk2qs07mz5hb3cxbq2mjh-libepoxy-1.5.10                        	   1.7M	  39.3M
/nix/store/rghlzvxcv2jrmv5pm94ql2c1as66fmk0-xkeyboard-config-2.39                  	   6.6M	   6.6M
/nix/store/ipc7l2dwwwl2cqfjhc5k410bwb2drgcm-libxkbcommon-1.5.0                     	 553.7K	  44.2M
/nix/store/p8kckfh04k083ylbas604g3nhdlbxq1z-libXcursor-1.2.1                       	  78.2K	  35.2M
/nix/store/imhyvbpd6a4h849nmddsl8fphdxnhkc6-graphite2-1.3.14                       	 219.3K	  39.0M
/nix/store/rb0nbjxrj32k7gcbsqihwq1gq6qlv1li-harfbuzz-7.3.0                         	   2.7M	  64.2M
/nix/store/v9sznb6ikzlv8mwwx0q2n4zb9rv7dk1l-libXdamage-1.1.6                       	  18.1K	  35.1M
/nix/store/b05p3r9l0x4fbwh57qv06cxgq24604k0-libdatrie-2019-12-20-lib               	  42.2K	  31.1M
/nix/store/hvx95p0cq3mr5zd6wx4izbhva64j4rf8-libthai-0.1.29                         	 627.1K	  31.7M
/nix/store/lv0c78rn9c3imdbif7bvzfq6p0bqwi21-libXft-2.3.8                           	 148.3K	  42.3M
/nix/store/yr9vkflhl34250qv7v3d3c8702857mpm-pango-1.50.14                          	 847.2K	  78.1M
/nix/store/90v3wqw9rc0m9kj2kd322dq9ijkpn1cv-gtk+3-3.24.38                          	  37.3M	 331.3M
/nix/store/0wawa4j72z57km09lc66gf6v2zjiq670-stoken-0.93                            	 219.8K	 331.5M
/nix/store/sl7vlzy53zivn5p971agmcrd5xr1rijm-xcb-util-renderutil-0.3.10             	  28.1K	  32.5M
/nix/store/c2nkm5zsvz0khhlj47prgm6shg55mi6i-xcb-util-0.4.1                         	  31.8K	  32.5M
/nix/store/ylfqzfvw1r5yzbabgcjzd8f70yxjazhg-xcb-util-image-0.4.1                   	  27.1K	  32.5M
/nix/store/12gbss5663m02aqfzshrwjc29dd66r0w-xcb-util-cursor-0.1.4                  	  29.1K	  32.6M
/nix/store/jdag9r2y75xzbzs93hba1z1mgajh244h-binutils-2.40-lib                      	  25.9M	  57.1M
/nix/store/srlc9yv0jw1csbyyhl8a8zdfqlmgq0q7-rdma-core-47.0                         	   4.6M	 222.8M
/nix/store/v4jwv7lk7ljd3pnl4rqs82w72szsc3lv-numactl-2.0.16                         	 243.1K	  31.3M
/nix/store/15pmbri8d5703g972bld7amig4mlr40x-ucx-1.14.1                             	   5.4M	 254.3M
/nix/store/qllchk5a3jzwscmxbjnn1ansq7yv6k64-gcc-11.4.0-libgcc                      	 114.2K	 114.2K
/nix/store/78vn2bhbrg2h04bcqgr0zp0434s4ysnq-gcc-11.4.0-lib                         	   7.4M	  46.3M
/nix/store/8dsr170m1q1lj9s9w1vb8p274y577kgs-libgudev-238                           	  69.2K	 177.4M
/nix/store/9dgshfnpkjscnn8m6ai71x6swj6v9yq6-libwacom-2.7.0                         	 797.3K	 178.2M
/nix/store/hliscv1pcphzvn16n4zkqywi9smqlicr-mtdev-1.1.6                            	  62.3K	  31.2M
/nix/store/s5rc8cc5q916sl9dirw64dhmgcd56p1p-libevdev-1.13.1                        	 280.6K	  31.4M
/nix/store/4pv2nayq4404cbykwh19gph2wris40fg-libinput-1.23.0                        	 551.3K	 179.1M
/nix/store/xy9vslaa04j05xfgwg951j5gj23almkj-jansson-2.14                           	 112.6K	  31.2M
/nix/store/ycmh32jai4bb3xgvs5sgffsvh7ggyip1-libedit-20221030-3.1                   	 282.8K	  34.9M
/nix/store/3la1rsa2ilgjvklfx2c2dn8b5rwfb5rb-nftables-1.0.8                         	   1.1M	  51.8M
/nix/store/5qd6w6027w5ixn75c673hr1m7fbl1a59-popt-1.19                              	 186.9K	  31.3M
/nix/store/jqgaqyxsvmx9yj45i808hz5bw5gsl1dg-slang-2.3.3                            	   2.7M	  38.2M
/nix/store/41xrw8g7ax9r4mgr705y7pyq3aw2nisq-newt-0.52.23                           	 469.0K	  38.9M
/nix/store/fa4qyz1nl0ldd521mhvwl6656hz7k2wp-duktape-2.7.0                          	   1.2M	  32.3M
/nix/store/714ccvpq43av0v4mj084j3zaxy3ldccm-polkit-122                             	 527.3K	  99.9M
/nix/store/mgn5imqks0yvw6s1ab0nysxddnqxrm5v-libqrtr-glib-1.2.2                     	  59.1K	  49.7M
/nix/store/q5sslarzfvb1cqi3fl8lhq1qnjyqz1gy-libmbim-1.28.4                         	   1.3M	  52.5M
/nix/store/b9wagm7bk2y7mh8ad88bzk9wsl46s3xg-libqmi-1.32.4                          	   6.3M	 185.1M
/nix/store/43cg159gsvdg8w30p1r9m5pdymv4vk8k-modemmanager-1.20.6                    	  12.3M	 199.3M
/nix/store/4xqfa4l6jv6j3aawpa7rayig4k620asv-libndp-1.8                             	  75.7K	  31.2M
/nix/store/krjigpdksfqwhr0vrkmv33mb4jci8dmm-libidn-1.41                            	 411.5K	  31.5M
/nix/store/77i7pyqx930ic0gb6fqkhpkyrfibc0nq-dnsmasq-2.89                           	 587.7K	  84.1M
/nix/store/9wd21mnhd24x796bzqz9g57hahq3hcpk-ethtool-6.1                            	 589.6K	  31.7M
/nix/store/csrwwz7j2kdm8ji4mbdjzdsaay647jkq-iputils-20221126                       	 472.4K	  31.6M
/nix/store/k9pykza9a52x9kymvxch3cmfngvi84j1-dhcpcd-9.4.1                           	 478.5K	 163.0M
/nix/store/mcm19dzyd324marpc07ramjz76gkz0b5-ppp-2.5.0                              	 991.7K	  42.4M
/nix/store/8r73shyjpkpx84m3285nzq4hqak0rmpm-db-5.3.28                              	   4.0M	  42.8M
/nix/store/w7aqy4v5sx93s3gk01hfsv4iwagpzq4s-libelf-0.8.13                          	 335.2K	  31.4M
/nix/store/kgfysj0pxcaaxnh5vs6mmndh95d70d3j-iproute2-6.4.0                         	   3.8M	  54.2M
/nix/store/kzd05c4jvl3j3fny4j0p0lvdqij0pmmn-net-tools-2.10                         	 507.7K	  31.6M
/nix/store/v5d1skypla9bwp9fagimf1hm9y622rbr-vpnc-scripts-unstable-2023-01-03       	  40.5K	 173.9M
/nix/store/nfa77wls2mzfvylczmzm9nzwbsz0jijc-openconnect-9.12                       	 629.5K	 412.4M
/nix/store/v2z51rxgz5jlg9d23jv35gjqp5ifrjd0-mobile-broadband-provider-info-20230416	 511.5K	 511.5K
/nix/store/3m1cl7q6p0kxjj8aa6700dzdk7qqq5xh-networkmanager-1.42.8                  	  17.2M	 460.2M
/nix/store/4r3lffp2x6pshfczb3r8c33jmjw8lyci-libproxy-0.4.18                        	 401.7K	 460.6M
/nix/store/cafshx4z112b3v3m37g33cmlfq0cq1sq-pkg-config-0.29.2                      	 645.0K	  31.7M
/nix/store/sgdq3c3lp6qabfwnrq26qzvrxx101hgi-strip.sh                               	   3.9K	   3.9K
/nix/store/6gvzma127ffp5x7mg4fmf0snbm15cciz-pkg-config-wrapper-0.29.2              	  11.0K	  33.3M
/nix/store/6lydwnjzl3kg3njaqkf5mqgqr3b358pn-qttranslations-6.5.2                   	  12.9M	  12.9M
/nix/store/8sjwy79kflgc6yspgj3hz1x4pffkn2qp-libb2-0.98.1                           	 130.5K	  38.9M
/nix/store/2g5287nbipd9xr1mqjp1m9pmg292nhal-dbus-1.14.8                            	 550.6K	  82.6M
/nix/store/xvhhciclxnwsld0989079iwz1i003lmc-expat-2.5.0-dev                        	 107.8K	  31.4M
/nix/store/h3m24d406gpfgnr2v2hkip46x721rir7-dbus-1.14.8-dev                        	 130.2K	  82.8M
/nix/store/mdi2343b2z8x5l2lcvbipj8zmss6nzqa-xcb-util-wm-0.4.2                      	 107.8K	  32.6M
/nix/store/ic5hcavv8kcqbmfd8k6z20jcl0v86zs5-libossp-uuid-1.6.2                     	  99.6K	  32.8M
/nix/store/mk7dc7n3r6mlpzg6gm6ycv7lcnbgk57r-postgresql-14.9-lib                    	   6.0M	  48.9M
/nix/store/rw1jcl70r6g0s03h7gpxfs9l0h61k0hk-xcb-util-keysyms-0.4.1                 	  18.1K	  32.5M
/nix/store/scb43iiaq5qmb8h98k04ray05scg9376-md4c-0.4.8                             	 271.2K	  31.4M
/nix/store/kir66dxqcpx2y317f9r48b08d84djp7q-hwdata-0.373                           	   8.8M	   8.8M
/nix/store/6q8bh4ig65054kfln57z5zdh8bnkrdkw-libpciaccess-0.17                      	  68.0K	  40.0M
/nix/store/yf8xc8a9a9xbqkx3ygd17sq1flb2k6cc-libdrm-2.4.115                         	 530.2K	  40.5M
/nix/store/zvhhp8n13xzcd2piydcfqg7li861186b-unixODBC-2.3.11                        	   1.1M	  32.2M
/nix/store/zw53vzm9m6qmq26gg01i4m39lg5crx3i-double-conversion-3.3.0                	 181.3K	  38.9M
/nix/store/b9fmk3s2id2hv73n9gm51yi6lc8wpkmh-qtbase-6.5.2                           	  68.5M	 562.5M
/nix/store/rr263k2cl5xqn5fxg138nry03863xv2j-qtlanguageserver-6.5.2                 	   2.1M	 564.6M
/nix/store/3sjldk0basdpclck86ll7688q0d4rgg2-qtdeclarative-6.5.2                    	  89.6M	 654.2M
/nix/store/66hlvqib21rfgklm3gjxyhwzbprxvjhp-alsa-ucm-conf-1.2.9                    	 429.0K	 429.0K
/nix/store/7i8akvhiyjfs8v6kj8298drxffynx56k-alsa-topology-conf-1.2.5.1             	 336.1K	 336.1K
/nix/store/7kir90rk6clsih6fix7231lfsfy033i1-alsa-lib-1.2.9                         	   1.6M	  33.4M
/nix/store/rk1jaibxvzr9sxvackkw9738yg4v29n3-giflib-5.2.1                           	 400.7K	  31.5M
/nix/store/90hdsrqasasq20yby6afajgsv0sai945-libwebp-1.3.1                          	   1.2M	  44.0M
/nix/store/91k2i1xd22xajm8y4bqc60dvbp59svv9-libxshmfence-1.3.2                     	  17.8K	  31.1M
/nix/store/ah160c0l4wc4shsmi7vwjkr4da6zk2za-libxkbfile-1.1.2                       	 170.6K	  35.2M
/nix/store/fd5bwfzk2f979jqcjb5yw2dqsbn67xbr-lcms2-2.15                             	 445.3K	  31.5M
/nix/store/dnr9i4ivmjz8s3z1z6p07wzm5iivfsbp-libmng-2.0.3                           	 511.0K	  33.7M
/nix/store/mrifbzyrhjb7gzjf7xvlzqhxgjlyclv0-qtwayland-6.5.2                        	   9.0M	 663.2M
/nix/store/q3mw2hn1g8z3kswywv4rxpp20jdfw4z2-jasper-2.0.32                          	   1.1M	  32.2M
/nix/store/7zgqvshmmssix8calhip51aq480yhahw-openssl-3.0.10                         	   6.2M	  37.3M
/nix/store/ngzvq5jac6dbxnfvwphxnlgml5rx4n84-mailcap-2.1.53                         	 109.4K	 109.4K
/nix/store/vzdlb2gwnnigsgdmdglr3nxml39i20sv-gdbm-1.23                              	 805.6K	  31.9M
/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c                           	   2.0M	   2.0M
/nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12                        	  83.0M	 139.3M
/nix/store/z94ifzrv96p2m9fpjmylllcva1y3r8rz-nspr-4.35                              	 337.8K	  31.4M
/nix/store/vqpg2hlqxkhsdfy20dskh97bsd800wb8-nss-3.90                               	   3.7M	  49.3M
/nix/store/cw6x1hkbjynrlvmb22mh5amwijvxf1i0-glibc-2.37-8-bin                       	   2.6M	  33.7M
/nix/store/9j2h0dr7lnblz3mik5zcg3fy0mi669ca-linux-headers-6.4                      	   6.1M	   6.1M
/nix/store/p1wjbmik8bzpzcm2ck4yfxr6fnnc76mn-glibc-2.37-8-dev                       	   2.2M	  42.0M
/nix/store/vpz9qqg1nlbnyk4jawhljlf5wpqz3gqh-mpfr-4.2.0                             	 774.0K	  40.2M
/nix/store/v8bn2ra7ilyd25lsysj6k54jc2rgyll3-libmpc-1.3.1                           	 273.4K	  40.5M
/nix/store/hbp79a4ilv18vna6lah9n0syabajffg7-gcc-11.4.0                             	 183.6M	 245.2M
/nix/store/qn9xk2mjghmw06sp9kv0snnwdk8y4p3d-binutils-2.40-lib                      	   2.7M	  33.9M
/nix/store/8zxgqm6d879hskwh5g1l4crysl01kdv0-binutils-2.40                          	  28.2M	  69.8M
/nix/store/vydzy74yybdsxydxzjp11kwd9ajf25ll-expand-response-params                 	  16.4K	  31.1M
/nix/store/r4a8waqi90mmwafz86cj012h81smng3d-binutils-wrapper-2.40                  	  50.1K	  84.8M
/nix/store/848ld56pzbywlxy1pv9xi5d8gsvzb6hl-gcc-wrapper-11.4.0                     	  59.9K	 282.9M
/nix/store/xg9nksypxpc7iika8k3milm01mihyccx-setup-cuda-hook                        	   3.2K	 282.9M
/nix/store/y214hg2nqk65h7ss0zdspq7nn1lrlxln-cudatoolkit-11.8.0-lib                 	   1.8M	   1.8M
/nix/store/d5gz94syl8vsv4hr8hfz987l0y9m6p0s-cudatoolkit-11.8.0                     	   5.7G	   6.7G
/nix/store/qqmbs2nlf21pa1r7jdk78l7s8nik1mng-nccl-2.18.5-1                          	  72.6M	 111.3M
/nix/store/s4c12816qm25j4aq8vxcfkhgm592lhw7-nccl-2.18.5-1-dev                      	  77.4M	 188.8M
/nix/store/hj6vs6x90krcvc8mr4ilxiar372mrdk5-cudatoolkit-11.8.0-unsplit             	 689.8K	   6.8G
/nix/store/qih1c2kfdc05h9cl7mw96v3gfggjfiv9-libcublas-11.11.3.6-lib                	 639.2M	 678.0M
/nix/store/78v49jkm04djgmchdngfddkcxh8j7057-cudatoolkit-11-cudnn-8.9.1-lib         	   1.1G	   1.8G
/nix/store/45fkx4mrxfi3z7k0ah5289r3jwmmc6yf-gfortran-12.3.0-libgcc                 	 139.1K	 139.1K
/nix/store/h3q51rc8vrba4mvgdr01y9v1gnxkkki7-gfortran-12.3.0-lib                    	  10.5M	  41.7M
/nix/store/zq0zlml8mnhvxacgl7dkd0i6vs9mhzia-openblas-0.3.21                        	  26.1M	  67.8M
/nix/store/j6c0spaairw1rwkilsqfx885x7b2bgjm-python3.10-torch-2.0.1-lib             	 473.3M	   9.0G
/nix/store/2agqm11avdxkyqd378c87qzg3cdn9a3b-python3.10-torch-2.0.1                 	  88.3M	   9.1G
```

PR values:

```console
$ nix path-info -rsSh ./torch-pr-249259-applied
/nix/store/gnzwqa9df994g01yw5x75qnbl1rhp9ds-libunistring-1.1              	   1.8M	   1.8M
/nix/store/h3aw16j1c54jv8s39yvdhpfcx3538jwi-libidn2-2.3.4                 	 350.4K	   2.1M
/nix/store/kv0v4h5i911gj39m7n9q10k8r8gbn3sa-xgcc-12.3.0-libgcc            	 139.1K	 139.1K
/nix/store/905gkx2q1pswixwmi1qfhfl6mik3f22l-glibc-2.37-8                  	  28.8M	  31.1M
/nix/store/m1rszkm1s0d5z12r3pyg1rp0rns5hdm9-zlib-1.2.13                   	 125.6K	  31.2M
/nix/store/05vjzaa5sqpbijhj80klmmb3g07szyk9-sqlite-3.42.0                 	   1.4M	  32.6M
/nix/store/s2pgr9iqj60mfnmabixnqacxl4bzb408-gcc-12.3.0-libgcc             	 139.1K	 139.1K
/nix/store/31lxlw0m5by4zi5y9a8xydkgip0icqm6-cuda_cupti-11.8.87-lib        	  38.9M	  39.0M
/nix/store/3dmavjv0mj5h014i90bj9gsa9vddhnjb-expat-2.5.0                   	 253.0K	  31.3M
/nix/store/45fkx4mrxfi3z7k0ah5289r3jwmmc6yf-gfortran-12.3.0-libgcc        	 139.1K	 139.1K
/nix/store/518h89cfqw895n7fhhyzpycz32xk2rbk-libcufft-10.9.0.58-lib        	 267.8M	 268.0M
/nix/store/58zvgaag2sh39iqd0i78wis9npj676cb-ncurses-6.4                   	   3.5M	  34.6M
/nix/store/76xssy04mbjrjvccfkn43d4x0x2xp5ic-xz-5.4.4                      	 795.6K	  31.9M
/nix/store/gi26p79iq8jrw51irq5x82c2cqlgicxi-gcc-12.3.0-lib                	   7.5M	  38.8M
/nix/store/qih1c2kfdc05h9cl7mw96v3gfggjfiv9-libcublas-11.11.3.6-lib       	 639.2M	 678.0M
/nix/store/78v49jkm04djgmchdngfddkcxh8j7057-cudatoolkit-11-cudnn-8.9.1-lib	   1.1G	   1.8G
/nix/store/qllchk5a3jzwscmxbjnn1ansq7yv6k64-gcc-11.4.0-libgcc             	 114.2K	 114.2K
/nix/store/78vn2bhbrg2h04bcqgr0zp0434s4ysnq-gcc-11.4.0-lib                	   7.4M	  46.3M
/nix/store/7zgqvshmmssix8calhip51aq480yhahw-openssl-3.0.10                	   6.2M	  37.3M
/nix/store/ab0qx99x3xsa0m358l0yc9i8fw9kaarz-libcurand-10.3.0.86-lib       	  96.7M	  96.8M
/nix/store/dr9cbap84cx7wa7i8ywdz8xxqas1rpx7-cuda_nvtx-11.8.86-lib         	  47.1K	  38.8M
/nix/store/kh5pgvhvw2y13qsbmqihg4gkshh1bks4-cuda_cudart-11.8.89-lib       	 833.1K	 833.1K
/nix/store/rfihzqjj1w09z1biwf24sqpc8kzcz7xl-cuda_cudart-11.8.89-dev       	   3.6M	   3.6M
/nix/store/v6f3m5c4ffb73w8rc624w39978g1vrmc-cuda_cudart-11.8.89-static    	   2.1M	   2.1M
/nix/store/fpj21gi5qx1x2q3l30krbgj91c5s17vq-cuda_cudart-11.8.89           	  33.4K	   6.6M
/nix/store/p09bq7r0mxpk5xpclhqdsphx7z96p7rv-libcusolver-11.4.1.48-lib     	 465.1M	   1.1G
/nix/store/sw9w6c652mkqxhhqi8z9waq6fygycnvj-cuda_nvrtc-11.8.89-lib        	  59.3M	  98.1M
/nix/store/v4jwv7lk7ljd3pnl4rqs82w72szsc3lv-numactl-2.0.16                	 243.1K	  31.3M
/nix/store/zm6a0si267rk1wnp3q7d7n54bsdzm2n7-libcusparse-11.7.5.86-lib     	 267.0M	 267.2M
/nix/store/h3q51rc8vrba4mvgdr01y9v1gnxkkki7-gfortran-12.3.0-lib           	  10.5M	  41.7M
/nix/store/zq0zlml8mnhvxacgl7dkd0i6vs9mhzia-openblas-0.3.21               	  26.1M	  67.8M
/nix/store/9k8wi2r0rnpdd97bgcllklgmgmq8mlvx-python3.10-torch-2.0.1-lib    	 560.4M	   3.5G
/nix/store/afnipzq5w9ggwb4pn7s17id8hfd87hwi-bzip2-1.0.8                   	  79.5K	  31.2M
/nix/store/df10ppbxbsc5xnyc1bsh4xra2vxq5dbb-libffi-3.4.4                  	  55.2K	  31.1M
/nix/store/fcdkcrsrg289h6k33fwmfkhsdj55r6yr-libxcrypt-4.4.36              	 128.0K	  31.2M
/nix/store/i9gbgjzfvfpphb4yxjca71lakvwsixj4-readline-8.2p1                	 455.5K	  35.1M
/nix/store/m36d29gn5gm9bk0g7fcln1v8171hvn95-bash-5.2-p15                  	   1.6M	  32.7M
/nix/store/ngzvq5jac6dbxnfvwphxnlgml5rx4n84-mailcap-2.1.53                	 109.4K	 109.4K
/nix/store/vzdlb2gwnnigsgdmdglr3nxml39i20sv-gdbm-1.23                     	 805.6K	  31.9M
/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c                  	   2.0M	   2.0M
/nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12               	  83.0M	 139.3M
/nix/store/kxrrpb3py0d5d443wy7bw1idjnk80sfb-python3.10-torch-2.0.1        	  88.3M	   3.7G
```

</details>

Sadly, looks like no reduction in build times. For that, we'll likely need something like https://github.com/NixOS/nixpkgs/pull/239291.

Here's my favorite part though -- if we were to throw this in a Nix binary cache using ZSTD with compression level 19:

```console
$ nix copy ./torch-pr-249259-applied --to "file://$(pwd)/temp-store?compression=zstd&compression-level=19"
$ du -sh "$(pwd)/temp-store"
1.3G	/home/connorbaker/nixpkgs/temp-store
```

It compresses down to 1.3G!

For reference, the download size of the latest stable copy of the equivalent PyTorch environment from Anaconda: 3GB.

Although, to be fair, the Anaconda distribution *does* include triton, which we package separately.

<details><summary>Here's how I got that number.</summary>

Unrelated, but I cannot recommend micromamba highly enough. It's *very* fast.

```console
$ micromamba create --dry-run --name pytorch --channel conda-forge --channel pytorch --channel nvidia pytorch=2.0.1=py3.10_cuda11.8_cudnn8.7.0_0

                                           __
          __  ______ ___  ____ _____ ___  / /_  ____ _
         / / / / __ `__ \/ __ `/ __ `__ \/ __ \/ __ `/
        / /_/ / / / / / / /_/ / / / / / / /_/ / /_/ /
       / .___/_/ /_/ /_/\__,_/_/ /_/ /_/_.___/\__,_/
      /_/

warning  libmamba 'root_prefix' set with default value: /home/connorbaker/micromamba
pytorch/noarch                                      10.4kB @  82.8kB/s  0.1s
nvidia/linux-64                                    136.1kB @ 900.7kB/s  0.2s
pytorch/linux-64                                   168.8kB @   1.1MB/s  0.2s
nvidia/noarch                                        4.4kB @  27.1kB/s  0.0s
conda-forge/noarch                                  13.8MB @   4.6MB/s  3.1s
conda-forge/linux-64                                33.7MB @   5.1MB/s  6.9s

Transaction

  Prefix: /home/connorbaker/micromamba/envs/pytorch

  Updating specs:

   - pytorch==2.0.1=py3.10_cuda11.8_cudnn8.7.0_0


  Package                Version  Build                         Channel          Size
───────────────────────────────────────────────────────────────────────────────────────
  Install:
───────────────────────────────────────────────────────────────────────────────────────

  + _libgcc_mutex            0.1  conda_forge                   conda-forge       3kB
  + _openmp_mutex            4.5  2_kmp_llvm                    conda-forge       6kB
  + blas                   2.116  mkl                           conda-forge      13kB
  + blas-devel             3.9.0  16_linux64_mkl                conda-forge      13kB
  + bzip2                  1.0.8  h7f98852_4                    conda-forge     496kB
  + ca-certificates    2023.7.22  hbcca054_0                    conda-forge     150kB
  + cuda-cudart          11.8.89  0                             nvidia          202kB
  + cuda-cupti           11.8.87  0                             nvidia           27MB
  + cuda-libraries        11.8.0  0                             nvidia            2kB
  + cuda-nvrtc           11.8.89  0                             nvidia           20MB
  + cuda-nvtx            11.8.86  0                             nvidia           58kB
  + cuda-runtime          11.8.0  0                             nvidia            1kB
  + cuda-version            12.0  hffde075_2                    conda-forge      21kB
  + filelock              3.12.2  pyhd8ed1ab_0                  conda-forge      15kB
  + gmp                    6.2.1  h58526e2_0                    conda-forge     826kB
  + gmpy2                  2.1.2  py310h3ec546c_1               conda-forge     220kB
  + icu                     72.1  hcb278e6_0                    conda-forge      12MB
  + jinja2                 3.1.2  pyhd8ed1ab_1                  conda-forge     101kB
  + ld_impl_linux-64        2.40  h41732ed_0                    conda-forge     705kB
  + libblas                3.9.0  16_linux64_mkl                conda-forge      13kB
  + libcblas               3.9.0  16_linux64_mkl                conda-forge      13kB
  + libcublas          11.11.3.6  0                             nvidia          382MB
  + libcufft           10.9.0.58  0                             nvidia          150MB
  + libcufile           1.5.0.59  hcb278e6_0                    conda-forge     682kB
  + libcurand          10.3.1.50  hcb278e6_0                    conda-forge      42MB
  + libcusolver        11.4.1.48  0                             nvidia          101MB
  + libcusparse        11.7.5.86  0                             nvidia          185MB
  + libffi                 3.4.2  h7f98852_5                    conda-forge      58kB
  + libgcc-ng             13.1.0  he5830b7_0                    conda-forge     776kB
  + libgfortran-ng        13.1.0  h69a702a_0                    conda-forge      23kB
  + libgfortran5          13.1.0  h15d22d2_0                    conda-forge       1MB
  + libhwloc               2.9.2  nocuda_h7313eea_1008          conda-forge       3MB
  + libiconv                1.17  h166bdaf_0                    conda-forge       1MB
  + liblapack              3.9.0  16_linux64_mkl                conda-forge      13kB
  + liblapacke             3.9.0  16_linux64_mkl                conda-forge      13kB
  + libnpp             11.8.0.86  0                             nvidia          155MB
  + libnsl                 2.0.0  h7f98852_0                    conda-forge      31kB
  + libnvjpeg          11.9.0.86  0                             nvidia            3MB
  + libsqlite             3.42.0  h2797004_0                    conda-forge     829kB
  + libstdcxx-ng          13.1.0  hfd8a6a1_0                    conda-forge       4MB
  + libuuid               2.38.1  h0b41bf4_0                    conda-forge      34kB
  + libxml2               2.11.5  h0d562d8_0                    conda-forge     705kB
  + libzlib               1.2.13  hd590300_5                    conda-forge      62kB
  + llvm-openmp           16.0.6  h4dfa4b3_0                    conda-forge      42MB
  + markupsafe             2.1.3  py310h2372a71_0               conda-forge      24kB
  + mkl                 2022.1.0  h84fe81f_915                  conda-forge     209MB
  + mkl-devel           2022.1.0  ha770c72_916                  conda-forge      26kB
  + mkl-include         2022.1.0  h84fe81f_915                  conda-forge     763kB
  + mpc                    1.3.1  hfe3b2da_0                    conda-forge     116kB
  + mpfr                   4.2.0  hb012696_0                    conda-forge     631kB
  + mpmath                 1.3.0  pyhd8ed1ab_0                  conda-forge     438kB
  + ncurses                  6.4  hcb278e6_0                    conda-forge     881kB
  + networkx                 3.1  pyhd8ed1ab_0                  conda-forge       1MB
  + openssl                3.1.2  hd590300_0                    conda-forge       3MB
  + pip                   23.2.1  pyhd8ed1ab_0                  conda-forge       1MB
  + python               3.10.12  hd12c33a_0_cpython            conda-forge      26MB
  + python_abi              3.10  3_cp310                       conda-forge       6kB
  + pytorch                2.0.1  py3.10_cuda11.8_cudnn8.7.0_0  pytorch           2GB
  + pytorch-cuda            11.8  h7e8668a_5                    pytorch           4kB
  + pytorch-mutex            1.0  cuda                          pytorch           3kB
  + readline                 8.2  h8228510_1                    conda-forge     281kB
  + rocm-smi               5.6.0  h59595ed_1                    conda-forge       4MB
  + setuptools            68.1.2  pyhd8ed1ab_0                  conda-forge     462kB
  + sympy                   1.12  pypyh9d50eac_103              conda-forge       4MB
  + tbb                2021.10.0  h00ab1b0_0                    conda-forge     186kB
  + tk                    8.6.12  h27826a3_0                    conda-forge       3MB
  + torchtriton            2.0.0  py310                         pytorch          66MB
  + typing_extensions      4.7.1  pyha770c72_0                  conda-forge      36kB
  + tzdata                 2023c  h71feb2d_0                    conda-forge     118kB
  + wheel                 0.41.2  pyhd8ed1ab_0                  conda-forge      57kB
  + xz                     5.2.6  h166bdaf_0                    conda-forge     418kB
  + zstd                   1.5.2  hfc55251_7                    conda-forge     431kB

  Summary:

  Install: 72 packages

  Total download: 3GB

───────────────────────────────────────────────────────────────────────────────────────


Dry run. Not executing the transaction.
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
