### PR TITLE
libsndfile: enable tests, add passthru.tests

### DIFF
--- a/pkgs/development/libraries/libsndfile/default.nix
+++ b/pkgs/development/libraries/libsndfile/default.nix
@@ -1,6 +1,15 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, autogen, pkg-config, python3
 , flac, lame, libmpg123, libogg, libopus, libvorbis
 , alsa-lib, Carbon, AudioToolbox
+
+# for passthru.tests
+, audacity
+, freeswitch
+, gst_all_1
+, libsamplerate
+, moc
+, pipewire
+, pulseaudio
 }:
 
 stdenv.mkDerivation rec {
@@ -40,6 +49,21 @@ stdenv.mkDerivation rec {
     substituteInPlace tests/test_wrapper.sh \
       --replace '/usr/bin/env' "$(type -P env)"
   '';
+
+  passthru.tests = {
+    inherit
+      audacity
+      freeswitch
+      libsamplerate
+      moc
+      pipewire
+      pulseaudio;
+    inherit (python3.pkgs)
+      soundfile
+      wavefile;
+    inherit (gst_all_1) gst-plugins-bad;
+    lame = (lame.override { sndfileFileIOSupport = true; });
+  };
 
   meta = with lib; {
     description = "A C library for reading and writing files containing sampled sound";

--- a/pkgs/development/libraries/libsndfile/default.nix
+++ b/pkgs/development/libraries/libsndfile/default.nix
@@ -33,6 +33,14 @@ stdenv.mkDerivation rec {
   # Needed on Darwin.
   NIX_CFLAGS_LINK = "-logg -lvorbis";
 
+  doCheck = true;
+  preCheck = ''
+    patchShebangs tests/test_wrapper.sh tests/pedantic-header-test.sh
+
+    substituteInPlace tests/test_wrapper.sh \
+      --replace '/usr/bin/env' "$(type -P env)"
+  '';
+
   meta = with lib; {
     description = "A C library for reading and writing files containing sampled sound";
     homepage    = "https://libsndfile.github.io/libsndfile/";


### PR DESCRIPTION
## Description of changes

Tests are good, so is having suggested testing targets for packages with thousands of reverse-dependencies.

Also tested `pkgsStatic` variant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
