### PR TITLE
brogue-ce: init at 1.12

### DIFF
--- a/pkgs/games/brogue-ce/default.nix
+++ b/pkgs/games/brogue-ce/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, SDL2
+, SDL2_image
+}:
+
+stdenv.mkDerivation rec {
+  pname = "brogue-ce";
+  version = "1.12";
+
+  src = fetchFromGitHub {
+    owner = "tmewett";
+    repo = "BrogueCE";
+    rev = "v${version}";
+    hash = "sha256-bGAE0hRiKBo3ikyObGxAiPRRO24KtC+upO3XLj+f4yo=";
+  };
+
+  postPatch = ''
+    substituteInPlace linux/brogue-multiuser.sh \
+      --replace broguedir= "broguedir=$out/opt/brogue-ce #"
+  '';
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+  ];
+
+  makeFlags = [ "DATADIR=$(out)/opt/brogue-ce" ];
+
+  desktopItems = [(makeDesktopItem {
+    name = "brogue-ce";
+    desktopName = "Brogue CE";
+    genericName = "Roguelike";
+    comment = "Brave the Dungeons of Doom!";
+    icon = "brogue-ce";
+    exec = "brogue-ce";
+    categories = [ "Game" "AdventureGame" ];
+  })];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/opt
+    cp -r bin $out/opt/brogue-ce
+    install -Dm755 linux/brogue-multiuser.sh $out/bin/brogue-ce
+    install -Dm 644 bin/assets/icon.png $out/share/icons/hicolor/256x256/apps/brogue-ce.png
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A community-lead fork of the minimalist roguelike game Brogue";
+    homepage = "https://github.com/tmewett/BrogueCE";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37177,6 +37177,8 @@ with pkgs;
 
   brogue = callPackage ../games/brogue { };
 
+  brogue-ce = callPackage ../games/brogue-ce { };
+
   brutalmaze = callPackage ../games/brutalmaze { };
 
   bsdgames = callPackage ../games/bsdgames { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

@svenkeidel since you are the maintainer of `brogue`, would you like to help maintain `brogue-ng` too?
