### PR TITLE
nwg-displays: added missing dependency

### DIFF
--- a/pkgs/applications/misc/nwg-displays/default.nix
+++ b/pkgs/applications/misc/nwg-displays/default.nix
@@ -5,6 +5,7 @@
 , gobject-introspection
 , gtk-layer-shell
 , gtk3
+, wlr-randr
 , pango
 , python310Packages
 , wrapGAppsHook
@@ -31,6 +32,7 @@ python310Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = [
+    wlr-randr
     atk
     gdk-pixbuf
     gtk-layer-shell

--- a/pkgs/applications/misc/nwg-displays/default.nix
+++ b/pkgs/applications/misc/nwg-displays/default.nix
@@ -32,7 +32,6 @@ python310Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = [
-    wlr-randr
     atk
     gdk-pixbuf
     gtk-layer-shell
@@ -40,6 +39,7 @@ python310Packages.buildPythonApplication rec {
     python310Packages.gst-python
     python310Packages.i3ipc
     python310Packages.pygobject3
+    wlr-randr
   ];
 
   dontWrapGApps = true;


### PR DESCRIPTION
## Description of changes

Without `wlr-randr` package `nwg-displays` fails to launch with this error :
```
wlr-randr package required, but not found, terminating.
```

## Things done

Added `wlr-randr` needed dependency.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
