### PR TITLE
expr: 1.14.0 -> 1.14.1

### DIFF
--- a/pkgs/development/interpreters/expr/default.nix
+++ b/pkgs/development/interpreters/expr/default.nix
@@ -5,20 +5,24 @@
 
 buildGoModule rec {
   pname = "expr";
-  version = "1.14.0";
+  version = "1.14.1";
 
   src = fetchFromGitHub {
     owner = "antonmedv";
     repo = "expr";
     rev = "v${version}";
-    hash = "sha256-K5UIBkuTXsMaSUhys2Ij7JCwdLE/aZiiipiSucgtkIk=";
+    hash = "sha256-X55l2pSlwrcxM4JFcd25yfc5AQJPzNrZRHEHPWPevHw=";
   };
 
   sourceRoot = "${src.name}/repl";
 
-  vendorHash = "sha256-Sc4Md9O32SOQIyEbIkkJUiowEhLtQN6JzTymk9o3nWE=";
+  vendorHash = "sha256-pX8Yk/md6I27PPmdwoixSMMbopDjXOOnXyUxq0D97YA=";
 
   ldflags = [ "-s" "-w" ];
+
+  postInstall = ''
+    mv $out/bin/{repl,expr}
+  '';
 
   meta = with lib; {
     description = "Expression language and expression evaluation for Go";


### PR DESCRIPTION
Diff: https://github.com/antonmedv/expr/compare/v1.14.0...v1.14.1

Changelog: https://github.com/antonmedv/expr/releases/tag/v1.14.1

## Description of changes

also fixed the binary name

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
