### PR TITLE
angsd: pull patch pending upstream inclusion for parallel build fix

### DIFF
--- a/pkgs/applications/science/biology/angsd/default.nix
+++ b/pkgs/applications/science/biology/angsd/default.nix
@@ -1,4 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, htslib, zlib, bzip2, xz, curl, openssl }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, htslib
+, zlib
+, bzip2
+, xz
+, curl
+, openssl
+}:
 
 stdenv.mkDerivation rec {
   pname = "angsd";
@@ -11,7 +21,19 @@ stdenv.mkDerivation rec {
     rev = version;
   };
 
+  patches = [
+    # Pull pending inclusion upstream patch for parallel buil fixes:
+    #   https://github.com/ANGSD/angsd/pull/590
+    (fetchpatch {
+      name = "parallel-make.patch";
+      url = "https://github.com/ANGSD/angsd/commit/89fd1d898078016df390e07e25b8a3eeadcedf43.patch";
+      hash = "sha256-KQgUfr3v8xc+opAm4qcSV2eaupztv4gzJJHyzJBCxqA=";
+    })
+  ];
+
   buildInputs = [ htslib zlib bzip2 xz curl openssl ];
+
+  enableParallelBuilding = true;
 
   makeFlags = [ "HTSSRC=systemwide" "prefix=$(out)" ];
 


### PR DESCRIPTION
Without the change rapallel builds fail occasionally as:

    $ make --shuffle -j
    ...
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   argStruct.cpp
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   ancestral_likes.cpp
    gcc -c   -O3 -D__STDC_FORMAT_MACROS   fet.c
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   abcGL.cpp
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   pop1_read.cpp
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   angsd.cpp
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   abcHWE_F.cpp
    gcc -c   -O3 -D__STDC_FORMAT_MACROS   kprobaln.c
    g++ -c   -O3 -D__STDC_FORMAT_MACROS   mpileup.cpp
    argStruct.cpp:3:10: fatal error: version.h: No such file or directory
        3 | #include "version.h"
          |          ^~~~~~~~~~~
    compilation terminated.
    angsd.cpp:11:10: fatal error: version.h: No such file or directory
       11 | #include "version.h"
          |          ^~~~~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
