### PR TITLE
etlegacy: fix and refactor

### DIFF
--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -24,15 +24,14 @@
   cjson,
 }: let
   version = "2.81.1";
-  pkgname = "etlegacy";
-  mirror = "https://mirror.etlegacy.com";
+
   fetchAsset = {
     asset,
     sha256,
   }:
     fetchurl
     {
-      url = mirror + "/etmain/" + asset;
+      url = "https://mirror.etlegacy.com/etmain/${asset}";
       inherit sha256;
     };
   pak0 =
@@ -64,8 +63,8 @@
     then "etl.i386"
     else "etl.x86_64";
 in
-  stdenv.mkDerivation rec {
-    pname = pkgname;
+  stdenv.mkDerivation {
+    pname = "etlegacy";
     inherit version;
 
     src = fetchFromGitHub {

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -5,7 +5,6 @@
   writeScriptBin,
   fetchFromGitHub,
   fetchurl,
-  runCommand,
   cmake,
   git,
   glew,

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -104,19 +104,18 @@ in
       "-DINSTALL_GEOIP=0"
       "-DINSTALL_WOLFADMIN=0"
       "-DFEATURE_AUTOUPDATE=0"
-      "-DINSTALL_DEFAULT_BASEDIR=."
-      "-DINSTALL_DEFAULT_BINDIR=."
-      "-DINSTALL_DEFAULT_MODDIR=."
+      "-DINSTALL_DEFAULT_BASEDIR=${placeholder "out"}/lib/etlegacy"
+      "-DINSTALL_DEFAULT_BINDIR=${placeholder "out"}/bin"
     ];
 
     postInstall = ''
-      ETMAIN=$out/etmain
+      ETMAIN=$out/lib/etlegacy/etmain
       mkdir -p $ETMAIN
       ln -s ${pak0} $ETMAIN/pak0.pk3
       ln -s ${pak1} $ETMAIN/pak1.pk3
       ln -s ${pak2} $ETMAIN/pak2.pk3
-      makeWrapper $out/${mainProgram} $out/bin/${mainProgram} --chdir $out
-      makeWrapper $out/etlded.* $out/bin/etlded --chdir $out
+      makeWrapper $out/bin/etl.* $out/bin/etl
+      makeWrapper $out/bin/etlded.* $out/bin/etlded
     '';
 
     meta = with lib; {

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -124,6 +124,11 @@ in
       homepage = "https://etlegacy.com";
       platforms = ["i686-linux" "x86_64-linux"];
       license = [licenses.gpl3 licenses.cc-by-nc-sa-30];
+      longDescription = ''
+        ET: Legacy, an open source project fully compatible client and server
+        for the popular online FPS game Wolfenstein: Enemy Territory - whose
+        gameplay is still considered unmatched by many, despite its great age.
+      '';
       mainProgram = "etl";
       maintainers = with maintainers; [ashleyghooper drupol];
     };

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -132,6 +132,6 @@ in
       platforms = ["i686-linux" "x86_64-linux"];
       license = [licenses.gpl3 licenses.cc-by-nc-sa-30];
       inherit mainProgram;
-      maintainers = with maintainers; [ashleyghooper];
+      maintainers = with maintainers; [ashleyghooper drupol];
     };
   }

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -51,10 +51,6 @@
       echo "${version}"
     fi
   '';
-  mainProgram =
-    if stdenv.hostPlatform.system == "i686-linux"
-    then "etl.i386"
-    else "etl.x86_64";
 in
   stdenv.mkDerivation {
     pname = "etlegacy";
@@ -125,7 +121,7 @@ in
       homepage = "https://etlegacy.com";
       platforms = ["i686-linux" "x86_64-linux"];
       license = [licenses.gpl3 licenses.cc-by-nc-sa-30];
-      inherit mainProgram;
+      mainProgram = "etl";
       maintainers = with maintainers; [ashleyghooper drupol];
     };
   }

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -95,7 +95,7 @@ in
     cmakeFlags = [
       "-DCMAKE_BUILD_TYPE=Release"
       "-DCROSS_COMPILE32=0"
-      "-DBUILD_SERVER=0"
+      "-DBUILD_SERVER=1"
       "-DBUILD_CLIENT=1"
       "-DBUNDLED_JPEG=0"
       "-DBUNDLED_LIBS=0"
@@ -116,6 +116,7 @@ in
       ln -s ${pak1} $ETMAIN/pak1.pk3
       ln -s ${pak2} $ETMAIN/pak2.pk3
       makeWrapper $out/${mainProgram} $out/bin/${mainProgram} --chdir $out
+      makeWrapper $out/etlded.* $out/bin/etlded --chdir $out
     '';
 
     meta = with lib; {

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   makeWrapper,
-  writeScriptBin,
+  writeShellApplication,
   fetchFromGitHub,
   fetchurl,
   cmake,
@@ -45,12 +45,15 @@
     hash = "sha256-pIq3SaGhKrTZE3KGsfI9ZCwp2lmEWyuvyPZOBSzwbz4=";
   };
 
-  fakeGit = writeScriptBin "git" ''
-    #! ${stdenv.shell} -e
-    if [ "$1" = "describe" ]; then
-      echo "${version}"
-    fi
-  '';
+  fakeGit = writeShellApplication {
+    name = "git";
+
+    text = ''
+      if [ "$1" = "describe" ]; then
+        echo "${version}"
+      fi
+    '';
+  };
 in
   stdenv.mkDerivation {
     pname = "etlegacy";

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -118,6 +118,8 @@ in
       makeWrapper $out/bin/etlded.* $out/bin/etlded
     '';
 
+    hardeningDisable = [ "fortify" ];
+
     meta = with lib; {
       description = "ET: Legacy is an open source project based on the code of Wolfenstein: Enemy Territory which was released in 2010 under the terms of the GPLv3 license";
       homepage = "https://etlegacy.com";

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -1,28 +1,28 @@
-{
-  stdenv,
-  lib,
-  makeWrapper,
-  writeShellApplication,
-  fetchFromGitHub,
-  fetchurl,
-  cmake,
-  git,
-  glew,
-  SDL2,
-  zlib,
-  minizip,
-  libjpeg,
-  curl,
-  lua,
-  libogg,
-  libtheora,
-  freetype,
-  libpng,
-  sqlite,
-  openal,
-  unzip,
-  cjson,
-}: let
+{ lib
+, stdenv
+, fetchurl
+, writeShellApplication
+, fetchFromGitHub
+, cjson
+, cmake
+, git
+, makeWrapper
+, unzip
+, curl
+, freetype
+, glew
+, libjpeg
+, libogg
+, libpng
+, libtheora
+, lua
+, minizip
+, openal
+, SDL2
+, sqlite
+, zlib
+}:
+let
   version = "2.81.1";
 
   fetchAsset = { asset, hash }: fetchurl {
@@ -55,81 +55,88 @@
     '';
   };
 in
-  stdenv.mkDerivation {
-    pname = "etlegacy";
-    inherit version;
+stdenv.mkDerivation {
+  pname = "etlegacy";
+  inherit version;
 
-    src = fetchFromGitHub {
-      owner = "etlegacy";
-      repo = "etlegacy";
-      rev = "refs/tags/v" + version;
-      sha256 = "sha256-CGXtc51vaId/SHbD34ZeT0gPsrl7p2DEw/Kp+GBZIaA="; # 2.81.1
-    };
+  src = fetchFromGitHub {
+    owner = "etlegacy";
+    repo = "etlegacy";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-CGXtc51vaId/SHbD34ZeT0gPsrl7p2DEw/Kp+GBZIaA="; # 2.81.1
+  };
 
-    nativeBuildInputs = [cmake fakeGit git makeWrapper unzip cjson];
-    buildInputs = [
-      glew
-      SDL2
-      zlib
-      minizip
-      libjpeg
-      curl
-      lua
-      libogg
-      libtheora
-      freetype
-      libpng
-      sqlite
-      openal
-    ];
+  nativeBuildInputs = [
+    cjson
+    cmake
+    fakeGit
+    git
+    makeWrapper
+    unzip
+  ];
 
-    preBuild = ''
-      # Required for build time to not be in 1980
-      export SOURCE_DATE_EPOCH=$(date +%s)
-      # This indicates the build was by a CI pipeline and prevents the resource
-      # files from being flagged as 'dirty' due to potentially being custom built.
-      export CI="true"
+  buildInputs = [
+    curl
+    freetype
+    glew
+    libjpeg
+    libogg
+    libpng
+    libtheora
+    lua
+    minizip
+    openal
+    SDL2
+    sqlite
+    zlib
+  ];
+
+  preBuild = ''
+    # Required for build time to not be in 1980
+    export SOURCE_DATE_EPOCH=$(date +%s)
+    # This indicates the build was by a CI pipeline and prevents the resource
+    # files from being flagged as 'dirty' due to potentially being custom built.
+    export CI="true"
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCROSS_COMPILE32=0"
+    "-DBUILD_SERVER=1"
+    "-DBUILD_CLIENT=1"
+    "-DBUNDLED_JPEG=0"
+    "-DBUNDLED_LIBS=0"
+    "-DINSTALL_EXTRA=0"
+    "-DINSTALL_OMNIBOT=0"
+    "-DINSTALL_GEOIP=0"
+    "-DINSTALL_WOLFADMIN=0"
+    "-DFEATURE_AUTOUPDATE=0"
+    "-DINSTALL_DEFAULT_BASEDIR=${placeholder "out"}/lib/etlegacy"
+    "-DINSTALL_DEFAULT_BINDIR=${placeholder "out"}/bin"
+  ];
+
+  postInstall = ''
+    ln -s ${pak0} $out/lib/etlegacy/etmain/pak0.pk3
+    ln -s ${pak1} $out/lib/etlegacy/etmain/pak1.pk3
+    ln -s ${pak2} $out/lib/etlegacy/etmain/pak2.pk3
+
+    makeWrapper $out/bin/etl.* $out/bin/etl
+    makeWrapper $out/bin/etlded.* $out/bin/etlded
+  '';
+
+  hardeningDisable = [ "fortify" ];
+
+  meta = {
+    description = "ET: Legacy is an open source project based on the code of Wolfenstein: Enemy Territory which was released in 2010 under the terms of the GPLv3 license";
+    homepage = "https://etlegacy.com";
+    license = with lib.licenses; [ gpl3 cc-by-nc-sa-30 ];
+    longDescription = ''
+      ET: Legacy, an open source project fully compatible client and server
+      for the popular online FPS game Wolfenstein: Enemy Territory - whose
+      gameplay is still considered unmatched by many, despite its great age.
     '';
-
-    cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
-      "-DCROSS_COMPILE32=0"
-      "-DBUILD_SERVER=1"
-      "-DBUILD_CLIENT=1"
-      "-DBUNDLED_JPEG=0"
-      "-DBUNDLED_LIBS=0"
-      "-DINSTALL_EXTRA=0"
-      "-DINSTALL_OMNIBOT=0"
-      "-DINSTALL_GEOIP=0"
-      "-DINSTALL_WOLFADMIN=0"
-      "-DFEATURE_AUTOUPDATE=0"
-      "-DINSTALL_DEFAULT_BASEDIR=${placeholder "out"}/lib/etlegacy"
-      "-DINSTALL_DEFAULT_BINDIR=${placeholder "out"}/bin"
-    ];
-
-    postInstall = ''
-      ETMAIN=$out/lib/etlegacy/etmain
-      mkdir -p $ETMAIN
-      ln -s ${pak0} $ETMAIN/pak0.pk3
-      ln -s ${pak1} $ETMAIN/pak1.pk3
-      ln -s ${pak2} $ETMAIN/pak2.pk3
-      makeWrapper $out/bin/etl.* $out/bin/etl
-      makeWrapper $out/bin/etlded.* $out/bin/etlded
-    '';
-
-    hardeningDisable = [ "fortify" ];
-
-    meta = with lib; {
-      description = "ET: Legacy is an open source project based on the code of Wolfenstein: Enemy Territory which was released in 2010 under the terms of the GPLv3 license";
-      homepage = "https://etlegacy.com";
-      platforms = ["i686-linux" "x86_64-linux"];
-      license = [licenses.gpl3 licenses.cc-by-nc-sa-30];
-      longDescription = ''
-        ET: Legacy, an open source project fully compatible client and server
-        for the popular online FPS game Wolfenstein: Enemy Territory - whose
-        gameplay is still considered unmatched by many, despite its great age.
-      '';
-      mainProgram = "etl";
-      maintainers = with maintainers; [ashleyghooper drupol];
-    };
-  }
+    mainProgram = "etl";
+    maintainers = with lib.maintainers; [ ashleyghooper drupol ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/games/etlegacy/default.nix
+++ b/pkgs/games/etlegacy/default.nix
@@ -25,33 +25,26 @@
 }: let
   version = "2.81.1";
 
-  fetchAsset = {
-    asset,
-    sha256,
-  }:
-    fetchurl
-    {
-      url = "https://mirror.etlegacy.com/etmain/${asset}";
-      inherit sha256;
-    };
-  pak0 =
-    fetchAsset
-    {
-      asset = "pak0.pk3";
-      sha256 = "712966b20e06523fe81419516500e499c86b2b4fec823856ddbd333fcb3d26e5";
-    };
-  pak1 =
-    fetchAsset
-    {
-      asset = "pak1.pk3";
-      sha256 = "5610fd749024405b4425a7ce6397e58187b941d22092ef11d4844b427df53e5d";
-    };
-  pak2 =
-    fetchAsset
-    {
-      asset = "pak2.pk3";
-      sha256 = "a48ab749a1a12ab4d9137286b1f23d642c29da59845b2bafc8f64e052cf06f3e";
-    };
+  fetchAsset = { asset, hash }: fetchurl {
+    url = "https://mirror.etlegacy.com/etmain/${asset}";
+    inherit hash;
+  };
+
+  pak0 = fetchAsset {
+    asset = "pak0.pk3";
+    hash = "sha256-cSlmsg4GUj/oFBlRZQDkmchrK0/sgjhW3b0zP8s9JuU=";
+  };
+
+  pak1 = fetchAsset {
+    asset = "pak1.pk3";
+    hash = "sha256-VhD9dJAkQFtEJafOY5flgYe5QdIgku8R1IRLQn31Pl0=";
+  };
+
+  pak2 = fetchAsset {
+    asset = "pak2.pk3";
+    hash = "sha256-pIq3SaGhKrTZE3KGsfI9ZCwp2lmEWyuvyPZOBSzwbz4=";
+  };
+
   fakeGit = writeScriptBin "git" ''
     #! ${stdenv.shell} -e
     if [ "$1" = "describe" ]; then


### PR DESCRIPTION
Hello,

I'm unable to run `etlegacy` on my machine, I get the following error log:

```
❯ etl.x86_64
tty]*** buffer overflow detected ***: terminated
*** buffer overflow detected ***: terminated
DOUBLE SIGNAL FAULT: Received signal 6, exiting...
*** buffer overflow detected ***: terminated
DOUBLE SIGNAL FAULT: Received signal 6, exiting...
*** buffer overflow detected ***: terminated
DOUBLE SIGNAL FAULT: Received signal 6, exiting...
*** buffer overflow detected ***: terminated
DOUBLE SIGNAL FAULT: Received signal 6, exiting...
...
DOUBLE SIGNAL FAULT: Received signal 6, exiting...
*** buffer overflow detected ***: terminated
DOUBLE SIGNAL FAULT: Received signal 6, exiting...
*** buffer overflow detected ***: terminated
fish: Job 1, 'etl.x86_64' terminated by signal SIGSEGV (Address boundary error)
~ ✘
```

This PR:

- [x] Added the `etl` and `etlded` binaries
- [x] Disable `fortify` to have fully working binaries and fix the aforementioned issue
- [x] Remove unused `runCommand` argument
- [x] Add myself as maintainer
- [x] Reduce amount of local vars
- [x] Refactor `fetchAsset` function
- [x] Build server and client
- [x] Update `cmakeFlags` and change default install directories

Ping @ashleyghooper 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
