### PR TITLE
python310Packages.pypdf: Apply patch for CVE-2023-3646

### DIFF
--- a/pkgs/development/python-modules/pypdf/CVE-2023-36464.patch
+++ b/pkgs/development/python-modules/pypdf/CVE-2023-36464.patch
@@ -1,0 +1,31 @@
+diff --git a/pypdf/generic/_data_structures.py b/pypdf/generic/_data_structures.py
+index 824dc16..15a0d0a 100644
+--- a/pypdf/generic/_data_structures.py
++++ b/pypdf/generic/_data_structures.py
+@@ -1002,7 +1002,7 @@ class ContentStream(DecodedStreamObject):
+                 # encountering a comment -- but read_object assumes that
+                 # following the comment must be the object we're trying to
+                 # read.  In this case, it could be an operator instead.
+-                while peek not in (b"\r", b"\n"):
++                while peek not in (b"\r", b"\n", b""):
+                     peek = stream.read(1)
+             else:
+                 operands.append(read_object(stream, None, self.forced_encoding))
+diff --git a/tests/test_reader.py b/tests/test_reader.py
+index 5f70ed3..911bf5c 100644
+--- a/tests/test_reader.py
++++ b/tests/test_reader.py
+@@ -1350,3 +1350,13 @@ def test_iss1689():
+     name = "iss1689.pdf"
+     in_pdf = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+     in_pdf.pages[0]
++
++
++@pytest.mark.enable_socket()
++@pytest.mark.timeout(30)
++def test_iss1825():
++    url = "https://github.com/py-pdf/pypdf/files/11367871/MiFO_LFO_FEIS_NOA_Published.3.pdf"
++    name = "iss1825.pdf"
++    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
++    page = reader.pages[0]
++    page.extract_text()

--- a/pkgs/development/python-modules/pypdf/default.nix
+++ b/pkgs/development/python-modules/pypdf/default.nix
@@ -20,6 +20,7 @@
 
 # tests
 , pytestCheckHook
+, pytest-timeout
 }:
 
 buildPythonPackage rec {
@@ -50,6 +51,11 @@ buildPythonPackage rec {
     myst-parser
   ];
 
+  patches = [
+    # https://github.com/py-pdf/pypdf/security/advisories/GHSA-4vvm-4w3v-6mr8
+    ./CVE-2023-36464.patch
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace "--disable-socket" ""
@@ -75,6 +81,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-timeout
   ] ++ passthru.optional-dependencies.full;
 
   pytestFlagsArray = [


### PR DESCRIPTION
## Description of changes

https://github.com/py-pdf/pypdf/security/advisories/GHSA-4vvm-4w3v-6mr8

Tests did not apply cleanly, so I rebased the relevant parts of the upstream commit.

https://github.com/py-pdf/pypdf/commit/b0e5c689df689ab173df84dacd77b6fc3c161932

cc #250339

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
