### PR TITLE
ldid-procursus: install zsh completion

### DIFF
--- a/pkgs/development/tools/ldid-procursus/default.nix
+++ b/pkgs/development/tools/ldid-procursus/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, installShellFiles
 , pkg-config
 , libplist
 , openssl
@@ -9,17 +10,31 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "ldid-procursus";
   version = "2.1.5-procursus7";
+
   src = fetchFromGitHub {
     owner = "ProcursusTeam";
     repo = "ldid";
     rev = "v${finalAttrs.version}";
     hash = "sha256-QnSmWY9zCOPYAn2VHc5H+VQXjTCyr0EuosxvKGGpDtQ=";
   };
-  nativeBuildInputs = [ pkg-config libplist openssl ];
+
+  nativeBuildInputs = [ pkg-config installShellFiles ];
+  buildInputs = [ libplist openssl ];
+
   stripDebugFlags = [ "--strip-unneeded" ];
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "pkg-config" "$PKG_CONFIG"
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd ldid --zsh _ldid
+  '';
+
   meta = with lib; {
+    mainProgram = "ldid";
     description = "Put real or fake signatures in a Mach-O binary";
     homepage = "https://github.com/ProcursusTeam/ldid";
     maintainers = with maintainers; [ keto ];


### PR DESCRIPTION
## Description of changes

Install zsh completions when installing `ldid-procursus`.  Originally, I believed the project's Makefile handled available completions; rather than opening an issue on upstream, I decided it was best for it to be handled here.

On top of that, I decided to add `meta.mainProgram`, since `ldid-procursus` provides two binaries.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
