### PR TITLE
selenium webdriver at spi

### DIFF
--- a/pkgs/development/python-modules/appium-python-client/default.nix
+++ b/pkgs/development/python-modules/appium-python-client/default.nix
@@ -1,0 +1,55 @@
+{ fetchFromGitHub
+, buildPythonPackage
+, selenium
+, pytestCheckHook
+, pythonOlder
+, python-dateutil
+, mock
+, httpretty
+, typing-extensions
+, types-python-dateutil
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "appium-python-client";
+  version = "2.11.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "appium";
+    repo = "python-client";
+    rev = "v${version}";
+    hash = "sha256-XI1JfeTmMxP6UVZ6lxpRc1R2KB0JRQNEP6beDnAzzEk=";
+  };
+
+  propagatedBuildInputs = [ selenium ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+
+    # upstream does not distinguish between dev and test dependencies,
+    # added dependencies probably used on tests
+    httpretty
+    mock
+    python-dateutil
+    typing-extensions
+    types-python-dateutil
+  ];
+
+  disabledTestPaths = [
+    "test/functional/mac/execute_script_test.py"
+    "test/functional/mac/webelement_test.py"
+  ];
+
+  meta = with lib;{
+    description = "Python language bindings for Appium";
+    longDescription = "An extension library for adding WebDriver Protocol and Appium commands to the Selenium Python language binding for use with the mobile testing framework Appium.";
+    homepage = "https://github.com/appium/python-client";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Alper-Celik ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -566,6 +566,8 @@ self: super: with self; {
 
   appdirs = callPackage ../development/python-modules/appdirs { };
 
+  appium-python-client = callPackage ../development/python-modules/appium-python-client { };
+
   applicationinsights = callPackage ../development/python-modules/applicationinsights { };
 
   appnope = callPackage ../development/python-modules/appnope { };


### PR DESCRIPTION
python3Packages.appium-python-client: init at 2.11.2

## Description of changes

this adds appium python client kde tests will use this probably
and could be useful for adding gui testing inside nixos tests in the future

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
