### PR TITLE
grapejuice: 7.8.3 -> 7.14.4

### DIFF
--- a/pkgs/games/grapejuice/default.nix
+++ b/pkgs/games/grapejuice/default.nix
@@ -19,13 +19,13 @@
 
 python3Packages.buildPythonApplication rec  {
   pname = "grapejuice";
-  version = "7.8.3";
+  version = "7.14.4";
 
   src = fetchFromGitLab {
     owner = "BrinkerVII";
     repo = "grapejuice";
     rev = "v${version}";
-    sha256 = "sha256-jNh3L6JDuJryFpHQaP8UesBmepmJopoHxb/XUfOwZz4=";
+    hash = "sha256-CWTnofJXx9T/hGXx3rdephXHjpiVRdFEJQ1u2v6n7yo=";
   };
 
   nativeBuildInputs = [
@@ -86,6 +86,16 @@ python3Packages.buildPythonApplication rec  {
 
     substituteInPlace src/grapejuice_common/models/settings_model.py \
       --replace 'default_wine_home: Optional[str] = ""' 'default_wine_home: Optional[str] = "${wine}"'
+
+    # Removed in 7.10.3. Required to set up the binary files.
+   substituteInPlace setup.py \
+      --replace 'install_requires=install_requires(),' 'install_requires=install_requires(),
+        entry_points={
+            "console_scripts": [
+                "grapejuice=grapejuice.cli.main:easy_install_main",
+                "grapejuice-gui=grapejuice.cli.gui:easy_install_main"
+            ]
+        },'
   '';
 
   postInstall = ''

--- a/pkgs/games/grapejuice/default.nix
+++ b/pkgs/games/grapejuice/default.nix
@@ -15,6 +15,7 @@
 , wine
 , glxinfo
 , xrandr
+, bash
 }:
 
 python3Packages.buildPythonApplication rec  {
@@ -39,6 +40,7 @@ python3Packages.buildPythonApplication rec  {
     cairo
     gettext
     gtk3
+    bash
   ];
 
   propagatedBuildInputs = with python3Packages; [
@@ -57,7 +59,6 @@ python3Packages.buildPythonApplication rec  {
   dontWrapGApps = true;
 
   makeWrapperArgs = [
-    "\${gappsWrapperArgs[@]}"
     "--prefix PATH : ${lib.makeBinPath [ xdg-user-dirs wine winetricks pciutils glxinfo xrandr ]}"
     # make xdg-open overrideable at runtime
     "--suffix PATH : ${lib.makeBinPath [ xdg-utils ]}"
@@ -77,7 +78,7 @@ python3Packages.buildPythonApplication rec  {
       --replace \$GRAPEJUICE_EXECUTABLE "$out/bin/grapejuice" \
       --replace \$PLAYER_ICON "grapejuice-roblox-player"
 
-    substituteInPlace src/grapejuice_common/assets/desktop/roblox-studio.desktop \
+    substituteInPlace src/grapejuice_common/assets/desktop/roblox-studio.desktop src/grapejuice_common/assets/desktop/roblox-studio-auth.desktop \
       --replace \$GRAPEJUICE_EXECUTABLE "$out/bin/grapejuice" \
       --replace \$STUDIO_ICON "grapejuice-roblox-studio"
 
@@ -87,38 +88,37 @@ python3Packages.buildPythonApplication rec  {
     substituteInPlace src/grapejuice_common/models/settings_model.py \
       --replace 'default_wine_home: Optional[str] = ""' 'default_wine_home: Optional[str] = "${wine}"'
 
-    # Removed in 7.10.3. Required to set up the binary files.
-   substituteInPlace setup.py \
-      --replace 'install_requires=install_requires(),' 'install_requires=install_requires(),
-        entry_points={
-            "console_scripts": [
-                "grapejuice=grapejuice.cli.main:easy_install_main",
-                "grapejuice-gui=grapejuice.cli.gui:easy_install_main"
-            ]
-        },'
+    substituteInPlace src/grapejuice_packaging/builders/linux_package_builder.py \
+      --replace '"--no-dependencies",' '"--no-dependencies", "--no-build-isolation",'
+
+    substituteInPlace src/grapejuice_packaging/packaging_resources/bin/grapejuice src/grapejuice_packaging/packaging_resources/bin/grapejuice-gui \
+      --replace "/usr/bin/env python3" "${python3Packages.python.interpreter}"
   '';
 
-  postInstall = ''
-    mkdir -p "$out/share/icons" "$out/share/applications" "$out/share/mime/packages"
-    cp -r src/grapejuice_common/assets/desktop/* $out/share/applications/
-    cp -r src/grapejuice_common/assets/icons $out/share/
-    cp src/grapejuice_common/assets/mime_xml/*.xml $out/share/mime/packages/
+  installPhase = ''
+    runHook preInstall
 
-    # compile locales (*.po -> *.mo)
-    # from https://gitlab.com/brinkervii/grapejuice/-/blob/master/src/grapejuice_common/util/mo_util.py
-    LOCALE_DIR="$out/share/locale"
-    PO_DIR="src/grapejuice_common/assets/po"
-    LINGUAS_FILE="src/grapejuice_common/assets/po/LINGUAS"
+    PYTHONPATH=$(pwd)/src:$PYTHONPATH python3 -m grapejuice_packaging linux_package
 
-    for lang in $(<"$LINGUAS_FILE") # extract langs from LINGUAS_FILE
-    do
-      po_file="$PO_DIR/$lang.po"
-      mo_file_dir="$LOCALE_DIR/$lang/LC_MESSAGES"
+    mkdir -p "$out" "$out/${python3Packages.python.sitePackages}"
+    tar -xvf ./dist/linux_package/grapejuice-''${version}.tar.gz --strip-components=1 -C "$out"
 
-      mkdir -p $mo_file_dir
+    mv "$out/lib/python3/dist-packages/"* "$out/${python3Packages.python.sitePackages}"
+    rmdir --ignore-fail-on-non-empty -p "$out/lib/python3/dist-packages"
 
-      mo_file="$mo_file_dir/grapejuice.mo"
-      msgfmt $po_file -o $mo_file # msgfmt from gettext
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    patchShebangs "$out/bin/grapejuice{,-gui}"
+
+    buildPythonPath "$out $pythonPath"
+
+    for bin in grapejuice grapejuice-gui; do
+    wrapProgram "$out/bin/$bin" \
+      --prefix PYTHONPATH : "$PYTHONPATH:$(toPythonPath $out)" \
+      ''${makeWrapperArgs[@]} \
+      ''${gappsWrapperArgs[@]}
     done
   '';
 


### PR DESCRIPTION
## Description of changes
Changelog: https://gitlab.com/brinkervii/grapejuice/-/releases

The primary justification for the update is the new release channel selection in Grapejuice. ~~While Roblox is currently blocking WINE users on the live version, the "`zintegration`" branch unblocks WINE users again.~~ (Edit: No longer required - `live` has the changes)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
