### PR TITLE
cobang: minor fix to patch replacing poetry with poetry-core

### DIFF
--- a/pkgs/applications/misc/cobang/0001-Poetry-core-and-pillow-9.patch
+++ b/pkgs/applications/misc/cobang/0001-Poetry-core-and-pillow-9.patch
@@ -23,7 +23,8 @@ index 5dc25e0..b3ba397 100644
 @@ -33,4 +33,4 @@ skip-string-normalization = true
  
  [build-system]
- requires = ["poetry>=0.12"]
+-requires = ["poetry>=0.12"]
++requires = ["poetry-core"]
 -build-backend = "poetry.masonry.api"
 +build-backend = "poetry.core.masonry.api"
 -- 


### PR DESCRIPTION
## Description of changes

As I was working on migrating Python builds to use [`build`](https://pypa-build.readthedocs.io/en/latest/), it flagged that the patch being used to replace poetry with poetry-core was missing one replacement. I've fixed that here.

Note that `cobang` is still broken on master after the pillow update. How it should be fixed is updated to v0.10.1, after which the current poetry patch can be removed, and then also patched to work with pillow v10. However, I would like to merge this small fix in the meantime because it changes the error signature to what is really wrong, which is that support for the new major version of pillow needs to be added.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
