### PR TITLE
vcard: Expand documentation

### DIFF
--- a/pkgs/development/python-modules/vcard/default.nix
+++ b/pkgs/development/python-modules/vcard/default.nix
@@ -28,6 +28,9 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://gitlab.com/engmark/vcard";
     description = "vCard validator, class and utility functions";
+    longDescription = ''
+      This program can be used for strict validation and parsing of vCards. It currently supports vCard 3.0 (RFC 2426).
+    '';
     license = lib.licenses.agpl3Plus;
     maintainers = [ lib.maintainers.l0b0 ];
   };

--- a/pkgs/development/python-modules/vcard/default.nix
+++ b/pkgs/development/python-modules/vcard/default.nix
@@ -32,6 +32,7 @@ buildPythonPackage rec {
       This program can be used for strict validation and parsing of vCards. It currently supports vCard 3.0 (RFC 2426).
     '';
     license = lib.licenses.agpl3Plus;
+    mainProgram = "vcard";
     maintainers = [ lib.maintainers.l0b0 ];
   };
 }


### PR DESCRIPTION
## Description of changes

- Add long description, helpful for anyone wondering about the version of vCard supported by this package.
- Add missing `mainProgram`, providing the hint for `command-not-found vcard`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).