### PR TITLE
libarchive: make static patch unconditional

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -30,7 +30,7 @@ let
   autoreconfHook = buildPackages.autoreconfHook269;
 in
 assert xarSupport -> libxml2 != null;
-(stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libarchive";
   version = "3.6.2";
 
@@ -42,6 +42,16 @@ assert xarSupport -> libxml2 != null;
   };
 
   outputs = [ "out" "lib" "dev" ];
+
+  patches = [
+    # fixes static linking; upstream in releases after 3.6.2
+    # https://github.com/libarchive/libarchive/pull/1825 merged upstream
+    (assert finalAttrs.version == "3.6.2"; fetchpatch {
+      name = "001-only-add-iconv-to-pc-file-if-needed.patch";
+      url = "https://github.com/libarchive/libarchive/commit/1f35c466aaa9444335a1b854b0b7223b0d2346c2.patch";
+      hash = "sha256-lb+zwWSH6/MLUIROvu9I/hUjSbb2jOWO755WC/r+lbY=";
+    })
+  ];
 
   postPatch = let
     skipTestPaths = [
@@ -119,16 +129,4 @@ assert xarSupport -> libxml2 != null;
   passthru.tests = {
     inherit cmake nix samba;
   };
-})).overrideAttrs(previousAttrs:
-  assert previousAttrs.version == "3.6.2";
-  lib.optionalAttrs stdenv.hostPlatform.isStatic {
-    patches = [
-      # fixes static linking; upstream in releases after 3.6.2
-      # https://github.com/libarchive/libarchive/pull/1825 merged upstream
-      (fetchpatch {
-        name = "001-only-add-iconv-to-pc-file-if-needed.patch";
-        url = "https://github.com/libarchive/libarchive/commit/1f35c466aaa9444335a1b854b0b7223b0d2346c2.patch";
-        hash = "sha256-lb+zwWSH6/MLUIROvu9I/hUjSbb2jOWO755WC/r+lbY=";
-      })
-    ];
-  })
+})


### PR DESCRIPTION
Cabal 3.8 has the same requirements as pkgsStatic even when linking dynamically, so this patch will be useful for compiling haskellPackages.libarchive.

https://github.com/haskell/cabal/issues/8455

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
