### PR TITLE
bash: disable `bash-malloc` everywhere, not just on `musl`

### DIFF
--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -64,6 +64,12 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
+    # At least on Linux bash memory allocator has pathological performance
+    # in scenarios involving use of larger memory:
+    #   https://lists.gnu.org/archive/html/bug-bash/2023-08/msg00052.html
+    # Various distributions default to system allocator. Let's nixpkgs
+    # do the same.
+    "--without-bash-malloc"
     (if interactive then "--with-installed-readline" else "--disable-readline")
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "bash_cv_job_control_missing=nomissing"
@@ -77,7 +83,6 @@ stdenv.mkDerivation rec {
     "bash_cv_dev_fd=standard"
     "bash_cv_termcap_lib=libncurses"
   ] ++ lib.optionals (stdenv.hostPlatform.libc == "musl") [
-    "--without-bash-malloc"
     "--disable-nls"
   ];
 


### PR DESCRIPTION
TIme to time I bump into pathological behaviour of `bash` memory allocator. Today's example:

    $ time { ls /nix/store/ > /dev/null; }
    real    0m0,965s user    0m0,876s sys     0m0,087s
    $ time { echo /nix/store/* > /dev/null; }
    real    2m18,287s user    2m17,946s sys     0m0,125s
    $ time { echo /nix/store/* > /dev/null; }
    real    0m1,764s user    0m1,712s sys     0m0,048s

Note how initial `echo` takes alsmot 2 minutes to finish.

Let's rely  on system's allocator instead.

After the change initial run is fast again:

    $ time { echo /nix/store/* > /dev/null; }
    real    0m1,328s user    0m1,264s sys     0m0,063s

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
