### PR TITLE
cava: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/audio/cava/default.nix
+++ b/pkgs/applications/audio/cava/default.nix
@@ -1,9 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, alsa-lib, fftw,
-  libpulseaudio, ncurses, iniparser }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, alsa-lib
+, fftw
+, iniparser
+, libpulseaudio
+, ncurses
+, pkgconf
+}:
 
 stdenv.mkDerivation rec {
   pname = "cava";
-  version = "0.9.0";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "karlstav";
+    repo = "cava";
+    rev = version;
+    hash = "sha256-W/2B9iTcO2F2vHQzcbg/6pYBwe+rRNfADdOiw4NY9Jk=";
+  };
 
   buildInputs = [
     alsa-lib
@@ -13,14 +29,14 @@ stdenv.mkDerivation rec {
     iniparser
   ];
 
-  src = fetchFromGitHub {
-    owner = "karlstav";
-    repo = "cava";
-    rev = version;
-    sha256 = "sha256-mIgkvgVcbRdE29lSLojIzIsnwZgnQ+B2sgScDWrLyd8=";
-  };
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconf
+  ];
 
-  nativeBuildInputs = [ autoreconfHook ];
+  preAutoreconf = ''
+    echo ${version} > version
+  '';
 
   meta = with lib; {
     description = "Console-based Audio Visualizer for Alsa";


### PR DESCRIPTION
https://github.com/karlstav/cava/releases/tag/0.9.1

Resolves #249565 

## Description of changes

https://github.com/karlstav/cava/compare/0.9.0...0.9.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
