### PR TITLE
linuxPackages.ena: 2.8.6 -> 2.8.9

### DIFF
--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -1,32 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel }:
+{ lib, stdenv, fetchFromGitHub, kernel }:
 
 stdenv.mkDerivation rec {
-  version = "2.8.6";
+  version = "2.8.9";
   name = "ena-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "amzn";
     repo = "amzn-drivers";
     rev = "ena_linux_${version}";
-    hash = "sha256-clRu+ecK/Je0kvlAAm6qCJqMyvZv0C88YIGDImhRhKA=";
+    hash = "sha256-9Csrq9wM7Q99qPj7+NlnQgP6KcciNHMbAAb+Wg7eYAU=";
   };
-
-  patches =
-    [ # https://github.com/amzn/amzn-drivers/issues/269#issuecomment-1552483792
-      (fetchpatch {
-        url = "https://github.com/amzn/amzn-drivers/files/11504862/phc_kernel_6_2_fix.patch";
-        hash = "sha256-/EBkISwXMd7t4WZjsG9KVP6vncFwcZq1QBsxQLXyWsY=";
-      })
-      # https://github.com/amzn/amzn-drivers/issues/270#issuecomment-1561924754
-      (fetchpatch {
-        url = "https://github.com/amzn/amzn-drivers/files/11559312/devlink_6_2_fix.patch";
-        hash = "sha256-Nc71u91G0dL+ld6ovqjHaE6X2TxduWeQYr5K0KdoA3Q=";
-      })
-      (fetchpatch {
-        url = "https://github.com/amzn/amzn-drivers/files/11559314/devlink_6_3_fix.patch";
-        hash = "sha256-aEQTbwHC1DcDrtj188eoGzi3GU9MXnwIxuJW4L7qb/I=";
-      })
-    ];
 
   hardeningDisable = [ "pic" ];
 


### PR DESCRIPTION
Removes several patches added in d915eb8 which are now included in-tree.

Notable commits, excluding aforementioned patches:
 + linux/ena: Add rx_overruns to ena-com structs
 + linux/ena: Report RX overrun errors via net device stats
 + linux/ena: Fix incorrect dma sync when SWIOTLB is on

full changelog: https://github.com/amzn/amzn-drivers/compare/ena_linux_2.8.6...ena_linux_2.8.9

## Description of changes

package bump

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux