### PR TITLE
signal-desktop: 6.27.1 -> 6.28.0, signal-desktop-beta: 6.24.0-beta.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,12 +1,12 @@
 { callPackage }: builtins.mapAttrs (pname: attrs: callPackage ./generic.nix (attrs // { inherit pname; })) {
   signal-desktop = {
     dir = "Signal";
-    version = "6.27.1";
-    hash = "sha256-nEOt6bep6SqhAab8yD9NlRrDGU2IvZeOxSqPj2u1bio=";
+    version = "6.28.0";
+    hash = "sha256-zJURX5VygBvW+0v29xqOx9HmQgFgfAbxoacd7ex3iec=";
   };
   signal-desktop-beta = {
     dir = "Signal Beta";
-    version = "6.24.0-beta.1";
-    hash = "sha256-tA1xsgtAeOn0c0HcZutj+Pqrsr0JV5bQOnknH4t/QkY=";
+    version = "6.29.0-beta.1";
+    hash = "sha256-ZUM2tVZbWtiatpI0ogo0MC6q8DIoPEBocIHuszx3Mv0=";
   };
 }


### PR DESCRIPTION
-> 6.29.0-beta.1

## Description of changes

New Versions: 
-  Signal Desktop:
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.28.0
- Signal Desktop Beta:
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.25.0-beta.1
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.26.0-beta.1
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.27.0-beta.1
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.27.0-beta.2
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.27.0-beta.3
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.27.0-beta.4
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.28.0-beta.1
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.28.0-beta.2
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.29.0-beta.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
