### PR TITLE
doc/builders/trivial-builders: improvements

### DIFF
--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -1,14 +1,29 @@
-# Trivial builders {#chap-trivial-builders}
+# Trivial Builders {#chap-trivial-builders}
 
-Nixpkgs provides a couple of functions that help with building derivations. The most important one, `stdenv.mkDerivation`, has already been documented above. The following functions wrap `stdenv.mkDerivation`, making it easier to use in certain cases.
+Nixpkgs provides a variety of functions that help with building derivations.
+The most important of these, `stdenv.mkDerivation`, has already been documented above.
+The following functions wrap `stdenv.mkDerivation`, making it easier to use in certain cases.
 
 ## `runCommand` {#trivial-builder-runCommand}
 
-This takes three arguments, `name`, `env`, and `buildCommand`. `name` is just the name that Nix will append to the store path in the same way that `stdenv.mkDerivation` uses its `name` attribute. `env` is an attribute set specifying environment variables that will be set for this derivation. These attributes are then passed to the wrapped `stdenv.mkDerivation`. `buildCommand` specifies the commands that will be run to create this derivation. Note that you will need to create `$out` for Nix to register the command as successful.
+This takes three arguments, `name`, `env`, and `buildCommand`:
 
-An example of using `runCommand` is provided below.
+* `name` is just the name that Nix will append to the store path in the same way that `stdenv.mkDerivation` uses its
+  `name` attribute.
+* `env` is an attribute set, specifying environment variables that will be available in the build script for this derivation.
+  These attributes are passed through in the underlying call to `stdenv.mkDerivation`.
+* `buildCommand` is a `bash` script that will be run to build this derivation.
+  Note that you will need to create `$out` as part of the build script for Nix to consider the command as having executed successfully.
+  It is sufficient to `touch $out` or `mkdir $out`.
+
+Some examples of using `runCommand` are provided below.
 
 ```nix
+(import <nixpkgs> {}).runCommand "hello-world" {} ''
+  echo 'hello world'
+  touch $out
+''
+
 (import <nixpkgs> {}).runCommand "my-example" {} ''
   echo My example command is running
 
@@ -31,34 +46,53 @@ An example of using `runCommand` is provided below.
 
 ## `runCommandCC` {#trivial-builder-runCommandCC}
 
-This works just like `runCommand`. The only difference is that it also provides a C compiler in `buildCommand`'s environment. To minimize your dependencies, you should only use this if you are sure you will need a C compiler as part of running your command.
+This works just like `runCommand`. The only difference is that it also provides a C compiler in `buildCommand`'s environment.
+To minimize your dependencies, you should only use this if you are sure you will need a C compiler to run your command.
 
 ## `runCommandLocal` {#trivial-builder-runCommandLocal}
 
-Variant of `runCommand` that forces the derivation to be built locally, it is not substituted. This is intended for very cheap commands (<1s execution time). It saves on the network round-trip and can speed up a build.
+A variant of `runCommand` that ensures the derivation is built locally instead of substituting a remote build.
+It can save time and speed up a larger collection of builds by avoiding the network round-trip to check if a remote substitution is available.
+However, it is only intended for very cheap commands (<1s execution time).
 
 ::: {.note}
-This sets [`allowSubstitutes` to `false`](https://nixos.org/nix/manual/#adv-attr-allowSubstitutes), so only use `runCommandLocal` if you are certain the user will always have a builder for the `system` of the derivation. This should be true for most trivial use cases (e.g., just copying some files to a different location or adding symlinks) because there the `system` is usually the same as `builtins.currentSystem`.
+This sets `allowSubstitutes` to `false`.
+Only use `runCommandLocal` if you are certain the user will always have a builder for the `system` of the derivation.
+This should be true for most trivial use cases (e.g., just copying some files to a different location or adding symlinks)
+because there the `system` is usually the same as `builtins.currentSystem`.
 :::
 
-## `writeTextFile`, `writeText`, `writeTextDir`, `writeScript`, `writeScriptBin` {#trivial-builder-writeText}
+## `writeTextFile` {#trivial-builder-writeTextFile}
 
-These functions write `text` to the Nix store. This is useful for creating scripts from Nix expressions. `writeTextFile` takes an attribute set and expects two arguments, `name` and `text`. `name` corresponds to the name used in the Nix store path. `text` will be the contents of the file. You can also set `executable` to true to make this file have the executable bit set.
+There are a range of functions that let you write text files into the Nix store, starting with `writeTextFile`.
 
-Many more commands wrap `writeTextFile` including `writeText`, `writeTextDir`, `writeScript`, and `writeScriptBin`. These are convenience functions over `writeTextFile`.
+It accepts one argument as an attribute set containing the following names:
 
-Here are a few examples:
+* `name` is the name that Nix will append to the store path in the same way that `stdenv.mkDerivation` uses its `name` attribute.
+* `text` is the contents of the file to be written.
+* `executable` is an optional boolean flag indicating if the output file should be executable. It is `false` by default.
+* `destination` is an optional relative path to be appended to the store path when adding the file to the Nix store.
+* `checkPhase` is an optional script that can be run to verify the output file. It is empty by default and is typically used to perform syntax checks.
+* `allowSubstitutes` is an optional boolean flag indicating if the derivation can be substituted for a remote build.
+  It is `false` by default.
+* `preferLocalBuild` is an optional boolean flag indicating a preference for the derivation to be built locally instead of with a remote builder.
+  It is `true` by default.
+* `meta` is an attribute set which is passed through and corresponds to the `meta` argument for `stdenv.mkDerivation`.
+
+Here are some examples:
+
 ```nix
 # Writes my-file to /nix/store/<store path>
+
 writeTextFile {
   name = "my-file";
   text = ''
     Contents of File
   '';
 }
-# See also the `writeText` helper function below.
 
 # Writes executable my-file to /nix/store/<store path>/bin/my-file
+
 writeTextFile {
   name = "my-file";
   text = ''
@@ -67,99 +101,178 @@ writeTextFile {
   executable = true;
   destination = "/bin/my-file";
 }
+```
+
+Building on `writeTextFile`there are a series of simplifications which tailor it to a particular use case and are listed below.
+
+### `writeText` {#trivial-builder-writeText}
+
+```nix
 # Writes contents of file to /nix/store/<store path>
+
 writeText "my-file"
   ''
   Contents of File
   '';
+```
+
+### `writeTextDir` {#trivial-builder-writeTextDir}
+
+```nix
 # Writes contents of file to /nix/store/<store path>/share/my-file
+
 writeTextDir "share/my-file"
   ''
   Contents of File
   '';
+```
+
+### `writeScript` {#trivial-builder-writeScript}
+
+```nix
 # Writes my-file to /nix/store/<store path> and makes executable
+
 writeScript "my-file"
   ''
   Contents of File
   '';
+```
+
+### `writeScriptBin` {#trivial-builder-writeScriptBin}
+
+```nix
 # Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
+
 writeScriptBin "my-file"
   ''
   Contents of File
   '';
-# Writes my-file to /nix/store/<store path> and makes executable.
-writeShellScript "my-file"
-  ''
-  Contents of File
-  '';
+```
+
+### `writeShellScriptBin` {#trivial-builder-writeShellScriptBin}
+
+```nix
 # Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
+
 writeShellScriptBin "my-file"
   ''
   Contents of File
   '';
-
 ```
 
-## `concatTextFile`, `concatText`, `concatScript` {#trivial-builder-concatText}
+## `concatTextFile` {#trivial-builder-concatTextFile}
 
-These functions concatenate `files` to the Nix store in a single file. This is useful for configuration files structured in lines of text. `concatTextFile` takes an attribute set and expects two arguments, `name` and `files`. `name` corresponds to the name used in the Nix store path. `files` will be the files to be concatenated. You can also set `executable` to true to make this file have the executable bit set.
-`concatText` and`concatScript` are simple wrappers over `concatTextFile`.
+There are a range of functions that let you concatenate a series of files into a single file within the Nix store, starting with `concatTextFile`.
 
-Here are a few examples:
+It accepts one argument as an attribute set containing the following names:
+
+* `name` is the name that Nix will append to the store path in the same way that `stdenv.mkDerivation` uses its `name` attribute.
+* `files` is a list of file paths to be concatenated.
+* `executable` is an optional boolean flag indicating if the output file should be executable.
+  It is `false` by default.
+* `destination` is an optional relative path to be appended to the store path when adding the file to the Nix store.
+* `checkPhase` is an optional script that can be run to verify the output file.
+  It is empty by default and is typically used to perform syntax checks.
+* `meta` is an attribute set which is passed through and corresponds to the `meta` argument for `stdenv.mkDerivation`.
+
+Here are some examples:
+
 ```nix
-
 # Writes my-file to /nix/store/<store path>
+
 concatTextFile {
   name = "my-file";
   files = [ drv1 "${drv2}/path/to/file" ];
 }
-# See also the `concatText` helper function below.
 
 # Writes executable my-file to /nix/store/<store path>/bin/my-file
+
 concatTextFile {
   name = "my-file";
   files = [ drv1 "${drv2}/path/to/file" ];
   executable = true;
   destination = "/bin/my-file";
 }
-# Writes contents of files to /nix/store/<store path>
-concatText "my-file" [ file1 file2 ]
+```
 
+Building on `concatTextFile` there are a series of simplifications which tailor it to a particular use case and are listed below.
+
+### `concatText` {#trivial-builder-concatText}
+
+```nix
 # Writes contents of files to /nix/store/<store path>
+
+concatText "my-file" [ file1 file2 ]
+```
+
+### `concatScript` {#trivial-builder-concatScript}
+
+```nix
+# Writes contents of files to /nix/store/<store path> and makes it executable
+
 concatScript "my-file" [ file1 file2 ]
 ```
 
 ## `writeShellApplication` {#trivial-builder-writeShellApplication}
 
-This can be used to easily produce a shell script that has some dependencies (`runtimeInputs`). It automatically sets the `PATH` of the script to contain all of the listed inputs, sets some sanity shellopts (`errexit`, `nounset`, `pipefail`), and checks the resulting script with [`shellcheck`](https://github.com/koalaman/shellcheck).
+This function accepts one argument as an attribute set containing the following names:
 
-For example, look at the following code:
+* `name` is the name that Nix will append to the store path in the same way that `stdenv.mkDerivation` uses its `name` attribute.
+* `text` is the contents of the script.
+* `runtimeInputs` is a list of derivations.
+  For each runtime input `/nix/store/<store path>/bin` will be added to the `PATH` of the script before executing the contents of `text`.
+* `checkPhase` is an optional script that can be run to verify the output file.
+  It is empty by default and is typically used to perform syntax checks.
+
+In addition to setting the `PATH` based on `runtimeInputs`, `writeShellApplication` also sets some sane shellopts (`errexit`, `nounset`, `pipefail`)
+and checks the resulting script with `shellcheck`.
+
+For example:
 
 ```nix
 writeShellApplication {
   name = "show-nixos-org";
-
   runtimeInputs = [ curl w3m ];
-
   text = ''
+
+    # instead of ${curl}/bin/curl we can call it directly as it available in the PATH
+    # we can do the same with w3m
+
     curl -s 'https://nixos.org' | w3m -dump -T text/html
   '';
 }
 ```
 
-Unlike with normal `writeShellScriptBin`, there is no need to manually write out `${curl}/bin/curl`, setting the PATH
-was handled by `writeShellApplication`. Moreover, the script is being checked with `shellcheck` for more strict
-validation.
-
 ## `symlinkJoin` {#trivial-builder-symlinkJoin}
 
-This can be used to put many derivations into the same directory structure. It works by creating a new derivation and adding symlinks to each of the paths listed. It expects two arguments, `name`, and `paths`. `name` is the name used in the Nix store path for the created derivation. `paths` is a list of paths that will be symlinked. These paths can be to Nix store derivations or any other subdirectory contained within.
+This function can be used to merge the directory structure of several derivations into one.
+It works by creating a new derivation and adding symbolic links to each of the paths provided.
+
+It accepts one argument as an attribute set containing the following names:
+
+* `name` is the name that Nix will append to the store path in the same way that `stdenv.mkDerivation` uses its `name` attribute.
+* `paths` is a list of paths to merge.
+  They can be paths to Nix store derivations or any other subdirectory contained within.
+* `preferLocalBuild` is an optional boolean flag indicating a preference for the derivation to be built locally instead of with a remote builder.
+  It is `true` by default.
+* `allowSubstitutes` is an optional boolean flag indicating if the derivation can be substituted for a remote build.
+  It is `false` by default.
+* `postBuild` is an optional script which can be run at the end of building the combined derivation.
+
 Here is an example:
+
 ```nix
 # adds symlinks of hello and stack to current build and prints "links added"
-symlinkJoin { name = "myexample"; paths = [ pkgs.hello pkgs.stack ]; postBuild = "echo links added"; }
+
+symlinkJoin {
+  name = "myexample";
+  paths = [ pkgs.hello pkgs.stack ];
+  postBuild = "echo links added";
+}
 ```
-This creates a derivation with a directory structure like the following:
+
+This creates a derivation with a directory structure as follows:
+
 ```
 /nix/store/sglsr5g079a5235hy29da3mq3hv8sjmm-myexample
 |-- bin
@@ -177,17 +290,16 @@ This creates a derivation with a directory structure like the following:
 
 ## `writeReferencesToFile` {#trivial-builder-writeReferencesToFile}
 
-Writes the closure of transitive dependencies to a file.
-
+Writes the closure of transitive dependencies for a given derivation to a file.
 This produces the equivalent of `nix-store -q --requisites`.
 
-For example,
+For example:
 
 ```nix
 writeReferencesToFile (writeScriptBin "hi" ''${hello}/bin/hello'')
 ```
 
-produces an output path `/nix/store/<hash>-runtime-deps` containing
+This produces an output path `/nix/store/<hash>-runtime-deps` containing
 
 ```nix
 /nix/store/<hash>-hello-2.10
@@ -197,27 +309,24 @@ produces an output path `/nix/store/<hash>-runtime-deps` containing
 /nix/store/<hash>-glibc-2.32-40
 ```
 
-You can see that this includes `hi`, the original input path,
-`hello`, which is a direct reference, but also
-the other paths that are indirectly required to run `hello`.
+You can see that this includes the derivation `hi` (from the call to `writeScriptBin`),  `hello` which is a direct reference,
+and the other paths that are indirectly required to run `hello`.
 
 ## `writeDirectReferencesToFile` {#trivial-builder-writeDirectReferencesToFile}
 
-Writes the set of references to the output file, that is, their immediate dependencies.
+Writes the set of immediate references for a given derivation to a file.
+This does not include any transitive dependencies and produces the equivalent of `nix-store -q --references`.
 
-This produces the equivalent of `nix-store -q --references`.
-
-For example,
+For example:
 
 ```nix
 writeDirectReferencesToFile (writeScriptBin "hi" ''${hello}/bin/hello'')
 ```
 
-produces an output path `/nix/store/<hash>-runtime-references` containing
+This produces an output path `/nix/store/<hash>-runtime-references` containing
 
 ```nix
 /nix/store/<hash>-hello-2.10
 ```
 
-but none of `hello`'s dependencies because those are not referenced directly
-by `hi`'s output.
+It does not include any of `hello`'s dependencies because those are not referenced directly by `hi`'s output.


### PR DESCRIPTION
## Description of changes

- fully document the parameters for the base builders
- push simplfications of `writeTextFile` and `concatTextFile` into subsections to allow for direct links and make it visually clearer/easier to follow
- general grammar and aesthetic changes to the text.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
