### PR TITLE
apparency: init at 1.5.1

### DIFF
--- a/pkgs/os-specific/darwin/apparency/default.nix
+++ b/pkgs/os-specific/darwin/apparency/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchurl
+, stdenv
+, undmg
+}:
+
+stdenv.mkDerivation {
+  pname = "apparency";
+  version = "1.5.1";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20230815073821/https://www.mothersruin.com/software/downloads/Apparency.dmg";
+    hash = "sha256-JpaBdlt8kTNFzK/yZVZ+ZFJ3DnPQbogJC7QBmtSVkoQ=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = "Apparency.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications/Apparency.app $out/bin
+    cp -R . $out/Applications/Apparency.app
+    ln -s ../Applications/Apparency.app/Contents/MacOS/appy $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "The App That Opens Apps";
+    homepage = "https://www.mothersruin.com/software/Apparency/";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = with lib.maintainers; [ Enzime ];
+    mainProgram = "appy";
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27441,6 +27441,8 @@ with pkgs;
     alsa-ucm-conf
     alsa-utils;
 
+  apparency = callPackage ../os-specific/darwin/apparency { };
+
   arm-trusted-firmware = callPackage ../misc/arm-trusted-firmware { };
   inherit (arm-trusted-firmware)
     buildArmTrustedFirmware


### PR DESCRIPTION
## Description of changes

Apparency allows you to see the notarization, gatekeeper and code signing statuses of macOS apps.

https://www.mothersruin.com/software/Apparency/

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).