### PR TITLE
stm32cubemx: 6.8.1 -> 6.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1066,6 +1066,11 @@
     github = "an-empty-string";
     githubId = 681716;
   };
+  angaz = {
+    name = "Angus Dippenaar";
+    github = "angaz";
+    githubId = 10219618;
+  };
   angristan = {
     email = "angristan@pm.me";
     github = "angristan";

--- a/pkgs/development/embedded/stm32/stm32cubemx/default.nix
+++ b/pkgs/development/embedded/stm32/stm32cubemx/default.nix
@@ -1,23 +1,27 @@
-{ lib, stdenv, makeDesktopItem, icoutils, fdupes, imagemagick, jdk11, fetchzip }:
-# TODO: JDK16 causes STM32CubeMX to crash right now, so we fixed the version to JDK11
-# This may be fixed in a future version of STM32CubeMX. This issue has been reported to ST:
-# https://community.st.com/s/question/0D53W00000jnOzPSAU/stm32cubemx-crashes-on-launch-with-openjdk16
-# If you're updating this derivation, check the link above to see if it's been fixed upstream
-# and try replacing all occurrences of jdk11 with jre and test whether it works.
+{ fdupes
+, fetchzip
+, icoutils
+, imagemagick
+, jdk17
+, lib
+, makeDesktopItem
+, stdenv
+}:
+
 let
   iconame = "STM32CubeMX";
 in
 stdenv.mkDerivation rec {
   pname = "stm32cubemx";
-  version = "6.8.1";
+  version = "6.9.1";
 
   src = fetchzip {
     url = "https://sw-center.st.com/packs/resource/library/stm32cube_mx_v${builtins.replaceStrings ["."] [""] version}-lin.zip";
-    sha256 = "sha256-0WzdyRP09rRZzVZhwMOxA/SwHrQOYGBnv8UwvjMT22Q=";
+    sha256 = "sha256-KTbIRj7DkWoC2h/TLKjVduvsKVSue28kGOL34JqBVx4=";
     stripRoot = false;
   };
 
-  nativeBuildInputs = [ icoutils fdupes imagemagick ];
+  nativeBuildInputs = [ fdupes icoutils imagemagick ];
   desktopItem = makeDesktopItem {
     name = "STM32CubeMX";
     exec = "stm32cubemx";
@@ -41,7 +45,7 @@ stdenv.mkDerivation rec {
 
     cat << EOF > $out/bin/${pname}
     #!${stdenv.shell}
-    ${jdk11}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX
+    ${jdk17}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX
     EOF
     chmod +x $out/bin/${pname}
 
@@ -74,7 +78,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.st.com/en/development-tools/stm32cubemx.html";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ wucke13 ];
+    maintainers = with maintainers; [ angaz wucke13 ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Release notes: https://www.st.com/resource/en/release_note/rn0094-stm32cubemx-release-691-stmicroelectronics.pdf

In the release notes, it mentions that it's bundled with Java 17, so
this is the same version which is pinned in this package.

## Description of changes

- Add maintainer angaz
- Update stm32cubemx to the latest version, use JDK 17 for the runtime.

I chose JDK 17 because this is what is mentioned in the release notes as the version which is bundled with the application, so I suppose this is the version which was used for their internal testing. I tried JDK 19 and 20. It worked, but there could be unexpected bugs, so I think it's safest to stay with the version suggested by the release notes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
