### PR TITLE
mommy: init at 1.2.3

### DIFF
--- a/pkgs/tools/misc/mommy/default.nix
+++ b/pkgs/tools/misc/mommy/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, writeText
+, shellspec
+, fetchpatch
+  # usage:
+  # pkgs.mommy.override {
+  #  mommySettings.sweetie = "catgirl";
+  # }
+  #
+  # $ mommy
+  # who's my good catgirl~
+, mommySettings ? null
+}:
+
+let
+  variables = lib.mapAttrs'
+    (name: value: lib.nameValuePair "MOMMY_${lib.toUpper name}" value)
+    mommySettings;
+  configFile = writeText "mommy-config" (lib.toShellVars variables);
+in
+stdenv.mkDerivation rec {
+  pname = "mommy";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "FWDekker";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-LT21MJg2rF84o2rWKguEP4UUOOu27nNGls95sBYgICw=";
+  };
+
+  patches = [
+    # 🫣 mommy finds your config with an environment variable now~
+    (fetchpatch {
+      url = "https://github.com/FWDekker/mommy/commit/d5785521fe2ce9ec832dbfe20abc483545b1df97.patch";
+      hash = "sha256-GacUjQyvvwRRYKIHHTTAL0mQSPMZbbxacqilBaw807Y=";
+    })
+    # 💜 mommy follows the XDG base directory specification now~
+    (fetchpatch {
+      url = "https://github.com/FWDekker/mommy/commit/71806bc0ace2822ac32dc8dd5bb0b0881d849982.patch";
+      hash = "sha256-Znq3VOgYI7a13Fqyz9nevtrvn7S5Jb2uBc78D0BG8rY=";
+    })
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+  nativeCheckInputs = [ shellspec ];
+  installFlags = [ "prefix=$(out)" ];
+
+  doCheck = true;
+  checkTarget = "test/unit";
+
+  postInstall = ''
+    ${lib.optionalString (mommySettings != null) ''
+      wrapProgram $out/bin/mommy \
+        --set-default MOMMY_OPT_CONFIG_FILE "${configFile}"
+    ''}
+  '';
+
+  meta = with lib; {
+    description = "mommy's here to support you, in any shell, on any system~ ❤️";
+    homepage = "https://github.com/FWDekker/mommy";
+    changelog = "https://github.com/FWDekker/mommy/blob/v${version}/CHANGELOG.md";
+    license = licenses.unlicense;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ckie ];
+    mainProgram = "mommy";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19457,6 +19457,8 @@ with pkgs;
 
   mold = callPackage ../development/tools/mold { };
 
+  mommy = callPackage ../tools/misc/mommy { };
+
   moon = callPackage ../development/tools/build-managers/moon/default.nix { };
 
   msgpack-tools = callPackage ../development/tools/msgpack-tools { };


### PR DESCRIPTION
## Description of changes

[mommy](https://github.com/FWDekker/mommy)'s here to support you, in any shell, on every NixOS system~ ❤️ 

an opt-in wrapper is included to configure mommy— once mommy is configured with `pkgs.mommy.override` you can take her store path with you to other machines.

cc @FWDekker

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
