### PR TITLE
kns: init at unstable-2023-04-25

### DIFF
--- a/pkgs/applications/networking/cluster/kns/default.nix
+++ b/pkgs/applications/networking/cluster/kns/default.nix
@@ -1,0 +1,38 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, fzf
+, kubectl
+}:
+stdenvNoCC.mkDerivation {
+  pname = "kns";
+  version = "unstable-2023-04-25";
+
+  src = fetchFromGitHub {
+    owner = "blendle";
+    repo = "kns";
+    rev = "86502949c31432bd95895cfb26d1c5893c533d5c";
+    hash = "sha256-8AR/fEKPAfiKCZrp/AyJo3Ic8dH7SfncYZSdQA2GywQ=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [ fzf kubectl ];
+
+  installPhase = ''
+    runHook preInstall
+
+    substituteInPlace bin/kns bin/ktx --replace fzf ${fzf}/bin/fzf --replace kubectl ${kubectl}/bin/kubectl
+    install -D -m755 -t $out/bin bin/kns bin/ktx
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Kubernetes namespace switcher";
+    homepage = "https://github.com/blendle/kns";
+    license = licenses.isc;
+    maintainers = with maintainers; [ mmlb ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32952,6 +32952,8 @@ with pkgs;
 
   kn = callPackage ../applications/networking/cluster/kn { };
 
+  kns = callPackage ../applications/networking/cluster/kns { };
+
   kondo = callPackage ../applications/misc/kondo { };
 
   kooha = callPackage ../applications/video/kooha { };


### PR DESCRIPTION
## Description of changes

Added package for [blendle/kns](https://github.com/blendle/kns) the "quick Kubernetes Namespace Switcher".

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [x] [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
