### PR TITLE
dpkg: fix paths and disable start-stop-daemon

### DIFF
--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -1,5 +1,19 @@
-{ lib, stdenv, fetchgit, perl, gnutar, zlib, bzip2, xz, zstd
-, libmd, makeWrapper, coreutils, autoreconfHook, pkg-config
+{ lib
+, stdenv
+, fetchgit
+, perl
+, gnutar
+, zlib
+, bzip2
+, xz
+, zstd
+, libmd
+, makeWrapper
+, coreutils
+, autoreconfHook
+, pkg-config
+, diffutils
+, glibc
 }:
 
 stdenv.mkDerivation rec {
@@ -14,12 +28,11 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-dselect"
+    "--disable-start-stop-daemon"
     "--with-admindir=/var/lib/dpkg"
     "PERL_LIBDIR=$(out)/${perl.libPrefix}"
     "TAR=${gnutar}/bin/tar"
-    (lib.optionalString stdenv.isDarwin "--disable-linker-optimisations")
-    (lib.optionalString stdenv.isDarwin "--disable-start-stop-daemon")
-  ];
+  ] ++ lib.optional stdenv.isDarwin "--disable-linker-optimisations";
 
   enableParallelBuilding = true;
 
@@ -37,7 +50,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs .
 
     # Dpkg commands sometimes calls out to shell commands
@@ -52,7 +65,9 @@ stdenv.mkDerivation rec {
        --replace '"debsig-verify"' \"$out/bin/debsig-verify\" \
        --replace '"rm"' \"${coreutils}/bin/rm\" \
        --replace '"cat"' \"${coreutils}/bin/cat\" \
-       --replace '"diff"' \"${coreutils}/bin/diff\"
+       --replace '"diff"' \"${diffutils}/bin/diff\"
+    substituteInPlace src/main/help.c \
+       --replace '"ldconfig"' \"${glibc.bin}/bin/ldconfig\"
   '';
 
   buildInputs = [ perl zlib bzip2 xz zstd libmd ];


### PR DESCRIPTION
## Description of changes

- Fix replacement of diff, which is part of `pkgs.diffutils` rather than `pkgs.coreutils`
- Replace ldconfig with store path
- Disable start-stop-daemon on all systems. start-stop-daemon is part of dpkg but wasn't build properly before. Most systems will use systemd anyway.

I've tried to run nixpkgs-review on this change, but while the change itself seems to work pretty well (nearly all of those dependents require dpkg to unpackage .deb files), many of the packages fail as their hash changed or upstream url is broken/gone.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
