### PR TITLE
proxysql: 2.5.4 -> 2.5.5

### DIFF
--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -33,13 +33,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "proxysql";
-  version = "2.5.4";
+  version = "2.5.5";
 
   src = fetchFromGitHub {
     owner = "sysown";
     repo = "proxysql";
     rev = finalAttrs.version;
-    hash = "sha256-HFhfAWyDB20t+c4s9NlVwdANrFobVyr+vnmZqx+X20Q=";
+    hash = "sha256-+3cOEM5b5HBQhuI+92meupvQnrUj8jgbedzPJqMoXc8=";
   };
 
   patches = [

--- a/pkgs/servers/sql/proxysql/makefiles.patch
+++ b/pkgs/servers/sql/proxysql/makefiles.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index c053ab64..03f38a21 100644
+index f8902b4f..57844bd7 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -59,11 +59,7 @@ endif
@@ -15,7 +15,7 @@ index c053ab64..03f38a21 100644
  USERCHECK := $(shell getent passwd proxysql)
  GROUPCHECK := $(shell getent group proxysql)
  
-@@ -868,16 +864,10 @@ cleanbuild:
+@@ -303,16 +299,10 @@ cleanbuild:
  
  .PHONY: install
  install: src/proxysql
@@ -36,7 +36,7 @@ index c053ab64..03f38a21 100644
  	install -m 0755 etc/init.d/proxysql /etc/init.d
  ifeq ($(DISTRO),"CentOS Linux")
 diff --git a/deps/Makefile b/deps/Makefile
-index dbe495c0..9c50bab8 100644
+index 710e070b..fd1352f6 100644
 --- a/deps/Makefile
 +++ b/deps/Makefile
 @@ -69,10 +69,7 @@ default: $(tmpdefault)
@@ -50,16 +50,19 @@ index dbe495c0..9c50bab8 100644
  	cd libinjection/libinjection && patch -p1 < ../libinjection_sqli.c.patch
  endif
  ifeq ($(UNAME_S),Darwin)
-@@ -91,8 +88,6 @@ $(error Incompatible OpenSSL version: struct bio_st mismatch!)
- endif
+@@ -86,11 +83,7 @@ libinjection: libinjection/libinjection/src/libinjection.a
+ 
  
  libssl/openssl/libssl.a:
 -	cd libssl && rm -rf openssl-openssl-*/ openssl-3*/ || true
 -	cd libssl && tar -zxf openssl-*.tar.gz
- #	cd libssl/openssl && patch crypto/ec/curve448/curve448.c < ../curve448.c-multiplication-overflow.patch
- #	cd libssl/openssl && patch crypto/asn1/a_time.c < ../a_time.c-multiplication-overflow.patch
+ 	cd libssl && ./verify-bio_st-match.sh
+-#	cd libssl/openssl && patch crypto/ec/curve448/curve448.c < ../curve448.c-multiplication-overflow.patch
+-#	cd libssl/openssl && patch crypto/asn1/a_time.c < ../a_time.c-multiplication-overflow.patch
  	cd libssl/openssl && ./config no-ssl3 no-tests
-@@ -112,8 +107,6 @@ ifeq ($(MIN_VERSION),$(lastword $(SORTED_VERSIONS)))
+ 	cd libssl/openssl && CC=${CC} CXX=${CXX} ${MAKE}
+ 	cd libssl/openssl && ln -s . lib # curl wants this path
+@@ -108,8 +101,6 @@ ifeq ($(MIN_VERSION),$(lastword $(SORTED_VERSIONS)))
  endif
  
  libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a re2/re2/obj/libre2.a
@@ -68,7 +71,7 @@ index dbe495c0..9c50bab8 100644
  #ifeq ($(REQUIRE_PATCH), true)
  	cd libhttpserver/libhttpserver && patch -p1 < ../noexcept.patch
  	cd libhttpserver/libhttpserver && patch -p1 < ../re2_regex.patch
-@@ -131,8 +124,6 @@ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
+@@ -127,8 +118,6 @@ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
  
  
  libev/libev/.libs/libev.a:
@@ -77,7 +80,7 @@ index dbe495c0..9c50bab8 100644
  	cd libev/libev && patch ev.c < ../ev.c-multiplication-overflow.patch
  	cd libev/libev && ./configure
  	cd libev/libev && CC=${CC} CXX=${CXX} ${MAKE}
-@@ -148,8 +139,6 @@ coredumper/coredumper/src/libcoredumper.a:
+@@ -144,8 +133,6 @@ coredumper/coredumper/src/libcoredumper.a:
  coredumper: coredumper/coredumper/src/libcoredumper.a
  
  curl/curl/lib/.libs/libcurl.a: libssl/openssl/libssl.a
@@ -86,7 +89,7 @@ index dbe495c0..9c50bab8 100644
  #	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --with-ssl=$(shell pwd)/../../libssl/openssl/ && CC=${CC} CXX=${CXX} ${MAKE}
  	cd curl/curl && autoreconf -fi
  ifeq ($(UNAME_S),Darwin)
-@@ -161,16 +150,6 @@ curl: curl/curl/lib/.libs/libcurl.a
+@@ -157,16 +144,6 @@ curl: curl/curl/lib/.libs/libcurl.a
  
  
  libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:
@@ -103,7 +106,7 @@ index dbe495c0..9c50bab8 100644
  	cd libmicrohttpd/libmicrohttpd && ./configure --enable-https && CC=${CC} CXX=${CXX} ${MAKE}
  
  microhttpd: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
-@@ -186,8 +165,6 @@ cityhash: cityhash/cityhash/src/.libs/libcityhash.a
+@@ -182,8 +159,6 @@ cityhash: cityhash/cityhash/src/.libs/libcityhash.a
  
  
  lz4/lz4/lib/liblz4.a:
@@ -112,16 +115,16 @@ index dbe495c0..9c50bab8 100644
  	cd lz4/lz4 && CC=${CC} CXX=${CXX} ${MAKE}
  
  lz4: lz4/lz4/lib/liblz4.a
-@@ -213,8 +190,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
+@@ -209,8 +184,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
  
  
  libdaemon/libdaemon/libdaemon/.libs/libdaemon.a:
 -	cd libdaemon && rm -rf libdaemon-*/ || true
 -	cd libdaemon && tar -zxf libdaemon-0.14.tar.gz
+ 	cd libdaemon/libdaemon && patch -p0 < ../daemon_fork_umask.patch
  	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && cp ../config.sub . && chmod +x config.sub && ./configure --disable-examples
  	cd libdaemon/libdaemon && CC=${CC} CXX=${CXX} ${MAKE}
- 
-@@ -302,8 +277,6 @@ sqlite3: sqlite3/sqlite3/sqlite3.o
+@@ -299,8 +272,6 @@ sqlite3: sqlite3/sqlite3/sqlite3.o
  
  
  libconfig/libconfig/lib/.libs/libconfig++.a:
@@ -130,7 +133,7 @@ index dbe495c0..9c50bab8 100644
  	cd libconfig/libconfig && ./configure --disable-examples
  	cd libconfig/libconfig && CC=${CC} CXX=${CXX} ${MAKE}
  
-@@ -311,9 +284,6 @@ libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
+@@ -308,9 +279,6 @@ libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
  
  
  prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
@@ -140,7 +143,7 @@ index dbe495c0..9c50bab8 100644
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../serial_exposer.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../registry_counters_reset.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../fix_old_distros.patch
-@@ -324,10 +294,6 @@ prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
+@@ -321,10 +289,6 @@ prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
  
  
  re2/re2/obj/libre2.a:
@@ -151,7 +154,7 @@ index dbe495c0..9c50bab8 100644
  	cd re2/re2 && patch re2/onepass.cc < ../onepass.cc-multiplication-overflow.patch
  ifeq ($(UNAME_S),Darwin)
  	cd re2/re2 && sed -i '' -e 's/-O3 -g/-O3 -g -std=c++11 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
-@@ -342,8 +308,6 @@ re2: re2/re2/obj/libre2.a
+@@ -339,8 +303,6 @@ re2: re2/re2/obj/libre2.a
  
  
  pcre/pcre/.libs/libpcre.a:


### PR DESCRIPTION
## Description of changes
https://github.com/sysown/proxysql/releases/tag/v2.5.5

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).