### PR TITLE
rdiff-backup: 2.0.5 -> 2.2.5

### DIFF
--- a/pkgs/tools/backup/rdiff-backup/default.nix
+++ b/pkgs/tools/backup/rdiff-backup/default.nix
@@ -6,22 +6,18 @@ let
 in
 pypkgs.buildPythonApplication rec {
   pname = "rdiff-backup";
-  version = "2.0.5";
+  version = "2.2.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-VNFgOOYgFO2RbHHIMDsH0vphpqaAOMoYn8LTFTSw84s=";
+    sha256 = "sha256-huKCa3hOw+pO8YfZNu5fFSd0IsQHfvoBVu9n4xOeoI4=";
   };
 
-  # pkg_resources fails to find the version and then falls back to "DEV"
-  postPatch = ''
-    substituteInPlace src/rdiff_backup/Globals.py \
-      --replace 'version = "DEV"' 'version = "${version}"'
-  '';
+  nativeBuildInputs = with pypkgs; [ setuptools-scm ];
 
   buildInputs = [ librsync ];
 
-  nativeBuildInputs = with pypkgs; [ setuptools-scm ];
+  propagatedBuildInputs = with pypkgs; [ pyyaml ];
 
   # no tests from pypi
   doCheck = false;


### PR DESCRIPTION
https://github.com/rdiff-backup/rdiff-backup/blob/master/CHANGELOG.adoc

## Description of changes

I'm very new to nix, but hope this is all correct. 

As this is the first update in three years, a lot of versions have been skipped. 

There's a new dependency in pyyaml that I added to `propagatedBuildInputs = with pypkgs; [pyyaml];`. 

I also removed the postPatch section as it seemingly isn't necessary anymore and formatted the file with alejandra.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

