### PR TITLE
nixos/restic: wait for network-online for timed backups

### DIFF
--- a/nixos/modules/services/backup/restic.nix
+++ b/nixos/modules/services/backup/restic.nix
@@ -333,6 +333,8 @@ in
               backup.rcloneConfig);
             path = [ pkgs.openssh ];
             restartIfChanged = false;
+            wants = [ "network-online.target" ];
+            after = [ "network-online.target" ];
             serviceConfig = {
               Type = "oneshot";
               ExecStart = (optionals (backupPaths != "") [ "${resticCmd} backup ${concatStringsSep " " (backup.extraBackupArgs ++ excludeFlags)} ${backupPaths}" ])


### PR DESCRIPTION
## Description of changes

The backup service can fail if the network is unavailable, possibly due to a race between dns resolution services and restic.
This is particularly likely when resuming from sleep and running missed timers before the network is up.

```
❯ journalctl -u restic-backups-fw.service
Aug 14 05:04:08 fw systemd[1]: Starting restic-backups-fw.service...
Aug 14 05:04:08 fw restic[223958]: open repository
Aug 14 05:04:23 fw restic[223958]: subprocess ssh: ssh: Could not resolve hostname <target>: Temporary failure in name resolution
Aug 14 05:04:23 fw restic[223958]: Fatal: unable to open repository at sftp:storage:restic-fw: unable to start the sftp session, error: EOF
Aug 14 05:04:23 fw systemd[1]: restic-backups-fw.service: Main process exited, code=exited, status=1/FAILURE
Aug 14 05:04:23 fw systemd[1]: restic-backups-fw.service: Failed with result 'exit-code'.
Aug 14 05:04:23 fw systemd[1]: Failed to start restic-backups-fw.service.
Aug 14 05:04:23 fw systemd[1]: restic-backups-fw.service: Consumed 24ms CPU time, received 184B IP traffic, sent 516B IP traffic.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
