### PR TITLE
uboot: restrict rpi kernel size patch to rpi uboot builds

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -29,6 +29,9 @@ let
     url = "https://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
     hash = "sha256-a2pIWBwUq7D5W9h8GvTXQJIkBte4AQAqn5Ryf93gIdU=";
   };
+  rpiOnlyPatches = [
+    ./0001-configs-rpi-allow-for-bigger-kernels.patch
+  ];
   buildUBoot = lib.makeOverridable ({
     version ? null
   , src ? null
@@ -46,9 +49,7 @@ let
 
     src = if src == null then defaultSrc else src;
 
-    patches = [
-      ./0001-configs-rpi-allow-for-bigger-kernels.patch
-    ] ++ extraPatches;
+    patches = extraPatches;
 
     postPatch = ''
       patchShebangs tools
@@ -436,42 +437,49 @@ in {
   ubootRaspberryPi = buildUBoot {
     defconfig = "rpi_defconfig";
     extraMeta.platforms = ["armv6l-linux"];
+    extraPatches = rpiOnlyPatches;
     filesToInstall = ["u-boot.bin"];
   };
 
   ubootRaspberryPi2 = buildUBoot {
     defconfig = "rpi_2_defconfig";
     extraMeta.platforms = ["armv7l-linux"];
+    extraPatches = rpiOnlyPatches;
     filesToInstall = ["u-boot.bin"];
   };
 
   ubootRaspberryPi3_32bit = buildUBoot {
     defconfig = "rpi_3_32b_defconfig";
     extraMeta.platforms = ["armv7l-linux"];
+    extraPatches = rpiOnlyPatches;
     filesToInstall = ["u-boot.bin"];
   };
 
   ubootRaspberryPi3_64bit = buildUBoot {
     defconfig = "rpi_3_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
+    extraPatches = rpiOnlyPatches;
     filesToInstall = ["u-boot.bin"];
   };
 
   ubootRaspberryPi4_32bit = buildUBoot {
     defconfig = "rpi_4_32b_defconfig";
     extraMeta.platforms = ["armv7l-linux"];
+    extraPatches = rpiOnlyPatches;
     filesToInstall = ["u-boot.bin"];
   };
 
   ubootRaspberryPi4_64bit = buildUBoot {
     defconfig = "rpi_4_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
+    extraPatches = rpiOnlyPatches;
     filesToInstall = ["u-boot.bin"];
   };
 
   ubootRaspberryPiZero = buildUBoot {
     defconfig = "rpi_0_w_defconfig";
     extraMeta.platforms = ["armv6l-linux"];
+    extraPatches = rpiOnlyPatches;
     filesToInstall = ["u-boot.bin"];
   };
 


### PR DESCRIPTION
NixOS maintains a uboot patch for the raspberry pi which enables larger kernels to be loaded. (background: [1,2])

Prior to this commit, this patch was applied to all callers of buildUBoot, regardless of whether it was relevant for that specific board. buildUBoot already accepts an argument `extraPatches' for board-specific patches, so use this mechanism to patch the raspberry pi uboot builds instead.

Without this change, passing a different `src' argument to buildUBoot (ie: pointing at upstream uboot or at a board-specific fork) becomes highly brittle as the patch will not usually apply cleanly.

[1]: github.com/NixOS/nixpkgs/pull/139825
[2]: github.com/NixOS/nixpkgs/issues/97064
