### PR TITLE
Shotcut: 21.09.20 -> 23.07.29

### DIFF
--- a/pkgs/applications/video/shotcut/default.nix
+++ b/pkgs/applications/video/shotcut/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitHub
-, mkDerivation
 , SDL2
 , frei0r
 , ladspaPlugins
@@ -10,29 +9,29 @@
 , pkg-config
 , qtbase
 , qtmultimedia
-, qtx11extras
 , qtwebsockets
-, qtquickcontrols2
-, qtgraphicaleffects
-, qmake
+, cmake
 , qttools
+, wrapQtAppsHook
 , gitUpdater
+, stdenv
+, fftw
 }:
 
 assert lib.versionAtLeast mlt.version "6.24.0";
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "shotcut";
-  version = "21.09.20";
+  version = "23.07.29";
 
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "shotcut";
     rev = "v${version}";
-    sha256 = "1y46n5gmlayfl46l0vhg5g5dbbc0sg909mxb68sia0clkaas8xrh";
+    hash = "sha256-hd8xUGvP/8eMO7KQfqLqIkIeG6Z5xENlMOOtNLRcvvU=";
   };
 
-  nativeBuildInputs = [ pkg-config qmake ];
+  nativeBuildInputs = [ pkg-config qttools cmake wrapQtAppsHook ];
   buildInputs = [
     SDL2
     frei0r
@@ -41,17 +40,13 @@ mkDerivation rec {
     mlt
     qtbase
     qtmultimedia
-    qtx11extras
     qtwebsockets
-    qtquickcontrols2
-    qtgraphicaleffects
+    fftw
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-I${mlt.dev}/include/mlt++ -I${mlt.dev}/include/mlt";
-  qmakeFlags = [
-    "QMAKE_LRELEASE=${lib.getDev qttools}/bin/lrelease"
-    "SHOTCUT_VERSION=${version}"
-    "DEFINES+=SHOTCUT_NOUPGRADE"
+  env.NIX_CFLAGS_COMPILE = "-I${mlt.dev}/include/mlt++ -I${mlt.dev}/include/mlt -DSHOTCUT_NOUPGRADE";
+  cmakeFlags = [
+    "-DSHOTCUT_VERSION=${version}"
   ];
 
   prePatch = ''
@@ -71,7 +66,7 @@ mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/share/shotcut
-    cp -r src/qml $out/share/shotcut/
+    cp -r ../src/qml $out/share/shotcut/
   '';
 
   passthru.updateScript = gitUpdater {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34081,7 +34081,7 @@ with pkgs;
 
   shod = callPackage ../applications/window-managers/shod { };
 
-  shotcut = libsForQt5.callPackage ../applications/video/shotcut { };
+  shotcut = qt6Packages.callPackage ../applications/video/shotcut { };
 
   shogun = callPackage ../applications/science/machine-learning/shogun {
     opencv = opencv3;


### PR DESCRIPTION
This is the new PR, I mentioned in #249538

https://github.com/mltframework/shotcut/releases/tag/v23.07.29

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
qmake swapped with cmake and Qt5 swapped with Qt6
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
