### PR TITLE
timg: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/tools/graphics/timg/default.nix
+++ b/pkgs/tools/graphics/timg/default.nix
@@ -1,26 +1,28 @@
-{ lib
-, stdenv
+{ cmake
 , fetchFromGitHub
-, cmake
-, pkg-config
 , ffmpeg
 , graphicsmagick
+, lib
 , libdeflate
 , libexif
 , libjpeg
 , libsixel
 , openslide
+, pkg-config
+, stb
+, qoi
+, stdenv
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "timg";
-  version = "1.5.1";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "hzeller";
     repo = "timg";
-    rev = "v${version}";
-    hash = "sha256-hGQL6MAsaSVV/w5fDKAcd4KIBuh2pvl3D2QUzi/aeG0=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-e2Uy1jvS0+gdhto4Sgz6YlqEqXJ7KGUAA6iuixfvvJg=";
   };
 
   buildInputs = [
@@ -31,6 +33,8 @@ stdenv.mkDerivation rec {
     libjpeg
     libsixel
     openslide
+    qoi.dev
+    stb
   ];
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -43,11 +47,12 @@ stdenv.mkDerivation rec {
     "-DWITH_LIBSIXEL=On"
   ];
 
-  meta = with lib; {
-    homepage = "https://timg.sh/";
+  meta = {
     description = "A terminal image and video viewer";
-    license = licenses.gpl2Only;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ hzeller ];
+    homepage = "https://timg.sh/";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "timg";
+    maintainers = with lib.maintainers; [ hzeller ];
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Release notes:
https://github.com/hzeller/timg/releases/tag/v1.5.2

## Description of changes

Important: fixes a buffer overflow issue.

Also: slightly clean-up default.nix:
  * sort  dependencies
  * sort metadata attributes
  * use finalAttrs.
  * 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
