### PR TITLE
mariadb: 11.0.3, 10.11.5, 10.10.6, 10.9.8, 10.6.15, 10.5.22 & 10.4.31

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -281,8 +281,8 @@ in
     };
     mariadb_110 = self.callPackage generic {
       # Supported until 2024-06-07
-      version = "11.0.2";
-      hash = "sha256-PHFXbK0OpBaIInDjg/lMyJaTt/vM4fpPMG/j6THkZK4=";
+      version = "11.0.3";
+      hash = "sha256-Up8IoGTudzOhNuxHSkI56Kyb1tsTm4unC/+KfxMDg5o=";
       inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -267,8 +267,8 @@ in
     };
     mariadb_1010 = self.callPackage generic {
       # Supported until 2023-11-17. TODO: remove ahead of 23.11 branchoff
-      version = "10.10.5";
-      hash = "sha256-kc1NQm04rwmFLr2vAOdCEXdexsyQf3TBruDUXN9dmWs=";
+      version = "10.10.6";
+      hash = "sha256-4eUwEZedKfDsJuE6uMr2E0gb8ClSBWb7loF1RhA5ONU=";
       inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -246,8 +246,8 @@ in
     # see https://mariadb.org/about/#maintenance-policy for EOLs
     mariadb_104 = self.callPackage generic {
       # Supported until 2024-06-18
-      version = "10.4.30";
-      hash = "sha256-/LvaZxxseEwDFQJiYj8NgYlMkRUz58PCdvJW8voSEAw=";
+      version = "10.4.31";
+      hash = "sha256-Uqv1Q0xqQuCgSKY6uZo4mPt/yhWA+t16Yb0OnOm4UFQ=";
       inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -260,8 +260,8 @@ in
     };
     mariadb_106 = self.callPackage generic {
       # Supported until 2026-07-06
-      version = "10.6.14";
-      hash = "sha256-RQQ3x0qORMdrPAs0O5NH65AyAVRYUVZdeNmmJGdqsgI=";
+      version = "10.6.15";
+      hash = "sha256-sva9uhfq1NkcTSVPr8NKcorGsCfdHXF4vCZ1jc5pQzU=";
       inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -274,8 +274,8 @@ in
     };
     mariadb_1011 = self.callPackage generic {
       # Supported until 2028-02-16
-      version = "10.11.4";
-      hash = "sha256-zo2sElVozF9A2nTBchJ2fJLY+u2BBmWAtSakhaWREn0=";
+      version = "10.11.5";
+      hash = "sha256-TJSEBI1NDHHdB2qzP8KpzoUQvfdiiG3g1j/lJJbz27s=";
       inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -253,8 +253,8 @@ in
     };
     mariadb_105 = self.callPackage generic {
       # Supported until 2025-06-24
-      version = "10.5.21";
-      hash = "sha256-yn63Mo4cAunZCxPfNpW3+ni9c92ZykniPjLWzImCIkI=";
+      version = "10.5.22";
+      hash = "sha256-PiOGu17iWo3c0hz/xIx2CX5cpBpuSgmPay7kASsNY44=";
       inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };


### PR DESCRIPTION
## Description of changes
10.4.x still doesn't support openssl 3.x

for details, see release notes linked in commit messages or go to https://mariadb.org/mariadb-11-0-3-10-11-5-10-10-6-10-9-8-10-6-15-10-5-22-10-4-31-now-available/

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)