### PR TITLE
junicode: 1.003 -> 2.200

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -339,6 +339,8 @@
 
 - `mkDerivation` now rejects MD5 hashes.
 
+- The `junicode` font package has been updated to [major version 2](https://github.com/psb1558/Junicode-font/releases/tag/v2.001), which is now a font family. In particular, plain `Junicode.ttf` no longer exists. In addition, TrueType font files are now placed in `font/truetype` instead of `font/junicode-ttf`; this change does not affect use via `fonts.packages` NixOS option.
+
 ## Other Notable Changes {#sec-release-23.11-notable-changes}
 
 - The Cinnamon module now enables XDG desktop integration by default. If you are experiencing collisions related to xdg-desktop-portal-gtk you can safely remove `xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];` from your NixOS configuration.

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -2,11 +2,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "junicode";
-  version = "2.001";
+  version = "2.002";
 
   src = fetchzip {
     url = "https://github.com/psb1558/Junicode-font/releases/download/v${version}/Junicode_${version}.zip";
-    hash = "sha256-AEbRU0KiB9gLdxcXn8Mn/XLjBEm0qa4cV6+xE1HKU5s=";
+    hash = "sha256-AHy4uT0LEof69+ECoFlKmALPTTPbvRNjmFD240koWAE=";
   };
 
   outputs = [ "out" "doc" ];

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -2,11 +2,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "junicode";
-  version = "2.004";
+  version = "2.100";
 
   src = fetchzip {
     url = "https://github.com/psb1558/Junicode-font/releases/download/v${version}/Junicode_${version}.zip";
-    hash = "sha256-bdtyfdNjCATlk74T6aADUmcf5nhyGSM/7kIpRl324Go=";
+    hash = "sha256-Sd3WhG846m2CXz+NKDAod5bfF91MOR1Vq0wpuOE+cDQ=";
   };
 
   outputs = [ "out" "doc" ];

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -1,22 +1,24 @@
-{ lib, stdenvNoCC, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchzip }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation rec {
   pname = "junicode";
-  version = "1.003";
+  version = "2.001";
 
-  src = fetchFromGitHub {
-    owner = "psb1558";
-    repo = "Junicode-font";
-    rev = "55d816d91a5e19795d9b66edec478379ee2b9ddb";
-    hash = "sha256-eTiMgI8prnpR4H6sqKRaB3Gcnt4C5QWZalRajWW49G4=";
+  src = fetchzip {
+    url = "https://github.com/psb1558/Junicode-font/releases/download/v${version}/Junicode_${version}.zip";
+    hash = "sha256-AEbRU0KiB9gLdxcXn8Mn/XLjBEm0qa4cV6+xE1HKU5s=";
   };
+
+  outputs = [ "out" "doc" ];
 
   installPhase = ''
     runHook preInstall
 
-    local out_ttf=$out/share/fonts/junicode-ttf
-    mkdir -p $out_ttf
-    cp legacy/*.ttf $out_ttf
+    install -Dt $out/share/fonts/truetype TTF/*.ttf VAR/*.ttf
+    install -Dt $out/share/fonts/opentype OTF/*.otf
+    install -Dt $out/share/fonts/woff2 WOFF2/*.woff2
+
+    install -Dt $doc/share/doc/${pname}-${version} docs/*.pdf
 
     runHook postInstall
   '';

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -2,11 +2,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "junicode";
-  version = "2.003";
+  version = "2.004";
 
   src = fetchzip {
     url = "https://github.com/psb1558/Junicode-font/releases/download/v${version}/Junicode_${version}.zip";
-    hash = "sha256-PD4rAZKTLVVblrQZgWKuuSF693nv2Od/uj1IOav+8/0=";
+    hash = "sha256-bdtyfdNjCATlk74T6aADUmcf5nhyGSM/7kIpRl324Go=";
   };
 
   outputs = [ "out" "doc" ];

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -2,11 +2,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "junicode";
-  version = "2.002";
+  version = "2.003";
 
   src = fetchzip {
     url = "https://github.com/psb1558/Junicode-font/releases/download/v${version}/Junicode_${version}.zip";
-    hash = "sha256-AHy4uT0LEof69+ECoFlKmALPTTPbvRNjmFD240koWAE=";
+    hash = "sha256-PD4rAZKTLVVblrQZgWKuuSF693nv2Od/uj1IOav+8/0=";
   };
 
   outputs = [ "out" "doc" ];
@@ -14,11 +14,11 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dt $out/share/fonts/truetype TTF/*.ttf VAR/*.ttf
-    install -Dt $out/share/fonts/opentype OTF/*.otf
-    install -Dt $out/share/fonts/woff2 WOFF2/*.woff2
+    install -Dm 444 -t $out/share/fonts/truetype TTF/*.ttf VAR/*.ttf
+    install -Dm 444 -t $out/share/fonts/opentype OTF/*.otf
+    install -Dm 444 -t $out/share/fonts/woff2 WOFF2/*.woff2
 
-    install -Dt $doc/share/doc/${pname}-${version} docs/*.pdf
+    install -Dm 444 -t $doc/share/doc/${pname}-${version} docs/*.pdf
 
     runHook postInstall
   '';

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -2,11 +2,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "junicode";
-  version = "2.100";
+  version = "2.200";
 
   src = fetchzip {
     url = "https://github.com/psb1558/Junicode-font/releases/download/v${version}/Junicode_${version}.zip";
-    hash = "sha256-Sd3WhG846m2CXz+NKDAod5bfF91MOR1Vq0wpuOE+cDQ=";
+    hash = "sha256-2K+zPq6Bjg+hZQhQrWWm1bxHVfwwRdsV7EseRGBnpUw=";
   };
 
   outputs = [ "out" "doc" ];

--- a/pkgs/tools/typesetting/satysfi/default.nix
+++ b/pkgs/tools/typesetting/satysfi/default.nix
@@ -65,10 +65,12 @@ in
       cp -r lib-satysfi/dist/ $out/share/satysfi/
       cp -r \
         ${ipaexfont}/share/fonts/opentype/* \
-        ${junicode}/share/fonts/junicode-ttf/* \
         ${lmodern}/share/fonts/opentype/public/lm/* \
         ${lmmath}/share/fonts/opentype/latinmodern-math.otf \
-        $out/share/satysfi/dist/fonts
+        ${junicode}/share/fonts/truetype/Junicode-{Bold,BoldItalic,Italic}.ttf \
+        $out/share/satysfi/dist/fonts/
+      cp ${junicode}/share/fonts/truetype/Junicode-Regular.ttf \
+        $out/share/satysfi/dist/fonts/Junicode.ttf
     '';
 
     meta = with lib; {


### PR DESCRIPTION
## Description of changes

Release announcement:
https://github.com/psb1558/Junicode-font/releases/tag/v2.001

This is a breaking change, at least in font file naming (Junicode.ttf is now Junicode-Regular.ttf). In general, 2.0 adds a lot more font variants and opentype and web font versions of the font.

Seeing as backward compatibility is broken anyway, I opted to break it a bit more and change custom install path (`junicode-ttf`) to seemingly more conventional `truetype`; new .otf and .woff2 variants are then naturally placed in corresponding directories. This does *not* affect the `fonts.packages` NixOS option, which rearranges font files anyway, but brings a degree of consistency with other fonts.

Both the file renaming and the directory structure change break satysfi, however, so I adjusted its builder accordingly, copying over only those font variants that were also present in 1.0 series.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
