### PR TITLE
pixi: init at 0.1.0

### DIFF
--- a/pkgs/tools/package-management/pixi/default.nix
+++ b/pkgs/tools/package-management/pixi/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pixi";
+  version = "v0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "prefix-dev";
+    repo = "pixi";
+    rev = version;
+    hash = "sha256-n1TZLgc3TTUs0F/DSKl3nPLkx8jmzlpp2dFII4u8hLQ=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  cargoHash = "sha256-6uhb38Ofa2QOKn+rp3/gv4mPXrJuyWfiudwgwnJb85s=";
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Package management made easy";
+    homepage = "https://github.com/prefix-dev/pixi";
+    license = licenses.bsd3;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/tools/package-management/pixi/shell.nix
+++ b/pkgs/tools/package-management/pixi/shell.nix
@@ -1,0 +1,20 @@
+{ lib
+, stdenv
+, buildFHSEnv
+, xorg
+, libselinux
+, libGL
+, pixi
+, pixiDeps ? [ stdenv.cc xorg.libSM xorg.libICE xorg.libX11 xorg.libXau xorg.libXi xorg.libXrender libselinux libGL ]
+, extraPkgs ? [ ]
+}:
+
+buildFHSEnv {
+  name = "pixi-shell";
+
+  targetPkgs = pkgs: (builtins.concatLists [ [ pixi ] pixiDeps extraPkgs]);
+
+  runScript = "bash -l";
+
+  meta = pixi.meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8865,6 +8865,10 @@ with pkgs;
 
   pigz = callPackage ../tools/compression/pigz { };
 
+  pixi = callPackage ../tools/package-management/pixi { };
+
+  pixi-shell = callPackage ../tools/package-management/pixi/shell.nix { };
+
   pixz = callPackage ../tools/compression/pixz { };
 
   plog = callPackage ../development/libraries/plog {};


### PR DESCRIPTION
## Description of changes

Adding [pixi](https://prefix.dev/docs/pixi/overview) which is a conda comparable package manager. Similar to conda in order for this package to properly work it needs to run within a `buildFHSUserEnv`. I've followed the pattern used in conda.

Pixi is a rust build conda implementation and shows a lot of promise for making working with conda packages/environments easier. 

closes #249998

## Things done

 - init pixi at 0.1.0 `pixi`
 - created an additional derivation `pixi-shell` which is required for pixi to work properly. This follows the same pattern that conda uses in nixpkgs.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
