### PR TITLE
python3.pkgs.compreffor: fix up build dependencies

### DIFF
--- a/pkgs/development/python-modules/compreffor/default.nix
+++ b/pkgs/development/python-modules/compreffor/default.nix
@@ -1,15 +1,17 @@
 { lib
 , buildPythonPackage
+, cython
+, fetchpatch
 , fetchPypi
 , setuptools-scm
 , fonttools
 , pytestCheckHook
+, wheel
 }:
 
 buildPythonPackage rec {
   pname = "compreffor";
   version = "0.5.4";
-
   format = "pyproject";
 
   src = fetchPypi {
@@ -17,8 +19,19 @@ buildPythonPackage rec {
     hash = "sha256-MGulQEUGPrQ30T3VYzwRRlvzvWkFqNzqsNzAjtjX9xU=";
   };
 
+  patches = [
+    # https://github.com/googlefonts/compreffor/pull/153
+    (fetchpatch {
+      name = "remove-setuptools-git-ls-files.patch";
+      url = "https://github.com/googlefonts/compreffor/commit/10f563564390568febb3ed1d0f293371cbd86953.patch";
+      hash = "sha256-wNQMJFJXTFILGzAgzUXzz/rnK67/RU+exYP6MhEQAkA=";
+    })
+  ];
+
   nativeBuildInputs = [
+    cython
     setuptools-scm
+    wheel
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

1. Pull in a patch that removes setuptools-git-ls-files (not needed for wheel builds).
2. Add wheel as an explicit build dependency.
3. Add cython as a build dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
