### PR TITLE
arrow-cpp: fixup after protobuf bump

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/cmake-find-protobuf.patch
+++ b/pkgs/development/libraries/arrow-cpp/cmake-find-protobuf.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake_modules/FindProtobufAlt.cmake b/cmake_modules/FindProtobufAlt.cmake
+index d29f757ae..61c6e16e1 100644
+--- a/cmake_modules/FindProtobufAlt.cmake
++++ b/cmake_modules/FindProtobufAlt.cmake
+@@ -22,11 +22,8 @@ else()
+ endif()
+ 
+ set(find_package_args)
+-if(ProtobufAlt_FIND_VERSION)
+-  list(APPEND find_package_args ${ProtobufAlt_FIND_VERSION})
+-endif()
+ if(ProtobufAlt_FIND_QUIETLY)
+   list(APPEND find_package_args QUIET)
+ endif()
+-find_package(Protobuf ${find_package_args})
+-set(ProtobufAlt_FOUND ${Protobuf_FOUND})
++find_package(protobuf ${find_package_args})
++set(ProtobufAlt_FOUND ${protobuf_FOUND})

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -122,6 +122,7 @@ stdenv.mkDerivation rec {
   patches = [
     # patch to fix python-test
     ./darwin.patch
+    ./cmake-find-protobuf.patch
   ];
 
   nativeBuildInputs = [
@@ -169,6 +170,7 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
+    "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
     "-DARROW_BUILD_SHARED=${if enableShared then "ON" else "OFF"}"
     "-DARROW_BUILD_STATIC=${if enableShared then "OFF" else "ON"}"
     "-DARROW_BUILD_TESTS=ON"


### PR DESCRIPTION
## Description of changes

This solves a CMake dependency resolution issue. Arrows `FindProtobufAlt` module looks for `Protobuf` with an uppercase P, which is matched by another find module that is provided by CMake itself. When it gets to look for `grpc` that tries to resolve `protobuf` with a lowercase p, which is matched by the upstream provided `protobuf-config.cmake`. At this point conflicting target definitions are detected and the configuration process aborts.

The patch proposed here modifies the arrow module so that it will `protobuf-config.cmake` as well.

Targeting #248496.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
