### PR TITLE
soulseekqt: don’t linger in a read-only directory after installing

### DIFF
--- a/pkgs/applications/networking/p2p/soulseekqt/default.nix
+++ b/pkgs/applications/networking/p2p/soulseekqt/default.nix
@@ -28,24 +28,20 @@ mkDerivation rec {
   buildInputs = [ qtmultimedia stdenv.cc.cc ];
 
   installPhase = ''
-      # directory in /nix/store so readonly
-      cd $appextracted
-
-      binary="$(readlink AppRun)"
+      binary="$(realpath ${appextracted}/AppRun)"
       install -Dm755 $binary -t $out/bin
 
       # fixup and install desktop file
       desktop-file-install --dir $out/share/applications \
         --set-key Exec --set-value $binary \
         --set-key Comment --set-value "${meta.description}" \
-        --set-key Categories --set-value Network default.desktop
+        --set-key Categories --set-value Network ${appextracted}/default.desktop
       mv $out/share/applications/default.desktop $out/share/applications/SoulseekQt.desktop
-
       #TODO: write generic code to read icon path from $binary.desktop
-      icon="$(readlink .DirIcon)"
+      icon="$(realpath ${appextracted}/.DirIcon)"
       for size in 16 32 48 64 72 96 128 192 256 512 1024; do
         mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-        convert -resize "$size"x"$size" $icon $out/share/icons/hicolor/"$size"x"$size"/apps/$icon
+        convert -resize "$size"x"$size" $icon $out/share/icons/hicolor/"$size"x"$size"/apps/$(basename $icon)
       done
     '';
 


### PR DESCRIPTION
## Description of changes

It appears that the strip phase assumes that CWD is writable now (when using mktemp) and will otherwise fail with:

    mktemp: failed to create file via template 'striperr.XXXXXX': No such file or directory

We now avoid this error by sticking to the build-directory and referencing files from the AppImage by path.

References: #248569

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
