### PR TITLE
python3.pkgs.pyproject-api: 1.5.0 -> 1.5.4

### DIFF
--- a/pkgs/development/python-modules/pyproject-api/default.nix
+++ b/pkgs/development/python-modules/pyproject-api/default.nix
@@ -6,7 +6,6 @@
 # build time
 , hatchling
 , hatch-vcs
-, setuptools-scm
 
 # runtime
 , packaging
@@ -21,13 +20,14 @@
 # tests
 , pytest-mock
 , pytestCheckHook
+, setuptools
 , virtualenv
 , wheel
 }:
 
 buildPythonPackage rec {
   pname = "pyproject-api";
-  version = "1.5.0";
+  version = "1.5.4";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "tox-dev";
     repo = "pyproject-api";
     rev = "refs/tags/${version}";
-    hash = "sha256-VO+huA9i7uMpCVaWHC29XlfestSu+N9vWWHteY21uqs=";
+    hash = "sha256-HX+5BypfEOfQ3vg3vha0QCVrEarjMu/Q8id+xgmWGfA=";
   };
 
   outputs = [
@@ -44,12 +44,11 @@ buildPythonPackage rec {
     "doc"
   ];
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     hatchling
     hatch-vcs
-    setuptools-scm
 
     # docs
     sphinxHook
@@ -66,6 +65,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-mock
     pytestCheckHook
+    setuptools
     virtualenv
     wheel
   ];


### PR DESCRIPTION
## Description of changes

This version update needs to be made in lockstep with `wheel` being updated to 0.41.1 due to changes in https://github.com/pypa/wheel/pull/552 and how `pyproject-api` has chosen to adapt to them in its tests (in https://github.com/tox-dev/pyproject-api/commit/91cb132eb6cbe5e4c08773b4302ddc80baaedca1).

https://github.com/tox-dev/pyproject-api/releases/tag/1.5.4
https://github.com/tox-dev/pyproject-api/releases/tag/1.5.3
https://github.com/tox-dev/pyproject-api/releases/tag/1.5.2
https://github.com/tox-dev/pyproject-api/releases/tag/1.5.1

I am making and merging this change against the `python-updates` branch because that is being used to house and test Python bootstrapping changes that includes the update to `wheel`. Please still feel free to review this, and I will carry over the feedback over to that branch. 

Note: setuptools-scm is removed from `nativeBuildInputs` not because it isn't being used but because it is used indirectly by hatch-vcs and will already be included by it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
