### PR TITLE
guilt: init at 0.37-rc1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7704,6 +7704,12 @@
     githubId = 488556;
     name = "Javier Aguirre";
   };
+  javimerino = {
+    email = "merino.jav@gmail.com";
+    name = "Javi Merino";
+    github = "JaviMerino";
+    githubId = 44926;
+  };
   jayesh-bhoot = {
     name = "Jayesh Bhoot";
     email = "jb@jayeshbhoot.com";

--- a/pkgs/applications/version-management/guilt/darwin-fix.patch
+++ b/pkgs/applications/version-management/guilt/darwin-fix.patch
@@ -1,0 +1,20 @@
+uname -s is used to determine the differences between the command line
+utilities like stat or awk in linux and darwin. However, in nix, guilt
+will be using the nix versions of this programs, not the ones
+installed in the system.  Therefore, guilt should use the command-line
+parameters that the linux forms of these commands expect, even if it
+is being run on Darwin.
+
+diff --git a/guilt b/guilt
+index bf50343..cfc9332 100755
+--- a/guilt
++++ b/guilt
+@@ -986,7 +986,7 @@ guards_file="$GUILT_DIR/$branch/guards"
+ pager="more"
+ [ ! -z "$PAGER" ] && pager="$PAGER"
+ 
+-UNAME_S=`uname -s`
++UNAME_S="Linux"
+ 
+ if [ -r "$GUILT_PATH/os.$UNAME_S" ]; then
+ 	. "$GUILT_PATH/os.$UNAME_S"

--- a/pkgs/applications/version-management/guilt/default.nix
+++ b/pkgs/applications/version-management/guilt/default.nix
@@ -1,0 +1,92 @@
+{ asciidoc
+, docbook_xml_dtd_45
+, docbook_xsl
+, fetchFromGitHub
+, gawk
+, git
+, gnused
+, lib
+, makeWrapper
+, openssl
+, perl
+, stdenv
+, xmlto
+}:
+
+stdenv.mkDerivation rec {
+  pname = "guilt";
+  version = "0.37-rc1";
+
+  src = fetchFromGitHub {
+    owner = "jeffpc";
+    repo = "guilt";
+    rev = "v${version}";
+    sha256 = "sha256-7OgRbMGYWtGvrZxKfJe0CkpmU3AUkPebF5NyTsfXeGA=";
+  };
+
+  doCheck = true;
+
+  patches = [
+    ./guilt-help-mandir.patch
+    ./darwin-fix.patch
+  ];
+  nativeBuildInputs = [
+    asciidoc
+    docbook_xml_dtd_45
+    docbook_xsl
+    makeWrapper
+    perl
+    xmlto
+  ];
+  buildInputs = [
+    gawk
+    git
+    gnused
+  ] ++ lib.optionals stdenv.isDarwin [ openssl ];
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  postBuild = ''
+    make -j $NIX_BUILD_CORES doc
+  '';
+
+  preCheck = ''
+    patchShebangs regression/run-tests regression/*.sh
+  '';
+
+  postInstall = ''
+    make PREFIX=$out install-doc
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/guilt --prefix PATH : ${lib.makeBinPath buildInputs}
+  '';
+
+  meta = with lib; {
+    description = "Manage patches like quilt, on top of a git repository";
+    longDescription = ''
+      Andrew Morton originally developed a set of scripts for
+      maintaining kernel patches outside of any SCM tool. Others
+      extended these into a suite called quilt]. The basic idea behind
+      quilt is to maintain patches instead of maintaining source
+      files. Patches can be added, removed or reordered, and they can
+      be refreshed as you fix bugs or update to a new base
+      revision. quilt is very powerful, but it is not integrated with
+      the underlying SCM tools. This makes it difficult to visualize
+      your changes.
+
+      Guilt allows one to use quilt functionality on top of a Git
+      repository. Changes are maintained as patches which are
+      committed into Git. Commits can be removed or reordered, and the
+      underlying patch can be refreshed based on changes made in the
+      working directory. The patch directory can also be placed under
+      revision control, so you can have a separate history of changes
+      made to your patches.
+    '';
+    homepage = "https://github.com/jeffpc/guilt";
+    maintainers = with lib.maintainers; [ javimerino ];
+    license = [ licenses.gpl2 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/version-management/guilt/guilt-help-mandir.patch
+++ b/pkgs/applications/version-management/guilt/guilt-help-mandir.patch
@@ -1,0 +1,15 @@
+nixpkgs' post-installation fixup moves the pages to share/man.  Tell guilt-help so that it can find them.
+
+diff --git a/guilt-help b/guilt-help
+index 93442a3..b29e059 100755
+--- a/guilt-help
++++ b/guilt-help
+@@ -34,7 +34,7 @@ case $# in
+ 		;;
+ esac
+ 
+-MANDIR=`dirname $0`/../man
++MANDIR=`dirname $0`/../share/man
+ MANDIR=`(cd "$MANDIR"; pwd)`
+ exec man -M "$MANDIR" "$page"
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2446,6 +2446,8 @@ with pkgs;
 
   gst = callPackage ../applications/version-management/gst { };
 
+  guilt = callPackage ../applications/version-management/guilt { };
+
   gut = callPackage ../applications/version-management/gut { };
 
   hred = callPackage ../development/tools/hred { };


### PR DESCRIPTION
## Description of changes

[guilt](https://github.com/jeffpc/guilt) lets you manage patches like quilt, on top of a git repository. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - Yes
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
