### PR TITLE
libicns: 0.8.1 → 0.8.1-unstable-2022-04-10

### DIFF
--- a/pkgs/development/libraries/libicns/default.nix
+++ b/pkgs/development/libraries/libicns/default.nix
@@ -1,24 +1,17 @@
-{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, libpng, openjpeg }:
+{ lib, stdenv, fetchgit, autoreconfHook, libpng, openjpeg, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "libicns";
-  version = "0.8.1";
+  version = "0.8.1-unstable-2022-04-10";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/icns/${pname}-${version}.tar.gz";
-    sha256 = "1hjm8lwap7bjyyxsyi94fh5817xzqhk4kb5y0b7mb6675xw10prk";
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/icns/code";
+    rev = "921f972c461c505e5ac981aaddbdfdde97e8bb2b";
+    hash = "sha256-YeO0rlTujDNmrdJ3DRyl3TORswF2KFKA+wVUxJo8Dno=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/libi/libicns/0.8.1-3.1/debian/patches/support-libopenjp2.patch";
-      sha256 = "0ss298lyzvydxvaxsadi6kbbjpwykd86jw3za76brcsg2dpssgas";
-    })
-  ];
-
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ libpng openjpeg ];
-  env.NIX_CFLAGS_COMPILE = toString [ "-I${openjpeg.dev}/include/${openjpeg.incDir}" ];
 
   meta = with lib; {
     description = "Library for manipulation of the Mac OS icns resource format";


### PR DESCRIPTION
## Description of changes

Update libicns from 0.8.1 (2012-06-14, yes, thirteen years ago) to the current Git commit. This is also the commit packaged in Debian as 0.8.1.83.g921f972-0.1, and fixes many issues.

https://github.com/GerHobbelt/libicns/compare/0.8.1...921f972c461c505e5ac981aaddbdfdde97e8bb2b

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1041512

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).