### PR TITLE
python310Packages.paddleocr: init

### DIFF
--- a/pkgs/development/python-modules/bce-python-sdk/default.nix
+++ b/pkgs/development/python-modules/bce-python-sdk/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, future
+, pycryptodome
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "bce-python-sdk";
+  version = "0.8.87";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-vgTf1HiD/R/1m24zq/vB+Dt2KzacfwePrfe1q0jB0qk=";
+  };
+
+  propagatedBuildInputs = [
+    future
+    pycryptodome
+    six
+  ];
+
+  # there is no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "baidubce" ];
+
+  meta = with lib; {
+    description = "Baidu Cloud Engine Python SDK";
+    homepage = "http://bce.baidu.com/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ happysalada ];
+  };
+}

--- a/pkgs/development/python-modules/paddleocr/default.nix
+++ b/pkgs/development/python-modules/paddleocr/default.nix
@@ -1,0 +1,106 @@
+{ lib
+, buildPythonPackage
+, pythonRelaxDepsHook
+, fetchFromGitHub
+, attrdict
+, beautifulsoup4
+, cython
+, fire
+, fonttools
+, lmdb
+, lxml
+, numpy
+, opencv4
+, openpyxl
+, pdf2docx
+, pillow
+, premailer
+, pyclipper
+, pymupdf
+, python-docx
+, rapidfuzz
+, scikit-image
+, shapely
+, tqdm
+, paddlepaddle
+, lanms-neo
+, polygon3
+}:
+
+let
+
+in buildPythonPackage rec {
+  pname = "paddleocr";
+  version = "2.6.1.0";
+
+  src = fetchFromGitHub {
+    owner = "PaddlePaddle";
+    repo = "PaddleOCR";
+    rev = "df54a7b4223c64a8480380f618fe95de3b8cf73b";
+    hash = "sha256-H8sBu6+ApquJy/Kr56cYuAuBEz3cDTPh1QutfyzDnG4=";
+  };
+
+  # TODO: The tests depend, among possibly other things, on `cudatoolkit`.
+  # But Cudatoolkit fails to install.
+  # preCheck = "export HOME=$TMPDIR";
+  # nativeCheckInputs = with pkgs; [ which cudatoolkit ];
+  doCheck = false;
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  pythonRelaxDeps = [ "PyMuPDF" ];
+  pythonRemoveDeps = [
+    "imgaug"
+    "visualdl"
+    "opencv-python"
+    "opencv-contrib-python"
+  ];
+
+  patches = [
+    # The `ppocr.data.imaug` re-exports the `IaaAugment` and `CopyPaste`
+    # classes. These classes depend on the `imgaug` package which is
+    # unmaintained and has been removed from nixpkgs.
+    #
+    # The image OCR feature of PaddleOCR doesn't use these classes though, so
+    # they work even after stripping the the `IaaAugment` and `CopyPaste`
+    # exports. It probably breaks some of the OCR model creation tooling that
+    # PaddleOCR provides, however.
+    ./remove-import-imaug.patch
+  ];
+
+  propagatedBuildInputs = [
+    attrdict
+    beautifulsoup4
+    cython
+    fire
+    fonttools
+    lmdb
+    lxml
+    numpy
+    opencv4
+    openpyxl
+    pdf2docx
+    pillow
+    premailer
+    pyclipper
+    pymupdf
+    python-docx
+    rapidfuzz
+    scikit-image
+    shapely
+    tqdm
+    paddlepaddle
+    lanms-neo
+    polygon3
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/PaddlePaddle/PaddleOCR";
+    license = licenses.asl20;
+    description = "Multilingual OCR toolkits based on PaddlePaddle";
+    longDescription = ''
+      PaddleOCR aims to create multilingual, awesome, leading, and practical OCR
+      tools that help users train better models and apply them into practice.
+    '';
+    maintainers = with maintainers; [ happysalada ];
+  };
+}

--- a/pkgs/development/python-modules/paddleocr/remove-import-imaug.patch
+++ b/pkgs/development/python-modules/paddleocr/remove-import-imaug.patch
@@ -1,0 +1,20 @@
+diff --git a/ppocr/data/imaug/__init__.py b/ppocr/data/imaug/__init__.py
+index 121582b4..a6987c75 100644
+--- a/ppocr/data/imaug/__init__.py
++++ b/ppocr/data/imaug/__init__.py
+@@ -16,7 +16,6 @@ from __future__ import division
+ from __future__ import print_function
+ from __future__ import unicode_literals
+
+-from .iaa_augment import IaaAugment
+ from .make_border_map import MakeBorderMap
+ from .make_shrink_map import MakeShrinkMap
+ from .random_crop_data import EastRandomCropData, RandomCropImgMask
+@@ -30,7 +29,6 @@ from .rec_img_aug import BaseDataAugmentation, RecAug, RecConAug, RecResizeImg,
+     RFLRecResizeImg, SVTRRecAug
+ from .ssl_img_aug import SSLRotateResize
+ from .randaugment import RandAugment
+-from .copy_paste import CopyPaste
+ from .ColorJitter import ColorJitter
+ from .operators import *
+ from .label_ops import *

--- a/pkgs/development/python-modules/paddlepaddle/binary-hashes.nix
+++ b/pkgs/development/python-modules/paddlepaddle/binary-hashes.nix
@@ -1,23 +1,27 @@
-{ pythonVersion, system }:
+{ pythonVersion, system, cudaSupport ? false }:
 let
   all = {
     x86_64-linux = {
       platform = "manylinux1_x86_64";
-      hashes = {
+      cpu = {
         cp39 = "sha256-Yu/FWoMhYp+behAth/jH0FKlf2LJr8TyvL9MBwmuews=";
         cp310 = "sha256-O7d/5LY2dEMf5gW5WrN3xzIIEi2vT0RWoMeVOk5lATk=";
+      };
+      gpu = {
+        cp39 = "sha256-XHREY27jc+BrVyCJgpMvPVOFiKgPwuiNXPXO3biMLnc=";
+        cp310 = "sha256-oTEBa26o5g6ruuTBgUljjDqign5fXmCn0EnL/0mv+ao=";
       };
     };
     x86_64-darwin = {
       platform = "macosx_10_9_x86_64";
-      hashes = {
+      cpu = {
         cp39 = "sha256-5g9b2gC6uosMpoJiobpj8yToIS6ifAFRvLEqnc/o/QQ=";
         cp310 = "sha256-2c1hjwNCOOOx9tVfBk+Pyk/pF0m/2tAmRsBH91834eM=";
       };
     };
     aarch64-darwin = {
       platform = "macosx_11_0_arm64";
-      hashes = {
+      cpu = {
         cp39 = "sha256-JhYNTOx1UkuNf/63lHXBDry6FQjPnbIB8jU5jKcyX2k=";
         cp310 = "sha256-4ltYEYm2OzPBc6D2bQt2dEh6Sz+5m1mMKGGYgQGLSAY=";
       };
@@ -26,9 +30,8 @@ let
     # Satisfy ofborg:
     aarch64-linux = {platform = ""; hashes = {cp39 = ""; cp310 = "";};};
   };
-  selected = all."${system}";
 in
 {
-  hash = selected.hashes."${pythonVersion}";
-  platform = selected.platform;
+  hash = all."${system}"."${if cudaSupport then "gpu" else "cpu"}"."${pythonVersion}";
+  platform = all."${system}".platform;
 }

--- a/pkgs/development/python-modules/paddlepaddle/binary-hashes.nix
+++ b/pkgs/development/python-modules/paddlepaddle/binary-hashes.nix
@@ -1,0 +1,24 @@
+{ pythonVersion, system }:
+let
+  all = {
+    x86_64-linux = {
+      platform = "manylinux1_x86_64";
+      hashes = {
+        cp39 = "sha256-Yu/FWoMhYp+behAth/jH0FKlf2LJr8TyvL9MBwmuews=";
+        cp310 = "sha256-O7d/5LY2dEMf5gW5WrN3xzIIEi2vT0RWoMeVOk5lATk=";
+      };
+    };
+    x86_64-darwin = {
+      platform = "macosx_10_9_x86_64";
+      hashes = {
+        cp39 = "sha256-5g9b2gC6uosMpoJiobpj8yToIS6ifAFRvLEqnc/o/QQ=";
+        cp310 = "sha256-2c1hjwNCOOOx9tVfBk+Pyk/pF0m/2tAmRsBH91834eM=";
+      };
+    };
+  };
+  selected = all."${system}";
+in
+{
+  hash = selected.hashes."${pythonVersion}";
+  platform = selected.platform;
+}

--- a/pkgs/development/python-modules/paddlepaddle/binary-hashes.nix
+++ b/pkgs/development/python-modules/paddlepaddle/binary-hashes.nix
@@ -15,6 +15,16 @@ let
         cp310 = "sha256-2c1hjwNCOOOx9tVfBk+Pyk/pF0m/2tAmRsBH91834eM=";
       };
     };
+    aarch64-darwin = {
+      platform = "macosx_11_0_arm64";
+      hashes = {
+        cp39 = "sha256-JhYNTOx1UkuNf/63lHXBDry6FQjPnbIB8jU5jKcyX2k=";
+        cp310 = "sha256-4ltYEYm2OzPBc6D2bQt2dEh6Sz+5m1mMKGGYgQGLSAY=";
+      };
+    };
+
+    # Satisfy ofborg:
+    aarch64-linux = {platform = ""; hashes = {cp39 = ""; cp310 = "";};};
   };
   selected = all."${system}";
 in

--- a/pkgs/development/python-modules/paddlepaddle/default.nix
+++ b/pkgs/development/python-modules/paddlepaddle/default.nix
@@ -69,6 +69,6 @@ buildPythonPackage {
     homepage = "https://github.com/PaddlePaddle/Paddle";
     license = licenses.asl20;
     maintainers = with maintainers; [ happysalada ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 }

--- a/pkgs/development/python-modules/paddlepaddle/default.nix
+++ b/pkgs/development/python-modules/paddlepaddle/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, python
+, pythonOlder
+, pythonAtLeast
+, autoPatchelfHook
+, openssl_1_1
+, zlib
+, setuptools
+# runtime dependencies
+, httpx
+, numpy
+, protobuf
+, pillow
+, decorator
+, astor
+, paddle-bfloat
+, opt-einsum
+}:
+
+let
+  pname = "paddlepaddle";
+  version = "2.5.0";
+  format = "wheel";
+  pyShortVersion = "cp${builtins.replaceStrings ["."] [""] python.pythonVersion}";
+  hashAndPlatform = import ./binary-hashes.nix { pythonVersion = pyShortVersion; system = stdenv.system; };
+  src = fetchPypi ({
+    inherit pname version format;
+    dist = pyShortVersion;
+    python = pyShortVersion;
+    abi = pyShortVersion;
+  } // hashAndPlatform);
+in
+buildPythonPackage {
+  inherit pname version format src;
+
+  disabled = pythonOlder "3.9" || pythonAtLeast "3.11";
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    # TODO: remove openssl_1_1 and zlib, maybe by building paddlepaddle from
+    # source as suggested in the following comment:
+    # https://github.com/NixOS/nixpkgs/pull/243583#issuecomment-1641450848
+    openssl_1_1
+    zlib
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    httpx
+    numpy
+    protobuf
+    pillow
+    decorator
+    astor
+    paddle-bfloat
+    opt-einsum
+  ];
+
+  pythonImportsCheck = [ "paddle" ];
+
+  meta = with lib; {
+    description = "PArallel Distributed Deep LEarning: Machine Learning Framework from Industrial Practice （『飞桨』核心框架，深度学习&机器学习高性能单机、分布式训练和跨平台部署";
+    homepage = "https://github.com/PaddlePaddle/Paddle";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ happysalada ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/development/python-modules/pdf2docx/default.nix
+++ b/pkgs/development/python-modules/pdf2docx/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pythonRelaxDepsHook
+, pytestCheckHook
+, pymupdf
+, fire
+, fonttools
+, numpy
+, opencv4
+, tkinter
+, python-docx
+}:
+
+buildPythonPackage rec {
+  pname = "pdf2docx";
+  version = "0.5.6";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "dothinking";
+    repo = "pdf2docx";
+    rev = "v${version}";
+    hash = "sha256-NrT4GURQIJbqnHstfJrPzwLXT9c2oGBi4QJ6eGIFwu4=";
+  };
+
+  nativeBuildInputs = [ pytestCheckHook pythonRelaxDepsHook ];
+  pythonRemoveDeps = [ "opencv-python" ];
+
+  preBuild = "echo '${version}' > version.txt";
+
+  pytestFlagsArray = [ "-v" "./test/test.py::TestConversion" ];
+
+  # Test fails due to "RuntimeError: cannot find builtin font with name 'Arial'":
+  disabledTests = [ "test_unnamed_fonts" ];
+
+  propagatedBuildInputs = [
+    tkinter
+    pymupdf
+    fire
+    fonttools
+    numpy
+    opencv4
+    python-docx
+  ];
+
+  meta = with lib; {
+    description = "Convert PDF to DOCX";
+    homepage = "https://github.com/dothinking/pdf2docx";
+    changelog = "https://github.com/dothinking/pdf2docx/releases/tag/${src.rev}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ happysalada ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1187,7 +1187,13 @@ self: super: with self; {
 
   paddleocr = callPackage ../development/python-modules/paddleocr { };
 
-  paddlepaddle = callPackage ../development/python-modules/paddlepaddle { };
+  paddlepaddle = callPackage ../development/python-modules/paddlepaddle {
+    cudaSupport = pkgs.config.cudaSupport or false;
+  };
+
+  paddlepaddle-gpu = callPackage ../development/python-modules/paddlepaddle {
+    cudaSupport = true;
+  };
 
   pulumi = callPackage ../development/python-modules/pulumi { inherit (pkgs) pulumi; };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1185,6 +1185,8 @@ self: super: with self; {
 
   paddle2onnx = callPackage ../development/python-modules/paddle2onnx { };
 
+  paddlepaddle = callPackage ../development/python-modules/paddlepaddle { };
+
   pulumi = callPackage ../development/python-modules/pulumi { inherit (pkgs) pulumi; };
 
   pulumi-aws = callPackage ../development/python-modules/pulumi-aws { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1185,6 +1185,8 @@ self: super: with self; {
 
   paddle2onnx = callPackage ../development/python-modules/paddle2onnx { };
 
+  paddleocr = callPackage ../development/python-modules/paddleocr { };
+
   paddlepaddle = callPackage ../development/python-modules/paddlepaddle { };
 
   pulumi = callPackage ../development/python-modules/pulumi { inherit (pkgs) pulumi; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1275,6 +1275,8 @@ self: super: with self; {
 
   bcdoc = callPackage ../development/python-modules/bcdoc { };
 
+  bce-python-sdk = callPackage ../development/python-modules/bce-python-sdk { };
+
   bcf = callPackage ../development/python-modules/bcf { };
 
   bcg = callPackage ../development/python-modules/bcg { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7768,6 +7768,8 @@ self: super: with self; {
 
   pdb2pqr = callPackage ../development/python-modules/pdb2pqr { };
 
+  pdf2docx = callPackage ../development/python-modules/pdf2docx { };
+
   pdf2image = callPackage ../development/python-modules/pdf2image { };
 
   pdfkit = callPackage ../development/python-modules/pdfkit { };


### PR DESCRIPTION
## Description of changes

This pull request builds off #243583 in an attempt to get [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) packaged. My understanding is that PaddleOCR can be used for multiple purposes:

1. It provides tooling for data scientists to *create OCR models*.
2. It provides an SDK for *running pre-created OCR models*.

My efforts have gone towards getting the *2nd* feature to work, and I haven't tested any of the functionality for the 1st. As it stands, this 2nd feature is working (on the CPU without CUDA):

```console
$ # Assuming you're in this nixpkgs fork:
$ NIXPKGS_ALLOW_INSECURE=1 nix-shell -I nixpkgs=. -p wget -p 'python310.withPackages (p: [p.paddleocr])'
$ wget https://media.makeameme.org/created/one-does-not-732d600cca.jpg
$ python
Python 3.10.12 (main, Jun  6 2023, 22:43:10) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from paddleocr import PaddleOCR
>>> ocr = PaddleOCR(use_angle_cls=True, lang='en', show_log=False)
>>> ocr.ocr('./one-does-not-732d600cca.jpg', cls=True)
[[[[[80.0, 23.0], [518.0, 23.0], [518.0, 61.0], [80.0, 61.0]], ('ONEDOESNOTSIMPY', 0.953844428062439)], [[[78.0, 404.0], [518.0, 404.0], [518.0, 435.0], [78.0, 435.0]], ('MAKES OCR PRECISION 9O%', 0.9581981897354126)], [[[458.0, 441.0], [583.0, 443.0], [583.0, 458.0], [458.0, 456.0]], ('makeameme.org', 0.9980811476707458)]]]
```

## Remaining work

- [x] Collect feedback from nixpkgs community and improve the quality of this PR.
- [ ] Use `buildPythonApplication` instead of `buildPythonPackage` for `paddleocr` to ship executables.
- [x] Add CUDA support to `paddlepaddle` ([wip](https://github.com/Avaq/nixpkgs/compare/avaq/paddleocr...avaq/paddle-gpu)).
- [x] Add `aarch64-darwin` support to `paddlepaddle` ([wip](https://github.com/Avaq/nixpkgs/compare/avaq/paddleocr...avaq/paddlepaddle-darwin)).
- [ ] Wait for `imgaug` to be removed from PaddleOCR (https://github.com/PaddlePaddle/PaddleOCR/issues/10455), and remove my corresponding patch.
- [ ] Enable [support for `visualdl`](https://github.com/PaddlePaddle/PaddleOCR/blob/release/2.7/doc/doc_en/logging_en.md#visualdl), which is currently broken / not included. This involves packaging `visualdl` ([wip](https://github.com/Avaq/nixpkgs/compare/avaq/paddleocr...avaq/visualdl)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
