### PR TITLE
zsh-syntax-highlighting: 0.7.1 -> 0.8.0

### DIFF
--- a/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/zsh-users/zsh-syntax-highlighting";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ loskutov ];
+    maintainers = with maintainers; [ gepbird loskutov ];
   };
 })

--- a/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
@@ -3,14 +3,14 @@
 # To make use of this derivation, use the `programs.zsh.enableSyntaxHighlighting` option
 
 stdenv.mkDerivation rec {
-  version = "0.7.1";
+  version = "0.8.0";
   pname = "zsh-syntax-highlighting";
 
   src = fetchFromGitHub {
     owner = "zsh-users";
     repo = "zsh-syntax-highlighting";
     rev = version;
-    sha256 = "03r6hpb5fy4yaakqm3lbf4xcvd408r44jgpv4lnzl9asp4sb9qc0";
+    sha256 = "sha256-iJdWopZwHpSyYl5/FQXEW7gl/SrKaYDEtTH9cGP7iPo=";
   };
 
   strictDeps = true;

--- a/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
@@ -2,15 +2,15 @@
 
 # To make use of this derivation, use the `programs.zsh.enableSyntaxHighlighting` option
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "0.8.0";
   pname = "zsh-syntax-highlighting";
 
   src = fetchFromGitHub {
     owner = "zsh-users";
     repo = "zsh-syntax-highlighting";
-    rev = version;
-    sha256 = "sha256-iJdWopZwHpSyYl5/FQXEW7gl/SrKaYDEtTH9cGP7iPo=";
+    rev = finalAttrs.version;
+    hash = "sha256-iJdWopZwHpSyYl5/FQXEW7gl/SrKaYDEtTH9cGP7iPo=";
   };
 
   strictDeps = true;
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/zsh-users/zsh-syntax-highlighting";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = [ maintainers.loskutov ];
+    maintainers = with maintainers; [ loskutov ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

diff: https://github.com/zsh-users/zsh-syntax-highlighting/compare/0.7.1...0.8.0<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

# Motivation
I'm migrating my arch config to nix, and noticed that I get this error with my zsh config:
`zsh-syntax-highlighting: unhandled ZLE widget 'zvm_readkeys_handler'`.
Minimal zsh config for reproducing:
```nix
home-manager.sharedModules = [
  {
    programs.zsh = {
      enable = true;
      syntaxHighlighting.enable = true;
      initExtra = ''
        source ${pkgs.zsh-vi-mode}/share/zsh-vi-mode/zsh-vi-mode.plugins.zsh
        # this binds the <end> key to end-of-line 
        # and causes the error message but only if old syntax highlighting is enabled
        zvm_bindkey viins '^[[4~' end-of-line
      '';
    }
  }
]
```
Using a newer version of zsh-syntax-highlighting (at least https://github.com/zsh-users/zsh-syntax-highlighting/commit/637e1c702e07b9a3cb76063d27e2118ed3ac1503) fixes the issue.