### PR TITLE
libsForQt5.qtwayland: Fix cross

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -1,10 +1,10 @@
-{ qtModule, qtbase, qtquickcontrols, wayland, pkg-config }:
+{ qtModule, qtbase, qtquickcontrols, wayland, wayland-scanner, pkg-config }:
 
 qtModule {
   pname = "qtwayland";
   qtInputs = [ qtbase qtquickcontrols ];
   buildInputs = [ wayland ];
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config wayland-scanner ];
   outputs = [ "out" "dev" "bin" ];
   patches = [
     # NixOS-specific, ensure that app_id is correctly determined for


### PR DESCRIPTION
## Description of changes

#227900 will make `qtbase` cross work which is technically required to test this, but this change should be easy to comprehend even without it.

`qtwayland` needs `wayland` libraries for the `hostPlatform`:
```
Checking for Wayland client library... yes
Checking for Wayland cursor library... yes
[...]
```

And `wayland-scanner` to execute on the `buildPlatform`:
```
Checking for wayland-scanner... yes
```

So without `wayland` in `buildInputs` AND `nativeBuildInputs` the build gives up under cross, because there is no `wayland-scanner` for `buildPlatform`:
```
Running configuration tests...
Checking for Wayland client library... yes
Checking for Wayland cursor library... yes
Checking for wayland-scanner... no
Checking for Wayland EGL library... yes
Checking for wayland-server... yes
Done running configuration tests.

Configure summary:

Qt Wayland Client ........................ no
Qt Wayland Compositor .................... no
```

When applied onto #227900, this lets me cross-compile up to `bambootracker` for `aarch64-linux`:
![image](https://github.com/NixOS/nixpkgs/assets/23431373/51063ba3-dd33-4dbd-acaa-87f1f8d2c47e)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
