### PR TITLE
aws-encryption-sdk-cli: init at 4.1.0

### DIFF
--- a/pkgs/development/python-modules/aws-encryption-sdk/default.nix
+++ b/pkgs/development/python-modules/aws-encryption-sdk/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, attrs
+, boto3
+, cryptography
+, setuptools
+, wrapt
+, mock
+, pytest
+, pytest-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "aws-encryption-sdk";
+  version = "3.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-jV+/AY/GjWscrL5N0Df9gFKWx3Nqn+RX62hNBT9/lWM=";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    boto3
+    cryptography
+    setuptools
+    wrapt
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    mock
+    pytest
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # requires networking
+    "examples"
+    "test/integration"
+  ];
+
+  meta = with lib; {
+    homepage = "https://aws-encryption-sdk-python.readthedocs.io/";
+    changelog = "https://github.com/aws/aws-encryption-sdk-python/blob/v${version}/CHANGELOG.rst";
+    description = "Fully compliant, native Python implementation of the AWS Encryption SDK.";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ anthonyroussel ];
+  };
+}

--- a/pkgs/development/python-modules/base64io/default.nix
+++ b/pkgs/development/python-modules/base64io/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "base64io";
+  version = "1.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-JPLQ/nZcNTOeGy0zqpX5E3sbdltZQWT60QFsFYJ6cHM=";
+  };
+
+  nativeCheckInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    homepage = "https://base64io-python.readthedocs.io/";
+    changelog = "https://github.com/aws/base64io-python/blob/${version}/CHANGELOG.rst";
+    description = "Python stream implementation for base64 encoding/decoding";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ anthonyroussel ];
+  };
+}

--- a/pkgs/tools/admin/aws-encryption-sdk-cli/default.nix
+++ b/pkgs/tools/admin/aws-encryption-sdk-cli/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, python3Packages
+, fetchPypi
+, nix-update-script
+, testers
+, aws-encryption-sdk-cli
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "aws-encryption-sdk-cli";
+  version = "4.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-OCbt0OkDVfpzUIogbsKzaPAle2L6l6N3cmZoS2hEaSM=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    attrs
+    aws-encryption-sdk
+    base64io
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = with python3Packages; [
+    mock
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # requires networking
+    "test/integration"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = aws-encryption-sdk-cli;
+      command = "aws-encryption-cli --version";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://aws-encryption-sdk-cli.readthedocs.io/";
+    changelog = "https://github.com/aws/aws-encryption-sdk-cli/blob/v${version}/CHANGELOG.rst";
+    description = "CLI wrapper around aws-encryption-sdk-python";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ anthonyroussel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3246,6 +3246,8 @@ with pkgs;
 
   aliyun-cli = callPackage ../tools/admin/aliyun-cli { };
 
+  aws-encryption-sdk-cli = callPackage ../tools/admin/aws-encryption-sdk-cli { };
+
   aws-iam-authenticator = callPackage ../tools/security/aws-iam-authenticator { };
 
   awscli = callPackage ../tools/admin/awscli { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1239,6 +1239,8 @@ self: super: with self; {
 
   base58check = callPackage ../development/python-modules/base58check { };
 
+  base64io = callPackage ../development/python-modules/base64io { };
+
   baseline = callPackage ../development/python-modules/baseline { };
 
   baselines = callPackage ../development/python-modules/baselines { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -903,6 +903,8 @@ self: super: with self; {
 
   aws-adfs = callPackage ../development/python-modules/aws-adfs { };
 
+  aws-encryption-sdk = callPackage ../development/python-modules/aws-encryption-sdk { };
+
   aws-lambda-builders = callPackage ../development/python-modules/aws-lambda-builders { };
 
   aws-sam-translator = callPackage ../development/python-modules/aws-sam-translator { };


### PR DESCRIPTION
## Description of changes

* python311Packages.base64io: init at 1.0.3
  * See https://base64io-python.readthedocs.io/

* python311Packages.aws-encryption-sdk: init at 3.1.1
  * https://aws-encryption-sdk-python.readthedocs.io/

* aws-encryption-sdk-cli: init at 4.1.0
  * See https://aws-encryption-sdk-cli.readthedocs.io/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
