### PR TITLE
pipenv: remove wheel install test, enable unit tests

### DIFF
--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , python3
-, fetchPypi
+, fetchFromGitHub
 , installShellFiles
 }:
 
@@ -25,15 +25,22 @@ let
 in buildPythonApplication rec {
   pname = "pipenv";
   version = "2023.2.4";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-GKPrpRnjbVnw1af5xCvSaFIeS5t7PRvWrc8TFWkyMnU=";
+  src = fetchFromGitHub {
+    owner = "pypa";
+    repo = "pipenv";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-jZOBu4mWyu8U6CGqtYgfcCCDSa0pGqoZEFnXl5IO+JY=";
   };
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    setuptools
+    wheel
+  ];
 
   postPatch = ''
     # pipenv invokes python in a subprocess to create a virtualenv
@@ -46,18 +53,32 @@ in buildPythonApplication rec {
 
   propagatedBuildInputs = runtimeDeps python3.pkgs;
 
+  preCheck = ''
+    export HOME="$TMPDIR"
+  '';
+
+  nativeCheckInputs = [
+    mock
+    pytestCheckHook
+    pytest-xdist
+    pytz
+    requests
+  ];
+
+  disabledTests = [
+    "test_convert_deps_to_pip"
+    "test_download_file"
+  ];
+
+  disabledTestPaths = [
+    "tests/integration"
+  ];
+
   postInstall = ''
     installShellCompletion --cmd pipenv \
       --bash <(_PIPENV_COMPLETE=bash_source $out/bin/pipenv) \
       --zsh <(_PIPENV_COMPLETE=zsh_source $out/bin/pipenv) \
       --fish <(_PIPENV_COMPLETE=fish_source $out/bin/pipenv)
-  '';
-
-  doCheck = true;
-  checkPhase = ''
-    export HOME=$(mktemp -d)
-    cp -r --no-preserve=mode ${wheel.src} $HOME/wheel-src
-    $out/bin/pipenv install $HOME/wheel-src
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

The current test for pipenv installs `wheel` using the binary. However, when updating `wheel` to version 0.40.0+, it has switched from setuptools to flit-core as the build backend, and pipenv now tries to download flit-core from the Internet. I do not know how to fix this test, so instead I removed it and enabled at least the unit tests for some validation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
