### PR TITLE
qutebrowser: use pyqt6-webengine

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -60,7 +60,7 @@ python3.pkgs.buildPythonApplication {
   ];
 
   propagatedBuildInputs = with python3.pkgs; ([
-    pyyaml pyqtwebengine jinja2 pygments
+    pyyaml pyqt6-webengine jinja2 pygments
     # scripts and userscripts libs
     tldextract beautifulsoup4
     readability-lxml pykeepass stem


### PR DESCRIPTION
## Description of changes

pyqtwebengine uses qt5, but since qutebrowser 3.0.0 the derivation is only building for qt6.

To test I built on x86_64-linux, started up qutebrowser and browsed a few sites. The first thing you notice is you aren't pulling in a bunch of qt5 dependencies.

Additionally before this commit qutebrowser would not start up for me on linux. I would get the following error:

```shellsession
$ /nix/store/9xrf1cbsb4fps6z73yygh9ixx9b6xgk7-qutebrowser-3.0.0/bin/qutebrowser 
21:39:38 WARNING: Could not find the Qt platform plugin "xcb" in ""
21:39:38 CRITICAL: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Fatal Python error: Aborted

Current thread 0x00007fb6b3c82740 (most recent call first):
  File "/nix/store/9xrf1cbsb4fps6z73yygh9ixx9b6xgk7-qutebrowser-3.0.0/lib/python3.10/site-packages/qutebrowser/app.py", line 541 in __init__
  File "/nix/store/9xrf1cbsb4fps6z73yygh9ixx9b6xgk7-qutebrowser-3.0.0/lib/python3.10/site-packages/qutebrowser/app.py", line 80 in run
  File "/nix/store/9xrf1cbsb4fps6z73yygh9ixx9b6xgk7-qutebrowser-3.0.0/lib/python3.10/site-packages/qutebrowser/qutebrowser.py", line 231 in main
  File "/nix/store/9xrf1cbsb4fps6z73yygh9ixx9b6xgk7-qutebrowser-3.0.0/bin/.qutebrowser-wrapped", line 34 in <module>

Extension modules: PyQt5.QtCore, PyQt5.QtGui, PyQt5.QtWidgets, markupsafe._speedups, yaml._yaml, PyQt5.QtNetwork, PyQt5.QtQml, PyQt5.QtOpenGL, PyQt5.QtDBus, PyQt5.QtPrintSupport, PyQt5.QtWebEngineCore, PyQt5.QtWebChannel, PyQt5.QtWebEngineWidgets, PyQt5.QtWebEngine, PyQt5.QtSql (total: 15)
Aborted (core dumped)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
