### PR TITLE
python310Packages.readability-lxml: disable broken test on darwin

### DIFF
--- a/pkgs/development/python-modules/readability-lxml/default.nix
+++ b/pkgs/development/python-modules/readability-lxml/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     timeout-decorator
   ];
 
-  disabledTests = [
+  disabledTests = lib.optionals stdenv.isDarwin [
     # Test is broken on darwin. Fix in master from https://github.com/buriy/python-readability/pull/178
     "test_many_repeated_spaces"
   ];

--- a/pkgs/development/python-modules/readability-lxml/default.nix
+++ b/pkgs/development/python-modules/readability-lxml/default.nix
@@ -31,8 +31,12 @@ buildPythonPackage rec {
     timeout-decorator
   ];
 
+  disabledTests = [
+    # Test is broken on darwin. Fix in master from https://github.com/buriy/python-readability/pull/178
+    "test_many_repeated_spaces"
+  ];
+
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Fast python port of arc90's readability tool";
     homepage = "https://github.com/buriy/python-readability";
     license = licenses.asl20;


### PR DESCRIPTION
## Description of changes

This test is broken on darwin. The test is fixed in master for readability-lxml, but the fix requires pulling in a few dependencies which are not packaged in nixpkgs.

My goal is to have no dependencies of qutebrowser marked as broken.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
