### PR TITLE
python3.pkgs.scipy: 1.11.1 -> 1.11.2

### DIFF
--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -80,6 +80,7 @@ in buildPythonPackage {
     })
   ];
 
+  # Relax deps a bit
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace 'numpy==' 'numpy>=' \
@@ -117,9 +118,6 @@ in buildPythonPackage {
   doCheck = !(stdenv.isx86_64 && stdenv.isDarwin);
 
   preConfigure = ''
-    # Relax deps a bit
-    substituteInPlace pyproject.toml \
-      --replace 'numpy==' 'numpy>='
     # Helps parallelization a bit
     export NPY_NUM_BUILD_JOBS=$NIX_BUILD_CORES
     # We download manually the datasets and this variable tells the pooch

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -34,8 +34,8 @@ let
   #     nix-shell maintainers/scripts/update.nix --argstr package python3.pkgs.scipy
   #
   # The update script uses sed regexes to replace them with the updated hashes.
-  version = "1.11.1";
-  srcHash = "sha256-bgnYXe3EhzL7+Gfriz1cXCl2eYQJ8zF+rcIwHyZR8bQ=";
+  version = "1.11.2";
+  srcHash = "sha256-7FE740/yKUXtujVX60fQB/xvCZFfV69FRihvSi6+UWo=";
   datasetsHashes = {
     ascent = "1qjp35ncrniq9rhzb14icwwykqg2208hcssznn3hz27w39615kh3";
     ecg = "1bwbjp43b7znnwha5hv6wiz3g0bhwrpqpi75s12zidxrbwvd62pj";

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -33,9 +33,7 @@ let
   #
   #     nix-shell maintainers/scripts/update.nix --argstr package python3.pkgs.scipy
   #
-  # Even if you do update these hashes manually, don't change their base
-  # (base16 or base64), because the update script uses sed regexes to replace
-  # them with the updated hashes.
+  # The update script uses sed regexes to replace them with the updated hashes.
   version = "1.11.1";
   srcHash = "sha256-bgnYXe3EhzL7+Gfriz1cXCl2eYQJ8zF+rcIwHyZR8bQ=";
   datasetsHashes = {

--- a/pkgs/development/python-modules/scipy/update.sh
+++ b/pkgs/development/python-modules/scipy/update.sh
@@ -16,10 +16,12 @@ if grep -q 'version = "'$version $fname; then
     echo "Current version $version is the latest available, will update only datasets' hashes (don't take long)"
 else
     echoerr got version $version
-    sed -i -E 's/(version = ).*=/\1'$version'/g' $fname
+    sed -i -E 's/(version = ").*(";)/\1'$version'\2/g' $fname
+    # Verify the sed command above did not fail
+    grep -q $version $fname
     # Update srcHash
-    srcHash='"sha256-'$(nix-prefetch-github scipy scipy --rev v${version} --fetch-submodules | jq --raw-output .sha256)'"'
-    sed -i 's/srcHash = .*=";/srcHash = '$srcHash';/g' $fname
+    srcHash="$(nix-prefetch-github scipy scipy --rev v${version} --fetch-submodules | jq --raw-output .hash)"
+    sed -i -E 's#(srcHash = ").*(";)#\1'$srcHash'\2#g' $fname
 fi
 
 for d in $datasets; do


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
