### PR TITLE
g2o: 20230223 -> 20230806

### DIFF
--- a/pkgs/applications/video/rtabmap/default.nix
+++ b/pkgs/applications/video/rtabmap/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , pkg-config
 , cmake
 , opencv
@@ -34,6 +35,19 @@ stdenv.mkDerivation rec {
     rev = "refs/tags/${version}";
     hash = "sha256-1xb8O3VrErldid2OgAUMG28mSUO7QBUsPuSz8p03tSI";
   };
+
+  patches = [
+    # Fix build with g2o 20230806
+    (fetchpatch {
+      url = "https://github.com/introlab/rtabmap/commit/85cc6fe3c742855ad16c8442895e12dbb10b6e8b.patch";
+      hash = "sha256-P6GkYKCNwe9dgZdgF/oEhgjA3bJnwXFWJCPoyIknQCo=";
+    })
+    # Fix typo in previous patch
+    (fetchpatch {
+      url = "https://github.com/introlab/rtabmap/commit/c4e94bcdc31b859c1049724dbb7671e4597d86de.patch";
+      hash = "sha256-1btkV4/y+bnF3xEVqlUy/9F6BoANeTOEJjZLmRzG3iA=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook wrapGAppsHook ];
   buildInputs = [

--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -1,15 +1,15 @@
 { lib, stdenv, mkDerivation, fetchFromGitHub, cmake, eigen, suitesparse, blas
-, lapack, libGLU, qtbase, libqglviewer, makeWrapper }:
+, lapack, libGLU, qtbase, libqglviewer, spdlog }:
 
 mkDerivation rec {
   pname = "g2o";
-  version = "20230223";
+  version = "20230806";
 
   src = fetchFromGitHub {
     owner = "RainerKuemmerle";
     repo = pname;
     rev = "${version}_git";
-    sha256 = "sha256-J2Z3oRkyiinIfywBQvnq1Q8Z5WuzQXOVTZTwN8oivf0=";
+    hash = "sha256-9u1FFRWe7qvDhzSKdGTduuGBXmmgzcSriGFb/oCJjNA=";
   };
 
   # Removes a reference to gcc that is only used in a debug message
@@ -17,8 +17,9 @@ mkDerivation rec {
 
   separateDebugInfo = true;
 
-  nativeBuildInputs = [ cmake makeWrapper ];
+  nativeBuildInputs = [ cmake ];
   buildInputs = [ eigen suitesparse blas lapack libGLU qtbase libqglviewer ];
+  propagatedBuildInputs = [ spdlog ];
 
   dontWrapQtApps = true;
 

--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -15,6 +15,7 @@ mkDerivation rec {
   # Removes a reference to gcc that is only used in a debug message
   patches = [ ./remove-compiler-reference.patch ];
 
+  outputs = [ "out" "dev" ];
   separateDebugInfo = true;
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
## Description of changes

https://github.com/RainerKuemmerle/g2o/releases/tag/20230806_git

The only package in nixpkgs that depends on g2o is rtabmap, which requires a patch to be compatible with this update. There are ROS distro specific tags of rtabmap 0.21.1 (ie. [`0.21.1-rolling`](https://github.com/introlab/rtabmap/releases/tag/0.21.1-rolling), [`0.21.1-humble`](https://github.com/introlab/rtabmap/releases/tag/0.21.1-humble), etc.) that include this patch, but there is no plain `0.21.1` tag, so I decided not to update rtabmap and just backport the patch.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @ckiee