### PR TITLE
gawkextlib: unstable-2019-11-21 -> unstable-2022-10-20

### DIFF
--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -9,12 +9,12 @@ let
       let is_extension = gawkextlib != null;
       in stdenv.mkDerivation rec {
         pname = "gawkextlib-${name}";
-        version = "unstable-2019-11-21";
+        version = "unstable-2022-10-20";
 
         src = fetchgit {
           url = "git://git.code.sf.net/p/gawkextlib/code";
-          rev = "f70f10da2804e4fd0a0bac57736e9c1cf21e345d";
-          sha256 = "0r8fz89n3l4dfszs1980yqj0ah95430lj0y1lb7blfkwxa6c2xik";
+          rev = "f6c75b4ac1e0cd8d70c2f6c7a8d58b4d94cfde97";
+          sha256 = "sha256-0p3CrQ3TBl7UcveZytK/9rkAzn69RRM2GwY2eCeqlkg=";
         };
 
         postPatch = ''
@@ -83,11 +83,12 @@ let
       name = "gd";
       extraBuildInputs = [ gd ];
     };
-    haru = buildExtension {
-      inherit gawkextlib;
-      name = "haru";
-      extraBuildInputs = [ libharu ];
-    };
+    # Build has been broken: https://github.com/NixOS/nixpkgs/issues/191072
+    # haru = buildExtension {
+    #   inherit gawkextlib;
+    #   name = "haru";
+    #   extraBuildInputs = [ libharu ];
+    # };
     json = buildExtension {
       inherit gawkextlib;
       name = "json";


### PR DESCRIPTION
## Description of changes

Version bump and remove broken extension.

[gawk-haru](https://sourceforge.net/p/gawkextlib/code/ci/master/tree/haru/) (PDF generation) has [been broken](https://github.com/NixOS/nixpkgs/issues/191072) for some time

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Fixes: https://github.com/NixOS/nixpkgs/issues/191072