### PR TITLE
commitmsgfmt: init at 1.6.0

### DIFF
--- a/pkgs/by-name/co/commitmsgfmt/package.nix
+++ b/pkgs/by-name/co/commitmsgfmt/package.nix
@@ -1,0 +1,31 @@
+{ lib
+, rustPlatform
+, fetchFromGitLab
+, testers
+, commitmsgfmt
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "commitmsgfmt";
+  version = "1.6.0";
+
+  src = fetchFromGitLab {
+    owner = "mkjeldsen";
+    repo = "commitmsgfmt";
+    rev = "v${version}";
+    hash = "sha256-HEkPnTO1HeJg8gpHFSUTkEVBPWJ0OdfUhNn9iGfaDD4=";
+  };
+  cargoSha256 = "sha256-jTRB9ogFQGVC4C9xpGxsJYV3cnWydAJLMcjhzUPULTE=";
+
+  passthru.tests.version = testers.testVersion {
+    package = commitmsgfmt;
+    command = "commitmsgfmt -V";
+  };
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/mkjeldsen/commitmsgfmt";
+    changelog = "https://gitlab.com/mkjeldsen/commitmsgfmt/-/raw/v${version}/CHANGELOG.md";
+    description = "Formats commit messages better than fmt(1) and Vim";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mmlb ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds new package [commitmsgfmt](https://gitlab.com/mkjeldsen/commitmsgfmt)

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [x] [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
