### PR TITLE
nixos/matrix-synapse: fix type of certificate options

### DIFF
--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -374,7 +374,7 @@ in {
             };
 
             tls_certificate_path = mkOption {
-              type = types.nullOr types.str;
+              type = types.nullOr types.path;
               default = null;
               example = "/var/lib/acme/example.com/fullchain.pem";
               description = lib.mdDoc ''
@@ -387,7 +387,7 @@ in {
             };
 
             tls_private_key_path = mkOption {
-              type = types.nullOr types.str;
+              type = types.nullOr types.path;
               default = null;
               example = "/var/lib/acme/example.com/key.pem";
               description = lib.mdDoc ''


### PR DESCRIPTION
## Description of changes

I don't yet handle my secrets cleanly and directly pass a local file path to `tls_certificate_path`, that is my certs are added to the Nix store. When executing `nixos-rebuild switch --target-host user@host`, my certs aren't copied over to the target host because `tls_certificate_path` has type `types.str`. Using `types.path` fixes this issue.

Nginx also uses `types.path` for the `sslCertificate` option:
https://github.com/NixOS/nixpkgs/blob/2fc73d0977a73b2f99e661fb34b6c9e1e18e9fdb/nixos/modules/services/web-servers/nginx/vhost-options.nix#L191-L192

I am new to Nix, so I am not sure how to answer the last bullet point of the "Things done" list: Is this considered a breaking change? Should I instead allow both `types.str` and `types.path` like other packages do, such that it's a more backwards compatible change?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
