### PR TITLE
python3.pkgs.pygobject-stubs: init at 2.8.0

### DIFF
--- a/pkgs/development/python-modules/pygobject-stubs/default.nix
+++ b/pkgs/development/python-modules/pygobject-stubs/default.nix
@@ -26,6 +26,8 @@ buildPythonPackage rec {
     setuptools
   ];
 
+  # This package does not include any tests.
+  doCheck = false;
 
   meta = with lib; {
     description = "PEP 561 Typing Stubs for PyGObject";

--- a/pkgs/development/python-modules/pygobject-stubs/default.nix
+++ b/pkgs/development/python-modules/pygobject-stubs/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, black
+, codespell
+, isort
+, mypy
+, pre-commit
+, pygobject3
+}:
+
+buildPythonPackage rec {
+  pname = "pygobject-stubs";
+  version = "2.8.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "pygobject";
+    repo = "pygobject-stubs";
+    rev = "v${version}";
+    hash = "sha256-8TB8eqXPhvoKtyQ8+hnCQnH4NwO2WC1NYAxmVj+FCvg=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  passthru.optional-dependencies = {
+    dev = [
+      black
+      codespell
+      isort
+      mypy
+      pre-commit
+      pygobject3
+    ];
+  };
+
+  meta = with lib; {
+    description = "PEP 561 Typing Stubs for PyGObject";
+    homepage = "https://github.com/pygobject/pygobject-stubs";
+    changelog = "https://github.com/pygobject/pygobject-stubs/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ hacker1024 ];
+  };
+}

--- a/pkgs/development/python-modules/pygobject-stubs/default.nix
+++ b/pkgs/development/python-modules/pygobject-stubs/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     description = "PEP 561 Typing Stubs for PyGObject";
     homepage = "https://github.com/pygobject/pygobject-stubs";
     changelog = "https://github.com/pygobject/pygobject-stubs/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.lgpl21Only;
+    license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ hacker1024 ];
   };
 }

--- a/pkgs/development/python-modules/pygobject-stubs/default.nix
+++ b/pkgs/development/python-modules/pygobject-stubs/default.nix
@@ -26,16 +26,6 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
-    dev = [
-      black
-      codespell
-      isort
-      mypy
-      pre-commit
-      pygobject3
-    ];
-  };
 
   meta = with lib; {
     description = "PEP 561 Typing Stubs for PyGObject";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9046,6 +9046,8 @@ self: super: with self; {
     inherit (pkgs.buildPackages) meson;
   };
 
+  pygobject-stubs = callPackage ../development/python-modules/pygobject-stubs { };
+
   pygogo = callPackage ../development/python-modules/pygogo { };
 
   pygpgme = callPackage ../development/python-modules/pygpgme { };


### PR DESCRIPTION
## Description of changes

[Typing Stubs for PyGObject](https://github.com/pygobject/pygobject-stubs)

This package is useful for development and type checking tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
