### PR TITLE
ip2unix: 2.1.4 -> 2.2.0

### DIFF
--- a/pkgs/tools/networking/ip2unix/default.nix
+++ b/pkgs/tools/networking/ip2unix/default.nix
@@ -5,18 +5,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ip2unix";
-  version = "2.1.4";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "nixcloud";
     repo = "ip2unix";
     rev = "v${version}";
-    sha256 = "1pl8ayadxb0zzh5s26yschkjhr1xffbzzv347m88f9y0jv34d24r";
+    hash = "sha256-7Q2s7wBkt5OTbQnx7Q5mGRWBOtr6yRsFBh+CUu8CmMQ";
   };
-
-  postPatch = ''
-    sed '1i#include <array>' -i src/dynports/dynports.cc # gcc12
-  '';
 
   nativeBuildInputs = [
     meson ninja pkg-config asciidoc libxslt.bin docbook_xml_dtd_45 docbook_xsl


### PR DESCRIPTION
## Description of changes

Upstream changes:

  * Unlink socket file before `bind` if `SO_REUSEADDR` is used.
  * Add support for Linux abstract sockets.
  * Add support for matching an existing Unix domain socket or abstract socket.
  * Add `stream`/`datagram` aliases for `tcp`/`udp` socket types.
  * Add flag to prevent unlinking of socket files when closing sockets.
  * Fix missing header files for newer GCC versions, thanks to Varun Madiath.
  * Fix use-after-free of blackhole working directory path.
  * Fix a few compiler warnings on unnecessary allocation of string literals.
  * Add deprecation warnings if rules are specified in YAML format.
  * Rule files (`-f`) are now just a list of newline-separated rule (`-r`) arguments instead of YAML files.
  * Improve serializer to be more robust in end-of-stream conditions.
  * Bump requirements to require at least GCC version 9.
  * No longer prefer C library path over using `RTLD_NEXT`.

The missing include added via `postPatch` is no longer needed as it has been fixed upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
