### PR TITLE
srisum: init at 5.0.0

### DIFF
--- a/pkgs/tools/misc/srisum/default.nix
+++ b/pkgs/tools/misc/srisum/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "srisum";
+  version = "5.0.0";
+
+  src = fetchFromGitHub {
+    owner = "zkat";
+    repo = "srisum-rs";
+    rev = "v${version}";
+    hash = "sha256-Nw3uTGOcz1ivAm9X+PnOdNA937wuK3vtJQ0iJHlHVdw=";
+  };
+  cargoHash = "sha256-q6FGykY+HmU3/jMaGRO36OlYGVLG9mU8yZ8j/Shux3s=";
+
+  doInstallCheck = true;
+
+  meta = with lib; {
+    description = "A command-line utility to compute and check subresource integrity hashes";
+    homepage = "https://github.com/zkat/srisum-rs";
+    changelog = "https://github.com/zkat/srisum-rs/raw/v${version}/CHANGELOG.md";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ pjjw ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28588,6 +28588,8 @@ with pkgs;
 
   skopeo = callPackage ../development/tools/skopeo { };
 
+  srisum = callPackage ../tools/misc/srisum { };
+
   smem = callPackage ../os-specific/linux/smem { };
 
   smimesign = callPackage ../os-specific/darwin/smimesign { };


### PR DESCRIPTION


## Description of changes

this is a small utility in the shape of shasum to generate subresource integrity hashes on the command line.

https://github.com/zkat/srisum-rs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
