### PR TITLE
fusuma: enable "essential" plugins

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -379,6 +379,7 @@ The module update takes care of the new config syntax and the data itself (user 
 
   If you use this feature, updates to CoreDNS may require updating `vendorHash` by following these steps again.
 
+- `fusuma` now enables the following plugins: [appmatcher](https://github.com/iberianpig/fusuma-plugin-appmatcher), [keypress](https://github.com/iberianpig/fusuma-plugin-keypress), [sendkey](https://github.com/iberianpig/fusuma-plugin-sendkey), [tap](https://github.com/iberianpig/fusuma-plugin-tap) and [wmctrl](https://github.com/iberianpig/fusuma-plugin-wmctrl).
 
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 

--- a/pkgs/tools/inputmethods/fusuma/Gemfile
+++ b/pkgs/tools/inputmethods/fusuma/Gemfile
@@ -1,2 +1,17 @@
 source 'https://rubygems.org'
 gem "fusuma"
+gem "fusuma-plugin-appmatcher"
+gem "fusuma-plugin-keypress"
+gem "fusuma-plugin-sendkey"
+gem "fusuma-plugin-tap"
+gem "fusuma-plugin-wmctrl"
+
+# I've not activated the following plugins for the reasons given below.
+
+# touchscreen needs specific h/w support I don't have access to, so I can't confirm
+# if it's problem free.  A quick check didn't reveal any problems.
+#gem "fusuma-plugin-touchscreen"
+
+# thumbsense pulls in remap, and at best remap requires further configuration to allow the use access to event devices.
+#gem "fusuma-plugin-thumbsense"
+#gem "fusuma-plugin-remap"

--- a/pkgs/tools/inputmethods/fusuma/Gemfile.lock
+++ b/pkgs/tools/inputmethods/fusuma/Gemfile.lock
@@ -2,12 +2,34 @@ GEM
   remote: https://rubygems.org/
   specs:
     fusuma (3.1.0)
+    fusuma-plugin-appmatcher (0.6.0)
+      fusuma (~> 3.0)
+      rexml
+      ruby-dbus
+    fusuma-plugin-keypress (0.8.0)
+      fusuma (~> 2.0)
+    fusuma-plugin-sendkey (0.10.1)
+      fusuma (~> 3.1)
+      revdev
+    fusuma-plugin-tap (0.4.2)
+      fusuma (~> 2.0)
+    fusuma-plugin-wmctrl (1.3.1)
+      fusuma (~> 3.1)
+    revdev (0.2.1)
+    rexml (3.2.5)
+    ruby-dbus (0.19.0)
+      rexml
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   fusuma
+  fusuma-plugin-appmatcher
+  fusuma-plugin-keypress
+  fusuma-plugin-sendkey
+  fusuma-plugin-tap
+  fusuma-plugin-wmctrl
 
 BUNDLED WITH
-   2.1.4
+   2.4.6

--- a/pkgs/tools/inputmethods/fusuma/gemset.nix
+++ b/pkgs/tools/inputmethods/fusuma/gemset.nix
@@ -9,4 +9,90 @@
     };
     version = "3.1.0";
   };
+  fusuma-plugin-appmatcher = {
+    dependencies = ["fusuma" "rexml" "ruby-dbus"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "28e8c59d5984a5723510f19868c37c363bec93e51f6cb7a573170cf7f5b9189f";
+      type = "gem";
+    };
+    version = "0.6.0";
+  };
+  fusuma-plugin-keypress = {
+    dependencies = ["fusuma"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "045c1820d909307abb1d232c0cf26bbd88eafa0453004124c07b15fff5d680de";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  fusuma-plugin-sendkey = {
+    dependencies = ["fusuma" "revdev"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "f792fec194b611d5d79b93b6694876292c43bee55635d9422f885b6509eeb765";
+      type = "gem";
+    };
+    version = "0.10.1";
+  };
+  fusuma-plugin-tap = {
+    dependencies = ["fusuma"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jlw08iw20fpykjglzj4c2fy3z13zsnmi63zbfpn0gmvs05869ys";
+      type = "gem";
+    };
+    version = "0.4.2";
+  };
+  fusuma-plugin-wmctrl = {
+    dependencies = ["fusuma"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "067939b2d8b99cf8fce43be40341cda3de3371596a8a4fb24eb13ca84c0bffe5";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+  revdev = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1b6zg6vqlaik13fqxxcxhd4qnkfgdjnl4wy3a1q67281bl0qpsz9";
+      type = "gem";
+    };
+    version = "0.2.1";
+  };
+  rexml = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08ximcyfjy94pm1rhcx04ny1vx2sk0x4y185gzn86yfsbzwkng53";
+      type = "gem";
+    };
+    version = "3.2.5";
+  };
+  ruby-dbus = {
+    dependencies = ["rexml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18zbsr03drpx7mknm927i2kz5b49s0lwmrbmsdknfa674z0xy6sm";
+      type = "gem";
+    };
+    version = "0.19.0";
+  };
 }


### PR DESCRIPTION
[This commit changes the gem files, but no changes to `default.nix`.]

A lot of useful Fusuma functionality is split out in to plugins, which means that this functionality isn't currently available on NixOS.

This pull request enable specifically the following plugins:

  * [fusuma-plugin-appmatcher](https://github.com/iberianpig/fusuma-plugin-appmatcher)
  * [fusuma-plugin-keypress](https://github.com/iberianpig/fusuma-plugin-keypress)
  * [fusuma-plugin-sendkey](https://github.com/iberianpig/fusuma-plugin-sendkey)
  * [fusuma-plugin-tap](https://github.com/iberianpig/fusuma-plugin-tap)
  * [fusuma-plugin-wmctrl](https://github.com/iberianpig/fusuma-plugin-wmctrl)

I've not enabled the other plugins available on rubygems for the following reasons:

  * [fusuma-plugin-remap](https://github.com/iberianpig/fusuma-plugin-remap) : seems niche functionality and requires [udev configuration](https://github.com/iberianpig/fusuma-plugin-remap#set-up-udev-rules) to create a virtual input device.

  * [fusuma-plugin-thumbsense](https://github.com/iberianpig/fusuma-plugin-thumbsense) : again, niche (?) and pulls in remap (see above).

  * [fusuma-plugin-touchscreen](https://github.com/Phaengris/fusuma-plugin-touchscreen) : I've no way of testing.  Note: enabling didn't appear to cause any problems.

Ideally all of the plugin implemented functionality would be made available as separate pkgs, but that would require patching Fusuma to search outside of the Gem directory, which would require more than my pretty much zero Ruby knowledge.

Enabling this subset of plugins for what appears to be widely useful functionality seems a good option.


## Description of changes

See the various plugin links above.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
