### PR TITLE
irp-transmogrifier: init at 1.2.12

### DIFF
--- a/pkgs/tools/misc/irp-transmogrifier/default.nix
+++ b/pkgs/tools/misc/irp-transmogrifier/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, fetchFromGitHub
+, maven
+, libxslt
+, jre
+, makeWrapper
+}:
+
+maven.buildMavenPackage rec {
+  pname = "irp-transmogrifier";
+  version = "1.2.12";
+
+  src = fetchFromGitHub {
+    owner = "bengtmartensson";
+    repo = "IrpTransmogrifier";
+    rev = "Version-${version}";
+    hash = "sha256-AqIfdoqb/a2eeyxPwfm5P8QdVG1n6h3x+15ZvFX7s2Y=";
+  };
+
+  nativeBuildInputs = [ libxslt jre makeWrapper ];
+
+  mvnHash = "sha256-Pz7T3uzagqjUI/AfzdGX3RorCulrY8ZlVTLyDQhCGDg=";
+  mvnParameters = "-Dmaven.gitcommitid.skip=true -Dgit.commit.id=${src.rev}";
+
+  makeFlags = [
+    "INSTALLDIR=${placeholder "out"}/share/${pname}"
+    "BINLINK=${placeholder "out"}/bin/${pname}"
+    "BROWSELINK=${placeholder "out"}/bin/irpbrowse"
+  ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/${pname} \
+      --prefix PATH : "${lib.makeBinPath [ jre ]}"
+  '';
+
+  meta = with lib; {
+    description = "Parser for IRP notation protocols, with rendering, code generation, and decoding";
+    homepage = "https://github.com/bengtmartensson/IrpTransmogrifier";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mrene ];
+    platforms = jre.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5622,6 +5622,8 @@ with pkgs;
 
   irpf = callPackage ../applications/finance/irpf { };
 
+  irp-transmogrifier = callPackage ../tools/misc/irp-transmogrifier { };
+
   jellycli = callPackage ../applications/audio/jellycli { };
 
   jellyfin = callPackage ../servers/jellyfin {


### PR DESCRIPTION
## Description of changes

[IrpTransmogrifier](https://github.com/bengtmartensson/IrpTransmogrifier) is a command line utility that helps analyze and decode captured data from an infrared remote control receiver.

It can analyze a raw capture, extract timing parameters and an IRP expression, which is a domain-specific languagae defining how IR data is modulated using Pulse Width Modulation. It also contains a database of common modulation schemes (as IRP expressions) that help associate a sample with a particular scheme.

### How to test
You need some raw infrared captures, then you can use it to inspect the signal.
```
echo "+8831 -4446 +487 -1705 +578 -578 +517 -578 +548 -548 +548 -548 +548 -548 +578 -548 +548 -548 +548 -548 +548 -1674 +548 -1674 +548 -1674 +517 -1705 +487 -1705 +517 -1705 +548 -1674 +517 -1674 +517 -1705 +548 -578 +548 -548 +548 -548 +548 -578 +517 -578 +517 -609 +517 -578 +517 -578 +517 -1674 +548 -1674 +578 -1674 +487 -1705 +548 -1674 +517 -1674 +517 -1705 +548 -1644 +548 -609 +517 -578 +517 -578 +548 -578 +517 -578 +517 -578 +517 -578 +548 -578 +517 -1674 +548 -1674 +487 -1735 +548 -1674 +517 -1705 +517 -1674 +548 -13277 +8861 -2223 +548 -95228 +8801 -2253 +548 -101501" > sample.txt

# Attempt a best effort modulation classification and decode the sample
$ irp-transmogrifier decode --input ./sample.txt
        48-NEC1: {D=1,F=7,E=7}, beg=0, end=107, reps=2

# Analyze the input without decoding it
$ irp-transmogrifier analyze --input ./sample.txt
{544,msb}<1,-1|1,-3>(16,-8,A:48,1,-13.308m,16,-3,1,-98m,16,-3,1,-98m){A=0x807fe01fe01f}

# Retrieve the IRP expression for the 48-NEC1 standard
$ irp-transmogrifier list --irp 48-NEC1
name=48-NEC1
irp={38.4k,564}<1,-1|1,-3>(16,-8,D:8,S:8,F:8,~F:8,E:8,~E:8,1,^108m,(16,-4,1,^108m)*)[D:0..255,S:0..255=255-D,F:0..255,E:0..255]
```

## Things done
I patched the pom.xml file to remove a plugin which attempts to read the current git commit info from `.git`, since it doesn't exist in the source checkout.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
