### PR TITLE
faraday-agent-dispatcher: 2.4.0 -> 2.6.2

### DIFF
--- a/pkgs/development/python-modules/pytenable/default.nix
+++ b/pkgs/development/python-modules/pytenable/default.nix
@@ -1,5 +1,4 @@
 { lib
-, appdirs
 , buildPythonPackage
 , defusedxml
 , fetchFromGitHub
@@ -33,26 +32,22 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    semver
-  ];
-
-  buildInputs = [
-    appdirs
     defusedxml
     marshmallow
     python-box
     python-dateutil
     requests
-    requests-pkcs12
     restfly
+    semver
     typing-extensions
   ];
 
   nativeCheckInputs = [
-    responses
     pytest-datafiles
     pytest-vcr
     pytestCheckHook
+    requests-pkcs12
+    responses
   ];
 
   disabledTests = [

--- a/pkgs/tools/security/faraday-agent-dispatcher/default.nix
+++ b/pkgs/tools/security/faraday-agent-dispatcher/default.nix
@@ -5,15 +5,20 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "faraday-agent-dispatcher";
-  version = "2.4.0";
+  version = "2.6.2";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "infobyte";
     repo = "faraday_agent_dispatcher";
     rev = "refs/tags/${version}";
-    hash = "sha256-gZXA+2zW25Dl8JmBgg7APZt6ZdpFOEFZXAkiZ+tn/4g=";
+    hash = "sha256-+lsejepg/iBHo6CRAGNHjiUC7ZgboHbKu7EDmlN3lVk=";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace '"pytest-runner",' ""
+  '';
 
   nativeBuildInputs = with python3.pkgs; [
     setuptools-scm
@@ -26,6 +31,7 @@ python3.pkgs.buildPythonApplication rec {
     faraday-plugins
     itsdangerous
     psutil
+    pytenable
     python-gvm
     python-owasp-zap-v2-4
     pyyaml
@@ -38,11 +44,6 @@ python3.pkgs.buildPythonApplication rec {
     pytest-asyncio
     pytestCheckHook
   ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace '"pytest-runner",' ""
-  '';
 
   preCheck = ''
     export HOME=$(mktemp -d);


### PR DESCRIPTION
## Description of changes

I am not sure why, but the current version is [failing to build](https://hydra.nixos.org/build/231864786/nixlog/1) with test failures after Python bootstrapping changes I've made:

```
FAILED tests/unittests/test_config_wizard.py::test_new_config[no .ini-Basic Repo Executors input] - AssertionError: assert set() == {'ex1'}
FAILED tests/unittests/test_config_wizard.py::test_new_config[0.1.ini-Basic Repo Executors input] - AssertionError: assert {'unnamed_executor'} == {'ex1', 'unnamed_executor'}
FAILED tests/unittests/test_config_wizard.py::test_new_config[1.0.ini-Basic Repo Executors input] - AssertionError: assert {'test', 'test2'} == {'ex1', 'test', 'test2'}
FAILED tests/unittests/test_config_wizard.py::test_new_config[1.2.ini-Basic Repo Executors input] - AssertionError: assert {'test', 'test2', 'test3'} == {'ex1', 'test...st2', ...
FAILED tests/unittests/test_config_wizard.py::test_new_config[1.5.ini-Basic Repo Executors input] - AssertionError: assert {'test', 'test2', 'test3'} == {'ex1', 'test...st2', ...
```

However, everything starts to pass once we update to the latest version, so let's try that! The new version also revealed that `pytenable`'s dependencies were not being properly propagated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
