### PR TITLE
nixos-rebuild: Add list-generations

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -8,6 +8,8 @@
 
 - LXD now supports virtual machine instances to complement the existing container support
 
+- The `nixos-rebuild` command has been given a `list-generations` subcommand. See `man nixos-rebuild` for more details.
+
 ## New Services {#sec-release-23.11-new-services}
 
 - [MCHPRS](https://github.com/MCHPR/MCHPRS), a multithreaded Minecraft server built for redstone. Available as [services.mchprs](#opt-services.mchprs.enable).

--- a/pkgs/os-specific/linux/nixos-rebuild/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/default.nix
@@ -3,6 +3,8 @@
 , coreutils
 , gnused
 , gnugrep
+, jq
+, util-linux
 , nix
 , lib
 , nixosTests
@@ -20,7 +22,7 @@ substituteAll {
   nix_x86_64_linux = fallback.x86_64-linux;
   nix_i686_linux = fallback.i686-linux;
   nix_aarch64_linux = fallback.aarch64-linux;
-  path = lib.makeBinPath [ coreutils gnused gnugrep ];
+  path = lib.makeBinPath [ coreutils gnused gnugrep jq util-linux ];
   nativeBuildInputs = [
     installShellFiles
   ];

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -10,7 +10,7 @@
 .Sh SYNOPSIS
 .Nm
 .Bro
-.Cm switch | boot | test | build | dry-build | dry-activate | edit | build-vm | build-vm-with-bootloader
+.Cm switch | boot | test | build | dry-build | dry-activate | edit | build-vm | build-vm-with-bootloader | list-generations Op Fl -json
 .Brc
 .br
 .Op Fl -upgrade | -upgrade-all
@@ -196,6 +196,14 @@ The boot loader is installed on an automatically generated virtual disk
 containing a
 .Pa /boot
 partition.
+.
+.It Cm list-generations Op Fl -json
+List the available generations in a similar manner to the boot loader
+menu. It shows the generation number, build date and time, NixOS version,
+kernel version and the configuration revision. This is useful to get
+information e.g. for which generation to roll back to with
+.Ic nixos-rebuild switch Fl -generation Ar N
+There is also a json version of output available.
 .El
 .
 .

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -36,6 +36,7 @@ verboseScript=
 noFlake=
 # comma separated list of vars to preserve when using sudo
 preservedSudoVars=NIXOS_INSTALL_BOOTLOADER
+json=
 
 # log the given argument to stderr
 log() {
@@ -48,7 +49,7 @@ while [ "$#" -gt 0 ]; do
       --help)
         showSyntax
         ;;
-      switch|boot|test|build|edit|dry-build|dry-run|dry-activate|build-vm|build-vm-with-bootloader)
+      switch|boot|test|build|edit|dry-build|dry-run|dry-activate|build-vm|build-vm-with-bootloader|list-generations)
         if [ "$i" = dry-run ]; then i=dry-build; fi
         # exactly one action mandatory, bail out if multiple are given
         if [ -n "$action" ]; then showSyntax; fi
@@ -145,6 +146,9 @@ while [ "$#" -gt 0 ]; do
         j="$1"; shift 1
         k="$1"; shift 1
         lockFlags+=("$i" "$j" "$k")
+        ;;
+      --json)
+        json=1
         ;;
       *)
         log "$0: unknown option \`$i'"
@@ -505,6 +509,87 @@ fi
 
 if [ "$action" = dry-build ]; then
     extraBuildFlags+=(--dry-run)
+fi
+
+if [ "$action" = list-generations ]; then
+    if [ ! -L "$profile" ]; then
+        log "No profile \`$(basename "$profile")' found"
+        exit 1
+    fi
+
+    generation_from_dir() {
+        generation_dir="$1"
+        generation_base="$(basename "$generation_dir")" # Has the format "system-123-link" for generation 123
+        no_link_gen="${generation_base%-link}"  # remove the "-link"
+        echo "${no_link_gen##*-}" # remove everything before the last dash
+    }
+    describe_generation(){
+        generation_dir="$1"
+        generation_number="$(generation_from_dir "$generation_dir")"
+        nixos_version="$(cat "$generation_dir/nixos-version" 2> /dev/null || echo "Unknown")"
+
+        kernel_dir="$(dirname "$(realpath "$generation_dir/kernel")")"
+        kernel_version="$(ls "$kernel_dir/lib/modules" || echo "Unknown")"
+
+        configurationRevision="$("$generation_dir/sw/bin/nixos-version" --configuration-revision 2> /dev/null || true)"
+
+        # Old nixos-version output ignored unknown flags and just printed the version
+        # therefore the following workaround is done not to show the default output
+        nixos_version_default="$("$generation_dir/sw/bin/nixos-version")"
+        if [ "$configurationRevision" == "$nixos_version_default" ]; then
+             configurationRevision=""
+        fi
+
+        # jq automatically quotes the output => don't try to quote it in output!
+        build_date="$(stat "$generation_dir" --format=%W | jq 'todate')"
+
+        pushd "$generation_dir/specialisation/" > /dev/null || :
+        specialisation_list=(*)
+        popd > /dev/null || :
+
+        specialisations="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${specialisation_list[@]}")"
+
+        if [ "$(basename "$generation_dir")" = "$(readlink "$profile")" ]; then
+            current_generation_tag="true"
+        else
+            current_generation_tag="false"
+        fi
+
+        # Escape userdefined strings
+        nixos_version="$(jq -aR <<< "$nixos_version")"
+        kernel_version="$(jq -aR <<< "$kernel_version")"
+        configurationRevision="$(jq -aR <<< "$configurationRevision")"
+        cat << EOF
+{
+  "generation": $generation_number,
+  "date": $build_date,
+  "nixosVersion": $nixos_version,
+  "kernelVersion": $kernel_version,
+  "configurationRevision": $configurationRevision,
+  "specialisations": $specialisations,
+  "current": $current_generation_tag
+}
+EOF
+    }
+
+    find "$(dirname "$profile")" -regex "$profile-[0-9]+-link" |
+        sort -Vr |
+        while read -r generation_dir; do
+            describe_generation "$generation_dir"
+        done |
+        if [ -z "$json" ]; then
+            jq --slurp -r '.[] | [
+                    ([.generation, (if .current == true then "current" else "" end)] | join(" ")),
+                    (.date | fromdate | strflocaltime("%Y-%m-%d %H:%M:%S")),
+                    .nixosVersion, .kernelVersion, .configurationRevision,
+                    (.specialisations | join(" "))
+                ] | @tsv' |
+                column --separator $'\t' --table --table-columns "Generation,Build-date,NixOS version,Kernel,Configuration Revision,Specialisation" |
+                ${PAGER:cat}
+        else
+            jq --slurp .
+        fi
+    exit 0
 fi
 
 


### PR DESCRIPTION
## Description of changes

Add new option `nixos-rebuild list-generations`. It will show an output like

```
$ nixos-rebuild list-generations
Generation      Build-date               NixOS version           Kernel  Configuration Revision                    Specialisations
52   (current)  Fri 2023-08-18 08:17:27  23.11.20230817.0f46300  6.4.10  448160aeccf6a7184bd8a84290d527819f1c552c  *
51              Mon 2023-08-07 17:56:41  23.11.20230807.31b1eed  6.4.8   99ef480007ca51e3d440aa4fa6558178d63f9c42  *
```
or in a more machine readable format with `--json`:
```json
[
  {
    "generation": 52,
    "date": "2023-08-18T06:17:27Z",
    "nixosVersion": "23.11.20230817.0f46300",
    "kernelVersion": "6.4.10",
    "configurationRevision": "448160aeccf6a7184bd8a84290d527819f1c552c",
    "specialisations": [
      "*"
    ],
    "current": true
  },
  {
    "generation": 51,
    "date": "2023-08-07T15:56:41Z",
    "nixosVersion": "23.11.20230807.31b1eed",
    "kernelVersion": "6.4.8",
    "configurationRevision": "99ef480007ca51e3d440aa4fa6558178d63f9c42",
    "specialisations": [
      "*"
    ],
    "current": false
  }
]
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This is actually the first commit of https://github.com/NixOS/nixpkgs/pull/105910 because it does not really make sense to couple the two changes into one single merge-request and so this is hopefully easier to review. I am sorry for doing it like this in the first place :see_no_evil:

@Mic92 @SuperSandro2000 and @xaverdh already had a first look at the combined merge request a while ago, hopefully it is easier now to review this one change that is also not as critical as the second part.

What is missing that anyone would like to have in the overview?