### PR TITLE
cmospwd: init at 5.1

### DIFF
--- a/pkgs/tools/security/cmospwd/default.nix
+++ b/pkgs/tools/security/cmospwd/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchurl
+, stdenv
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cmospwd";
+  version = "5.1";
+
+  src = fetchurl {
+    url = "https://www.cgsecurity.org/cmospwd-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-8pbSl5eUsKa3JrgK/JLk0FnGXcJhKksJN3wWiDPYYvQ=";
+  };
+
+  preConfigure = ''
+    cd src
+
+    # It already contains compiled executable (that doesn't work), so make
+    # will refuse to build if it's still there
+    rm cmospwd
+  '';
+
+  # There is no install make target
+  installPhase = ''
+    runHook preInstall
+    install -Dm0755 cmospwd -t "$out/bin"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Decrypt password stored in cmos used to access BIOS SETUP";
+    homepage = "https://www.cgsecurity.org/wiki/CmosPwd";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ t4ccer ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6725,6 +6725,8 @@ with pkgs;
 
   cmigemo = callPackage ../tools/text/cmigemo { };
 
+  cmospwd = callPackage ../tools/security/cmospwd { };
+
   cmst = libsForQt5.callPackage ../tools/networking/cmst { };
 
   cmt = callPackage ../applications/audio/cmt { };


### PR DESCRIPTION
## Description of changes

Tracked in #81418

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
