### PR TITLE
[23.05] Emacs backport #247357

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -54,7 +54,7 @@ lib.makeScope pkgs.newScope (self:
       withPgtk = true;
     };
 
-    emacs-macport = callPackage (self.sources.emacs-macport) {
+    emacs28-macport = callPackage (self.sources.emacs28-macport) {
       inherit gconf;
 
       inherit (pkgs.darwin) sigtool;

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -62,4 +62,13 @@ lib.makeScope pkgs.newScope (self:
         AppKit Carbon Cocoa GSS ImageCaptureCore ImageIO IOKit OSAKit Quartz
         QuartzCore WebKit;
     };
+
+    emacs29-macport = callPackage (self.sources.emacs29-macport) {
+      inherit gconf;
+
+      inherit (pkgs.darwin) sigtool;
+      inherit (pkgs.darwin.apple_sdk.frameworks)
+        AppKit Carbon Cocoa GSS ImageCaptureCore ImageIO IOKit OSAKit Quartz
+        QuartzCore WebKit;
+    };
   })

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -90,4 +90,19 @@ in
 
     meta = metaFor "macport" "28.2" "emacs-28.2-mac-9.1";
   };
+
+  emacs29-macport = import ./generic.nix {
+    pname = "emacs-mac";
+    version = "29.1";
+    variant = "macport";
+
+    src = fetchFromBitbucket {
+      owner = "mituharu";
+      repo = "emacs-mac";
+      rev = "emacs-29.1-mac-10.0";
+      hash = "sha256-TE829qJdPjeOQ+kD0SfyO8d5YpJjBge/g+nScwj+XVU=";
+    };
+
+    meta = metaFor "macport" "29.1" "emacs-29.1-mac-10.0";
+  };
 }

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -4,9 +4,13 @@
 }:
 
 let
-  mainlineMeta = {
-    homepage = "https://www.gnu.org/software/emacs/";
-    description = "The extensible, customizable GNU text editor";
+  metaFor = variant: version: rev: {
+    homepage = {
+      "mainline" = "https://www.gnu.org/software/emacs/";
+      "macport" = "https://bitbucket.org/mituharu/emacs-mac/";
+    }.${variant};
+    description = "The extensible, customizable GNU text editor"
+                  + lib.optionalString (variant == "macport") " - macport variant";
     longDescription = ''
       GNU Emacs is an extensible, customizable text editor—and more. At its core
       is an interpreter for Emacs Lisp, a dialect of the Lisp programming
@@ -21,7 +25,15 @@ let
       functionality, including a project planner, mail and news reader, debugger
       interface, calendar, and more. Many of these extensions are distributed
       with GNU Emacs; others are available separately.
+    '' + lib.optionalString (variant == "macport") ''
+
+      This release is built from Mitsuharu Yamamoto's patched source code
+      tailored for macOS.
     '';
+    changelog = {
+      "mainline" = "https://www.gnu.org/savannah-checkouts/gnu/emacs/news/NEWS.${version}";
+      "macport" = "https://bitbucket.org/mituharu/emacs-mac/raw/${rev}/NEWS-mac";
+    }.${variant};
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       AndersonTorres
@@ -31,7 +43,11 @@ let
       lovek323
       matthewbauer
     ];
-    platforms = lib.platforms.all;
+    platforms = {
+      "mainline" = lib.platforms.all;
+      "macport" = lib.platforms.darwin;
+    }.${variant};
+    mainProgram = "emacs";
   };
 in
 {
@@ -45,7 +61,7 @@ in
       hash = "sha256-4oSLcUDR0MOEt53QOiZSVU8kPJ67GwugmBxdX3F15Ag=";
     };
 
-    meta = mainlineMeta;
+    meta = metaFor "mainline" "28.2" "28.2";
   };
 
   emacs29 = import ./generic.nix {
@@ -58,7 +74,7 @@ in
       hash = "sha256-p0lBSKsHrFwYTqO5UVIF/PgiqwdhYQE4oUVcPtd+gsU=";
     };
 
-    meta = mainlineMeta;
+    meta = metaFor "mainline" "29.1-rc1" "29.1-rc1";
   };
 
   emacs28-macport = import ./generic.nix {
@@ -72,16 +88,6 @@ in
       hash = "sha256-Ne2jQ2nVLNiQmnkkOXVc5AkLVkTpm8pFC7VNY2gQjPE=";
     };
 
-    meta = {
-      homepage = "https://bitbucket.org/mituharu/emacs-mac/";
-      description = mainlineMeta.description + " - with macport patches";
-      longDescription = mainlineMeta.longDescription + ''
-
-        This release is built from Mitsuharu Yamamoto's patched source code
-        tailoired for MacOS X.
-      '';
-      inherit (mainlineMeta) license maintainers;
-      platforms = lib.platforms.darwin;
-    };
+    meta = metaFor "macport" "28.2" "emacs-28.2-mac-9.1";
   };
 }

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -61,7 +61,7 @@ in
     meta = mainlineMeta;
   };
 
-  emacs-macport = import ./generic.nix {
+  emacs28-macport = import ./generic.nix {
     pname = "emacs-mac";
     version = "28.2";
     variant = "macport";

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -66,15 +66,15 @@ in
 
   emacs29 = import ./generic.nix {
     pname = "emacs";
-    version = "29.1-rc1";
+    version = "29.1";
     variant = "mainline";
     src = fetchFromSavannah {
       repo = "emacs";
-      rev = "29.1-rc1";
-      hash = "sha256-p0lBSKsHrFwYTqO5UVIF/PgiqwdhYQE4oUVcPtd+gsU=";
+      rev = "29.1";
+      hash = "sha256-3HDCwtOKvkXwSULf3W7YgTz4GV8zvYnh2RrL28qzGKg=";
     };
 
-    meta = metaFor "mainline" "29.1-rc1" "29.1-rc1";
+    meta = metaFor "mainline" "29.1" "29.1";
   };
 
   emacs28-macport = import ./generic.nix {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -444,6 +444,7 @@ mapAliases ({
   emacs28NativeComp = emacs28; # Added 2022-06-08
   emacs28Packages = emacs28.pkgs; # Added 2021-10-04
   emacs28WithPackages = emacs28.pkgs.withPackages; # Added 2021-10-04
+  emacsMacport = emacs-macport; # Added 2023-08-10
   emacsNativeComp = emacs28NativeComp; # Added 2022-06-08
   emacsPackagesGen = throw "'emacsPackagesGen' has been renamed to/replaced by 'emacsPackagesFor'"; # Converted to throw 2022-02-22
   emacsPackagesNg = emacs.pkgs; # Added 2019-08-07

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30167,6 +30167,7 @@ with pkgs;
     emacs29-nox
     emacs29-pgtk
     emacs28-macport
+    emacs29-macport
   ;
 
   emacs-macport = emacs28-macport;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30166,10 +30166,10 @@ with pkgs;
     emacs29-gtk3
     emacs29-nox
     emacs29-pgtk
-    emacs-macport
+    emacs28-macport
   ;
 
-  emacsMacport = emacs-macport;
+  emacs-macport = emacs28-macport;
   emacs = emacs28;
   emacs-gtk = emacs28-gtk3;
   emacs-nox = emacs28-nox;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
