### PR TITLE
obs-studio: fix script plugin path 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10542,6 +10542,12 @@
     githubId = 7878181;
     name = "Mateo Diaz";
   };
+  materus = {
+    email = "materus@podkos.pl";
+    github = "materusPL";
+    githubId = 28183516;
+    name = "Mateusz Słodkowicz";
+  };
   math-42 = {
     email = "matheus.4200@gmail.com";
     github = "Math-42";

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -154,7 +154,7 @@ stdenv.mkDerivation rec {
       video content, efficiently
     '';
     homepage = "https://obsproject.com";
-    maintainers = with maintainers; [ jb55 MP2E V ];
+    maintainers = with maintainers; [ jb55 MP2E V materus ];
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
     mainProgram = "obs";

--- a/pkgs/applications/video/obs-studio/fix-nix-plugin-path.patch
+++ b/pkgs/applications/video/obs-studio/fix-nix-plugin-path.patch
@@ -1,5 +1,18 @@
+diff --git a/cmake/Modules/ObsDefaults_Linux.cmake b/cmake/Modules/ObsDefaults_Linux.cmake
+index d1e58a083..a03c6b98e 100644
+--- a/cmake/Modules/ObsDefaults_Linux.cmake
++++ b/cmake/Modules/ObsDefaults_Linux.cmake
+@@ -76,7 +76,7 @@ macro(setup_obs_project)
+     set(OBS_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/")
+     set(OBS_DATA_PATH "${OBS_DATA_DESTINATION}")
+ 
+-    set(OBS_SCRIPT_PLUGIN_PATH "${CMAKE_INSTALL_PREFIX}/${OBS_SCRIPT_PLUGIN_DESTINATION}")
++    set(OBS_SCRIPT_PLUGIN_PATH "${OBS_SCRIPT_PLUGIN_DESTINATION}")
+     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${OBS_LIBRARY_DESTINATION}")
+   else()
+     set(OBS_EXECUTABLE_DESTINATION "bin/${_ARCH_SUFFIX}bit")
 diff --git a/libobs/obs-nix.c b/libobs/obs-nix.c
-index 36aac7097..801cec788 100644
+index b006a5598..531655eb3 100644
 --- a/libobs/obs-nix.c
 +++ b/libobs/obs-nix.c
 @@ -56,7 +56,7 @@ const char *get_module_extension(void)


### PR DESCRIPTION
## Description of changes
Fix for https://github.com/NixOS/nixpkgs/issues/245235

After change, lua and python scripts seem to load without errors.

## Things done
Edited patch so it will also change OBS_SCRIPT_PLUGIN_PATH, both OBS_SCRIPT_PLUGIN_DESTINATION and CMAKE_INSTALL_PREFIX are absolute path while building with nix so merging them makes non existing path.

OBS_SCRIPT_PLUGIN_PATH is now  same as OBS_SCRIPT_PLUGIN_DESTINATION

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
