### PR TITLE
python3.pkgs.jedi: 0.18.2 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/jedi/default.nix
+++ b/pkgs/development/python-modules/jedi/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , buildPythonPackage
-, pythonAtLeast
 , pythonOlder
 , fetchFromGitHub
 , attrs
@@ -12,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "jedi";
-  version = "0.18.2";
+  version = "0.19.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -21,7 +20,7 @@ buildPythonPackage rec {
     owner = "davidhalter";
     repo = "jedi";
     rev = "v${version}";
-    hash = "sha256-hNRmUFpRzVKJQAtfsSNV4jeTR8vVj1+mGBIPO6tUGto=";
+    hash = "sha256-Hw0+KQkB9ICWbBJDQQmHyKngzJlJ8e3wlpe4aSrlkvo=";
     fetchSubmodules = true;
   };
 
@@ -43,16 +42,6 @@ buildPythonPackage rec {
   ] ++ lib.optionals (stdenv.isAarch64 && pythonOlder "3.9") [
     # AssertionError: assert 'foo' in ['setup']
     "test_init_extension_module"
-  ] ++ lib.optionals (pythonAtLeast "3.11") [
-    # disabled until 3.11 is added to _SUPPORTED_PYTHONS in jedi/api/environment.py
-    "test_find_system_environments"
-
-    # disabled until https://github.com/davidhalter/jedi/issues/1858 is resolved
-    "test_interpreter"
-    "test_scanning_venvs"
-    "test_create_environment_venv_path"
-    "test_create_environment_executable"
-    "test_venv_and_pths"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

https://github.com/davidhalter/jedi/blob/master/CHANGELOG.rst#0190-2023-07-29

This version has fixes for Python 3.11 and also is now compatible with `attrs` 23.1.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
