### PR TITLE
pmbootstrap: 1.50.1->2.0.0

### DIFF
--- a/pkgs/tools/misc/pmbootstrap/default.nix
+++ b/pkgs/tools/misc/pmbootstrap/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonApplication rec {
   pname = "pmbootstrap";
-  version = "1.50.1";
+  version = "2.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-2S3I3J3wmRkVSUshyQCUTuYgHLsDMnXZQHt7KySBzIY=";
+    hash = "sha256-nN4KUP9l3g5Q+QeWr4Fju2GiOyu2f7u94hz/VJlCYdw=";
   };
 
   repo = fetchFromGitLab {
@@ -87,6 +87,12 @@ buildPythonApplication rec {
     "test_skip_already_built"
     "test_switch_to_channel_branch"
     "test_version"
+    "test_build_abuild_leftovers"
+    "test_get_all_component_names"
+    "test_check_config"
+    "test_extract_arch"
+    "test_extract_version"
+    "test_check"
   ];
 
   makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ git openssl ]}" ];


### PR DESCRIPTION
## Description of changes

```
Release 2.0.0

After bumping the minor version 53 (!) times in 1.x.y, we have some
breaking changes justifying a major version bump. For users it should
still feel the same overall. Enjoy this release, and thanks so much to
everybody who contributed to it!

"Breaking" changes:
* Remove distcc support (was already disabled by default since
  crossdirect had been added in 2019)
  * Remove --no-crossdirect argument
* flasher: remove long deprecated flash_system alias
* flasher: set default fastboot rootfs partition to userdata

Features:
* aportgen: replace deviceinfo_modules_initfs for modules file
* pmb.install: create fstab and crypttab
* Add mtkclient as a flasher option
* Install makedepends in native chroot for packages using Rust
* Support --no-cgpt
* lint: drop call to pmb.build.init
* aportgen: use pmb.build.init_abuild_minimal
* pmb.config: only show first 3 releases
* init: allow all locales
* pmb.flasher: Improve flash_lk2nd action
* pmb.helpers.frontend: Also clear testsuite log when running log -c
* Don't use 'sudo' when running as root
* config: use en_US as default locale
* pmb: Remind users to ensure pmbootstrap is updated before reporting errors

Fixes:
* pmb.helpers.run_core: fix proxy env var logic
* pmb/partition: fix cgpt root_size to not cause resize on boot
* pmb.helpers.run_core: always configure proxy vars if set in environment
* install/partition: set efi flag with cgpt
* pmb.config: Use Python 3.8-compatible type annotation
* envkernel.sh: use realpath to deal with symlink
* pmb.helpers.run_core: fix sudo timer when not using sudo
* install: run setup-timezone with "-i" when appropriate
* pmb.config: select default UI in case current is not available
* pmb.config: set default UI to console
* pmb.config: add missing flash_rk_partition* flags
* pmb.qemu.run: replace removed -soundhw option
* pmb.helpers.run: fix sudo timer
* pmb.config.sudo: Use type union compatible with Python 3.7

Other:
* aportgen: device: rename modules to modules-initfs
* test: fix test_build_depends_binary_outdated
* test: fix running test_build_package.py standalone
* deviceinfo: make parse_kernel_suffix private
* pmb.helpers.run_core: move flat_cmd here
* test/test_pkgrel_bump: make sure pmb doesn't cross compile
* test: crossdirect: update stable branch ref
* test: specify default git branch
* test: dont fail on githook symlinks
* CI: add codespell
* treewide: fix typos found with codespell
* install/partition: rearrange cgpt commands in natural order
* CI: enable eval-annotations for vermin
* Remove workaround for gcc with !tracedeps
* install: move setup_timezone to its own function
* treewide: rename _system to _rootfs in various places
* pmb.flasher: remove outdated comment
* Use ruff for linting
* aportgen/binutils: set pmOS bugurl
* aportgen/binutils: add more makedepends_host
* aportgen/binutils: order fields alphabetically
* pmb.flasher.frontend: Use elif instead of repeated if
```
```
Release 1.53.0

Features:
* Speed up 'pmbootstrap checksum'
* build: make preferred target arch configurable
* kconfig check: Add USB gadget check to community

Fixes:
* install: write new file instead of modifying locale.sh from alpine-baselayout

Other:
* pmb.build.init: refactor init marker related code
* config: sort config_keys and fix layout
```

```
Release 1.52.0

Features:
* pmb.config.init: copy pmaports githooks to default git hooks dir
* pmb: Set PMBOOTSTRAP_CMD to argv[0] in environment
* pmb.parse.kconfig: Pass background color for menuconfig
* install/partition: set esp flag for /boot when using GPT
* qemu/run: add support for EFI boot
* parse/arguments: add qemu --efi option
* install: make cached remote repositories available on first install
* install: run alpine-appstream-downloader if available
* qemu: warn that network won't work with ui=none
* config: Add BINFMT_ELF and BINFMT_SCRIPT
* pmb.config: mount go caching directories

Fixes:
* build: support new abuild.conf path
* envkernel.sh: building x86 on x86_64 does not require a cross compiler
* setup.py: adjust path to pmb.__version__
* pmb.config.pmaports: replace aports split msg
* pmb.helpers.other.validate_hostname: allow periods
* pmb.parse.kconfig.check: fix writing to list arg
* pmb.parse.arguments: don't use python 3.9 feature
* pmb.aportgen.device: fix flash method autocomplete
* kconfig check: ANDROID_BINDER_IPC_SELFTEST not set
* kconfig_options_waydroid: enable PSI
* kconfig_options_waydroid: update to android 11
* kconfig check: extract_arch: support riscv64
* kconfig check: extract_version: replace - with _
* pmb.config.apkbuild_attributes: Add _depends_dev
* pmb/parse/arch.py: add riscv64 -> riscv to kernel carch mapping
* pmb.aportgen.linux: Depend on findutils
* pmb.helpers.run: don't pass stdin to output=stdout

Other:
* Move version to pmb.__version__
* pmbootstrap.py: move all features to pmb:main()
* pmbootstrap.py: require at least python 3.7
* Bump min. required Python version to 3.7
* test/test_zzz_keys.py: move from test/test_keys.py
* kconfig_options_waydroid: order alphabetically
* pmb.build.kconfig: split extract_and_patch_sources
* parse.arguments.add_kernel_arg: add nargs param
* pmb/build/kconfig.py: rename from menuconfig.py
* test: rework kconfig check tests
* kconfig check: less errors for non-detailed mode
* kconfig check: add --no-details argument
* kconfig check: add descriptions to more functions
* kconfig check: move check_config_options_set up
* kconfig check: drop "necessary_"
* kconfig check: config_file -> config_path
* kconfig check: remove redundant component lists
* pmb.parse.kconfig: remove config_path_pretty
* pmb.parse.kconfig.check_option: refactor
* pmb.parse.arch: Include comma after last dictionary items
* partition_cgpt: use pmb.chroot.apk.install
* ci/pytest.sh: check if pmaports dir is clean
```
```
Release 1.51.0

Features:
* pmbootstrap init: don't allow 'root' as username
* check_binfmt_misc: print more helpful error
* pmb.build.other: do not copy leftover abuild dirs

Fixes:
* qemu: ssh hostfwd on 127.0.0.1 instead of 0.0.0.0
* pmb.qemu.run: fix 3d accel on amd64

Other:
* Bump copyright to 2023
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
I've flashed pmOS using a local build of 2.0.0 to one of my phones and everything seems good with pmbootstrap.
Five new tests were added since version 1.50.1 that are not happy but the binary still seems to work if you add them do the list of disabled tests.

Backport to release-23.05 would be appreciated.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
