### PR TITLE
python3Packages.pillow: pull zlib-1.3 fix pending upstream inclusion

### DIFF
--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -24,6 +24,16 @@ import ./generic.nix (rec {
     hash = "sha256-nIK1s+BDx68NlXktDSDM9o9hof7Gs1MOcYtohCJyc5Y=";
   };
 
+  patches = [
+    # Pull in zlib-1.3 fix pending upstream inclusion
+    #   https://github.com/python-pillow/Pillow/pull/7344
+    (fetchpatch {
+      name = "zlib-1.3.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/9ef7cb39def45b0fe1cdf4828ca20838a1fc39d1.patch";
+      hash = "sha256-N7V6Xz+SBHSm3YIgmbty7zbqkv8MzpLMhU4Xxerhx8w=";
+    })
+  ];
+
   passthru.tests = {
     inherit imageio matplotlib pilkit pydicom reportlab;
   };


### PR DESCRIPTION
Without the change tests fails against `zlib-1.3` as:

        def test_sanity(self, tmp_path):
            # internal version number
    >       assert re.search(r"\d+\.\d+\.\d+(\.\d+)?$", features.version_codec("zlib"))
    E       AssertionError: assert None
    E        +  where None = <function search at 0x7ffff74c5c60>('\\d+\\.\\d+\\.\\d+(\\.\\d+)?$', '1.3')
    E        +    where <function search at 0x7ffff74c5c60> = re.search
    E        +    and   '1.3' = <function version_codec at 0x7ffff6896680>('zlib')
    E        +      where <function version_codec at 0x7ffff6896680> = features.version_codec
    Tests/test_file_png.py:82: AssertionError

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
