### PR TITLE
ssh-tpm-agent: init at 0.3.1

### DIFF
--- a/pkgs/by-name/ss/ssh-tpm-agent/package.nix
+++ b/pkgs/by-name/ss/ssh-tpm-agent/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildGo122Module
+, fetchFromGitHub
+, openssl
+}:
+
+buildGo122Module rec {
+  pname = "ssh-tpm-agent";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Foxboron";
+    repo = "ssh-tpm-agent";
+    rev = "v${version}";
+    hash = "sha256-8CGSiCOcns4cWkYWqibs6hAFRipYabKPCpkhxF4OE8w=";
+  };
+
+  proxyVendor = true;
+
+  vendorHash = "sha256-zUAIesBeuh1zlxXcjKSNmMawZGgUr9z3NzT0XKn/YCQ=";
+
+  buildInputs = [
+    openssl
+  ];
+
+  meta = with lib; {
+    description = "SSH agent with support for TPM sealed keys for public key authentication";
+    homepage = "https://github.com/Foxboron/ssh-agent-tpm";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sgo ];
+    mainProgram = "ssh-tpm-agent";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds the `ssh-tpm-agent` package

https://github.com/Foxboron/ssh-tpm-agent

Fixes #281090

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
