### PR TITLE
[23.05] python3Packages.starlette: add patch for CVE-2023-29159

### DIFF
--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , hatchling
 
 # runtime
@@ -33,6 +34,14 @@ buildPythonPackage rec {
     rev = "refs/tags/${version}";
     hash = "sha256-/zYqYmmCcOLU8Di9b4BzDLFtB5wYEEF1bYN6u2rb8Lg=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2023-29159.patch";
+      url = "https://github.com/encode/starlette/commit/1797de464124b090f10cf570441e8292936d63e3.patch";
+      hash = "sha256-IZFFc0hE4eBFMltpsNPMJ0u6mobrXtd87LXrUIGbBa0=";
+    })
+  ];
 
   nativeBuildInputs = [
     hatchling

--- a/pkgs/servers/misc/irrd/default.nix
+++ b/pkgs/servers/misc/irrd/default.nix
@@ -1,6 +1,7 @@
 { lib
 , python3
 , fetchPypi
+, fetchpatch
 , git
 , postgresql
 , postgresqlTestHook
@@ -21,6 +22,14 @@ let
       });
       starlette = prev.starlette.overridePythonAttrs (oldAttrs: rec {
         version = "0.20.4";
+        patches = [
+          (fetchpatch {
+            name = "CVE-2023-29159.no-tests.patch";
+            url = "https://github.com/encode/starlette/commit/1797de464124b090f10cf570441e8292936d63e3.patch";
+            excludes = ["tests/test_staticfiles.py"];
+            hash = "sha256-bFcbM7rbopot/Fh7y86zbPj+73mK3ml39JtJAykomKI=";
+          })
+        ];
         src = fetchPypi {
           inherit (oldAttrs) pname;
           inherit version;


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2023-29159

Simple patch, includes a new test.

`irrd` needed a patch omitting the test addition.

See  #249639 for unstable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
