### PR TITLE
ioquake3: fix missing `.so` files at startup and clean-up

### DIFF
--- a/pkgs/games/quake3/ioquake/default.nix
+++ b/pkgs/games/quake3/ioquake/default.nix
@@ -1,47 +1,52 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, which
 , pkg-config
+, which
+, copyDesktopItems
+, makeBinaryWrapper
 , SDL2
 , libGL
-, openalSoft
+, openal
 , curl
 , speex
 , opusfile
 , libogg
 , libvorbis
-, libopus
 , libjpeg
-, mumble
+, makeDesktopItem
 , freetype
 }:
 
 stdenv.mkDerivation {
   pname = "ioquake3";
-  version = "unstable-2022-11-24";
+  version = "unstable-2023-08-13";
 
   src = fetchFromGitHub {
     owner = "ioquake";
     repo = "ioq3";
-    rev = "70d07d91d62dcdd2f2268d1ac401bfb697b4c991";
-    sha256 = "sha256-WDjR0ik+xAs6OA1DNbUGIF1MXSuEoy8nNkPiHaegfF0=";
+    rev = "ee950eb7b0e41437cc23a9943254c958da8a61ab";
+    sha256 = "sha256-NfhInwrtw85i2mnv7EtBrrpNaslaQaVhLNlK0I9aYto=";
   };
 
-  nativeBuildInputs = [ which pkg-config ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeBinaryWrapper
+    pkg-config
+    which
+  ];
+
   buildInputs = [
     SDL2
     libGL
-    openalSoft
+    openal
     curl
     speex
     opusfile
     libogg
     libvorbis
-    libopus
     libjpeg
     freetype
-    mumble
   ];
 
   enableParallelBuilding = true;
@@ -50,17 +55,32 @@ stdenv.mkDerivation {
 
   installTargets = [ "copyfiles" ];
 
-  installFlags = [ "COPYDIR=$(out)" "COPYBINDIR=$(out)/bin" ];
+  installFlags = [ "COPYDIR=$(out)/share/ioquake3" ];
 
-  preInstall = ''
-    mkdir -p $out/baseq3 $out/bin
+  postInstall = ''
+    install -Dm644 misc/quake3.svg $out/share/icons/hicolor/scalable/apps/ioquake3.svg
+
+    makeWrapper $out/share/ioquake3/ioquake3.* $out/bin/ioquake3
+    makeWrapper $out/share/ioquake3/ioq3ded.* $out/bin/ioq3ded
   '';
 
-  meta = with lib; {
+  desktopItems = [
+    (makeDesktopItem {
+      name = "IOQuake3";
+      exec = "ioquake3";
+      icon = "ioquake3";
+      comment = "A fast-paced 3D first-person shooter, a community effort to continue supporting/developing id's Quake III Arena";
+      desktopName = "ioquake3";
+      categories = [ "Game" "ActionGame" ];
+    })
+  ];
+
+  meta = {
     homepage = "https://ioquake3.org/";
-    description = "First person shooter engine based on the Quake 3: Arena and Quake 3: Team Arena";
-    license = licenses.gpl2Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ rvolosatovs eelco abbradar ];
+    description = "A fast-paced 3D first-person shooter, a community effort to continue supporting/developing id's Quake III Arena";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "ioquake3";
+    maintainers = with lib.maintainers; [ abbradar drupol eelco rvolosatovs ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
The current version of `ioquake3` in `nixpkgs` is broken. Missing `.so` files when running the main binary:

```
❯ nix shell nixpkgs#ioquake3
❯ ioquake3.x86_64 
ioq3 1.36 linux-x86_64 Jan  1 1980
SSE instruction set enabled
----- FS_Startup -----
We are looking in the current search path:
/home/pol/.q3a/baseq3
/home/pol/.q3a/baseq3/pak8.pk3 (9 files)
/home/pol/.q3a/baseq3/pak7.pk3 (4 files)
/home/pol/.q3a/baseq3/pak6.pk3 (64 files)
/home/pol/.q3a/baseq3/pak5.pk3 (7 files)
/home/pol/.q3a/baseq3/pak4.pk3 (272 files)
/home/pol/.q3a/baseq3/pak3.pk3 (4 files)
/home/pol/.q3a/baseq3/pak2.pk3 (148 files)
/home/pol/.q3a/baseq3/pak1.pk3 (26 files)
/home/pol/.q3a/baseq3/pak0.pk3 (3539 files)
./baseq3
    
----------------------
4073 files in pk3 files
execing default.cfg
execing q3config.cfg
couldn't exec autoexec.cfg
Hunk_Clear: reset the hunk ok
----- Client Initialization -----
Couldn't read q3history.
----- Initializing Renderer ----
Trying to load "renderer_opengl2_x86_64.so" from "."...
Loading "renderer_opengl2_x86_64.so" failed
failed:
"Failed loading ./renderer_opengl2_x86_64.so: ./renderer_opengl2_x86_64.so: cannot open shared object file: No such file or directory"
Failed to load renderer
~ ✘   
```

Also, the binaries should not be suffixed with the arch it has been compiled for.

## Description of changes

ioquake3:

- Fix `ioquake3`
- Remove the arch suffix from the binaries (`ioquake3.x86-64` -> `ioquake3`, `ioq3ded.x86-64` -> `ioq3ded`)
- Add `.desktop` file
- Remove unneeded dependencies
- Clean-up installation phase
- Add `meta.mainProgram` attribute
- Add myself in the maintainer list

nixos/quake3-server:

- add `package` config option
- remove top-level `with lib;`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
