### PR TITLE
bookxnote-pro: init at 2.0.0.1112

### DIFF
--- a/pkgs/applications/misc/bookxnote-pro/default.nix
+++ b/pkgs/applications/misc/bookxnote-pro/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchurl
+
+, autoPatchelfHook
+, dpkg
+, wrapQtAppsHook
+, makeDesktopItem
+, copyDesktopItems
+
+, qtmultimedia
+, qtspeech
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bookxnote-pro";
+  version = "2.0.0.1112";
+
+  src = fetchurl {
+    url = "http://www.bookxnote.com/setup/BookxNotePro_ubuntu_amd64-${finalAttrs.version}.deb";
+    hash = "sha256-ZIRxoGvQHXOw0FNzvLB/t+bsRXi5qz9BIt0ioXcNOnk=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    dpkg
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtmultimedia
+    qtspeech
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "BookxNotePro";
+      exec = "BookxNotePro %u";
+      icon = "bxn_pro_logo";
+      comment = finalAttrs.meta.description;
+      desktopName = "BookxNotePro";
+    })
+  ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/app $out/bin
+
+    pushd usr/local/BookxNotePro
+    cp -r emojis lang theme BookxNotePro $out/app
+    install -Dm644 bxn_pro_logo.png $out/share/icons/hicolor/512x512/apps/bxn_pro_logo.png
+    popd
+
+    ln -s $out/app/BookxNotePro $out/bin/BookxNotePro
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A book reader for Linux, an alternative to Marginnote on macOS";
+    homepage = "http://www.bookxnote.com";
+    license = lib.licenses.unfree;
+    mainProgram = "BookxNotePro";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4331,6 +4331,8 @@ with pkgs;
 
   bookstack = callPackage ../servers/web-apps/bookstack { };
 
+  bookxnote-pro = libsForQt5.callPackage ../applications/misc/bookxnote-pro { };
+
   boomerang = libsForQt5.callPackage ../development/tools/boomerang { };
 
   boost-build = callPackage ../development/tools/boost-build { };


### PR DESCRIPTION
## Description of changes

Closes: https://github.com/NixOS/nixpkgs/issues/249882

This PR adds 1 package: `bookxnote-pro`

This is proprietary software, so `NIXPKGS_ALLOW_UNFREE=1` is needed to run.

The software is in Chinese and I don't speak Chinese, so it was really difficult to test, but it seemed to work. If you know how to use the software, please, tell us whether it's working as expected.

The original `.deb` package had a lot of `.so` files packaged, but I could replace them with the nix-built libraries without issue, so, in the install phase, I only copy the non-`.so` files.

The package was built for `ubuntu_amd64` so I think it will only run on `x86_64-linux`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
