### PR TITLE
osmscout-server: add patches to support valhalla 3.4.0

### DIFF
--- a/pkgs/applications/misc/osmscout-server/default.nix
+++ b/pkgs/applications/misc/osmscout-server/default.nix
@@ -1,7 +1,23 @@
-{ lib, mkDerivation, fetchFromGitHub, pkg-config
-, qmake, qttools, kirigami2, qtquickcontrols2, qtlocation
-, libosmscout, valhalla, libpostal, osrm-backend, protobuf
-, libmicrohttpd, sqlite, marisa, kyotocabinet, boost
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, fetchpatch
+, pkg-config
+, qmake
+, qttools
+, kirigami2
+, qtquickcontrols2
+, qtlocation
+, libosmscout
+, valhalla
+, libpostal
+, osrm-backend
+, protobuf
+, libmicrohttpd
+, sqlite
+, marisa
+, kyotocabinet
+, boost
 }:
 
 let
@@ -29,6 +45,19 @@ mkDerivation rec {
     kirigami2 qtquickcontrols2 qtlocation
     valhalla libosmscout osrm-backend libmicrohttpd
     libpostal sqlite marisa kyotocabinet boost protobuf date
+  ];
+
+  patches = [
+    # Valhalla 3.2.1 support. Only required for next patch to apply cleanly
+    (fetchpatch {
+      url = "https://github.com/rinigus/osmscout-server/commit/1df9d383e61dd14cbe9e5b52412a2e951cee2ee4.patch";
+      sha256 = "sha256-h+YTyHr4RYgwH5bfVgyujSekbL2LfV8vJgVkjXT0I10=";
+    })
+    # Valhalla 3.4.0 support
+    (fetchpatch {
+      url = "https://github.com/rinigus/osmscout-server/commit/fe6562a4c3ba5da2735232ea8fdc7f71d7e7e714.patch";
+      sha256 = "sha256-wibLTFk3cFS5mcC71TgMA9ZAAHS3mbjboFHqax6nCxs=";
+    })
   ];
 
   qmakeFlags = [


### PR DESCRIPTION
## Description of changes

Allows us to update valhalla to 3.4.0 (#248414)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
