### PR TITLE
playwright-browsers: move to their own file

### DIFF
--- a/pkgs/development/python-modules/pytest-playwright/default.nix
+++ b/pkgs/development/python-modules/pytest-playwright/default.nix
@@ -2,14 +2,12 @@
 , fetchFromGitHub
 , buildPythonPackage
 , playwright
-, playwright-driver
+, playwright-browsers
 , pytest
 , pytest-base-url
-, pytestCheckHook
 , python-slugify
 , pythonOlder
 , setuptools-scm
-, django
 }:
 
 buildPythonPackage rec {
@@ -47,7 +45,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   preCheck = ''
-    export PLAYWRIGHT_BROWSERS_PATH=${playwright-driver.browsers}
+    export PLAYWRIGHT_BROWSERS_PATH=${playwright-browsers}
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pytest-playwright/default.nix
+++ b/pkgs/development/python-modules/pytest-playwright/default.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , buildPythonPackage
 , playwright
-, playwright-browsers
+, playwright-driver
 , pytest
 , pytest-base-url
 , python-slugify
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   preCheck = ''
-    export PLAYWRIGHT_BROWSERS_PATH=${playwright-browsers}
+    export PLAYWRIGHT_BROWSERS_PATH=${playwright-driver.browsers}
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/web/playwright-test/wrapped.nix
+++ b/pkgs/development/web/playwright-test/wrapped.nix
@@ -4,16 +4,21 @@
 , fetchurl
 , python3
 , playwright-driver
+, playwright-browsers
 , makeWrapper
 }:
 let
   driver = playwright-driver;
-  browsers = playwright-driver.browsers;
-
 
   # nodeDependencies / package / shell
   playwright-test-raw = (callPackage ./default.nix { })."@playwright/test-${driver.version}";
 
+  /*
+  playwright-test usually installs patched browsers from their servers in a versioned folder
+  such as ~/.cache/ms-playwright/chromium-{browser_revision}
+  playwright-browsers contain the (potentially patched) browsers as expected by playwright, we tell
+  them plawyright-test how to find them via PLAYWRIGHT_BROWSERS_PATH
+  */
   playwright-test = playwright-test-raw.overrideAttrs (oa: {
     nativeBuildInputs = oa.nativeBuildInputs or [ ] ++ [
       makeWrapper
@@ -21,7 +26,7 @@ let
     postInstall = ''
       # you need to set both the path and version else playwright looks into the wrong one
       wrapProgram $out/bin/playwright \
-          --set-default PLAYWRIGHT_BROWSERS_PATH "${browsers}" \
+          --set-default PLAYWRIGHT_BROWSERS_PATH "${playwright-browsers}" \
           --prefix NODE_PATH : ${placeholder "out"}/lib/node_modules
     '';
   });

--- a/pkgs/development/web/playwright-test/wrapped.nix
+++ b/pkgs/development/web/playwright-test/wrapped.nix
@@ -4,11 +4,12 @@
 , fetchurl
 , python3
 , playwright-driver
-, playwright-browsers
 , makeWrapper
 }:
 let
   driver = playwright-driver;
+  browsers = playwright-driver.browsers;
+
 
   # nodeDependencies / package / shell
   playwright-test-raw = (callPackage ./default.nix { })."@playwright/test-${driver.version}";
@@ -26,7 +27,7 @@ let
     postInstall = ''
       # you need to set both the path and version else playwright looks into the wrong one
       wrapProgram $out/bin/playwright \
-          --set-default PLAYWRIGHT_BROWSERS_PATH "${playwright-browsers}" \
+          --set-default PLAYWRIGHT_BROWSERS_PATH "${browsers}" \
           --prefix NODE_PATH : ${placeholder "out"}/lib/node_modules
     '';
   });

--- a/pkgs/development/web/playwright/browsers.nix
+++ b/pkgs/development/web/playwright/browsers.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, chromium
+, ffmpeg
+, git
+, jq
+, nodejs
+, fetchFromGitHub
+, fetchurl
+, makeFontsConf
+, makeWrapper
+, runCommand
+, unzip
+, playwright-driver
+}:
+let
+
+  # playwright.browsers
+
+  browsers-linux = { withChromium ? true }: let
+    fontconfig = makeFontsConf {
+      fontDirectories = [];
+    };
+  in
+    runCommand ("playwright-browsers"
+    + lib.optionalString withChromium "-chromium")
+  {
+    nativeBuildInputs = [
+      makeWrapper
+      jq
+    ];
+  } (''
+    BROWSERS_JSON=${playwright-driver}/package/browsers.json
+  '' + lib.optionalString withChromium ''
+    CHROMIUM_REVISION=$(jq -r '.browsers[] | select(.name == "chromium").revision' $BROWSERS_JSON)
+    mkdir -p $out/chromium-$CHROMIUM_REVISION/chrome-linux
+
+    # See here for the Chrome options:
+    # https://github.com/NixOS/nixpkgs/issues/136207#issuecomment-908637738
+    makeWrapper ${chromium}/bin/chromium $out/chromium-$CHROMIUM_REVISION/chrome-linux/chrome \
+      --set SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
+      --set FONTCONFIG_FILE ${fontconfig}
+  '' + ''
+    FFMPEG_REVISION=$(jq -r '.browsers[] | select(.name == "ffmpeg").revision' $BROWSERS_JSON)
+    mkdir -p $out/ffmpeg-$FFMPEG_REVISION
+    ln -s ${ffmpeg}/bin/ffmpeg $out/ffmpeg-$FFMPEG_REVISION/ffmpeg-linux
+  '');
+
+  browsers-mac = stdenv.mkDerivation {
+    pname = "playwright-browsers";
+    inherit (playwright-driver) version;
+
+    dontUnpack = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      export PLAYWRIGHT_BROWSERS_PATH=$out
+      ${playwright-driver}/bin/playwright install
+      rm -r $out/.links
+
+      runHook postInstall
+    '';
+
+    meta.platforms = lib.platforms.darwin;
+  };
+
+in
+{
+  inherit browsers-linux;
+  inherit browsers-mac;
+}

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -11,6 +11,7 @@
 , makeWrapper
 , runCommand
 , unzip
+, callPackage
 }:
 let
   inherit (stdenv.hostPlatform) system;
@@ -68,15 +69,17 @@ let
       runHook postInstall
     '';
 
-    passthru = {
+    passthru = let
+      browsers = callPackage ./browsers.nix { };
+    in {
       inherit filename;
-      # browsers = {
-      #   x86_64-linux = browsers-linux { };
-      #   aarch64-linux = browsers-linux { };
-      #   x86_64-darwin = browsers-mac;
-      #   aarch64-darwin = browsers-mac;
-      # }.${system} or throwSystem;
-      # browsers-chromium = browsers-linux {};
+      browsers = {
+        x86_64-linux = browsers.browsers-linux { };
+        aarch64-linux = browsers.browsers-linux { };
+        x86_64-darwin = browsers.browsers-mac;
+        aarch64-darwin = browsers.browsers-mac;
+      }.${system} or throwSystem;
+      browsers-chromium = browsers.browsers-linux {};
     };
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12125,7 +12125,6 @@ with pkgs;
 
   playwright = with python3Packages; toPythonApplication playwright;
 
-  playwright-browsers = callPackage ../development/web/playwright/browsers.nix { };
   playwright-driver = callPackage ../development/web/playwright/driver.nix { };
   playwright-test = callPackage ../development/web/playwright-test/wrapped.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12125,6 +12125,7 @@ with pkgs;
 
   playwright = with python3Packages; toPythonApplication playwright;
 
+  playwright-browsers = callPackage ../development/web/playwright/browsers.nix { };
   playwright-driver = callPackage ../development/web/playwright/driver.nix { };
   playwright-test = callPackage ../development/web/playwright-test/wrapped.nix { };
 


### PR DESCRIPTION
moved from driver because passthru = bad : 
overriding playwright-test version doesn't change the driver version which generates a version mismatch and breaks playwright test.


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
