### PR TITLE
kikit and kicad package set

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8295,6 +8295,15 @@
     githubId = 18501;
     name = "Julien Langlois";
   };
+  jfly = {
+    name = "Jeremy Fleischman";
+    email = "jeremyfleischman@gmail.com";
+    github = "jfly";
+    githubId = 277474;
+    keys = [{
+      fingerprint = "F1F1 3395 8E8E 9CC4 D9FC  9647 1931 9CD8 416A 642B";
+    }];
+  };
   jfrankenau = {
     email = "johannes@frankenau.net";
     github = "jfrankenau";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11218,6 +11218,12 @@
     githubId = 11810057;
     name = "Matt Snider";
   };
+  matusf = {
+    email = "matus.ferech@gmail.com";
+    github = "matusf";
+    githubId = 18228995;
+    name = "Matúš Ferech";
+  };
   maurer = {
     email = "matthew.r.maurer+nix@gmail.com";
     github = "maurer";

--- a/pkgs/applications/science/electronics/kicad/addons/default.nix
+++ b/pkgs/applications/science/electronics/kicad/addons/default.nix
@@ -1,0 +1,5 @@
+{ kicad }:
+{
+  kikit = kicad.callPackage ./kikit.nix { addonName = "kikit"; };
+  kikit-library = kicad.callPackage ./kikit.nix { addonName = "kikit-library"; };
+}

--- a/pkgs/applications/science/electronics/kicad/addons/kikit.nix
+++ b/pkgs/applications/science/electronics/kicad/addons/kikit.nix
@@ -1,0 +1,52 @@
+# For building the multiple addons that are in the kikit repo.
+{ stdenv
+, bc
+, kikit
+, zip
+, python3
+, addonName
+, addonPath
+}:
+let
+  # This python is only used when building the package, it's not the python
+  # environment that will ultimately run the code packaged here. The python env defined
+  # in KiCad will import the python code packaged here when KiCad starts up.
+  python = python3.withPackages (ps: with ps; [ click ]);
+  kikit-module = python3.pkgs.toPythonModule (kikit.override { inherit python3; });
+
+  # The following different addons can be built from the same source.
+  targetSpecs = {
+    "kikit" = {
+      makeTarget = "pcm-kikit";
+      resultZip = "pcm-kikit.zip";
+      description = "KiCad plugin and a CLI tool to automate several tasks in a standard KiCad workflow";
+    };
+    "kikit-library" = {
+      makeTarget = "pcm-lib";
+      resultZip = "pcm-kikit-lib.zip";
+      description = "KiKit uses these symbols and footprints to annotate your boards (e.g., to place a tab in a panel).";
+    };
+  };
+  targetSpec = targetSpecs.${addonName};
+in
+stdenv.mkDerivation {
+  name = "kicadaddon-${addonName}";
+  inherit (kikit-module) src version;
+
+  nativeBuildInputs = [ python bc zip ];
+  propagatedBuildInputs = [ kikit-module ];
+
+  buildPhase = ''
+    patchShebangs scripts/setJson.py
+    make ${targetSpec.makeTarget}
+  '';
+
+  installPhase = ''
+    mkdir $out
+    mv build/${targetSpec.resultZip} $out/${addonPath}
+  '';
+
+  meta = kikit-module.meta // {
+    description = targetSpec.description;
+  };
+}

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -69,6 +69,8 @@ stdenv.mkDerivation rec {
   patches = [
     # upstream issue 12941 (attempted to upstream, but appreciably unacceptable)
     ./writable.patch
+    # https://gitlab.com/kicad/code/kicad/-/issues/15687
+    ./runtime_stock_data_path.patch
   ];
 
   # tagged releases don't have "unknown"

--- a/pkgs/applications/science/electronics/kicad/runtime_stock_data_path.patch
+++ b/pkgs/applications/science/electronics/kicad/runtime_stock_data_path.patch
@@ -1,0 +1,15 @@
+diff --git a/common/paths.cpp b/common/paths.cpp
+index a74cdd9..790cc58 100644
+--- a/common/paths.cpp
++++ b/common/paths.cpp
+@@ -151,6 +151,10 @@ wxString PATHS::GetStockDataPath( bool aRespectRunFromBuildDir )
+ {
+     wxString path;
+
++    if( wxGetEnv( wxT( "NIX_KICAD7_STOCK_DATA_PATH" ), &path ) ) {
++        return path;
++    }
++
+     if( aRespectRunFromBuildDir && wxGetEnv( wxT( "KICAD_RUN_FROM_BUILD_DIR" ), nullptr ) )
+     {
+         // Allow debugging from build dir by placing relevant files/folders in the build root

--- a/pkgs/by-name/ki/kikit/default.nix
+++ b/pkgs/by-name/ki/kikit/default.nix
@@ -1,0 +1,87 @@
+{ bc
+, zip
+, lib
+, fetchFromGitHub
+, bats
+, buildPythonApplication
+, pythonOlder
+, callPackage
+, kicad
+, numpy
+, click
+, markdown2
+, pytestCheckHook
+, commentjson
+, wxPython_4_2
+, pcbnew-transition
+, pybars3
+, versioneer
+}:
+let
+  solidpython = callPackage ./solidpython { };
+
+  # https://github.com/yaqwsx/KiKit/issues/574
+  # copy-pasted from nixpkgs#8d8e62e74f511160a599471549a98bc9e4f4818d
+  shapely = callPackage ./shapely { };
+in
+buildPythonApplication rec {
+  pname = "kikit";
+  version = "1.3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "yaqwsx";
+    repo = "KiKit";
+    rev = "v${version}";
+    hash = "sha256-kDTPk/R3eZtm4DjoUV4tSQzjGQ9k8MKQedX4oUXYzeo=";
+  };
+
+  propagatedBuildInputs = [
+    kicad
+    numpy
+    click
+    markdown2
+    commentjson
+    # https://github.com/yaqwsx/KiKit/issues/575
+    wxPython_4_2
+    pcbnew-transition
+    pybars3
+    shapely
+    # https://github.com/yaqwsx/KiKit/issues/576
+    solidpython
+  ];
+
+  nativeBuildInputs = [
+    versioneer
+    bc
+    zip
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    bats
+  ];
+
+  pythonImportsCheck = [
+    "kikit"
+  ];
+
+  preCheck = ''
+    export PATH=$PATH:$out/bin
+
+    make test-system
+
+    # pytest needs to run in a subdir. See https://github.com/yaqwsx/KiKit/blob/v1.3.0/Makefile#L43
+    cd test/units
+  '';
+
+  meta = with lib; {
+    description = "Automation for KiCAD boards";
+    homepage = "https://github.com/yaqwsx/KiKit/";
+    changelog = "https://github.com/yaqwsx/KiKit/releases/tag/v${version}";
+    maintainers = with maintainers; [ jfly matusf ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/by-name/ki/kikit/package.nix
+++ b/pkgs/by-name/ki/kikit/package.nix
@@ -1,0 +1,2 @@
+{ python3 }:
+(python3.pkgs.callPackage ./default.nix { })

--- a/pkgs/by-name/ki/kikit/shapely/default.nix
+++ b/pkgs/by-name/ki/kikit/shapely/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, substituteAll
+, pythonOlder
+, geos
+, pytestCheckHook
+, cython
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "Shapely";
+  version = "1.8.4";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-oZXlHKr6IYKR8suqP+9p/TNTyT7EtlsqRyLEz0DDGYw=";
+  };
+
+  nativeBuildInputs = [
+    geos # for geos-config
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # Environment variable used in shapely/_buildcfg.py
+  GEOS_LIBRARY_PATH = "${geos}/lib/libgeos_c${stdenv.hostPlatform.extensions.sharedLibrary}";
+
+  patches = [
+    # Patch to search form GOES .so/.dylib files in a Nix-aware way
+    (substituteAll {
+      src = ./library-paths.patch;
+      libgeos_c = GEOS_LIBRARY_PATH;
+      libc = lib.optionalString (!stdenv.isDarwin) "${stdenv.cc.libc}/lib/libc${stdenv.hostPlatform.extensions.sharedLibrary}.6";
+    })
+  ];
+
+  preCheck = ''
+    rm -r shapely # prevent import of local shapely
+  '';
+
+  disabledTests = lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+    # FIXME(lf-): these logging tests are broken, which is definitely our
+    # fault. I've tried figuring out the cause and failed.
+    #
+    # It is apparently some sandbox or no-sandbox related thing on macOS only
+    # though.
+    "test_error_handler_exception"
+    "test_error_handler"
+    "test_info_handler"
+  ];
+
+  pythonImportsCheck = [ "shapely" ];
+
+  meta = with lib; {
+    description = "Geometric objects, predicates, and operations";
+    homepage = "https://pypi.python.org/pypi/Shapely/";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ knedlsepp ];
+  };
+}

--- a/pkgs/by-name/ki/kikit/shapely/library-paths.patch
+++ b/pkgs/by-name/ki/kikit/shapely/library-paths.patch
@@ -1,0 +1,31 @@
+diff --git a/shapely/geos.py b/shapely/geos.py
+index 88c5f53..1ccd6e4 100644
+--- a/shapely/geos.py
++++ b/shapely/geos.py
+@@ -96,6 +96,7 @@ if sys.platform.startswith('linux'):
+         alt_paths = [
+             'libgeos_c.so.1',
+             'libgeos_c.so',
++            '@libgeos_c@',
+         ]
+         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
+
+@@ -160,6 +161,7 @@ elif sys.platform == 'darwin':
+             "/usr/local/lib/libgeos_c.dylib",
+             # homebrew Apple Silicon
+             "/opt/homebrew/lib/libgeos_c.dylib",
++            "@libgeos_c@",
+         ]
+         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
+
+diff --git a/tests/test_dlls.py b/tests/test_dlls.py
+index c71da8e..c36262c 100644
+--- a/tests/test_dlls.py
++++ b/tests/test_dlls.py
+@@ -18,4 +18,5 @@ class LoadingTestCase(unittest.TestCase):
+             '/opt/homebrew/lib/libgeos_c.dylib',  # homebrew (macOS)
+             os.path.join(sys.prefix, "lib", "libgeos_c.so"), # anaconda (Linux)
+             'libgeos_c.so.1',
+-            'libgeos_c.so'])
++            'libgeos_c.so',
++            '@libgeos_c@'])

--- a/pkgs/by-name/ki/kikit/solidpython/default.nix
+++ b/pkgs/by-name/ki/kikit/solidpython/default.nix
@@ -1,0 +1,66 @@
+# SolidPython is an unmaintained library with old dependencies.
+{ buildPythonPackage
+, callPackage
+, fetchFromGitHub
+, fetchFromGitLab
+, fetchpatch
+, lib
+, pythonRelaxDepsHook
+
+, poetry-core
+, prettytable
+, pypng
+, ply
+, setuptools
+, euclid3
+}:
+buildPythonPackage rec {
+  pname = "solidpython";
+  version = "1.1.3";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "SolidCode";
+    repo = "SolidPython";
+    rev = "d962740d600c5dfd69458c4559fc416b9beab575";
+    hash = "sha256-3fJta2a5c8hV9FPwKn5pj01aBtsCGSRCz3vvxR/5n0Q=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    ply
+    setuptools
+    euclid3
+
+    prettytable
+  ];
+
+  pythonRelaxDeps = [
+    # SolidPython has PrettyTable pinned to a hyper-specific version due to
+    # some ancient bug with Poetry. They aren't interested in unpinning because
+    # SolidPython v1 seems to be deprecated in favor of v2:
+    # https://github.com/SolidCode/SolidPython/issues/207
+    "PrettyTable"
+  ];
+
+  pythonRemoveDeps = [
+    # The pypng dependency is only used in an example script.
+    "pypng"
+  ];
+
+  pythonImportsCheck = [
+    "solid"
+  ];
+
+  meta = with lib; {
+    description = "Python interface to the OpenSCAD declarative geometry language";
+    homepage = "https://github.com/SolidCode/SolidPython";
+    changelog = "https://github.com/SolidCode/SolidPython/releases/tag/v${version}";
+    maintainers = with maintainers; [ jfly ];
+    license = licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/development/python-modules/euclid3/default.nix
+++ b/pkgs/development/python-modules/euclid3/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+}:
+buildPythonPackage rec {
+  pname = "euclid3";
+  version = "0.01";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-JbgnpXrb/Zo/qGJeQ6vD6Qf2HeYiND5+U4SC75tG/Qs=";
+  };
+
+  pythonImportsCheck = [
+    "euclid3"
+  ];
+
+  meta = with lib; {
+    description = "2D and 3D vector, matrix, quaternion and geometry module.";
+    homepage = "http://code.google.com/p/pyeuclid/";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ jfly matusf ];
+  };
+}

--- a/pkgs/development/python-modules/pcbnew-transition/default.nix
+++ b/pkgs/development/python-modules/pcbnew-transition/default.nix
@@ -1,0 +1,39 @@
+{ pythonOlder
+, buildPythonPackage
+, fetchPypi
+, lib
+, kicad
+, versioneer
+}:
+buildPythonPackage rec {
+  pname = "pcbnewTransition";
+  version = "0.3.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-3CJUG1kd63Lg0r9HpJRIvttHS5s2EuZRoxeXrqsJ/kQ=";
+  };
+
+  propagatedBuildInputs = [
+    kicad
+  ];
+
+  nativeBuildInputs = [
+    versioneer
+  ];
+
+  pythonImportsCheck = [
+    "pcbnewTransition"
+  ];
+
+  meta = with lib; {
+    description = "Library that allows you to support both, KiCad 5, 6 and 7 in your plugins";
+    homepage = "https://github.com/yaqwsx/pcbnewTransition";
+    changelog = "https://github.com/yaqwsx/pcbnewTransition/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jfly matusf ];
+  };
+}

--- a/pkgs/development/python-modules/pybars3/default.nix
+++ b/pkgs/development/python-modules/pybars3/default.nix
@@ -1,0 +1,38 @@
+{ python3
+, fetchPypi
+, lib
+, pymeta3
+, buildPythonPackage
+}:
+buildPythonPackage rec {
+  pname = "pybars3";
+  version = "0.9.7";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ashH6QXlO5xbk2rxEskQR14nv3Z/efRSjBb5rx7A4lI=";
+  };
+
+  propagatedBuildInputs = [
+    pymeta3
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python3.interpreter} tests.py
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [
+    "pybars"
+  ];
+
+  meta = with lib; {
+    description = "Handlebars.js template support for Python 3 and 2";
+    homepage = "https://github.com/wbond/pybars3";
+    changelog = "https://github.com/wbond/pybars3/releases/tag/${version}";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ jfly matusf ];
+  };
+}

--- a/pkgs/development/python-modules/pymeta3/default.nix
+++ b/pkgs/development/python-modules/pymeta3/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+}:
+buildPythonPackage rec {
+  pname = "pymeta3";
+  version = "0.5.1";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "PyMeta3";
+    hash = "sha256-GL2jJtmpu/WHv8DuC8loZJZNeLBnKIvPVdTZhoHQW8s=";
+  };
+
+  doCheck = false; # Tests do not support Python3
+
+  pythonImportsCheck = [
+    "pymeta"
+  ];
+
+  meta = with lib; {
+    description = "Pattern-matching language based on OMeta for Python 3 and 2";
+    homepage = "https://github.com/wbond/pymeta3";
+    changelog = "https://github.com/wbond/pymeta3/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jfly matusf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39768,6 +39768,8 @@ with pkgs;
     with3d = false;
   };
 
+  kicadAddons = recurseIntoAttrs (callPackage ../applications/science/electronics/kicad/addons {});
+
   librepcb = libsForQt5.callPackage ../applications/science/electronics/librepcb { };
 
   ngspice = libngspice.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9013,6 +9013,8 @@ self: super: with self; {
 
   psrpcore = callPackage ../development/python-modules/psrpcore { };
 
+  pybars3 = callPackage ../development/python-modules/pybars3 { };
+
   pypemicro = callPackage ../development/python-modules/pypemicro { };
 
   pyprecice = callPackage ../development/python-modules/pyprecice { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3657,6 +3657,8 @@ self: super: with self; {
 
   et-xmlfile = callPackage ../development/python-modules/et-xmlfile { };
 
+  euclid3 = callPackage ../development/python-modules/euclid3 { };
+
   eufylife-ble-client = callPackage ../development/python-modules/eufylife-ble-client { };
 
   evaluate = callPackage ../development/python-modules/evaluate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8845,6 +8845,8 @@ self: super: with self; {
     inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
   };
 
+  pcbnew-transition = callPackage ../development/python-modules/pcbnew-transition { };
+
   pcodedmp = callPackage ../development/python-modules/pcodedmp { };
 
   pcpp = callPackage ../development/python-modules/pcpp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9015,6 +9015,8 @@ self: super: with self; {
 
   pybars3 = callPackage ../development/python-modules/pybars3 { };
 
+  pymeta3 = callPackage ../development/python-modules/pymeta3 { };
+
   pypemicro = callPackage ../development/python-modules/pypemicro { };
 
   pyprecice = callPackage ../development/python-modules/pyprecice { };


### PR DESCRIPTION
kicad: Add support for 3rd party packages

kikit (init at 1.3.0)
kicadAddons.kikit (init at 1.3.0)
kicadAddons.kikit-library (init at 1.3.0)
python310Packages.euclid3 (init at 0.01)
python310Packages.pcbnew-transition (init at 0.3.4)
python310Packages.pybars3 (init at 0.9.7)
python310Packages.pymeta3 (init at 0.5.1)
python311Packages.euclid3 (init at 0.01)
python311Packages.pcbnew-transition (init at 0.3.4)
python311Packages.pybars3 (init at 0.9.7)
python311Packages.pymeta3 (init at 0.5.1)

Co-authored-by: Rohit <rohitsutradhar311@gmail.com>
Co-authored-by: Jeremy Fleischman <jeremyfleischman@gmail.com>
Co-authored-by: Shahar "Dawn" Or <mightyiampresence@gmail.com>
Co-authored-by: Alejandro Sanchez Medina <alejandrosanchzmedina@gmail.com>
Co-authored-by: Matúš Ferech <matus.ferech@gmail.com>


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
