### PR TITLE
writeDarwinBundle: use binary wrapper

### DIFF
--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchFromGitLab, cmake, ninja, pkg-config, wrapGAppsHook
+{ lib, stdenv, fetchFromGitLab, fetchpatch, cmake, ninja, pkg-config, wrapGAppsHook
+, desktopToDarwinBundle
 , glib, gtk3, gettext, libxkbfile, libX11, python3
 , freerdp, libssh, libgcrypt, gnutls, vte
 , pcre2, libdbusmenu-gtk3, libappindicator-gtk3
@@ -23,7 +24,16 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-oEgpav4oQ9Sld9PY4TsutS5xEnhQgOHnpQhDesRFTeQ=";
   };
 
-  nativeBuildInputs = [ cmake ninja pkg-config wrapGAppsHook ];
+  patches = [
+    # https://gitlab.com/Remmina/Remmina/-/merge_requests/2525
+    (fetchpatch {
+      url = "https://gitlab.com/Remmina/Remmina/-/commit/2ce153411597035d0f3db5177d703541e09eaa06.patch";
+      hash = "sha256-RV/8Ze9aN4dW49Z+y3z0jFs4dyEWu7DK2FABtmse9Hc=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ninja pkg-config wrapGAppsHook ]
+    ++ lib.optionals stdenv.isDarwin [ desktopToDarwinBundle ];
 
   buildInputs = [
     gsettings-desktop-schemas

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -204,8 +204,8 @@ processExecFieldCodes() {
   local -r execNoKC="${execNoK/\%c/$(getDesktopParam "${file}" "Name")}"
   local -r icon=$(getDesktopParam "${file}" "Icon")
   local -r execNoKCI="${execNoKC/\%i/${icon:+--icon }${icon}}"
-  local -r execNoKCIfu="${execNoKCI/\%[fu]/\$1}"
-  local -r exec="${execNoKCIfu/\%[FU]/\$@}"
+  local -r execNoKCIfu="${execNoKCI/ \%[fu]/}"
+  local -r exec="${execNoKCIfu/ \%[FU]/}"
   if [[ "$exec" != "$execRaw" ]]; then
     echo 1>&2 "desktopToDarwinBundle: Application bundles do not understand desktop entry field codes. Changed '$execRaw' to '$exec'."
   fi


### PR DESCRIPTION
## Description of changes

- writeDarwinBundle: use binary wrapper

  Previously `writeDarwinBundle` used a handcrafted shell wrapper, however
  this causes issues on Apple Silicon Macs as script-only application
  bundles are always run under Rosetta\[0]\[1].
  
  Replacing the handcrafted shell wrapper with a binary wrapper allows
  apps to run natively instead of requiring Rosetta. However, this means
  we can no longer use `$1` and `$@`.
  
  After checking nearly every current usage of `desktopToDarwinBundle`,
  there were no apps that used `%[fFuU]` before the last argument, meaning
  removing them naively is good enough for the current apps.
  
  \[0]: https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
  \[1]: https://stackoverflow.com/a/68208374

- remmina: use `desktopToDarwinBundle`

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).