### PR TITLE
pantheon.elementary-default-settings: 7.0.2 -> 7.1.0

### DIFF
--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , meson
 , ninja
@@ -11,36 +10,18 @@
 , dbus
 , polkit
 , accountsservice
-, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "elementary-default-settings";
-  version = "7.0.2";
+  version = "7.1.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "default-settings";
     rev = version;
-    sha256 = "sha256-YFI1UM7CxjYkoIhSg9Fn81Ze6DX7D7p89xibk7ik8bI=";
+    sha256 = "sha256-j4K8qYwfu6/s4qnTSzwv6KRsk9f+Qr/l1bhLywKMHMU=";
   };
-
-  patches = [
-    # Don't set picture-uri-dark. elementary-gsettings-schemas won't
-    # aware of our custom remove-backgrounds.gschema.override so it
-    # will be a confusing invalid value otherwise (though gala actually
-    # can handle it well).
-    # https://github.com/elementary/default-settings/pull/282
-    (fetchpatch {
-      url = "https://github.com/elementary/default-settings/commit/881f84b8316e549ab627b7ac9acf352e0346a1a4.patch";
-      sha256 = "sha256-zf2Anr+ljLjHbn5ZmRj3nCRVJ52rwe4EkwdIfSOGeLQ=";
-    })
-    # https://github.com/elementary/default-settings/pull/283
-    (fetchpatch {
-      url = "https://github.com/elementary/default-settings/commit/37ef6062a8651875dd9d927c5730155c8b26e953.patch";
-      sha256 = "sha256-u7rrwuHgMPn1eIyIuwJcBgy8SshaXgrgFTSNm8IHbaY=";
-    })
-  ];
 
   nativeBuildInputs = [
     accountsservice
@@ -50,7 +31,6 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     polkit
-    python3
   ];
 
   mesonFlags = [
@@ -58,11 +38,6 @@ stdenv.mkDerivation rec {
     "-Ddefault-wallpaper=${nixos-artwork.wallpapers.simple-dark-gray.gnomeFilePath}"
     "-Dplank-dockitems=false"
   ];
-
-  postPatch = ''
-    chmod +x meson/post_install.py
-    patchShebangs meson/post_install.py
-  '';
 
   preInstall = ''
     # Install our override for plank dockitems as the desktop file path is different.


### PR DESCRIPTION
https://github.com/elementary/default-settings/releases/tag/7.1.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
