### PR TITLE
aws-mfa: fix script duplication when installing with installer

### DIFF
--- a/pkgs/tools/admin/aws-mfa/default.nix
+++ b/pkgs/tools/admin/aws-mfa/default.nix
@@ -1,24 +1,36 @@
 { lib
 , buildPythonApplication
 , fetchFromGitHub
+, fetchpatch
 , boto3
 }:
 
 buildPythonApplication rec {
   pname = "aws-mfa";
   version = "0.0.12";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "broamski";
     repo = "aws-mfa";
     rev = version;
-    sha256 = "1blcpa13zgyac3v8inc7fh9szxq2avdllx6w5ancfmyh5spc66ay";
+    hash = "sha256-XhnDri7QV8esKtx0SttWAvevE3SH2Yj2YMq/P4K6jK4=";
   };
+
+  patches = [
+    # https://github.com/broamski/aws-mfa/pull/87
+    (fetchpatch {
+      name = "remove-duplicate-script.patch";
+      url = "https://github.com/broamski/aws-mfa/commit/0d1624022c71cb92bb4436964b87f0b2ffd677ec.patch";
+      hash = "sha256-Bv8ffPbDysz87wLg2Xip+0yxaBfbEmu+x6fSXI8BVjA=";
+    })
+  ];
 
   propagatedBuildInputs = [
     boto3
   ];
 
+  # package has no tests
   doCheck = false;
 
   pythonImportsCheck = [
@@ -28,7 +40,7 @@ buildPythonApplication rec {
   meta = with lib; {
     description = "Manage AWS MFA Security Credentials";
     homepage = "https://github.com/broamski/aws-mfa";
-    license = [ licenses.mit ];
+    license = licenses.mit;
     maintainers = [ maintainers.srapenne ];
   };
 }


### PR DESCRIPTION
## Description of changes

I'm working on changing how we install Python packages from using `pip` to using [`installer`](https://installer.pypa.io/en/stable/). Unlike pip, it throws an error when it finds two files with the same name in a wheel archive, and that is the case because aws-mfa defines both a script and a console script entry point with the same name. 

This PR pulls in a patch I submitted upstream to fix this.

I also made a few opportunistic changes (e.g. using SRI hash, adding `format` attribute, removing unnecessary list around the license).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
