### PR TITLE
veilid: 0.1.9 -> 0.1.10

### DIFF
--- a/pkgs/tools/networking/veilid/Cargo.lock
+++ b/pkgs/tools/networking/veilid/Cargo.lock
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "derivative"
@@ -5642,7 +5642,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "veilid-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "arboard",
  "async-std",
@@ -5678,7 +5678,7 @@ dependencies = [
 
 [[package]]
 name = "veilid-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "argon2",
  "async-io",
@@ -5781,7 +5781,7 @@ dependencies = [
 
 [[package]]
 name = "veilid-flutter"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "allo-isolate",
  "async-std",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "veilid-server"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ansi_term",
  "async-std",
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "veilid-tools"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "android-logd-logger",
  "async-lock",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "veilid-wasm"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "cfg-if 1.0.0",
  "console_error_panic_hook",

--- a/pkgs/tools/networking/veilid/default.nix
+++ b/pkgs/tools/networking/veilid/default.nix
@@ -10,14 +10,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "veilid";
-  version = "0.1.9";
+  version = "0.1.10";
 
   src = fetchFromGitLab {
     owner = "veilid";
     repo = pname;
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-mkb10JishprTyHV5lsFp/P57E2xTX+baHkJM4K2p4x4=";
+    sha256 = "sha256-43VCv0MqRIqKioM5Uj3sap9SvGnjgrZFxGPG98hk1v0=";
   };
 
   cargoLock = {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
