### PR TITLE
python3.pkgs.correctionlib: clean up / fix up build dependencies

### DIFF
--- a/pkgs/development/python-modules/correctionlib/default.nix
+++ b/pkgs/development/python-modules/correctionlib/default.nix
@@ -1,11 +1,13 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
 , cmake
 , numpy
 , scikit-build
 , setuptools
 , setuptools-scm
+, wheel
 , pybind11
 , pydantic
 , pytestCheckHook
@@ -24,12 +26,27 @@ buildPythonPackage rec {
     hash = "sha256-h3eggtPLSF/8ShQ5xzowZW1KSlcI/YBsPu3lsSyzHkw=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "ci-maintenance.patch";
+      url = "https://github.com/cms-nanoAOD/correctionlib/commit/924031637b040f6e8e4930c46a9f7560c59db23d.patch";
+      hash = "sha256-jq3ojMsO2Ex9om8tVpEY9uwwelXPzgQ+KCPN0bgda8w=";
+      includes = [ "pyproject.toml" ];
+    })
+    (fetchpatch {
+      name = "clean-up-build-dependencies.patch";
+      url = "https://github.com/cms-nanoAOD/correctionlib/commit/c4fd64ca0e5ce806890e8f0ae8e792dcc4537d38.patch";
+      hash = "sha256-8ID2jEnmfYmPxWMtRviBc3t1W4p3Y+lAzijFtYBEtyk=";
+    })
+  ];
+
   nativeBuildInputs = [
     cmake
     numpy
     scikit-build
     setuptools
     setuptools-scm
+    wheel
     pybind11
   ];
 
@@ -44,7 +61,7 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
## Description of changes

Do some build dependency clean up so that this package continues to build even after we switch to building with [`build`](https://pypa-build.readthedocs.io/en/latest/) with its stronger build dependency validation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
