### PR TITLE
deface: init at 1.4.0

### DIFF
--- a/pkgs/applications/video/deface/default.nix
+++ b/pkgs/applications/video/deface/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, python3
+, fetchFromGitHub
+, makeWrapper
+, pkgs
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "deface";
+  version = "1.4.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "ORB-HD";
+    repo = "deface";
+    rev = "v${version}";
+    hash = "sha256-tLNTgdnKKmyYHVajz0dHIb7cvC1by5LQ5CFIbMvPEYk=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    imageio
+    imageio-ffmpeg
+    numpy
+    onnx
+    onnxruntime # Nixpkgs onnxruntime is missing CUDA support
+    opencv4
+    scikit-image
+    tqdm
+  ];
+
+  # Native onnxruntime lib used by Python module onnxruntime can't find its other libs without this
+  makeWrapperArgs = [
+    ''--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ pkgs.onnxruntime ]}"''
+  ];
+
+  patchPhase = ''
+    substituteInPlace pyproject.toml requirements.txt --replace "opencv-python" "opencv"
+  '';
+
+  # Let setuptools know deface version
+  SETUPTOOLS_SCM_PRETEND_VERSION = "v${version}";
+
+  pythonImportsCheck = [ "deface" "onnx" "onnxruntime" ];
+
+  meta = with lib; {
+    description = "Video anonymization by face detection";
+    homepage = "https://github.com/ORB-HD/deface";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lurkki ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41866,6 +41866,8 @@ with pkgs;
 
   ov = callPackage ../tools/text/ov { };
 
+  deface = callPackage ../applications/video/deface { };
+
   tubekit = callPackage ../applications/networking/cluster/tubekit/wrapper.nix { };
 
   tubekit-unwrapped = callPackage ../applications/networking/cluster/tubekit { };


### PR DESCRIPTION
## Description of changes

Deface is an ML based tool for anonymizing faces in video.

CUDA doesn't seem to be enabled in the Nixpkgs `onnxruntime` package, so this package doesn't use it either.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
