### PR TITLE
grocy: 4.0.0 -> 4.0.2

### DIFF
--- a/nixos/modules/services/web-apps/grocy.nix
+++ b/nixos/modules/services/web-apps/grocy.nix
@@ -115,9 +115,9 @@ in {
       user = "grocy";
       group = "nginx";
 
-      # PHP 8.1 is the only version which is supported/tested by upstream:
-      # https://github.com/grocy/grocy/blob/v4.0.0/README.md#platform-support
-      phpPackage = pkgs.php81;
+      # PHP 8.1 and 8.2 are the only version which are supported/tested by upstream:
+      # https://github.com/grocy/grocy/blob/v4.0.2/README.md#platform-support
+      phpPackage = pkgs.php82;
 
       inherit (cfg.phpfpm) settings;
 

--- a/nixos/modules/services/web-apps/grocy.nix
+++ b/nixos/modules/services/web-apps/grocy.nix
@@ -130,6 +130,16 @@ in {
       };
     };
 
+    # After an update of grocy, the viewcache needs to be deleted. Otherwise grocy will not work
+    # https://github.com/grocy/grocy#how-to-update
+    systemd.services.grocy-setup = {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "phpfpm-grocy.service" ];
+      script = ''
+        rm -rf ${cfg.dataDir}/viewcache/*
+      '';
+    };
+
     services.nginx = {
       enable = true;
       virtualHosts."${cfg.hostName}" = mkMerge [

--- a/pkgs/servers/grocy/0001-Define-configs-with-env-vars.patch
+++ b/pkgs/servers/grocy/0001-Define-configs-with-env-vars.patch
@@ -1,4 +1,4 @@
-From 3ec6fce101083d4f23641fd015cbe4ade317ad59 Mon Sep 17 00:00:00 2001
+From 231ee836e357b83cc2fc0a3a977f74839308ec68 Mon Sep 17 00:00:00 2001
 From: Ember Keske <git@n0emis.eu>
 Date: Wed, 2 Aug 2023 06:36:02 +0200
 Subject: [PATCH 1/2] Define configs with env vars
@@ -11,7 +11,7 @@ Subject: [PATCH 1/2] Define configs with env vars
  4 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/app.php b/app.php
-index 31905be6..30b3eb82 100644
+index bc5b1b39..26f7687e 100644
 --- a/app.php
 +++ b/app.php
 @@ -12,7 +12,7 @@ use Slim\Views\Blade;
@@ -23,16 +23,16 @@ index 31905be6..30b3eb82 100644
  require_once __DIR__ . '/config-dist.php'; // For not in own config defined values we use the default ones
  require_once __DIR__ . '/helpers/ConfigurationValidator.php';
  
-@@ -63,7 +63,7 @@ $app = AppFactory::create();
- 
+@@ -64,7 +64,7 @@ $app = AppFactory::create();
  $container = $app->getContainer();
- $container->set('view', function (Container $container) {
+ $container->set('view', function (Container $container)
+ {
 -	return new Blade(__DIR__ . '/views', GROCY_DATAPATH . '/viewcache');
 +	return new Blade(__DIR__ . '/views', getenv('GROCY_CACHE_DIR'));
  });
  
- $container->set('UrlManager', function (Container $container) {
-@@ -103,7 +103,7 @@ $errorMiddleware->setDefaultErrorHandler(
+ $container->set('UrlManager', function (Container $container)
+@@ -106,7 +106,7 @@ $errorMiddleware->setDefaultErrorHandler(
  
  $app->add(new CorsMiddleware($app->getResponseFactory()));
  
@@ -42,10 +42,10 @@ index 31905be6..30b3eb82 100644
  ob_clean(); // No response output before here
  $app->run();
 diff --git a/services/DatabaseService.php b/services/DatabaseService.php
-index be5486b6..b6091ee7 100644
+index 4a05bda1..ce41ed17 100644
 --- a/services/DatabaseService.php
 +++ b/services/DatabaseService.php
-@@ -104,6 +104,6 @@ class DatabaseService
+@@ -125,6 +125,6 @@ class DatabaseService
  			return GROCY_DATAPATH . '/grocy_' . $dbSuffix . '.db';
  		}
  
@@ -67,10 +67,10 @@ index 7d070350..a6dd4b08 100644
  		{
  			mkdir($this->StoragePath);
 diff --git a/services/StockService.php b/services/StockService.php
-index 16cb468c..23228803 100644
+index 7265e82b..13af591a 100644
 --- a/services/StockService.php
 +++ b/services/StockService.php
-@@ -1769,7 +1769,7 @@ class StockService extends BaseService
+@@ -1761,7 +1761,7 @@ class StockService extends BaseService
  			throw new \Exception('No barcode lookup plugin defined');
  		}
  

--- a/pkgs/servers/grocy/0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch
+++ b/pkgs/servers/grocy/0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch
@@ -1,4 +1,4 @@
-From 0e834aa0ef712ce97acf24c05c43a04387fda18c Mon Sep 17 00:00:00 2001
+From b532add2d1287489d4541e79c976bb77795696cd Mon Sep 17 00:00:00 2001
 From: Ember Keske <git@n0emis.eu>
 Date: Wed, 2 Aug 2023 06:36:46 +0200
 Subject: [PATCH 2/2] Remove check for config-file as it's stored in /etc/grocy

--- a/pkgs/servers/grocy/default.nix
+++ b/pkgs/servers/grocy/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "grocy";
-  version = "4.0.0";
+  version = "4.0.2";
 
   src = fetchurl {
     url = "https://github.com/grocy/grocy/releases/download/v${version}/grocy_${version}.zip";
-    sha256 = "sha256-Sei+UYM5azzSWgnmgufxDl5ySbYJ52DBGPc0nTjnqqc=";
+    sha256 = "sha256-ZhXfZKmfg8lSzEAGIj7LMIfvaHG1FY5j+/OpOCTxm3c=";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
## Description of changes

https://github.com/grocy/grocy/releases/tag/v4.0.1
https://github.com/grocy/grocy/releases/tag/v4.0.2

- Updated php to 8.2
- add pre start script to clear viewcache

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
