### PR TITLE
python3Packages.pycyphal & python3Packages.pyuavcan: init pycyphal at 1.15.2 & deprecate pyuavcan

### DIFF
--- a/pkgs/development/python-modules/pycyphal/default.nix
+++ b/pkgs/development/python-modules/pycyphal/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, can
+, cobs
+, libpcap
+, nunavut
+, numpy
+, pyserial
+}:
+
+buildPythonPackage rec {
+  pname = "pycyphal";
+  version = "1.15.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-KVX+DwcJp1sjpcG1Utl9me1LwWDZPof+O6hoUt1xlXA=";
+  };
+
+  propagatedBuildInputs = [
+    can
+    cobs
+    libpcap
+    numpy
+    nunavut
+    pyserial
+  ];
+
+  # Can't seem to run the tests on nix
+  doCheck = false;
+  pythonImportsCheck = [
+    "pycyphal"
+  ];
+
+  meta = with lib; {
+    description = "A full-featured implementation of the Cyphal protocol stack in Python";
+    longDescription = ''
+      Cyphal is an open technology for real-time intravehicular distributed computing and communication based on modern networking standards (Ethernet, CAN FD, etc.).
+    '';
+    homepage = "https://opencyphal.org/";
+    license = licenses.mit;
+    maintainers = [ teams.ororatech ];
+  };
+}

--- a/pkgs/development/python-modules/pyuavcan/default.nix
+++ b/pkgs/development/python-modules/pyuavcan/default.nix
@@ -1,6 +1,10 @@
 { lib, buildPythonPackage, fetchFromGitHub, pythonOlder, numpy, nunavut
 , pyserial , pytest, ruamel-yaml}:
 
+# This has been renamed pycyphal, without any API changes; though this package is
+# quite outdated so transition might not be as seemless as it could be
+# See https://uavcan.org/ (which will redirect to https://opencyphal.org/)
+lib.warn "pyuavcan is deprecated and will be removed in 24.05; use pycyphal instead"
  buildPythonPackage rec {
   pname = "pyuavcan";
   version = "1.1.0.dev1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9027,6 +9027,18 @@ self: super: with self; {
 
   pycxx = callPackage ../development/python-modules/pycxx { };
 
+  pycyphal = callPackage ../development/python-modules/pycyphal {
+    # Does not yet support nunavut 2+, use latest 1.X version instead
+    # https://github.com/OpenCyphal/pycyphal/issues/277
+    nunavut = self.nunavut.overridePythonAttrs (prev: rec {
+      version = "1.9.0";
+      src = prev.src.override {
+        inherit version;
+        hash = "sha256-KhgijXJ908uxM7VZdXo1WU/RGU0cfqctBCbpF2wOcy8=";
+      };
+    });
+  };
+
   pydaikin = callPackage ../development/python-modules/pydaikin { };
 
   pydal = callPackage ../development/python-modules/pydal { };


### PR DESCRIPTION
## Description of changes

Adds the pycyphal python package, and deprecates pyuavcan (they're the same package, it's just been renamed).

~(Won't cross compile until dependencies bellow are merged)~

~Depends on #249520, #249524, #249532, & #249157~

NOTE: The "error" that ofborg shows seems to only be about the deprecation warning.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross compiled from x86_64-linux)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
