### PR TITLE
mkosi: init at 15.2-pre

### DIFF
--- a/pkgs/tools/virtualization/mkosi/default.nix
+++ b/pkgs/tools/virtualization/mkosi/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, fetchFromGitHub
+, setuptools
+, buildPythonApplication
+, pytestCheckHook
+, bubblewrap
+, systemd
+, stdenv
+}:
+let
+  # For systemd features used by mkosi, see
+  # https://github.com/systemd/mkosi/blob/19bb5e274d9a9c23891905c4bcbb8f68955a701d/action.yaml#L64-L72
+  systemdForMkosi = systemd.override {
+    # Will be added in #243242
+    # withRepart = true;
+    # withBootloader = true;
+    withEfi = true;
+    withUkify = true;
+  };
+in
+buildPythonApplication rec {
+  pname = "mkosi";
+  version = "15.2-pre"; # 15.1 is the latest release, but we require a newer commit
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "systemd";
+    repo = "mkosi";
+    # Fix from the commit is needed to run on NixOS,
+    # see https://github.com/systemd/mkosi/issues/1792
+    rev = "ca9673cbcbd9f293e5566cec4a1ba14bbcd075b8";
+    hash = "sha256-y5gG/g33HBpH1pTXfjHae25bc5p/BvlCm9QxOIYtcA8=";
+  };
+
+  # Fix ctypes finding library
+  # https://github.com/NixOS/nixpkgs/issues/7307
+  patchPhase = lib.optionalString stdenv.isLinux ''
+    substituteInPlace mkosi/run.py --replace \
+      'ctypes.util.find_library("c")' "'${stdenv.cc.libc}/lib/libc.so.6'"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+
+  propagatedBuildInputs = [
+    systemdForMkosi
+    bubblewrap
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/mkosi \
+      --prefix PYTHONPATH : "$PYTHONPATH"
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Build legacy-free OS images";
+    homepage = "https://github.com/systemd/mkosi";
+    license = licenses.lgpl21Only;
+    mainProgram = "mkosi";
+    maintainers = with maintainers; [ malt3 katexochen ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1846,6 +1846,8 @@ with pkgs;
 
   mgmt = callPackage ../applications/system/mgmt { };
 
+  mkosi = python3Packages.callPackage ../tools/virtualization/mkosi { inherit systemd; };
+
   monica = callPackage ../servers/web-apps/monica { };
 
   mprocs = callPackage ../tools/misc/mprocs { };


### PR DESCRIPTION
## Description of changes

Adding https://github.com/systemd/mkosi.
Packaged together with @malt3 

This PR builds on previous work by @onny in https://github.com/NixOS/nixpkgs/pull/194412.
Building Ubuntu OS images requires https://github.com/NixOS/nixpkgs/pull/249311
Some features of this mkosi version require systemd 254 https://github.com/NixOS/nixpkgs/pull/243242

Not sure how nixpkgs handles versions when building from master, feel free to suggest something better than the `15.2-pre` pseudo version.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
