### PR TITLE
maintainers/teams: add aws team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -43,6 +43,14 @@ with lib.maintainers; {
     enableFeatureFreezePing = true;
   };
 
+  aws = {
+    members = [
+      anthonyroussel
+    ];
+    scope = "Maintain AWS packages and modules.";
+    shortName = "AWS";
+  };
+
   bazel = {
     members = [
       mboes

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -7,6 +7,7 @@ let
   amiBootMode = if config.ec2.efi then "uefi" else "legacy-bios";
 
 in {
+  meta.maintainers = teams.aws.members;
 
   imports = [ ../../../modules/virtualisation/amazon-image.nix ];
 

--- a/nixos/modules/services/misc/ssm-agent.nix
+++ b/nixos/modules/services/misc/ssm-agent.nix
@@ -16,6 +16,8 @@ let
     esac
   '';
 in {
+  meta.maintainers = teams.aws.members;
+
   options.services.ssm-agent = {
     enable = mkEnableOption (lib.mdDoc "AWS SSM agent");
 

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -13,6 +13,8 @@ let
 in
 
 {
+  meta.maintainers = teams.aws.members;
+
   imports = [
     ../profiles/headless.nix
     # Note: While we do use the headless profile, we also explicitly

--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -55,6 +55,7 @@ let
     nixos-rebuild switch
   '';
 in {
+  meta.maintainers = teams.aws.members;
 
   options.virtualisation.amazon-init = {
     enable = mkOption {

--- a/nixos/modules/virtualisation/amazon-options.nix
+++ b/nixos/modules/virtualisation/amazon-options.nix
@@ -2,6 +2,8 @@
 let
   inherit (lib) literalExpression types;
 in {
+  meta.maintainers = with lib.maintainers; teams.aws.members;
+
   options = {
     ec2 = {
       zfs = {

--- a/nixos/modules/virtualisation/ec2-data.nix
+++ b/nixos/modules/virtualisation/ec2-data.nix
@@ -7,6 +7,8 @@
 with lib;
 
 {
+  meta.maintainers = teams.aws.members;
+
   imports = [
     (mkRemovedOptionModule [ "ec2" "metadata" ] "")
   ];

--- a/nixos/modules/virtualisation/ecs-agent.nix
+++ b/nixos/modules/virtualisation/ecs-agent.nix
@@ -5,6 +5,8 @@ with lib;
 let
   cfg = config.services.ecs-agent;
 in {
+  meta.maintainers = teams.aws.members;
+
   options.services.ecs-agent = {
     enable = mkEnableOption (lib.mdDoc "Amazon ECS agent");
 

--- a/nixos/tests/amazon-init-shell.nix
+++ b/nixos/tests/amazon-init-shell.nix
@@ -15,9 +15,11 @@ with pkgs.lib;
 
 makeTest {
   name = "amazon-init";
+
   meta = with maintainers; {
-    maintainers = [ urbas ];
+    maintainers = teams.aws.members ++ [ urbas ];
   };
+
   nodes.machine = { ... }:
   {
     imports = [ ../modules/profiles/headless.nix ../modules/virtualisation/amazon-init.nix ];

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2111,11 +2111,11 @@ let
             jq '.contributes.configuration.properties."cfnLint.path".default = "${cfn-lint}/bin/cfn-lint"' package.json | sponge package.json
           '';
 
-          meta = {
+          meta = with lib; {
             description = "CloudFormation Linter IDE integration, autocompletion, and documentation";
             homepage = "https://github.com/aws-cloudformation/cfn-lint-visual-studio-code";
-            license = lib.licenses.asl20;
-            maintainers = [ lib.maintainers.wolfangaukang ];
+            license = licenses.asl20;
+            maintainers = with maintainers; teams.aws.members ++ [ wolfangaukang ];
           };
         };
 

--- a/pkgs/applications/networking/cluster/eks-node-viewer/default.nix
+++ b/pkgs/applications/networking/cluster/eks-node-viewer/default.nix
@@ -32,6 +32,6 @@ buildGoModule rec {
     homepage = "https://github.com/awslabs/eks-node-viewer";
     changelog = "https://github.com/awslabs/eks-node-viewer/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = [ maintainers.ivankovnatsky ];
+    maintainers = with maintainers; teams.aws.members ++ [ ivankovnatsky ];
   };
 }

--- a/pkgs/applications/networking/cluster/ssm-agent/default.nix
+++ b/pkgs/applications/networking/cluster/ssm-agent/default.nix
@@ -134,6 +134,6 @@ buildGoPackage rec {
     homepage = "https://github.com/aws/amazon-ssm-agent";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ copumpkin manveru ];
+    maintainers = with maintainers; teams.aws.members ++ [ copumpkin manveru ];
   };
 }

--- a/pkgs/applications/networking/localproxy/default.nix
+++ b/pkgs/applications/networking/localproxy/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
       description = "AWS IoT Secure Tunneling Local Proxy Reference Implementation C++";
       homepage = "https://github.com/aws-samples/aws-iot-securetunneling-localproxy";
       license = licenses.asl20;
-      maintainers = with maintainers; [spalf];
+      maintainers = with maintainers; teams.aws.members ++ [ spalf ];
       platforms = platforms.unix;
     };
   })

--- a/pkgs/applications/networking/remote/nice-dcv-client/default.nix
+++ b/pkgs/applications/networking/remote/nice-dcv-client/default.nix
@@ -81,6 +81,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ rmcgibbo ];
+    maintainers = with maintainers; teams.aws.members ++ [ rmcgibbo ];
   };
 }

--- a/pkgs/applications/version-management/git-remote-codecommit/default.nix
+++ b/pkgs/applications/version-management/git-remote-codecommit/default.nix
@@ -29,11 +29,11 @@ buildPythonApplication rec {
     pytest
   '';
 
-  meta = {
+  meta = with lib; {
     description =
       "Git remote prefix to simplify pushing to and pulling from CodeCommit";
-    maintainers = [ lib.maintainers.zaninime ];
+    maintainers = with maintainers; teams.aws.members ++ [ zaninime ];
     homepage = "https://github.com/awslabs/git-remote-codecommit";
-    license = lib.licenses.asl20;
+    license = licenses.asl20;
   };
 }

--- a/pkgs/applications/version-management/git-secrets/default.nix
+++ b/pkgs/applications/version-management/git-secrets/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     description = "Prevents you from committing secrets and credentials into git repositories";
     homepage = "https://github.com/awslabs/git-secrets";
     license = licenses.asl20;
+    maintainers = with maintainers; teams.aws.members;
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/virtualization/ecs-agent/default.nix
+++ b/pkgs/applications/virtualization/ecs-agent/default.nix
@@ -25,8 +25,7 @@ buildGoModule rec {
     changelog = "https://github.com/aws/amazon-ecs-agent/raw/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = with maintainers; teams.aws.members ++ [ copumpkin ];
     mainProgram = "agent";
   };
 }
-

--- a/pkgs/development/java-modules/redshift_jdbc/default.nix
+++ b/pkgs/development/java-modules/redshift_jdbc/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
       "JDBC 4.2 driver for Amazon Redshift allowing Java programs to connect to a Redshift database";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ sir4ur0n ];
+    maintainers = with maintainers; teams.aws.members ++ [ sir4ur0n ];
   };
 }

--- a/pkgs/development/libraries/aws-c-auth/default.nix
+++ b/pkgs/development/libraries/aws-c-auth/default.nix
@@ -53,6 +53,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-c-auth";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ r-burns ];
+    maintainers = with maintainers; teams.aws.members ++ [ r-burns ];
   };
 }

--- a/pkgs/development/libraries/aws-c-cal/default.nix
+++ b/pkgs/development/libraries/aws-c-cal/default.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-c-cal";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ orivej ];
+    maintainers = with maintainers; teams.aws.members ++ [ orivej ];
   };
 }

--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-c-common";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ orivej eelco r-burns ];
+    maintainers = with maintainers; teams.aws.members ++ [ orivej eelco r-burns ];
   };
 }

--- a/pkgs/development/libraries/aws-c-compression/default.nix
+++ b/pkgs/development/libraries/aws-c-compression/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-c-compression";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ r-burns ];
+    maintainers = with maintainers; teams.aws.members ++ [ r-burns ];
   };
 }

--- a/pkgs/development/libraries/aws-c-event-stream/default.nix
+++ b/pkgs/development/libraries/aws-c-event-stream/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-c-event-stream";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ orivej eelco ];
+    maintainers = with maintainers; teams.aws.members ++ [ orivej eelco ];
   };
 }

--- a/pkgs/development/libraries/aws-c-http/default.nix
+++ b/pkgs/development/libraries/aws-c-http/default.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-c-http";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ r-burns ];
+    maintainers = with maintainers; teams.aws.members ++ [ r-burns ];
   };
 }

--- a/pkgs/development/libraries/aws-c-io/default.nix
+++ b/pkgs/development/libraries/aws-c-io/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-c-io";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ orivej ];
+    maintainers = with maintainers; teams.aws.members ++ [ orivej ];
   };
 }

--- a/pkgs/development/libraries/aws-c-mqtt/default.nix
+++ b/pkgs/development/libraries/aws-c-mqtt/default.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-c-mqtt";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ r-burns ];
+    maintainers = with maintainers; teams.aws.members ++ [ r-burns ];
   };
 }

--- a/pkgs/development/libraries/aws-c-s3/default.nix
+++ b/pkgs/development/libraries/aws-c-s3/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     description = "C99 library implementation for communicating with the S3 service";
     homepage = "https://github.com/awslabs/aws-c-s3";
     license = licenses.asl20;
-    maintainers = with maintainers; [ r-burns ];
+    maintainers = with maintainers; teams.aws.members ++ [ r-burns ];
     mainProgram = "s3";
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/aws-c-sdkutils/default.nix
+++ b/pkgs/development/libraries/aws-c-sdkutils/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-c-sdkutils";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ r-burns ];
+    maintainers = with maintainers; teams.aws.members ++ [ r-burns ];
   };
 }

--- a/pkgs/development/libraries/aws-checksums/default.nix
+++ b/pkgs/development/libraries/aws-checksums/default.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-checksums";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ orivej eelco ];
+    maintainers = with maintainers; teams.aws.members ++ [ orivej eelco ];
   };
 }

--- a/pkgs/development/libraries/aws-crt-cpp/default.nix
+++ b/pkgs/development/libraries/aws-crt-cpp/default.nix
@@ -75,6 +75,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awslabs/aws-crt-cpp";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ r-burns ];
+    maintainers = with maintainers; teams.aws.members ++ [ r-burns ];
   };
 }

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/aws/aws-sdk-cpp";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ eelco orivej ];
+    maintainers = with maintainers; teams.aws.members ++ [ eelco orivej ];
     # building ec2 runs out of memory: cc1plus: out of memory allocating 33554372 bytes after a total of 74424320 bytes
     broken = stdenv.buildPlatform.is32bit && ((builtins.elem "ec2" apis) || (builtins.elem "*" apis));
   };

--- a/pkgs/development/libraries/s2n-tls/default.nix
+++ b/pkgs/development/libraries/s2n-tls/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/aws/s2n-tls";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ orivej ];
+    maintainers = with maintainers; teams.aws.members ++ [ orivej ];
   };
 }

--- a/pkgs/development/python-modules/amazon-kclpy/default.nix
+++ b/pkgs/development/python-modules/amazon-kclpy/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "Amazon Kinesis Client Library for Python";
     homepage = "https://github.com/awslabs/amazon-kinesis-client-python";
     license = licenses.amazonsl;
-    maintainers = with maintainers; [ psyanticy ];
+    maintainers = with maintainers; teams.aws.members ++ [ psyanticy ];
   };
 }

--- a/pkgs/development/python-modules/aws-lambda-builders/default.nix
+++ b/pkgs/development/python-modules/aws-lambda-builders/default.nix
@@ -75,6 +75,6 @@ buildPythonPackage rec {
       AWS Lambda functions for several runtimes & frameworks.
     '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ dhkl ];
+    maintainers = with maintainers; teams.aws.members ++ [ dhkl ];
   };
 }

--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -62,6 +62,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/awslabs/serverless-application-model";
     changelog = "https://github.com/aws/serverless-application-model/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; teams.aws.members;
   };
 }

--- a/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
+++ b/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
@@ -60,6 +60,6 @@ buildPythonPackage rec {
       The AWS Secrets Manager Python caching client enables in-process caching of secrets for Python applications.
     '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ tomaskala ];
+    maintainers = with maintainers; teams.aws.members ++ [ tomaskala ];
   };
 }

--- a/pkgs/development/python-modules/aws-xray-sdk/default.nix
+++ b/pkgs/development/python-modules/aws-xray-sdk/default.nix
@@ -25,10 +25,11 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
-  meta = {
+  meta = with lib; {
     description = "AWS X-Ray SDK for the Python programming language";
-    license = lib.licenses.asl20;
+    license = licenses.asl20;
     homepage = "https://github.com/aws/aws-xray-sdk-python";
+    maintainers = with maintainers; teams.aws.members ++ [ davegallant ];
   };
 
   doCheck = false;

--- a/pkgs/development/python-modules/awscrt/default.nix
+++ b/pkgs/development/python-modules/awscrt/default.nix
@@ -56,6 +56,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/awslabs/aws-crt-python/releases/tag/v${version}";
     description = "Python bindings for the AWS Common Runtime";
     license = licenses.asl20;
-    maintainers = with maintainers; [ davegallant ];
+    maintainers = with maintainers; teams.aws.members ++ [ davegallant ];
   };
 }

--- a/pkgs/development/python-modules/awsiotpythonsdk/default.nix
+++ b/pkgs/development/python-modules/awsiotpythonsdk/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "Python SDK for connecting to AWS IoT";
     homepage = "https://github.com/aws/aws-iot-device-sdk-python";
     license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; teams.aws.members ++ [ fab ];
   };
 }

--- a/pkgs/development/python-modules/awslambdaric/default.nix
+++ b/pkgs/development/python-modules/awslambdaric/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     description = "AWS Lambda Runtime Interface Client for Python";
     homepage = "https://github.com/aws/aws-lambda-python-runtime-interface-client";
     license = licenses.asl20;
-    maintainers = with maintainers; [ austinbutler ];
+    maintainers = with maintainers; teams.aws.members ++ [ austinbutler ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/awswrangler/default.nix
+++ b/pkgs/development/python-modules/awswrangler/default.nix
@@ -83,6 +83,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/aws/aws-sdk-pandas";
     changelog = "https://github.com/aws/aws-sdk-pandas/releases/tag/${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ mcwitt ];
+    maintainers = with maintainers; teams.aws.members ++ [ mcwitt ];
   };
 }

--- a/pkgs/development/python-modules/cfn-flip/default.nix
+++ b/pkgs/development/python-modules/cfn-flip/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     description = "Tool for converting AWS CloudFormation templates between JSON and YAML formats";
     homepage = "https://github.com/awslabs/aws-cfn-template-flip";
     license = licenses.asl20;
-    maintainers = with maintainers; [ kamadorueda psyanticy ];
+    maintainers = with maintainers; teams.aws.members ++ [ kamadorueda psyanticy ];
   };
 }

--- a/pkgs/development/python-modules/cfn-lint/default.nix
+++ b/pkgs/development/python-modules/cfn-lint/default.nix
@@ -85,6 +85,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/aws-cloudformation/cfn-python-lint";
     changelog = "https://github.com/aws-cloudformation/cfn-lint/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; teams.aws.members;
   };
 }

--- a/pkgs/development/python-modules/chalice/default.nix
+++ b/pkgs/development/python-modules/chalice/default.nix
@@ -105,6 +105,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/aws/chalice";
     changelog = "https://github.com/aws/chalice/blob/${version}/CHANGELOG.rst";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; teams.aws.members;
   };
 }

--- a/pkgs/development/python-modules/pyqldb/default.nix
+++ b/pkgs/development/python-modules/pyqldb/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "Python driver for Amazon QLDB";
     homepage = "https://github.com/awslabs/amazon-qldb-driver-python";
     license = licenses.asl20;
-    maintainers = [ maintainers.terlar ];
+    maintainers = with maintainers; teams.aws.members ++ [ terlar ];
   };
 }

--- a/pkgs/development/python-modules/redshift-connector/default.nix
+++ b/pkgs/development/python-modules/redshift-connector/default.nix
@@ -52,11 +52,11 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true; # required for tests
 
-  meta = {
+  meta = with lib; {
     description = "Redshift interface library";
     homepage = "https://github.com/aws/amazon-redshift-python-driver";
     changelog = "https://github.com/aws/amazon-redshift-python-driver/releases/tag/v${version}";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ mcwitt ];
+    license = licenses.asl20;
+    maintainers = with maintainers; teams.aws.members ++ [ mcwitt ];
   };
 }

--- a/pkgs/development/python-modules/sagemaker/default.nix
+++ b/pkgs/development/python-modules/sagemaker/default.nix
@@ -83,6 +83,6 @@ buildPythonPackage rec {
     description = "Library for training and deploying machine learning models on Amazon SageMaker";
     homepage = "https://github.com/aws/sagemaker-python-sdk/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nequissimus ];
+    maintainers = with maintainers; teams.aws.members ++ [ nequissimus ];
   };
 }

--- a/pkgs/development/python-modules/serverlessrepo/default.nix
+++ b/pkgs/development/python-modules/serverlessrepo/default.nix
@@ -54,6 +54,6 @@ buildPythonPackage rec {
       AWS Serverless Application Repository.
     '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ dhkl ];
+    maintainers = with maintainers; teams.aws.members ++ [ dhkl ];
   };
 }

--- a/pkgs/development/python-modules/smdebug-rulesconfig/default.nix
+++ b/pkgs/development/python-modules/smdebug-rulesconfig/default.nix
@@ -18,6 +18,6 @@ buildPythonPackage rec {
     description = "These builtin rules are available in Amazon SageMaker";
     homepage = "https://github.com/awslabs/sagemaker-debugger-rulesconfig";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nequissimus ];
+    maintainers = with maintainers; teams.aws.members ++ [ nequissimus ];
   };
 }

--- a/pkgs/development/tools/amazon-qldb-shell/default.nix
+++ b/pkgs/development/tools/amazon-qldb-shell/default.nix
@@ -36,7 +36,7 @@ let
       description = "An interface to send PartiQL statements to Amazon Quantum Ledger Database (QLDB)";
       homepage = "https://github.com/awslabs/amazon-qldb-shell";
       license = licenses.asl20;
-      maintainers = [ maintainers.terlar ];
+      maintainers = with maintainers; teams.aws.members ++ [ terlar ];
       mainProgram = "qldb";
     };
   };

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -62,6 +62,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/awslabs/aws-sam-cli";
     changelog = "https://github.com/aws/aws-sam-cli/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ lo1tuma ];
+    maintainers = with maintainers; teams.aws.members ++ [ lo1tuma ];
   };
 }

--- a/pkgs/development/tools/database/dynein/default.nix
+++ b/pkgs/development/tools/database/dynein/default.nix
@@ -43,6 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/awslabs/dynein";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ pimeys ];
+    maintainers = with maintainers; teams.aws.members ++ [ pimeys ];
   };
 }

--- a/pkgs/development/tools/ec2-metadata-mock/default.nix
+++ b/pkgs/development/tools/ec2-metadata-mock/default.nix
@@ -21,6 +21,6 @@ buildGoModule rec {
     description = "Amazon EC2 Metadata Mock";
     homepage = "https://github.com/aws/amazon-ec2-metadata-mock";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ymatsiuk ];
+    maintainers = with maintainers; teams.aws.members ++ [ ymatsiuk ];
   };
 }

--- a/pkgs/development/tools/rain/default.nix
+++ b/pkgs/development/tools/rain/default.nix
@@ -32,6 +32,6 @@ buildGoModule rec {
     description = "A development workflow tool for working with AWS CloudFormation";
     homepage = "https://github.com/aws-cloudformation/rain";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jiegec ];
+    maintainers = with maintainers; teams.aws.members ++ [ jiegec ];
   };
 }

--- a/pkgs/tools/admin/amazon-ec2-utils/default.nix
+++ b/pkgs/tools/admin/amazon-ec2-utils/default.nix
@@ -73,6 +73,6 @@ stdenv.mkDerivation rec {
     description = "Contains a set of utilities and settings for Linux deployments in EC2";
     homepage = "https://github.com/amazonlinux/amazon-ec2-utils";
     license = licenses.mit;
-    maintainers = with maintainers; [ ketzacoatl thefloweringash anthonyroussel ];
+    maintainers = with maintainers; teams.aws.members ++ [ ketzacoatl thefloweringash ];
   };
 }

--- a/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
+++ b/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
     description = "The Amazon ECR Docker Credential Helper is a credential helper for the Docker daemon that makes it easier to use Amazon Elastic Container Registry";
     homepage = "https://github.com/awslabs/amazon-ecr-credential-helper";
     license = licenses.asl20;
-    maintainers = with maintainers; [ kalbasit ];
+    maintainers = with maintainers; teams.aws.members ++ [ kalbasit ];
     mainProgram = "docker-credential-ecr-login";
   };
 }

--- a/pkgs/tools/admin/aws-lambda-runtime-interface-emulator/default.nix
+++ b/pkgs/tools/admin/aws-lambda-runtime-interface-emulator/default.nix
@@ -20,6 +20,6 @@ buildGoModule rec {
     description = "To locally test their Lambda function packaged as a container image.";
     homepage = "https://github.com/aws/aws-lambda-runtime-interface-emulator";
     license = licenses.asl20;
-    maintainers = with maintainers; [ teto ];
+    maintainers = with maintainers; teams.aws.members ++ [ teto ];
   };
 }

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -65,6 +65,6 @@ python3.pkgs.buildPythonApplication rec {
     description = "Unified tool to manage your AWS services";
     license = licenses.asl20;
     mainProgram = "aws";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; teams.aws.members;
   };
 }

--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -130,7 +130,7 @@ with py.pkgs; buildPythonApplication rec {
     homepage = "https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html";
     changelog = "https://github.com/aws/aws-cli/blob/${version}/CHANGELOG.rst";
     license = licenses.asl20;
-    maintainers = with maintainers; [ bhipple davegallant bryanasdev000 devusb anthonyroussel ];
+    maintainers = with maintainers; teams.aws.members ++ [ bhipple davegallant bryanasdev000 devusb ];
     mainProgram = "aws";
   };
 }

--- a/pkgs/tools/admin/coldsnap/default.nix
+++ b/pkgs/tools/admin/coldsnap/default.nix
@@ -27,6 +27,6 @@ rustPlatform.buildRustPackage rec {
     description = "A command line interface for Amazon EBS snapshots";
     changelog = "https://github.com/awslabs/coldsnap/blob/${src.rev}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = teams.determinatesystems.members;
+    maintainers = teams.determinatesystems.members ++ teams.aws.members;
   };
 }

--- a/pkgs/tools/admin/copilot-cli/default.nix
+++ b/pkgs/tools/admin/copilot-cli/default.nix
@@ -42,6 +42,6 @@ buildGoModule rec {
     homepage = "https://github.com/aws/copilot-cli";
     changelog = "https://github.com/aws/copilot-cli/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jiegec ];
+    maintainers = with maintainers; teams.aws.members ++ [ jiegec ];
   };
 }

--- a/pkgs/tools/misc/flowgger/default.nix
+++ b/pkgs/tools/misc/flowgger/default.nix
@@ -37,6 +37,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/awslabs/flowgger";
     description = "A fast, simple and lightweight data collector written in Rust";
     license = licenses.bsd2;
-    maintainers = with maintainers; [];
+    maintainers = with maintainers; teams.aws.members;
   };
 }

--- a/pkgs/tools/system/awstats/default.nix
+++ b/pkgs/tools/system/awstats/default.nix
@@ -62,6 +62,7 @@ perlPackages.buildPerlPackage rec {
     description = "Real-time logfile analyzer to get advanced statistics";
     homepage = "https://awstats.org";
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; teams.aws.members;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -99,7 +99,8 @@ with localPython.pkgs; buildPythonApplication rec {
     homepage = "https://aws.amazon.com/elasticbeanstalk/";
     description = "A command line interface for Elastic Beanstalk";
     changelog = "https://github.com/aws/aws-elastic-beanstalk-cli/blob/${version}/CHANGES.rst";
-    maintainers = with maintainers; [ eqyiel kirillrdy ];
+    maintainers = with maintainers; teams.aws.members ++ [ eqyiel kirillrdy ];
+
     license = licenses.asl20;
   };
 }

--- a/pkgs/tools/virtualization/ec2-ami-tools/default.nix
+++ b/pkgs/tools/virtualization/ec2-ami-tools/default.nix
@@ -35,10 +35,11 @@ stdenv.mkDerivation rec {
       sed -i 's|/bin/bash|${stdenv.shell}|' $out/lib/ec2/platform/base/pipeline.rb
     '';  # */
 
-  meta = {
+  meta = with lib; {
     homepage = "https://aws.amazon.com/developertools/Amazon-EC2/368";
     description = "Command-line tools to create and manage Amazon EC2 virtual machine images";
-    license = lib.licenses.amazonsl;
+    license = licenses.amazonsl;
+    maintainers = with maintainers; teams.aws.members;
   };
 
 }

--- a/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
+++ b/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
@@ -20,6 +20,6 @@ buildPythonPackage rec {
     description = "Command Line Interface for AWS EC2 Instance Connect";
     homepage = "https://github.com/aws/aws-ec2-instance-connect-cli";
     license = licenses.asl20;
-    maintainers = with maintainers; [ yurrriq ];
+    maintainers = with maintainers; teams.aws.members ++ [ yurrriq ];
   };
 }


### PR DESCRIPTION
## Description of changes

With the growing list of AWS related packages and modules, I propose adding a `aws` team to:

* have a dedicated and [collectively responsible group of the AWS packages collection](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)
* keep the `meta.maintainers` consistent
* allow interested maintainers to be informed of AWS package updates
* make it easier to get help with creating AWS packages

Comment on this PR if you'd like to be added to this team.

What do you think?