### PR TITLE
lib.generators.toGitINI: escape string values in configuration

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -189,10 +189,10 @@ rec {
    * }
    *
    *> [url "ssh://git@github.com/"]
-   *>   insteadOf = https://github.com/
+   *>   insteadOf = "https://github.com"
    *>
    *> [user]
-   *>   name = edolstra
+   *>   name = "edolstra"
    */
   toGitINI = attrs:
     with builtins;
@@ -209,9 +209,17 @@ rec {
         else
           ''${section} "${subsection}"'';
 
+      mkValueString = v:
+        let
+          escapedV = ''
+            "${
+              replaceStrings [ "\n" "	" ''"'' "\\" ] [ "\\n" "\\t" ''\"'' "\\\\" ] v
+            }"'';
+        in mkValueStringDefault { } (if isString v then escapedV else v);
+
       # generation for multiple ini values
       mkKeyValue = k: v:
-        let mkKeyValue = mkKeyValueDefault { } " = " k;
+        let mkKeyValue = mkKeyValueDefault { inherit mkValueString; } " = " k;
         in concatStringsSep "\n" (map (kv: "\t" + mkKeyValue kv) (lib.toList v));
 
       # converts { a.b.c = 5; } to { "a.b".c = 5; } for toINI

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -948,6 +948,51 @@ runTests {
     '';
   };
 
+  testToGitINI = {
+    expr = generators.toGitINI {
+      user = {
+        email = "user@example.org";
+        name = "John Doe";
+        signingKey = "00112233445566778899AABBCCDDEEFF";
+      };
+      gpg.program = "path-to-gpg";
+      tag.gpgSign = true;
+      include.path = "~/path/to/config.inc";
+      includeIf."gitdif:~/src/dir".path = "~/path/to/conditional.inc";
+      extra = {
+        boolean = true;
+        integer = 38;
+        name = "value";
+        subsection.value = "test";
+      };};
+    expected = ''
+      [extra]
+      ${"\t"}boolean = true
+      ${"\t"}integer = 38
+      ${"\t"}name = "value"
+
+      [extra "subsection"]
+      ${"\t"}value = "test"
+
+      [gpg]
+      ${"\t"}program = "path-to-gpg"
+
+      [include]
+      ${"\t"}path = "~/path/to/config.inc"
+
+      [includeIf "gitdif:~/src/dir"]
+      ${"\t"}path = "~/path/to/conditional.inc"
+
+      [tag]
+      ${"\t"}gpgSign = true
+
+      [user]
+      ${"\t"}email = "user@example.org"
+      ${"\t"}name = "John Doe"
+      ${"\t"}signingKey = "00112233445566778899AABBCCDDEEFF"
+    '';
+  };
+
   /* right now only invocation check */
   testToJSONSimple =
     let val = {


### PR DESCRIPTION
## Description of changes

Upstreaming of https://github.com/nix-community/home-manager/commit/642d9ffe24eec1290e94d70e8129ba74922fddf2 which fixed https://github.com/nix-community/home-manager/issues/1206

Handles escaping of special characters in generated gitconfig.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
