### PR TITLE
pypaInstallHook: enter "dist" directory before installing

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pypa-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pypa-install-hook.sh
@@ -5,9 +5,14 @@ pypaInstallPhase() {
     echo "Executing pypaInstallPhase"
     runHook preInstall
 
-    for wheel in dist/*.whl; do
+    pushd dist > /dev/null
+
+    for wheel in *.whl; do
         @pythonInterpreter@ -m installer --prefix "$out" "$wheel"
+        echo "Successfully installed $wheel"
     done
+
+    popd > /dev/null
 
     export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
 


### PR DESCRIPTION
## Description of changes

[openshot-qt](https://github.com/OpenShot/openshot-qt) has an `installer` directory in its source tree, which breaks the current simple logic in pypaInstallHook. Let's fix that by always entering the `dist` directory before we install.

I paid a bit more attention to the log output and decided to silence the success output of `pushd` and `popd`, which just prints the directory stack and isn't useful and added a message to report when a wheel was successfully installed to mirror the output of `pypaBuildHook` (except without the nice terminal colors that [`build`](https://github.com/pypa/build) uses).

/cc @FRidh 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
