### PR TITLE
ocamlPackages.qcheck-{lin,stm}: init at 0.2

### DIFF
--- a/pkgs/development/ocaml-modules/qcheck/lin.nix
+++ b/pkgs/development/ocaml-modules/qcheck/lin.nix
@@ -1,0 +1,17 @@
+{ buildDunePackage
+, qcheck-multicoretests-util
+}:
+
+buildDunePackage {
+  pname = "qcheck-lin";
+
+  inherit (qcheck-multicoretests-util) version src;
+
+  propagatedBuildInputs = [ qcheck-multicoretests-util ];
+
+  doCheck = true;
+
+  meta = qcheck-multicoretests-util.meta // {
+    description = "A multicore testing library for OCaml";
+  };
+}

--- a/pkgs/development/ocaml-modules/qcheck/multicoretests-util.nix
+++ b/pkgs/development/ocaml-modules/qcheck/multicoretests-util.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, qcheck-core
+}:
+
+buildDunePackage rec {
+  pname = "qcheck-multicoretests-util";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-multicore";
+    repo = "multicoretests";
+    rev = version;
+    hash = "sha256-U1ZqfWMwpAvbPq5yp2U9YTFklT4MypzTSfNvcKJfaYE=";
+  };
+
+  propagatedBuildInputs = [ qcheck-core ];
+
+  doCheck = true;
+
+  minimalOCamlVersion = "4.12";
+
+  meta = {
+    homepage = "https://github.com/ocaml-multicore/multicoretests";
+    description = "Utility functions for property-based testing of multicore programs";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/qcheck/stm.nix
+++ b/pkgs/development/ocaml-modules/qcheck/stm.nix
@@ -1,0 +1,17 @@
+{ buildDunePackage
+, qcheck-multicoretests-util
+}:
+
+buildDunePackage {
+  pname = "qcheck-stm";
+
+  inherit (qcheck-multicoretests-util) src version;
+
+  propagatedBuildInputs = [ qcheck-multicoretests-util ];
+
+  doCheck = true;
+
+  meta = qcheck-multicoretests-util.meta // {
+    description = "State-machine testing library for sequential and parallel model-based tests";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1470,6 +1470,8 @@ let
 
     qcheck-ounit = callPackage ../development/ocaml-modules/qcheck/ounit.nix { };
 
+    qcheck-stm = callPackage ../development/ocaml-modules/qcheck/stm.nix { };
+
     qtest = callPackage ../development/ocaml-modules/qtest { };
 
     ### R ###

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1464,6 +1464,8 @@ let
 
     qcheck-core = callPackage ../development/ocaml-modules/qcheck/core.nix { };
 
+    qcheck-multicoretests-util = callPackage ../development/ocaml-modules/qcheck/multicoretests-util.nix { };
+
     qcheck-ounit = callPackage ../development/ocaml-modules/qcheck/ounit.nix { };
 
     qtest = callPackage ../development/ocaml-modules/qtest { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1464,6 +1464,8 @@ let
 
     qcheck-core = callPackage ../development/ocaml-modules/qcheck/core.nix { };
 
+    qcheck-lin = callPackage ../development/ocaml-modules/qcheck/lin.nix { };
+
     qcheck-multicoretests-util = callPackage ../development/ocaml-modules/qcheck/multicoretests-util.nix { };
 
     qcheck-ounit = callPackage ../development/ocaml-modules/qcheck/ounit.nix { };


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
