### PR TITLE
pip: generate and install man pages

### DIFF
--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -10,6 +10,9 @@
 , pretend
 , pytest
 
+# docs
+, sphinx
+
 # coupled downsteam dependencies
 , pip-tools
 }:
@@ -36,7 +39,37 @@ buildPythonPackage rec {
     installShellFiles
     setuptools
     wheel
+
+    # docs
+    sphinx
   ];
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  # pip uses a custom sphinx extension and unusual conf.py location, mimic the internal build rather than attempting
+  # to fit sphinxHook see https://github.com/pypa/pip/blob/0778c1c153da7da457b56df55fb77cbba08dfb0c/noxfile.py#L129-L148
+  postBuild = ''
+    cd docs
+
+    # remove references to sphinx extentions only required for html doc generation
+    # sphinx.ext.intersphinx requires network connection or packaged object.inv files for python and pypug
+    # sphinxcontrib.towncrier is not currently packaged
+    for ext in sphinx.ext.intersphinx sphinx_copybutton sphinx_inline_tabs sphinxcontrib.towncrier myst_parser; do
+      substituteInPlace html/conf.py --replace '"'$ext'",' ""
+    done
+
+    PYTHONPATH=$src/src:$PYTHONPATH sphinx-build -v \
+      -d build/doctrees/man \
+      -c html \
+      -d build/doctrees/man \
+      -b man \
+      man \
+      build/man
+    cd ..
+  '';
 
   nativeCheckInputs = [ mock scripttest virtualenv pretend pytest ];
 
@@ -44,6 +77,8 @@ buildPythonPackage rec {
   doCheck = false;
 
   postInstall = ''
+    installManPage docs/build/man/*
+
     installShellCompletion --cmd pip \
       --bash <($out/bin/pip completion --bash) \
       --fish <($out/bin/pip completion --fish) \

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -80,9 +80,9 @@ buildPythonPackage rec {
     installManPage docs/build/man/*
 
     installShellCompletion --cmd pip \
-      --bash <($out/bin/pip completion --bash) \
-      --fish <($out/bin/pip completion --fish) \
-      --zsh <($out/bin/pip completion --zsh)
+      --bash <($out/bin/pip completion --bash --no-cache-dir) \
+      --fish <($out/bin/pip completion --fish --no-cache-dir) \
+      --zsh <($out/bin/pip completion --zsh --no-cache-dir)
   '';
 
   passthru.tests = { inherit pip-tools; };


### PR DESCRIPTION
## Description of changes

Generates pip man pages following the arch pip package or the sketch of a working change. As this is a change to pip's definition the full build hasn't been tested on a machine I own.

1. Move scipy onto `pypaInstallHook` avoiding infinite recursion from `pipInstallHook` when scipy is pulled in via `checks` in either `myst-parser` or `sphinx`
2.  Add `sphinxcontrib-towncrier` based on the [arch package](https://gitlab.archlinux.org/archlinux/packaging/packages/python-sphinxcontrib-towncrier)
3. Invokes and `pip_sphinxext.py` to build and pass definitions to `sphinx`.

Couple things are some amount of incomplete

1. sphinx package references some? but no where near all sphinx packages
2. patch to `sphinxcontrib-towncrier` is blindly copied
3. `intersphinx` is part of the pip docs and wants to pull references from the internet. `pythonDocs` appears to have the needed python object file reference but `pypug` is not? currently packaged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
