### PR TITLE
maintainers: document expectations

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -25,7 +25,7 @@ For critical packages, this convention needs to be negociated with the
 maintainer. A critical package is one that causes mass-rebuild, or where an
 author is listed in the CODEOWNERS file.
 
-In case of critical security updates, the security team might override these
+In case of critical security updates, the [security team](https://nixos.org/community/teams/security) might override these
 heuristics in order to get the fixes in as fast as possible.
 
 In case of conflict, the maintainer takes priority and is allowed to revert

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -4,7 +4,6 @@ Unlike other packaging ecosystems, the maintainer doesn't have exclusive
 control over the packages and modules they maintain. This more fluid approach
 is one reason why we scale to so many packages.
 
-
 ## Definition and role of the maintainer
 
 The main responsibility of a maintainer is to keep the packages they maintain
@@ -37,6 +36,9 @@ not.
 The inactivity measure is currently not strictly enforced. We would typically
 look at it if we notice that the author hasn't reacted to package-related
 notifications for more than 3 months.
+
+Removing the maintainer happens by making a PR on the package, adding that
+person as a reviewer, and then waiting a week for a reaction.
 
 The maintainer is welcome to come back at any time.
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -30,9 +30,13 @@ package's `meta.maintainers` list, and send a PR with the changes.
 
 ### How to lose maintainer status
 
-Maintainers that have become inactive for more than 3 months on a given
-package can be removed. This helps us keep an accurate view of what parts of
-nixpkgs are well maintained or not.
+Maintainers that have become inactive on a given package can be removed. This
+helps us keep an accurate view of what parts of nixpkgs are well maintained or
+not.
+
+The inactivity measure is currently not strictly enforced. We would typically
+look at it if we notice that the author hasn't reacted to package-related
+notifications for more than 3 months.
 
 The maintainer is welcome to come back at any time.
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -10,10 +10,23 @@ The main responsibility of a maintainer is to keep the packages they maintain
 in a functioning state, and keep up with updates. In order to do that, they
 are empowered to make decisions over the packages they maintain.
 
-By default, we expect committers to wait at least a week before merging
+That being said, the maintainer is not alone proposing changes to the
+packages. Anybody (both bots and humans) can send PRs to bump or tweak the
+package.
+
+We also allow other non-maintainer committers to merge changes to the package,
+provided enough time and priority has been given to the maintainer.
+
+For most packages, we expect committers to wait at least a week before merging
 changes on packages they are not maintaining. This should leave enough time
-for the maintainers to provide feedback. The only exception would be for tiny
-version bumps and security updates that could be merged faster.
+for the maintainers to provide feedback.
+
+For critical packages, this convention needs to be negociated with the
+maintainer. A critical package is one that causes mass-rebuild, or where an
+author is listed in the CODEOWNERS file.
+
+In case of critical security updates, the security team might override these
+heuristics in order to get the fixes in as fast as possible.
 
 In case of conflict, the maintainer takes priority and is allowed to revert
 the changes. This can happen for example if the maintainer was on holiday.

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -21,7 +21,7 @@ For most packages, we expect committers to wait at least a week before merging
 changes not endorsed by a package maintainer (which may be themselves). This should leave enough time
 for the maintainers to provide feedback.
 
-For critical packages, this convention needs to be negociated with the
+For critical packages, this convention needs to be negotiated with the
 maintainer. A critical package is one that causes mass-rebuild, or where an
 author is listed in the [`CODEOWNERS`](../.github/CODEOWNERS) file.
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -23,7 +23,7 @@ for the maintainers to provide feedback.
 
 For critical packages, this convention needs to be negociated with the
 maintainer. A critical package is one that causes mass-rebuild, or where an
-author is listed in the CODEOWNERS file.
+author is listed in the [`CODEOWNERS`](../.github/CODEOWNERS) file.
 
 In case of critical security updates, the [security team](https://nixos.org/community/teams/security) might override these
 heuristics in order to get the fixes in as fast as possible.

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -43,8 +43,7 @@ package's `meta.maintainers` list, and send a PR with the changes.
 ### How to lose maintainer status
 
 Maintainers who have become inactive on a given package can be removed. This
-helps us keep an accurate view of what parts of nixpkgs are well maintained or
-not.
+helps us keep an accurate view of the state of maintenance in Nixpkgs.
 
 The inactivity measure is currently not strictly enforced. We would typically
 look at it if we notice that the author hasn't reacted to package-related

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -1,10 +1,45 @@
 # Nixpkgs Maintainers
 
-The *Nixpkgs maintainers* are people who have assigned themselves to
-maintain specific individual packages. We encourage people who care
-about a package to assign themselves as a maintainer. When a pull
-request is made against a package, OfBorg will notify the appropriate
-maintainer(s).
+Unlike other packaging ecosystems, the maintainer doesn't have exclusive
+control over the packages and modules they maintain. This more fluid approach
+is one reason why we scale to so many packages.
+
+
+## Definition and role of the maintainer
+
+The main responsibility of a maintainer is to keep the packages they maintain
+in a functioning state, and keep up with updates. In order to do that, they
+are empowered to make decisions over the packages they maintain.
+
+By default, we expect committers to wait at least a week before merging
+changes on packages they are not maintaining. This should leave enough time
+for the maintainers to provide feedback. The only exception would be for tiny
+version bumps and security updates that could be merged faster.
+
+In case of conflict, the maintainer takes priority and is allowed to revert
+the changes. This can happen for example if the maintainer was on holiday.
+
+### How to become a maintainer
+
+We encourage people who care about a package to assign themselves as a
+maintainer. You don't require to have nixpkgs commit access to do so.
+
+In order to do so, add yourself to the
+[`maintainer-list.nix`](./maintainer-list.nix), and then to the desired
+package's `meta.maintainers` list, and send a PR with the changes.
+
+### How to lose maintainer status
+
+Maintainers that have become inactive for more than 3 months on a given
+package can be removed. This helps us keep an accurate view of what parts of
+nixpkgs are well maintained or not.
+
+The maintainer is welcome to come back at any time.
+
+### Tools for maintainers
+
+When a pull request is made against a package, OfBorg will notify the
+appropriate maintainer(s).
 
 ## Reviewing contributions
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -34,7 +34,7 @@ the changes. This can happen for example if the maintainer was on holiday.
 ### How to become a maintainer
 
 We encourage people who care about a package to assign themselves as a
-maintainer. You don't require to have nixpkgs commit access to do so.
+maintainer. Commit access to the Nixpkgs repository is not required for that.
 
 In order to do so, add yourself to the
 [`maintainer-list.nix`](./maintainer-list.nix), and then to the desired

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -18,7 +18,7 @@ We also allow other non-maintainer committers to merge changes to the package,
 provided enough time and priority has been given to the maintainer.
 
 For most packages, we expect committers to wait at least a week before merging
-changes on packages they are not maintaining. This should leave enough time
+changes not endorsed by a package maintainer (which may be themselves). This should leave enough time
 for the maintainers to provide feedback.
 
 For critical packages, this convention needs to be negociated with the

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -42,7 +42,7 @@ package's `meta.maintainers` list, and send a PR with the changes.
 
 ### How to lose maintainer status
 
-Maintainers that have become inactive on a given package can be removed. This
+Maintainers who have become inactive on a given package can be removed. This
 helps us keep an accurate view of what parts of nixpkgs are well maintained or
 not.
 


### PR DESCRIPTION
Motivated by https://discourse.nixos.org/t/where-did-you-get-stuck-in-the-nix-ecosystem-tell-me-your-story

Address the uncertainty around maintainers by defining what it
means, what are the expectations and power you get.

Note to reviewers: some of the numbers are arbitrary and I expect would be tuned by experience.

Are there areas or cases that you think should be covered that I missed?

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
