### PR TITLE
Pokemon Red/Blue/Crystal decompilation project init.

### DIFF
--- a/pkgs/games/pokecrystal/default.nix
+++ b/pkgs/games/pokecrystal/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rgbds
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation {
+  pname = "pokecrystal";
+  version = "unstable-2023-08-16";
+
+  src = fetchFromGitHub {
+    owner = "pret";
+    repo = "pokecrystal";
+    rev = "0d899cbd3b318b50776aac0a4aafad6133a5e647";
+    hash = "sha256-dwtvNfpFHPeM5syCd9IUPRM/QDGFO//hNz59VaP4sao=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ rgbds ];
+
+  installPhase = ''
+    mkdir -p $out/rom/
+    cp pokecrystal.gbc $out/rom/
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Pokemon Crystal decomp";
+    homepage = "https://github.com/pret/pokecrystal/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ moody ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/games/pokegold/default.nix
+++ b/pkgs/games/pokegold/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rgbds
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation {
+  pname = "pokecrystal";
+  version = "unstable-2023-08-15";
+
+  src = fetchFromGitHub {
+    owner = "pret";
+    repo = "pokegold";
+    rev = "e06a6b1550abb88e24980493615e96393cd7ce98";
+    hash = "sha256-ZuhamUMKGHGam84a27YyYbpuVWnoH/Vo0E6sc3BSMPk=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ rgbds ];
+
+  installPhase = ''
+    mkdir -p $out/rom/
+    cp poke*.gbc $out/rom/
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Pokemon Gold/SIlver decomp";
+    homepage = "https://github.com/pret/pokegold/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ moody ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/games/pokered/default.nix
+++ b/pkgs/games/pokered/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rgbds
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation {
+  pname = "pokered";
+  version = "unstable-2023-08-15";
+
+  src = fetchFromGitHub {
+    owner = "pret";
+    repo = "pokered";
+    rev = "fa18a75dc55c58505b7c643560bc7d8f1198995b";
+    hash = "sha256-+bRXXdrpmuQ3pwRVrKFx01CkfaSnr5GJuN5L3dl9szM=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ rgbds ];
+
+  installPhase = ''
+    mkdir -p $out/rom/
+    cp poke*.gbc $out/rom/
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Pokemon Red/Blue decomp";
+    homepage = "https://github.com/pret/pokered/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ moody ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/games/pokeyellow/default.nix
+++ b/pkgs/games/pokeyellow/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rgbds
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation {
+  pname = "pokered";
+  version = "unstable-2023-07-16";
+
+  src = fetchFromGitHub {
+    owner = "pret";
+    repo = "pokeyellow";
+    rev = "613e1c64bd9668f996bb42ead52eabf1ae45a660";
+    hash = "sha256-uUUBkSGkZrQtigIwaaCTty3hHj2d94TFC2AFZeTZev4=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ rgbds ];
+
+  installPhase = ''
+    mkdir -p $out/rom/
+    cp poke*.gbc $out/rom/
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Pokemon Yellow decomp";
+    homepage = "https://github.com/pret/pokeyellow/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ moody ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34609,6 +34609,8 @@ with pkgs;
 
   pokefinder = qt6Packages.callPackage ../tools/games/pokefinder { };
 
+  pokegold = callPackage ../games/pokegold { };
+
   pokemonsay = callPackage ../tools/misc/pokemonsay { };
 
   pokered = callPackage ../games/pokered { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34609,6 +34609,8 @@ with pkgs;
 
   pokemonsay = callPackage ../tools/misc/pokemonsay { };
 
+  pokered = callPackage ../games/pokered { };
+
   polar-bookshelf = callPackage ../applications/misc/polar-bookshelf { };
 
   polar-bookshelf1 = callPackage ../applications/misc/polar-bookshelf1 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34615,6 +34615,8 @@ with pkgs;
 
   pokered = callPackage ../games/pokered { };
 
+  pokeyellow = callPackage ../games/pokeyellow { };
+
   polar-bookshelf = callPackage ../applications/misc/polar-bookshelf { };
 
   polar-bookshelf1 = callPackage ../applications/misc/polar-bookshelf1 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34605,6 +34605,8 @@ with pkgs;
 
   poke = callPackage ../applications/editors/poke { };
 
+  pokecrystal = callPackage ../games/pokecrystal { };
+
   pokefinder = qt6Packages.callPackage ../tools/games/pokefinder { };
 
   pokemonsay = callPackage ../tools/misc/pokemonsay { };


### PR DESCRIPTION
## Description of changes

Not sure if these are eligible to be added given ip ownership, but wanted to offer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
