### PR TITLE
discord-screenaudio: init at 1.9.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord-screenaudio/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord-screenaudio/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, wrapQtAppsHook
+, cmake
+, pkg-config
+, qtbase
+, qtwebengine
+, qtwayland
+, pipewire
+, nix-update-script
+}:
+
+stdenv.mkDerivation rec {
+  pname = "discord-screenaudio";
+  version = "1.9.2";
+
+  src = fetchFromGitHub {
+    owner = "maltejur";
+    repo = "discord-screenaudio";
+    rev = "v${version}";
+    hash = "sha256-it7JSmiDz3k1j+qEZrrNhyAuoixiQuiEbXac7lbJmko=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    qtbase
+    qtwebengine
+    qtwayland
+    pipewire
+  ];
+
+  preConfigure = ''
+    # version.cmake either uses git tags or a version.txt file to get app version.
+    # Since cmake can't access git tags, write the version to a version.txt ourselves.
+    echo "${version}" > version.txt
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A custom discord client that supports streaming with audio on Linux";
+    homepage = "https://github.com/maltejur/discord-screenaudio";
+    downloadPage = "https://github.com/maltejur/discord-screenaudio/releases";
+    changelog = "https://github.com/maltejur/discord-screenaudio/releases/tag/v${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ huantian ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41406,6 +41406,8 @@ with pkgs;
   };
 
 
+  discord-screenaudio = qt6.callPackage ../applications/networking/instant-messengers/discord-screenaudio { };
+
   discordo = callPackage ../applications/networking/discordo/default.nix { };
 
   golden-cheetah = libsForQt5.callPackage ../applications/misc/golden-cheetah { };


### PR DESCRIPTION
## Description of changes
https://github.com/maltejur/discord-screenaudio
> A custom discord client that supports streaming with audio on Linux. 

Follow up for #199379, closes #186957. Now properly works since #247726 closed #197728.

Not sure if I'm doing something wrong that means I have to pass those `cmakeFlags` to the pipewire library, or is that a bug in the rohrkabel library's pipewire detection? Also, is there a better way to not have rohrkabel install headers into `$out/include`?

@michaelBelsanti, in case you're still interested.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
