### PR TITLE
qutebrowser: 2.5.4 -> 3.0.0

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchzip, fetchFromGitHub, python3
+{ stdenv, lib, fetchurl, fetchzip, python3
 , wrapQtAppsHook, glib-networking
 , asciidoc, docbook_xml_dtd_45, docbook_xsl, libxml2
 , libxslt, gst_all_1 ? null
@@ -8,16 +8,14 @@
 , pipewireSupport    ? stdenv.isLinux
 , pipewire
 , qtwayland
-, mkDerivationWith ? null
-, qtbase ? null
-, qtwebengine ? null
-, wrapGAppsHook ? null
+, qtbase
+, qtwebengine
+, wrapGAppsHook
 , enableWideVine ? false
 , widevine-cdm
-}: let
-  isQt6 = mkDerivationWith == null;
+}:
 
-  python3Packages = python3.pkgs;
+let
   pdfjs = let
     version = "2.14.305";
   in
@@ -27,40 +25,21 @@
     stripRoot = false;
   };
 
-  backendPackage =
-   if backend == "webengine" then if isQt6 then python3Packages.pyqt6-webengine else python3Packages.pyqtwebengine else
-   if backend == "webkit"    then python3Packages.pyqt5_with_qtwebkit else
-   throw ''
-     Unknown qutebrowser backend "${backend}".
-     Valid choices are qtwebengine (recommended) or qtwebkit.
-   '';
-
-  buildPythonApplication = if isQt6 then python3Packages.buildPythonApplication else mkDerivationWith python3Packages.buildPythonApplication;
-
   pname = "qutebrowser";
-  version = if isQt6 then "unstable-2023-04-18" else "2.5.4";
+  version = "3.0.0";
 in
 
 assert withMediaPlayback -> gst_all_1 != null;
-assert isQt6 -> backend != "webkit";
+assert lib.assertMsg (backend != "webkit") ''
+  Support for the QtWebKit backend has been removed.
+  Please remove the `backend = "webkit"` option from your qutebrowser override.
+'';
 
-buildPythonApplication {
+python3.pkgs.buildPythonApplication {
   inherit pname version;
-
-  src = if isQt6 then
-    # comes from the master branch of upstream
-    # https://github.com/qutebrowser/qutebrowser/issues/7202
-    # https://github.com/qutebrowser/qutebrowser/discussions/7628
-    fetchFromGitHub {
-      owner = "qutebrowser";
-      repo = "qutebrowser";
-      rev = "d4cafc0019a4a5574caa11966fc40ede89076d26";
-      hash = "sha256-Ma79EPvnwmQkeXEG9aSnD/Vt1DGhK2JX9dib7uARH8M=";
-    }
-  # the release tarballs are different from the git checkout!
-   else fetchurl {
+  src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/${pname}-${version}.tar.gz";
-    hash = "sha256-pGCyICUn5CpnDCbSJdn6ZBfQkswfFvOpXnvJXdicGrE=";
+    hash = "sha256-Oer0p/DwUfOejUCgSCSkMvLLAjNyJx51qgN7bcQQ2Pw=";
   };
 
   # Needs tox
@@ -77,20 +56,18 @@ buildPythonApplication {
   nativeBuildInputs = [
     wrapQtAppsHook wrapGAppsHook asciidoc
     docbook_xml_dtd_45 docbook_xsl libxml2 libxslt
-  ]
-    ++ lib.optional isQt6 python3Packages.pygments;
+    python3.pkgs.pygments
+  ];
 
-  propagatedBuildInputs = with python3Packages; ([
-    pyyaml backendPackage jinja2 pygments
+  propagatedBuildInputs = with python3.pkgs; ([
+    pyyaml pyqtwebengine jinja2 pygments
     # scripts and userscripts libs
     tldextract beautifulsoup4
     readability-lxml pykeepass stem
     pynacl
     # extensive ad blocking
     adblock
-  ]
-    ++ lib.optional (pythonOlder "3.9") importlib-resources
-    ++ lib.optional stdenv.isLinux qtwayland
+  ] ++ lib.optional stdenv.isLinux qtwayland
   );
 
   patches = [
@@ -99,10 +76,6 @@ buildPythonApplication {
 
   dontWrapGApps = true;
   dontWrapQtApps = true;
-
-  preConfigure = lib.optionalString isQt6 ''
-    python scripts/asciidoc2html.py
-  '';
 
   postPatch = ''
     substituteInPlace qutebrowser/misc/quitter.py --subst-var-by qutebrowser "$out/bin/qutebrowser"
@@ -141,10 +114,7 @@ buildPythonApplication {
     makeWrapperArgs+=(
       "''${gappsWrapperArgs[@]}"
       "''${qtWrapperArgs[@]}"
-      --add-flags '--backend ${backend}'
-      --set QUTE_QTWEBENGINE_VERSION_OVERRIDE "${lib.getVersion qtwebengine}"
-      ${lib.optionalString isQt6 ''--set QUTE_QT_WRAPPER "PyQt6"''}
-      ${lib.optionalString (pipewireSupport && backend == "webengine") ''--prefix LD_LIBRARY_PATH : ${libPath}''}
+      ${lib.optionalString pipewireSupport ''--prefix LD_LIBRARY_PATH : ${libPath}''}
       ${lib.optionalString enableWideVine ''--add-flags "--qt-flag widevine-path=${widevine-cdm}/share/google/chrome/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so"''}
     )
   '';
@@ -153,7 +123,7 @@ buildPythonApplication {
     homepage    = "https://github.com/qutebrowser/qutebrowser";
     description = "Keyboard-focused browser with a minimal GUI";
     license     = licenses.gpl3Plus;
-    platforms   = if enableWideVine then [ "x86_64-linux" ] else backendPackage.meta.platforms;
+    platforms   = if enableWideVine then [ "x86_64-linux" ] else qtwebengine.meta.platforms;
     maintainers = with maintainers; [ jagajaga rnhmjoj ebzzry dotlambda nrdxp ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1473,6 +1473,7 @@ mapAliases ({
   quake3game = throw "'quake3game' has been renamed to/replaced by 'ioquake3'"; # Converted to throw 2022-02-22
   quaternion-git = throw "quaternion-git has been removed in favor of the stable version 'quaternion'"; # Added 2020-04-09
   quilter = throw "quilter has been removed from nixpkgs, as it was unmaintained"; # Added 2021-08-03
+  qutebrowser-qt6 = throw "'qutebrowser-qt6' has been replaced by 'qutebrowser', since the the qt5 version has been removed"; # Added 2023-08-19
   qvim = throw "qvim has been removed"; # Added 2020-08-31
   qweechat = throw "qweechat has been removed because it was broken"; # Added 2021-03-08
   qwt6 = throw "'qwt6' has been renamed to/replaced by 'libsForQt5.qwt'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34573,8 +34573,7 @@ with pkgs;
     withXineBackend = true;
   };
 
-  qutebrowser = libsForQt5.callPackage ../applications/networking/browsers/qutebrowser { };
-  qutebrowser-qt6 = callPackage ../applications/networking/browsers/qutebrowser {
+  qutebrowser = callPackage ../applications/networking/browsers/qutebrowser {
     inherit (qt6Packages) qtbase qtwebengine wrapQtAppsHook qtwayland;
   };
 


### PR DESCRIPTION
## Description of changes

Version bump

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
