### PR TITLE
nvd: use `finalAttrs` pattern, add `meta.mainProgram`, reformat

### DIFF
--- a/pkgs/tools/package-management/nvd/default.nix
+++ b/pkgs/tools/package-management/nvd/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Nix/NixOS package version diff tool";
     homepage = "https://gitlab.com/khumba/nvd";
     license = licenses.asl20;
+    mainProgram = "nvd";
     maintainers = with maintainers; [ khumba ];
     platforms = platforms.all;
   };

--- a/pkgs/tools/package-management/nvd/default.nix
+++ b/pkgs/tools/package-management/nvd/default.nix
@@ -1,4 +1,9 @@
-{ fetchFromGitLab, installShellFiles, lib, python3, stdenv }:
+{ fetchFromGitLab
+, installShellFiles
+, lib
+, python3
+, stdenv
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nvd";
@@ -6,14 +11,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitLab {
     owner = "khumba";
-    repo = finalAttrs.pname;
+    repo = "nvd";
     rev = "refs/tags/v${finalAttrs.version}";
-    sha256 = "sha256:005nh24j01s0hd5j0g0qp67wpivpjwryxyyh6y44jijb4arrfrjf";
+    hash = "sha256-TmaXsyJLRkmIN9D77jOXd8fLj7kYPCBLg0AHIImAtgA=";
   };
 
-  buildInputs = [ python3 ];
+  buildInputs = [
+    python3
+  ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -22,12 +31,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Nix/NixOS package version diff tool";
     homepage = "https://gitlab.com/khumba/nvd";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     mainProgram = "nvd";
-    maintainers = with maintainers; [ khumba ];
-    platforms = platforms.all;
+    maintainers = with lib.maintainers; [ khumba ];
+    platforms = lib.platforms.all;
   };
 })

--- a/pkgs/tools/package-management/nvd/default.nix
+++ b/pkgs/tools/package-management/nvd/default.nix
@@ -1,13 +1,13 @@
 { fetchFromGitLab, installShellFiles, lib, python3, stdenv }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nvd";
   version = "0.2.3";
 
   src = fetchFromGitLab {
     owner = "khumba";
-    repo = pname;
-    rev = "refs/tags/v${version}";
+    repo = finalAttrs.pname;
+    rev = "refs/tags/v${finalAttrs.version}";
     sha256 = "sha256:005nh24j01s0hd5j0g0qp67wpivpjwryxyyh6y44jijb4arrfrjf";
   };
 
@@ -29,4 +29,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ khumba ];
     platforms = platforms.all;
   };
-}
+})


### PR DESCRIPTION
This morning, while updating my home-manager profile on the corporate laptop, I got this message:

```
❯ home-manager switch --flake git+https://code.europa.eu/ecphp/devs-profile#default --impure
trace: warning: optionsDocBook is deprecated since 23.11 and will be removed in 24.05
trace: warning: optionsDocBook is deprecated since 23.11 and will be removed in 24.05
trace: warning: optionsDocBook is deprecated since 23.11 and will be removed in 24.05
trace: warning: getExe: Package "nvd-0.2.3" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
Starting Home Manager activation
Activating checkFilesChanged
Activating checkLinkTargets
Activating writeBoundary
Activating installPackages
```

So, I fixed it within this PR and also:

- Replaced `rec` with the `finalAttrs` pattern
- Updated the format of the file

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
