### PR TITLE
ocamlPackages.ppx_inline_test: 0.15.0 → 0.15.1

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -663,7 +663,8 @@ with self;
 
   ppx_inline_test = janePackage {
     pname = "ppx_inline_test";
-    hash = "1a0gaj9p6gbn5j7c258mnzr7yjlq0hqi3aqqgyj1g2dbk1sxdbjz";
+    version = "0.15.1";
+    hash = "sha256-9Up4/VK4gayuwbPc3r6gVRj78ILO2G3opL5UDOTKOgk=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Syntax extension for writing in-line tests in ocaml code";
     propagatedBuildInputs = [ ppxlib time_now ];

--- a/pkgs/development/ocaml-modules/ocamlformat/ocamlformat.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat/ocamlformat.nix
@@ -1,6 +1,7 @@
 { lib
 , callPackage
 , buildDunePackage
+, ocaml
 , re
 , ocamlformat-lib
 , menhir
@@ -8,13 +9,16 @@
 }:
 
 let inherit (callPackage ./generic.nix { inherit version; }) src library_deps;
+in
 
-in buildDunePackage {
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0" && !lib.versionAtLeast version "0.23")
+  "ocamlformat ${version} is not available for OCaml ${ocaml.version}"
+
+buildDunePackage {
   pname = "ocamlformat";
   inherit src version;
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   nativeBuildInputs =
     if lib.versionAtLeast version "0.25.1" then [ ] else [ menhir ];

--- a/pkgs/development/ocaml-modules/odoc-parser/default.nix
+++ b/pkgs/development/ocaml-modules/odoc-parser/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage, astring, result, camlp-streams, version ? "2.0.0" }:
+{ lib, fetchurl, buildDunePackage, ocaml, astring, result, camlp-streams, version ? "2.0.0" }:
 
 let param = {
   "2.0.0" = {
@@ -11,26 +11,29 @@ let param = {
   };
   "1.0.0" = {
     sha256 = "sha256-tqoI6nGp662bK+vE2h7aDXE882dObVfRBFnZNChueqE=";
+    max_version = "5.0";
     extraBuildInputs = [];
   };
   "0.9.0" = {
     sha256 = "sha256-3w2tG605v03mvmZsS2O5c71y66O3W+n3JjFxIbXwvXk=";
+    max_version = "5.0";
     extraBuildInputs = [];
   };
 }."${version}"; in
+
+lib.throwIf (param ? max_version && lib.versionAtLeast ocaml.version param.max_version)
+  "odoc-parser ${version} is not available for OCaml ${ocaml.version}"
 
 buildDunePackage rec {
   pname = "odoc-parser";
   inherit version;
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/ocaml-doc/odoc-parser/releases/download/${version}/odoc-parser-${version}.tbz";
     inherit (param) sha256;
   };
-
-  useDune2 = true;
 
   propagatedBuildInputs = [ astring result ] ++ param.extraBuildInputs;
 


### PR DESCRIPTION
## Description of changes

Compatibility with recent versions of `ppxlib`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
