### PR TITLE
esptool: 4.5.1 -> 4.6.2

### DIFF
--- a/pkgs/tools/misc/esptool/default.nix
+++ b/pkgs/tools/misc/esptool/default.nix
@@ -1,18 +1,28 @@
 { lib
 , fetchFromGitHub
 , python3
+, softhsm
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "esptool";
-  version = "4.5.1";
+  version = "4.6.2";
+
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     rev = "v${version}";
-    hash = "sha256-FKFw7czXzC8F3OXjlLoJEFaqsSgqWz0ZEqd7KjCy5Ik=";
+    hash = "sha256-3uvTyJrGCpulu/MR/VfCgnIxibxJj2ehBIBSveq7EfI=";
   };
+
+  postPatch = ''
+    patchShebangs ci
+
+    substituteInPlace test/test_espsecure_hsm.py \
+      --replace "/usr/lib/softhsm" "${lib.getLib softhsm}/lib/softhsm"
+  '';
 
   propagatedBuildInputs = with python3.pkgs; [
     bitstring
@@ -20,19 +30,27 @@ python3.pkgs.buildPythonApplication rec {
     ecdsa
     pyserial
     reedsolo
+    pyyaml
+    python-pkcs11
   ];
 
   nativeCheckInputs = with python3.pkgs; [
     pyelftools
     pytestCheckHook
+    softhsm
   ];
 
   # tests mentioned in `.github/workflows/test_esptool.yml`
   checkPhase = ''
     runHook preCheck
 
+    export SOFTHSM2_CONF=$(mktemp)
+    echo "directories.tokendir = $(mktemp -d)" > "$SOFTHSM2_CONF"
+    ./ci/setup_softhsm2.sh
+
     pytest test/test_imagegen.py
     pytest test/test_espsecure.py
+    pytest test/test_espsecure_hsm.py
     pytest test/test_merge_bin.py
     pytest test/test_image_info.py
     pytest test/test_modules.py


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/espressif/esptool/compare/v4.5.1...v4.6.2


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
