### PR TITLE
python3.pkgs.{cmake,ninja}: add __version__ to stub

### DIFF
--- a/pkgs/development/python-modules/cmake/default.nix
+++ b/pkgs/development/python-modules/cmake/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
       --subst-var version
 
     substituteInPlace "$sourceRoot/cmake/__init__.py" \
+      --subst-var version \
       --subst-var-by CMAKE_BIN_DIR "${cmake}/bin"
   '';
 

--- a/pkgs/development/python-modules/cmake/stub/cmake/__init__.py
+++ b/pkgs/development/python-modules/cmake/stub/cmake/__init__.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 
+__version__ = '@version@'
+
 CMAKE_BIN_DIR = '@CMAKE_BIN_DIR@'
 
 def _program(name, args):

--- a/pkgs/development/python-modules/ninja/default.nix
+++ b/pkgs/development/python-modules/ninja/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
       --subst-var version
 
     substituteInPlace "$sourceRoot/ninja/__init__.py" \
+      --subst-var version \
       --subst-var-by BIN_DIR "${ninja}/bin"
   '';
 

--- a/pkgs/development/python-modules/ninja/stub/ninja/__init__.py
+++ b/pkgs/development/python-modules/ninja/stub/ninja/__init__.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 
+__version__ = '@version@'
+
 BIN_DIR = '@BIN_DIR@'
 
 def _program(name, args):


### PR DESCRIPTION
## Description of changes

The `__version__` field is surprisingly used by `scikit-build-core`'s tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
