### PR TITLE
forgejo-actions-runner: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/development/tools/continuous-integration/forgejo-actions-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/forgejo-actions-runner/default.nix
@@ -7,17 +7,17 @@
 
 buildGoModule rec {
   pname = "forgejo-actions-runner";
-  version = "2.3.0";
+  version = "2.4.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "forgejo";
     repo = "runner";
     rev = "v${version}";
-    hash = "sha256-ZIhUlTGeNuJSrBVXYjAz/YHYmkR3wg1LAe0uUabEQRQ=";
+    hash = "sha256-EEwXo2MvdBlSMho4rrYD4wXLccS/30NbCuxO0CUktgE=";
   };
 
-  vendorHash = "sha256-OauNDA0mkarSWrZBfJE/SYspa3CTEYKpLRMvbPdIoRo=";
+  vendorHash = "sha256-FspNmiphGHSeZFmdlWIDsEUrCc8THfb0Wm67cMCTtHI=";
 
   ldflags = [
     "-s"
@@ -25,7 +25,7 @@ buildGoModule rec {
     "-X gitea.com/gitea/act_runner/internal/pkg/ver.version=${src.rev}"
   ];
 
-  doCheck = false; # Test try to lookuyp code.forgejo.org.
+  doCheck = false; # Test try to lookup code.forgejo.org.
 
   passthru.tests.version = testers.testVersion {
     package = forgejo-actions-runner;


### PR DESCRIPTION
## Description of changes

2.4.0 addresses a bug when building with Go 1.20.6+, resulting in missing Docker headers.

https://code.forgejo.org/forgejo/runner/src/branch/main/RELEASE-NOTES.md#v2-4-0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
