### PR TITLE
linux: make main update script slightly more robust

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "6.1.33-rt11"; # updated by ./update-rt.sh
+  version = "6.1.46-rt13"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -18,14 +18,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
-    sha256 = "1kfj7mi3n2lfaw4spz5cbvcl1md038figabyg80fha3kxal6nzdq";
+    sha256 = "15m228bllks2p8gpsmvplx08yxzp7bij9fnmnafqszylrk7ppxpm";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "0swzp6brk01r7pb73yada18vf6fhdqq4c78abq3abj6y8ay0awhh";
+      sha256 = "00pj02mvamxvlkwrca1j3baaa18rg6dra7al1xsvgw3ypckwyafz";
     };
   }; in [ rt-patch ] ++ kernelPatches;
 

--- a/pkgs/os-specific/linux/kernel/update.sh
+++ b/pkgs/os-specific/linux/kernel/update.sh
@@ -58,11 +58,15 @@ ls $NIXPKGS/pkgs/os-specific/linux/kernel | while read FILE; do
   echo "Updated $OLDVER -> $V"
 done
 
-# Update linux-rt
-COMMIT=1 $NIXPKGS/pkgs/os-specific/linux/kernel/update-rt.sh
+# Allowing errors again: one broken update script shouldn't inhibit the
+# update of other kernel variants.
+set +e
 
-# Update linux-libre
-COMMIT=1 $NIXPKGS/pkgs/os-specific/linux/kernel/update-libre.sh
+echo Update linux-rt
+COMMIT=1 $NIXPKGS/pkgs/os-specific/linux/kernel/update-rt.sh || echo "update-rt failed with exit code $?"
 
-# Update linux-hardened
-COMMIT=1 $NIXPKGS/pkgs/os-specific/linux/kernel/hardened/update.py
+echo Update linux-libre
+COMMIT=1 $NIXPKGS/pkgs/os-specific/linux/kernel/update-libre.sh || echo "update-libre failed with exit code $?"
+
+echo Update linux-hardened
+COMMIT=1 $NIXPKGS/pkgs/os-specific/linux/kernel/hardened/update.py || echo "update-hardened failed with exit code $?"


### PR DESCRIPTION
## Description of changes

On #249636 I had to manually run the updaters for hardened & libre kernels.
The cause was that `update-rt.sh` suddenly broke. Because I didn't want to
inhibit other kernel updates because of a rather niche variant, I decided to
move forward temporarily and take care of it later.

One issue was that the script failed silently, i.e. I only saw that the
script terminated early from my prompt. This is fixed now by making each
niche kernel updater print its exit code code if it failed. Also, errors
are allowed, i.e. a broken `update-rt.sh` doesn't block
`hardened/update.py` etc..

The issue itself is rather simple. When I updated the kernels in #249636,
the sha256sums.asc for rt kernels[1] looked like this:

    199bbb0cdb97ead22732473b95c8b2e8da62dfd71bde2339163119fb537a2b7c  patch-6.1.38-rt13-rc1.patch.gz
    a1af54f6987e96de06cad0a3226c5b5a992b60df084a904b6b94ea247fb46027  patch-6.1.38-rt13-rc1.patch.xz
    7bb68561787e46e3c433d9b514373ce368d587ac459b91df41934e70280d008f  patches-6.1.38-rt13-rc1.tar.gz
    ee65336dd6ae0be398796e7b75291918811a23e10121dc09bd84b244b12402fa  patches-6.1.38-rt13-rc1.tar.xz

However, the script itself skips any RC versions of the realtime
patches, so no releases were usable and the script failed. It's probably
possible to use the overview over all releases instead[2], however
that'd complicate the script notably. Anyways, since RT kernels don't
bump to each patch-level release, I don't think it hurts too much if
such an update is slightly more delayed. However if we want to fix this, I'd prefer
this to be fixed by folks who care more about rt kernels than I do.

[1] https://kernel.org/pub/linux/kernel/projects/rt/6.1/sha256sums.asc
[2] https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/6.1/older/sha256sums.asc

------

Also, now that it works again, I updated linux-rt-6.1 to the latest version available.

Backport label exists because linux-rt-6.1 is also on 23.05.

-------

Regarding a proper fix of the script ccing folks who recently contributed to rt kernels: @duxovni @orivej-nixos @vifino @whiteley. (Everyone else who touched them recently is in the maintainer team and should be pinged anyways ;-)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
