### PR TITLE
python3Packages.tabcmd: init at 2.0.12, python3Packages.pyinstaller-versionfile: init at 2.1.1, python3Packages.tableauserverclient: init at 0.25, python3Packages.types-appdirs: init at 1.4.3.5, python3Packages.types-mock: init at 5.1.0.1

### DIFF
--- a/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
+++ b/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, packaging
+, jinja2
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "pyinstaller-versionfile";
+  version = "2.1.1";
+
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "DudeNr33";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-lz1GuiXU+r8sMld5SsG3qS+FOsWfbvkQmO2bxAR3XcY=";
+  };
+
+  propagatedBuildInputs = [ packaging jinja2 pyyaml ];
+
+  meta = {
+    description = "Create a windows version-file from a simple YAML file that can be used by PyInstaller.";
+    homepage = "https://pypi.org/project/pyinstaller-versionfile/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/tabcmd/default.nix
+++ b/pkgs/development/python-modules/tabcmd/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, python3
+, pythonOlder
+, fetchPypi
+, ftfy
+, appdirs
+, requests
+, setuptools-scm
+, types-mock
+, types-appdirs
+, types-requests
+, types-setuptools
+, argparse
+, doit
+, pyinstaller-versionfile
+, tableauserverclient
+, pytestCheckHook
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "tabcmd";
+  version = "2.0.12";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-nsQJWDzSzSc1WRk5TBl/E7Mpfk8wGD1CsETAWILKxCM=";
+  };
+
+  propagatedBuildInputs = [ ftfy appdirs requests setuptools-scm types-mock types-appdirs argparse doit pyinstaller-versionfile types-requests types-setuptools tableauserverclient ];
+
+  nativeCheckInputs = [ pytestCheckHook mock ];
+
+  # Remove an unneeded dependency that can't be resolved
+  prePatch = ''
+    sed -i "/'argparse',/d" pyproject.toml
+  '';
+
+  # Create a "tabcmd" executable
+  postInstall = ''
+    # Create a directory for our wrapped binary.
+    mkdir -p $out/bin
+
+    cp -r build/lib/tabcmd/__main__.py $out/bin/
+
+    # Create a 'tabcmd' script with python3 shebang
+    echo "#!${python3}/bin/python3" > $out/bin/tabcmd
+
+    # Append __main__.py contents
+    cat $out/bin/__main__.py >> $out/bin/tabcmd
+
+    # Make it executable.
+    chmod +x $out/bin/tabcmd
+  '';
+
+
+  meta = {
+    description = "A command line client for working with Tableau Server.";
+    homepage = "https://pypi.org/project/tabcmd/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/tableauserverclient/default.nix
+++ b/pkgs/development/python-modules/tableauserverclient/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, python
+, fetchPypi
+, defusedxml
+, requests
+, packaging
+, requests-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "tableauserverclient";
+  version = "0.25";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-01TRYkXEWagFrSB7zvP6Bj4YvIFoaVkgrIm/gSWkILY=";
+  };
+
+  propagatedBuildInputs = [ defusedxml requests packaging ];
+
+  checkInputs = [ requests-mock ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  doCheck = false; # it attempts to create some file artifacts and fails
+
+  meta = {
+    description = "A Python module for working with the Tableau Server REST API.";
+    homepage = "https://pypi.org/project/tableauserverclient/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/types-appdirs/default.nix
+++ b/pkgs/development/python-modules/types-appdirs/default.nix
@@ -1,0 +1,21 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-appdirs";
+  version = "1.4.3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-gyaNpkWFNhv6KR+PUGogknYhKgSXvTfwUSqTmz1p/xQ=";
+  };
+
+  meta = {
+    description = "This is a PEP 561 type stub package for the appdirs package. It can be used by type-checking tools like mypy, pyright, pytype, PyCharm, etc. to check code that uses appdirs. ";
+    homepage = "https://pypi.org/project/types-appdirss";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/types-mock/default.nix
+++ b/pkgs/development/python-modules/types-mock/default.nix
@@ -1,0 +1,21 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-mock";
+  version = "5.1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-8H1Z3lDqgWq0A7pOJG/4CwCSY7N3vD93Tf3r8LQD+2A=";
+  };
+
+  meta = {
+    description = "This is a PEP 561 type stub package for the mock package. It can be used by type-checking tools like mypy, pyright, pytype, PyCharm, etc. to check code that uses mock.";
+    homepage = "https://pypi.org/project/types-mock";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13039,6 +13039,8 @@ self: super: with self; {
 
   types-ipaddress = callPackage ../development/python-modules/types-ipaddress { };
 
+  types-mock = callPackage ../development/python-modules/types-mock { };
+
   types-pillow = callPackage ../development/python-modules/types-pillow { };
 
   types-protobuf = callPackage ../development/python-modules/types-protobuf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13021,6 +13021,8 @@ self: super: with self; {
 
   typer = callPackage ../development/python-modules/typer { };
 
+  types-appdirs = callPackage ../development/python-modules/types-appdirs { };
+
   types-colorama = callPackage ../development/python-modules/types-colorama { };
 
   types-dateutil = callPackage ../development/python-modules/types-dateutil { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12353,6 +12353,8 @@ self: super: with self; {
 
   tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
 
+  tableauserverclient = callPackage ../development/python-modules/tableauserverclient { };
+
   tabledata = callPackage ../development/python-modules/tabledata { };
 
   tables = callPackage ../development/python-modules/tables { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8095,6 +8095,8 @@ self: super: with self; {
 
   pyhumps = callPackage ../development/python-modules/pyhumps { };
 
+  pyinstaller-versionfile = callPackage ../development/python-modules/pyinstaller-versionfile { };
+
   pyisy = callPackage ../development/python-modules/pyisy { };
 
   pykrakenapi = callPackage ../development/python-modules/pykrakenapi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12353,6 +12353,8 @@ self: super: with self; {
 
   syrupy = callPackage ../development/python-modules/syrupy { };
 
+  tabcmd = callPackage ../development/python-modules/tabcmd { };
+
   tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
 
   tableauserverclient = callPackage ../development/python-modules/tableauserverclient { };


### PR DESCRIPTION
## Description of changes

Add [tabcmd](https://pypi.org/project/tabcmd/) and its dependencies

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
