### PR TITLE
python3.pkgs.httpie: add pip as a test dependency

### DIFF
--- a/pkgs/development/python-modules/httpie/default.nix
+++ b/pkgs/development/python-modules/httpie/default.nix
@@ -16,6 +16,7 @@
 , rich
 , pysocks
 # CheckInputs
+, pip
 , pytest-httpbin
 , pytest-lazy-fixture
 , pytest-mock
@@ -52,8 +53,10 @@ buildPythonPackage rec {
     rich
   ] ++ requests.optional-dependencies.socks;
 
+  __darwinAllowLocalNetworking = true;
 
   nativeCheckInputs = [
+    pip
     pytest-httpbin
     pytest-lazy-fixture
     pytest-mock


### PR DESCRIPTION
## Description of changes

This is needed once we remove `pip` from the ambient environment (which will happen when switching to [`build`](https://pypa-build.readthedocs.io/en/latest/) to build Python packages), or else we get mysterious test errors like:

```
_______________________ test_plugins_installation[True] ________________________

httpie_plugins_success = <function httpie_plugins_success.<locals>.runner at 0x7ffff1df8550>
interface = Interface(path=PosixPath('/build/pytest-of-nixbld/pytest-0/test_plugins_installation_True0/interface'), environment=<M...out': <tempfile._TemporaryFileWrapper object at 0x7ffff1deee90>,
 'stdout_encoding': 'utf-8',
 'stdout_isatty': True}>)
dummy_plugin = Plugin(interface=Interface(path=PosixPath('/build/pytest-of-nixbld/pytest-0/test_plugins_installation_True0/interface'...ue}>), name='httpie-270ea5c7', version='1.0.0', entry_points=[EntryPoint(name='test', group='httpie.plugins.auth.v1')])
cli_mode = True

    @pytest.mark.requires_installation
    @pytest.mark.parametrize('cli_mode', [True, False])
    def test_plugins_installation(httpie_plugins_success, interface, dummy_plugin, cli_mode):
>       lines = httpie_plugins_success('install', dummy_plugin.path, cli_mode=cli_mode)

tests/test_plugins_cli.py:10: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cli_mode = True
args = ('install', PosixPath('/build/pytest-of-nixbld/pytest-0/test_plugins_installation_True0/interface/httpie-270ea5c7'))
response = 'Installing /build/pytest-of-nixbld/pytest-0/test_plugins_installation_True0/interface/httpie-270ea5c7...\n'

    def runner(*args, cli_mode: bool = True):
        response = httpie_plugins(*args, cli_mode=True)
>       assert response.exit_status == ExitStatus.SUCCESS
E       AssertionError

tests/utils/plugins_cli.py:233: AssertionError
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
