### PR TITLE
[Backport release-23.05] ungoogled-chromium: 115.0.5790.170 -> 116.0.5845.96

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -48,18 +48,18 @@
   ungoogled-chromium = {
     deps = {
       gn = {
-        rev = "e9e83d9095d3234adf68f3e2866f25daf766d5c7";
-        sha256 = "0y07c18xskq4mclqiz3a63fz8jicz2kqridnvdhqdf75lhp61f8a";
+        rev = "4bd1a77e67958fb7f6739bd4542641646f264e5d";
+        sha256 = "14h9jqspb86sl5lhh6q0kk2rwa9zcak63f8drp7kb3r4dx08vzsw";
         url = "https://gn.googlesource.com/gn";
-        version = "2023-05-19";
+        version = "2023-06-09";
       };
       ungoogled-patches = {
-        rev = "115.0.5790.170-1";
-        sha256 = "0vk82jacadb4id16596s4751j4idq6903w6sl2s7cj4ppxd6pyf1";
+        rev = "116.0.5845.96-1";
+        sha256 = "14smm0vmqzn2664qdbv7asm8n2gg88zcvwrjpsn54qwk0njv7zlr";
       };
     };
-    sha256 = "1h3j24ihn76qkvckzg703pm1jsh6nbkc48n2zx06kia8wz96567z";
-    sha256bin64 = "04jklk2zwkyy8i70v9nk7nw35w2g9pyxdw9w3sn9mddgbjjph5z9";
-    version = "115.0.5790.170";
+    sha256 = "108wrm64pig0v24n44zd52jfzsy2kda84r5k8abfvg4sjlm0bh8y";
+    sha256bin64 = "1sr7wfssayw94x8bfn7bk03040221npj7612ccxgzdgr4x5i4adl";
+    version = "116.0.5845.96";
   };
 }


### PR DESCRIPTION
## Description of changes

Manual backport of #249703

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
