### PR TITLE
python310Packages.ipympl: unbreak by adding missing dependency

### DIFF
--- a/pkgs/development/python-modules/ipympl/default.nix
+++ b/pkgs/development/python-modules/ipympl/default.nix
@@ -1,9 +1,14 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchPypi
 , ipykernel
+, ipython_genutils
 , ipywidgets
 , matplotlib
+, numpy
+, pillow
+, traitlets
 }:
 
 buildPythonPackage rec {
@@ -11,13 +16,22 @@ buildPythonPackage rec {
   version = "0.9.3";
   format = "wheel";
 
+  disabled = pythonOlder "3.5";
+
   src = fetchPypi {
     inherit pname version format;
     hash = "sha256-0RPNVYkbr+myfvmbbdERqHvra7KuVQxAQpInIQO+gBM=";
   };
 
-
-  propagatedBuildInputs = [ ipykernel ipywidgets matplotlib ];
+  propagatedBuildInputs = [
+    ipykernel
+    ipython_genutils
+    ipywidgets
+    matplotlib
+    numpy
+    pillow
+    traitlets
+  ];
 
   # There are no unit tests in repository
   doCheck = false;


### PR DESCRIPTION
## Description of changes

Package was failing to build due to missing `ipython_genutils` dependency; also added some other dependencies declared in `setup.py` presumably present in the closure but not declared in this expression.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).