### PR TITLE
percollate: init at 4.0.2

### DIFF
--- a/pkgs/tools/text/percollate/default.nix
+++ b/pkgs/tools/text/percollate/default.nix
@@ -1,0 +1,44 @@
+{ lib, buildNpmPackage, fetchFromGitHub, chromium, makeWrapper }:
+
+buildNpmPackage rec {
+  pname = "percollate";
+  version = "4.0.2";
+
+  src = fetchFromGitHub {
+    owner = "danburzo";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-QLbLg/zdDCZsRKgC4vR0OT//JHaapGmX33l7jIqUc1M=";
+  };
+
+  npmDepsHash = "sha256-Hxhgjdiz0zC/UlFXK8vvKZFI963Wi2Wx6iHWegr6f10=";
+
+  dontNpmBuild = true;
+
+  # Dev dependencies include an unnecessary Java dependency (epubchecker)
+  # https://github.com/danburzo/percollate/blob/v4.0.2/package.json#L40
+  npmInstallFlags = [ "--omit=dev" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  env = {
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = true;
+  };
+
+  postPatch = ''
+    substituteInPlace package.json --replace "git config core.hooksPath .git-hooks" ""
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/percollate \
+      --set PUPPETEER_EXECUTABLE_PATH ${chromium}/bin/chromium
+  '';
+
+  meta = with lib; {
+    description = "A command-line tool to turn web pages into readable PDF, EPUB, HTML, or Markdown docs";
+    homepage = "https://github.com/danburzo/percollate";
+    license = licenses.mit;
+    maintainers = [ maintainers.austinbutler ];
+    mainProgram = "percollate";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11893,6 +11893,8 @@ with pkgs;
 
   peco = callPackage ../tools/text/peco { };
 
+  percollate = callPackage ../tools/text/percollate { };
+
   pg_activity = callPackage ../development/tools/database/pg_activity { };
 
   pg_checksums = callPackage ../development/tools/database/pg_checksums { };


### PR DESCRIPTION
## Description of changes

Packages Percollate as a standalone tool instead of adding to `nodePackages` as suggested in https://github.com/NixOS/nixpkgs/pull/199952.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).