### PR TITLE
python3.pkgs.linear_operator: use setuptools-scm to get version

### DIFF
--- a/pkgs/development/python-modules/linear_operator/default.nix
+++ b/pkgs/development/python-modules/linear_operator/default.nix
@@ -2,9 +2,12 @@
 , buildPythonPackage
 , fetchFromGitHub
 , jaxtyping
-, scipy
-, torch
 , pytestCheckHook
+, scipy
+, setuptools
+, setuptools-scm
+, torch
+, wheel
 }:
 
 buildPythonPackage rec {
@@ -19,10 +22,13 @@ buildPythonPackage rec {
     hash = "sha256-7NkcvVDwFaLHBZZhq7aKY3cWxe90qeKmodP6cVsdrPM=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace 'find_version("linear_operator", "version.py")' \"$version\"
-  '';
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+    wheel
+  ];
 
   propagatedBuildInputs = [
     jaxtyping
@@ -30,10 +36,12 @@ buildPythonPackage rec {
     torch
   ];
 
-  checkInputs = [
+  pythonImportsCheck = [ "linear_operator" ];
+
+  nativeCheckInputs = [
     pytestCheckHook
   ];
-  pythonImportsCheck = [ "linear_operator" ];
+
   disabledTests = [
     # flaky numerical tests
     "test_svd"


### PR DESCRIPTION
## Description of changes

Trying to build this package using [`build`](https://pypa-build.readthedocs.io/en/latest/) flagged that it uses setuptools-scm for versioning, so we can refactor the derivation to leverage that and remove some patching we were doing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
