### PR TITLE
dyalog: init at 18.2.45405

### DIFF
--- a/pkgs/by-name/dy/dyalog/dyalogscript.patch
+++ b/pkgs/by-name/dy/dyalog/dyalogscript.patch
@@ -1,0 +1,8 @@
+--- a/scriptbin/dyalogscript
++++ b/scriptbin/dyalogscript
+@@ -5,1 +5,1 @@
+-INSTALLDIR="/opt/mdyalog/18.2/64/unicode"
++INSTALLDIR="@installdir@"
+@@ -40,1 +40,1 @@
+-: ${SCRIPTDIR:=$INSTALLDIR}
++SCRIPTDIR="@scriptdir@"

--- a/pkgs/by-name/dy/dyalog/mapl.patch
+++ b/pkgs/by-name/dy/dyalog/mapl.patch
@@ -1,0 +1,31 @@
+diff --git a/mapl b/mapl
+index c9d3727..de24c77 100755
+--- a/mapl
++++ b/mapl
+@@ -20,26 +20,8 @@ SHORTVERSION=182U64
+ LONGVERSION="18.2 64-bit Unicode"
+ REL="`echo "${LONGVERSION}" | sed 's/ .*$//'`"
+ 
+-# Find the Dyalog installation directory
+-if [ "$(uname)" = Linux ]; then
+-	# this script location, canonical.
+-	THIS="$(readlink -f $0)"
+-else
+-	# this script location.
+-	THIS="$0"
+-fi
+-export DYALOG=$(cd $(dirname $THIS) && pwd)
+-
+ export APL_LANGUAGE_BAR_FILE=${DYALOG}/languagebar.json
+ 
+-if [ "$(uname)" = Linux ]; then
+-	if [ "x" = "x${LD_LIBRARY_PATH}" ]; then
+-		export LD_LIBRARY_PATH="${DYALOG}"
+-	else
+-		export LD_LIBRARY_PATH="${DYALOG}:${LD_LIBRARY_PATH}"
+-	fi
+-fi
+-
+ # Setup the configuration directory
+ MYCONFIGDIR=${HOME}/.dyalog
+ if [ ! -d "${MYCONFIGDIR}" ] ; then

--- a/pkgs/by-name/dy/dyalog/package.nix
+++ b/pkgs/by-name/dy/dyalog/package.nix
@@ -1,0 +1,225 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchurl
+
+, config
+, acceptLicense ? config.dyalog.acceptLicense or false
+
+, autoPatchelfHook
+, dpkg
+, makeWrapper
+
+, copyDesktopItems
+, makeDesktopItem
+
+, glib
+, ncurses5
+
+, dotnet-sdk_6
+, dotnetSupport ? false
+
+, alsa-lib
+, gtk2
+, libXdamage
+, libXtst
+, libXScrnSaver
+, nss
+, htmlRendererSupport ? false
+
+, R
+, rPackages
+, rSupport ? false
+
+, unixODBC
+, sqaplSupport ? false
+
+, zeroFootprintRideSupport ? false
+
+, enableDocs ? false
+}:
+
+let
+  dyalogHome = "$out/lib/dyalog";
+
+  rscproxy = rPackages.buildRPackage {
+    name = "rscproxy";
+    src = fetchFromGitHub {
+      owner = "Dyalog";
+      repo = "rscproxy";
+      rev = "31de3323fb8596ff5ecbf4bacd030e542cfd8133";
+      hash = "sha256-SVoBoAWUmQ+jWaTG7hdmyRq6By4RnmmgWZXoua19/Kg=";
+    };
+  };
+
+  makeWrapperArgs = [
+    "--set DYALOG ${dyalogHome}"
+    # also needs to be set when the `-script` flag is used
+    "--add-flags DYALOG=${dyalogHome}"
+    # needed for default user commands to work
+    "--add-flags SESSION_FILE=${dyalogHome}/default.dse"
+  ]
+  ++ lib.optionals dotnetSupport [
+    # needs to be set to run .NET Bridge
+    "--set DOTNET_ROOT ${dotnet-sdk_6}"
+    # .NET Bridge files are runtime dependencies, but cannot be patchelf'd
+    "--prefix LD_LIBRARY_PATH : ${dyalogHome}"
+  ]
+  ++ lib.optionals rSupport [
+    # RConnect resolves R from PATH
+    "--prefix PATH : ${R}/bin"
+    # RConnect uses `ldd` to find `libR.so`
+    "--prefix LD_LIBRARY_PATH : ${R}/lib/R/lib"
+    # RConnect uses `rscproxy` to communicate with R
+    "--prefix R_LIBS_SITE : ${rscproxy}/library"
+  ];
+
+  licenseUrl = "https://www.dyalog.com/uploads/documents/Developer_Software_Licence.pdf";
+
+  licenseDisclaimer = ''
+    Dyalog is a licenced software. Dyalog licences do not include a licence to distribute Dyalog with your work.
+    For non-commercial purposes, a Basic Licence is granted when you accept the conditions and download a free copy of Dyalog.
+
+    More details about the license can be found here: ${licenseUrl}
+
+    If you agree to these terms, you can either override this package:
+    `dyalog.override { acceptLicense = true; }`
+
+    or you can set the following nixpkgs config option:
+    `config.dyalog.acceptLicense = true;`
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dyalog";
+  version = "18.2.45405";
+  shortVersion = lib.versions.majorMinor finalAttrs.version;
+
+  src =
+    assert !acceptLicense -> throw licenseDisclaimer;
+    fetchurl {
+      url = "https://download.dyalog.com/download.php?file=${finalAttrs.shortVersion}/linux_64_${finalAttrs.version}_unicode.x86_64.deb";
+      sha256 = "sha256-pA/WGTA6YvwG4MgqbiPBLKSKPtLGQM7BzK6Bmyz5pmM=";
+    };
+
+  outputs = [ "out" ] ++ lib.optional enableDocs "doc";
+
+  postUnpack = ''
+    sourceRoot=$sourceRoot/opt/mdyalog/${finalAttrs.shortVersion}/64/unicode
+  '';
+
+  patches = [ ./dyalogscript.patch ./mapl.patch ];
+
+  postPatch = lib.optionalString dotnetSupport ''
+    # Patch to use .NET 6.0 instead of .NET Core 3.1 (can be removed when Dyalog 19.0 releases)
+    substituteInPlace Dyalog.Net.Bridge.*.json --replace "3.1" "6.0"
+  '';
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    dpkg
+    makeWrapper
+  ];
+
+  buildInputs = [
+    glib # Used by Conga and .NET Bridge
+    ncurses5 # Used by the dyalog binary
+  ]
+  ++ lib.optionals htmlRendererSupport [
+    alsa-lib
+    gtk2
+    libXdamage
+    libXtst
+    libXScrnSaver
+    nss
+  ]
+  ++ lib.optionals sqaplSupport [
+    unixODBC
+  ];
+
+  # See which files are not really important: `https://github.com/Dyalog/DyalogDocker/blob/master/rmfiles.sh`
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p ${dyalogHome}
+    cp -r aplfmt aplkeys apltrans fonts Library PublicCACerts SALT StartupSession ${dyalogHome}
+    cp aplkeys.sh default.dse dyalog dyalog.rt dyalog.dcfg.template dyalog.ver.dcfg.template languagebar.json mapl startup.dyalog ${dyalogHome}
+
+    mkdir ${dyalogHome}/lib
+    cp lib/{conga34_64.so,dyalog64.so,libconga34ssl64.so} ${dyalogHome}/lib
+
+    # Only keep the most useful workspaces
+    mkdir ${dyalogHome}/ws
+    cp ws/{conga,dfns,isolate,loaddata,salt,sharpplot,util}.dws ${dyalogHome}/ws
+  ''
+  + lib.optionalString dotnetSupport ''
+    cp libnethost.so Dyalog.Net.Bridge.* ${dyalogHome}
+  ''
+  + lib.optionalString htmlRendererSupport ''
+    cp -r locales swiftshader ${dyalogHome}
+    cp libcef.so libEGL.so libGLESv2.so chrome-sandbox natives_blob.bin snapshot_blob.bin icudtl.dat v8_context_snapshot.bin *.pak ${dyalogHome}
+    cp lib/htmlrenderer.so ${dyalogHome}/lib
+  ''
+  + lib.optionalString rSupport ''
+    cp ws/rconnect.dws ${dyalogHome}/ws
+  ''
+  + lib.optionalString sqaplSupport ''
+    cp lib/cxdya64u64u.so ${dyalogHome}/lib
+    cp ws/sqapl.dws ${dyalogHome}/ws
+    cp odbc.ini.sample sqapl.err sqapl.ini ${dyalogHome}
+  ''
+  + lib.optionalString zeroFootprintRideSupport ''
+    cp -r RIDEapp ${dyalogHome}
+  ''
+  + lib.optionalString enableDocs ''
+    mkdir -p $doc/share/doc/dyalog
+    cp -r help/* $doc/share/doc/dyalog
+    ln -s $doc/share/doc/dyalog ${dyalogHome}/help
+  ''
+  + ''
+    install -Dm644 dyalog.svg $out/share/icons/hicolor/scalable/apps/dyalog.svg
+
+    makeWrapper ${dyalogHome}/dyalog $out/bin/dyalog ${lib.concatStringsSep " " makeWrapperArgs}
+    makeWrapper ${dyalogHome}/mapl $out/bin/mapl ${lib.concatStringsSep " " makeWrapperArgs}
+
+    install -Dm755 scriptbin/dyalogscript $out/bin/dyalogscript
+    substituteInPlace $out/bin/dyalogscript \
+        --subst-var-by installdir ${dyalogHome} \
+        --subst-var-by scriptdir $out/bin
+
+    runHook postInstall
+  '';
+
+  preFixup = lib.optionalString htmlRendererSupport ''
+    # `libudev.so` is a runtime dependency of CEF
+    patchelf ${dyalogHome}/libcef.so --add-needed libudev.so
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "dyalog";
+      desktopName = "Dyalog";
+      exec = finalAttrs.meta.mainProgram;
+      comment = finalAttrs.meta.description;
+      icon = "dyalog";
+      categories = [ "Development" ];
+      genericName = "APL interpreter";
+      terminal = true;
+    })
+  ];
+
+  meta = {
+    changelog = "https://dyalog.com/dyalog/dyalog-versions/${lib.replaceStrings [ "." ] [ "" ] finalAttrs.shortVersion}.htm";
+    description = "The Dyalog APL interpreter";
+    homepage = "https://www.dyalog.com";
+    license = {
+      fullName = "Dyalog License";
+      url = licenseUrl;
+      free = false;
+    };
+    mainProgram = "dyalog";
+    maintainers = with lib.maintainers; [ tomasajt markus1189 ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description of changes

This PR adds 1 main package: `dyalog`,
and 1 auxiliary, non-standalone package: `rscproxy`.

---

Homepage: https://www.dyalog.com
Changelog: https://dyalog.com/dyalog/dyalog-versions/182.htm

---

Dyalog is a proprietary implementation of APL. It has quite a strict [License Agreement](https://www.dyalog.com/uploads/documents/Developer_Software_Licence.pdf).
(here's the [Terms of Service](https://www.dyalog.com/uploads/documents/Terms_and_Conditions.pdf) also)
Though the 18.2 release has loosened up the default license.

I have reached out to Dyalog and it seems that if I put the package behind a license warning they will be OK with this.

---

There is an existing derivation outside of nixpkgs: [link](https://github.com/markus1189/dyalog-nixos/)
This is a reworked version of that.

---

I have added some optional flags
- `dotnetSupport` for `.NET` interop
- `htmlRendererSupport` for displaying GUIs with [CEF](https://en.wikipedia.org/wiki/Chromium_Embedded_Framework)
- `rSupport` for `R` interop
- `sqaplSupport` for accessing databases through `odbc` (I couldn't really test this)
- `zeroFootprintRideSupport` for being able to launch a web IDE with a command line flag
- `enableDocs` for whether to keep the contents of the `help` directory and place in `$doc`

These are all disabled by default, because compared to the actual program, they use up much more space, or are a really niche use case.

---

When testing, use `)Off` to exit the program

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
