### PR TITLE
Revert "docutils: 0.19 → 0.20.1"

### DIFF
--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "docutils";
-  version = "0.20.1";
+  version = "0.19";
 
   disabled = pythonOlder "3.7";
 
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-8IpOJ2w6FYOobc4+NKuj/gTQK7ot1R7RYQYkToqSPjs=";
+    hash = "sha256-M5laZ1PDC39Xf+v8LFBBH+xqrH9//rfEz+WZEHLc+eY=";
   };
 
   # Only Darwin needs LANG, but we could set it in general.


### PR DESCRIPTION
Reverts NixOS/nixpkgs#243078

Unfortunately
- Sphinx 5.3.0 does not support docutils >= 0.20;
- Sphinx 7.1.2 (the most recent) needs some heavy patching;