### PR TITLE
no more truncate elf size for jetbrain products

### DIFF
--- a/pkgs/applications/editors/jetbrains/linux.nix
+++ b/pkgs/applications/editors/jetbrains/linux.nix
@@ -58,31 +58,15 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
   nativeBuildInputs = [ makeWrapper patchelf unzip ];
 
   postPatch = ''
-    get_file_size() {
-      local fname="$1"
-      echo $(ls -l $fname | cut -d ' ' -f5)
-    }
-
-    munge_size_hack() {
-      local fname="$1"
-      local size="$2"
-      strip $fname
-      truncate --size=$size $fname
-    }
-
     rm -rf jbr
     # When using the IDE as a remote backend using gateway, it expects the jbr directory to contain the jdk
     ln -s ${jdk.home} jbr
 
     interpreter=$(echo ${stdenv.cc.libc}/lib/ld-linux*.so.2)
     if [[ "${stdenv.hostPlatform.system}" == "x86_64-linux" && -e bin/fsnotifier64 ]]; then
-      target_size=$(get_file_size bin/fsnotifier64)
       patchelf --set-interpreter "$interpreter" bin/fsnotifier64
-      munge_size_hack bin/fsnotifier64 $target_size
     else
-      target_size=$(get_file_size bin/fsnotifier)
       patchelf --set-interpreter "$interpreter" bin/fsnotifier
-      munge_size_hack bin/fsnotifier $target_size
     fi
 
     if [ -d "plugins/remote-dev-server" ]; then


### PR DESCRIPTION
## Description of changes
Tested on aarch64 and x86 linux, I didn't see any reason to truncate it to original size.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
