### PR TITLE
nixos/kubernetes: freeform options

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -149,6 +149,73 @@
 
 - The `html-proofer` package has been updated from major version 3 to major version 5, which includes [breaking changes](https://github.com/gjtorikian/html-proofer/blob/v5.0.8/UPGRADING.md).
 
+### Kubernetes {#sec-release-23.11-incompatibilities-kubernetes}
+
+Almost all kubernetes module options have been removed in favor of the freeform syntax.
+
+This also means that a lot of the default values for CLI arguments have been removed in nixpkgs. Hence these configuration options will *revert to their upstream defaults*. See below.
+
+Note that using `services.kubernetes.roles = [ ... ]` still results in some of the settings being set explicitly by the NixOS module, in order to provide a ready-to-use auto-configured cluster. See: `nixos/modules/services/cluster/kubernetes/default.nix`.
+
+Below are the subset of options that had former nixpkgs defaults which differed from Kubernetes upstream defaults **(action required)**:
+
+**[kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver)**
+
+| Cmdline arg              | Former NixOS default                 | Upstream default  |
+| ------------------------ | ------------------------------------ | ----------------- |
+| api-audiences            | api,https://kubernetes.default.svc   | <unset>           |
+| authorization-mode       | RBAC,Node                            | AlwaysAllow       |
+| enable-admission-plugins | ... *                                | <unset>           |
+| etcd-servers             | http://127.0.0.1:2379                | <unset>           |
+| runtime-config           | authentication.k8s.io/v1beta1=true   | <unset>           |
+| service-account-issuer   | https://kubernetes.default.svc       | <unset>           |
+| service-cluster-ip-range | 10.0.0.0/24                          | <unset>           |
+
+\* NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction
+
+
+**[kube-controller-manager](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager)**
+
+| Cmdline arg                     | Former NixOS default | Upstream default  |
+| ------------------------------- | -------------------- | ----------------- |
+| allocate-node-cidrs             | true                 | false             |
+| bind-address                    | 127.0.0.1            | 0.0.0.0           |
+| cluster-cidr                    | 10.1.0.0/16          | <unset>           |
+| secure-port                     | 10252                | 10257             |
+| use-service-account-credentials | true                 | false             |
+
+**[kube-proxy](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy)**
+
+| Cmdline arg                     | Former NixOS default          | Upstream default  |
+| ------------------------------- | ----------------------------- | ----------------- |
+| cluster-cidr                    | 10.1.0.0/16                   | <unset>           |
+| hostname-override               | ${config.networking.hostName} | <unset>           |
+
+**[kube-scheduler](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler)**
+
+| Cmdline arg                     | Former NixOS default  | Upstream default  |
+| ------------------------------- | --------------------- | ----------------- |
+| bind-address                    | 127.0.0.1             | 0.0.0.0           |
+| secure-port                     | 10251                 | 10259             |
+
+**[kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet)**
+
+| Cmdline arg                            | Former NixOS default                   | Upstream default          |
+| -------------------------------------- | -------------------------------------- | ------------------------- |
+| authentication-token-webhook           | true                                   | false                     |
+| authentication-token-webhook-cache-ttl | 10s                                    | 2m0s                      |
+| authorization-mode                     | Webhook                                | AlwaysAllow               |
+| cgroup-driver                          | systemd                                | cgroupfs                  |
+| container-runtime-endpoint             | unix:///run/containerd/containerd.sock | <unset>                   |
+| hairpin-mode                           | hairpin-veth                           | promiscuous-bridge        |
+| hostname-override                      | ${config.networking.fqdnOrHostName}    | <unset>                   |
+| pod-infra-container-image              | pause                                  | registry.k8s.io/pause:3.9 |
+| root-dir                               | /var/lib/kubernetes                    | /var/lib/kubelet          |
+
+**addons/dns**
+
+The CoreDNS clusterIP no longer has a default except for when using `roles` (auto-configuration).
+
 ## Other Notable Changes {#sec-release-23.11-notable-changes}
 
 - The Cinnamon module now enables XDG desktop integration by default. If you are experiencing collisions related to xdg-desktop-portal-gtk you can safely remove `xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];` from your NixOS configuration.

--- a/nixos/modules/services/cluster/kubernetes/addon-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/addon-manager.nix
@@ -6,7 +6,7 @@ let
   top = config.services.kubernetes;
   cfg = top.addonManager;
 
-  isRBACEnabled = elem "RBAC" top.apiserver.authorizationMode;
+  isRBACEnabled = elem "RBAC" top.apiserver.settings.authorization-mode;
 
   addons = pkgs.runCommand "kubernetes-addons" { } ''
     mkdir -p $out

--- a/nixos/modules/services/cluster/kubernetes/addons/dns.nix
+++ b/nixos/modules/services/cluster/kubernetes/addons/dns.nix
@@ -16,17 +16,6 @@ in {
 
     clusterIp = mkOption {
       description = lib.mdDoc "Dns addon clusterIP";
-
-      # this default is also what kubernetes users
-      default = (
-        concatStringsSep "." (
-          take 3 (splitString "." config.services.kubernetes.apiserver.serviceClusterIpRange
-        ))
-      ) + ".254";
-      defaultText = literalMD ''
-        The `x.y.z.254` IP of
-        `config.${options.services.kubernetes.apiserver.serviceClusterIpRange}`.
-      '';
       type = types.str;
     };
 
@@ -366,7 +355,7 @@ in {
       };
     };
 
-    services.kubernetes.kubelet.clusterDns = mkDefault cfg.clusterIp;
+    services.kubernetes.kubelet.settings.cluster-dns = mkDefault cfg.clusterIp;
   };
 
   meta.buildDocsInSandbox = false;

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -7,299 +7,93 @@ let
   otop = options.services.kubernetes;
   cfg = top.apiserver;
 
-  isRBACEnabled = elem "RBAC" cfg.authorizationMode;
+  isRBACEnabled = elem "RBAC" cfg.settings.authorization-mode;
 
   apiserverServiceIP = (concatStringsSep "." (
-    take 3 (splitString "." cfg.serviceClusterIpRange
+    take 3 (splitString "." cfg.settings.service-cluster-ip-range
   )) + ".1");
-in
-{
 
-  ###### interface
-  options.services.kubernetes.apiserver = with lib.types; {
-
-    advertiseAddress = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes apiserver IP address on which to advertise the apiserver
-        to members of the cluster. This address must be reachable by the rest
-        of the cluster.
-      '';
-      default = null;
-      type = nullOr str;
-    };
-
-    allowPrivileged = mkOption {
-      description = lib.mdDoc "Whether to allow privileged containers on Kubernetes.";
-      default = false;
-      type = bool;
-    };
-
-    authorizationMode = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes apiserver authorization mode (AlwaysAllow/AlwaysDeny/ABAC/Webhook/RBAC/Node). See
-        <https://kubernetes.io/docs/reference/access-authn-authz/authorization/>
-      '';
-      default = ["RBAC" "Node"]; # Enabling RBAC by default, although kubernetes default is AllowAllow
-      type = listOf (enum ["AlwaysAllow" "AlwaysDeny" "ABAC" "Webhook" "RBAC" "Node"]);
-    };
-
-    authorizationPolicy = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes apiserver authorization policy file. See
-        <https://kubernetes.io/docs/reference/access-authn-authz/authorization/>
-      '';
-      default = [];
-      type = listOf attrs;
-    };
-
-    basicAuthFile = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes apiserver basic authentication file. See
-        <https://kubernetes.io/docs/reference/access-authn-authz/authentication>
-      '';
-      default = null;
-      type = nullOr path;
-    };
-
-    bindAddress = mkOption {
-      description = lib.mdDoc ''
-        The IP address on which to listen for the --secure-port port.
-        The associated interface(s) must be reachable by the rest
-        of the cluster, and by CLI/web clients.
-      '';
-      default = "0.0.0.0";
-      type = str;
-    };
-
-    clientCaFile = mkOption {
-      description = lib.mdDoc "Kubernetes apiserver CA file for client auth.";
-      default = top.caFile;
-      defaultText = literalExpression "config.${otop.caFile}";
-      type = nullOr path;
-    };
-
-    disableAdmissionPlugins = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes admission control plugins to disable. See
-        <https://kubernetes.io/docs/admin/admission-controllers/>
-      '';
-      default = [];
-      type = listOf str;
-    };
-
-    enable = mkEnableOption (lib.mdDoc "Kubernetes apiserver");
-
-    enableAdmissionPlugins = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes admission control plugins to enable. See
-        <https://kubernetes.io/docs/admin/admission-controllers/>
-      '';
-      default = [
-        "NamespaceLifecycle" "LimitRanger" "ServiceAccount"
-        "ResourceQuota" "DefaultStorageClass" "DefaultTolerationSeconds"
-        "NodeRestriction"
-      ];
-      example = [
-        "NamespaceLifecycle" "NamespaceExists" "LimitRanger"
-        "SecurityContextDeny" "ServiceAccount" "ResourceQuota"
-        "PodSecurityPolicy" "NodeRestriction" "DefaultStorageClass"
-      ];
-      type = listOf str;
-    };
-
-    etcd = {
-      servers = mkOption {
-        description = lib.mdDoc "List of etcd servers.";
-        default = ["http://127.0.0.1:2379"];
-        type = types.listOf types.str;
-      };
-
-      keyFile = mkOption {
-        description = lib.mdDoc "Etcd key file.";
-        default = null;
-        type = types.nullOr types.path;
-      };
-
-      certFile = mkOption {
-        description = lib.mdDoc "Etcd cert file.";
-        default = null;
-        type = types.nullOr types.path;
-      };
-
-      caFile = mkOption {
-        description = lib.mdDoc "Etcd ca file.";
-        default = top.caFile;
-        defaultText = literalExpression "config.${otop.caFile}";
-        type = types.nullOr types.path;
-      };
-    };
-
-    extraOpts = mkOption {
-      description = lib.mdDoc "Kubernetes apiserver extra command line options.";
-      default = "";
-      type = separatedString " ";
-    };
-
-    extraSANs = mkOption {
-      description = lib.mdDoc "Extra x509 Subject Alternative Names to be added to the kubernetes apiserver tls cert.";
-      default = [];
-      type = listOf str;
-    };
-
-    featureGates = mkOption {
-      description = lib.mdDoc "List set of feature gates";
-      default = top.featureGates;
-      defaultText = literalExpression "config.${otop.featureGates}";
-      type = listOf str;
-    };
-
-    kubeletClientCaFile = mkOption {
-      description = lib.mdDoc "Path to a cert file for connecting to kubelet.";
-      default = top.caFile;
-      defaultText = literalExpression "config.${otop.caFile}";
-      type = nullOr path;
-    };
-
-    kubeletClientCertFile = mkOption {
-      description = lib.mdDoc "Client certificate to use for connections to kubelet.";
-      default = null;
-      type = nullOr path;
-    };
-
-    kubeletClientKeyFile = mkOption {
-      description = lib.mdDoc "Key to use for connections to kubelet.";
-      default = null;
-      type = nullOr path;
-    };
-
-    preferredAddressTypes = mkOption {
-      description = lib.mdDoc "List of the preferred NodeAddressTypes to use for kubelet connections.";
-      type = nullOr str;
-      default = null;
-    };
-
-    proxyClientCertFile = mkOption {
-      description = lib.mdDoc "Client certificate to use for connections to proxy.";
-      default = null;
-      type = nullOr path;
-    };
-
-    proxyClientKeyFile = mkOption {
-      description = lib.mdDoc "Key to use for connections to proxy.";
-      default = null;
-      type = nullOr path;
-    };
-
-    runtimeConfig = mkOption {
-      description = lib.mdDoc ''
-        Api runtime configuration. See
-        <https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/>
-      '';
-      default = "authentication.k8s.io/v1beta1=true";
-      example = "api/all=false,api/v1=true";
-      type = str;
-    };
-
-    storageBackend = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes apiserver storage backend.
-      '';
-      default = "etcd3";
-      type = enum ["etcd2" "etcd3"];
-    };
-
-    securePort = mkOption {
-      description = lib.mdDoc "Kubernetes apiserver secure port.";
-      default = 6443;
-      type = int;
-    };
-
-    apiAudiences = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes apiserver ServiceAccount issuer.
-      '';
-      default = "api,https://kubernetes.default.svc";
-      type = str;
-    };
-
-    serviceAccountIssuer = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes apiserver ServiceAccount issuer.
-      '';
-      default = "https://kubernetes.default.svc";
-      type = str;
-    };
-
-    serviceAccountSigningKeyFile = mkOption {
-      description = lib.mdDoc ''
-        Path to the file that contains the current private key of the service
-        account token issuer. The issuer will sign issued ID tokens with this
-        private key.
-      '';
-      type = path;
-    };
-
-    serviceAccountKeyFile = mkOption {
-      description = lib.mdDoc ''
-        File containing PEM-encoded x509 RSA or ECDSA private or public keys,
-        used to verify ServiceAccount tokens. The specified file can contain
-        multiple keys, and the flag can be specified multiple times with
-        different files. If unspecified, --tls-private-key-file is used.
-        Must be specified when --service-account-signing-key is provided
-      '';
-      type = path;
-    };
-
-    serviceClusterIpRange = mkOption {
-      description = lib.mdDoc ''
-        A CIDR notation IP range from which to assign service cluster IPs.
-        This must not overlap with any IP ranges assigned to nodes for pods.
-      '';
-      default = "10.0.0.0/24";
-      type = str;
-    };
-
-    tlsCertFile = mkOption {
-      description = lib.mdDoc "Kubernetes apiserver certificate file.";
-      default = null;
-      type = nullOr path;
-    };
-
-    tlsKeyFile = mkOption {
-      description = lib.mdDoc "Kubernetes apiserver private key file.";
-      default = null;
-      type = nullOr path;
-    };
-
-    tokenAuthFile = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes apiserver token authentication file. See
-        <https://kubernetes.io/docs/reference/access-authn-authz/authentication>
-      '';
-      default = null;
-      type = nullOr path;
-    };
-
-    verbosity = mkOption {
-      description = lib.mdDoc ''
-        Optional glog verbosity level for logging statements. See
-        <https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md>
-      '';
-      default = null;
-      type = nullOr int;
-    };
-
-    webhookConfig = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes apiserver Webhook config file. It uses the kubeconfig file format.
-        See <https://kubernetes.io/docs/reference/access-authn-authz/webhook/>
-      '';
-      default = null;
-      type = nullOr path;
-    };
-
+  # TODO: Remove in NixOS 24.05
+  removedOptions = {
+    "authorizationPolicy" = "Generate a policy file and set 'settings.authorization-policy-file' to its path";
+    "basicAuthFile" = "Support for basic auth was removed in Kubernetes v1.19";
+    "extraOpts" = "Use freeform settings";
   };
 
+  # TODO: Remove in NixOS 24.05
+  optName = n: builtins.filter (f: f != []) (builtins.split "\\." n);
+
+  # TODO: Remove in NixOS 24.05
+  renamedOptions = {
+    "apiAudiences" = "api-audiences";
+    "allowPrivileged" = "allow-privileged";
+    "authorizationMode" = "authorization-mode";
+    "advertiseAddress" = "advertise-address";
+    "bindAddress" = "bind-address";
+    "clientCaFile" = "client-ca-file";
+    "disableAdmissionPlugins" = "disable-admission-plugins";
+    "enableAdmissionPlugins" = "enable-admission-plugins";
+    "etcd.caFile" = "etcd-cafile";
+    "etcd.certFile" = "etcd-certfile";
+    "etcd.keyFile" = "etcd-keyfile";
+    "etcd.servers" = "etcd-servers";
+    "featureGates" = "feature-gates";
+    "kubeletClientCaFile" = "kubelet-certificate-authority";
+    "kubeletClientCertFile" = "kubelet-client-certificate";
+    "kubeletClientKeyFile" = "kubelet-client-key";
+    "preferredAddressTypes" = "kubelet-preferred-address-types";
+    "proxyClientCertFile" = "proxy-client-cert-file";
+    "proxyClientKeyFile" = "proxy-client-key-file";
+    "runtimeConfig" = "runtime-config";
+    "storageBackend" = "storage-backend";
+    "securePort" = "secure-port";
+    "serviceAccountIssuer" = "service-account-issuer";
+    "serviceAccountSigningKeyFile" = "service-account-signing-key-file";
+    "serviceAccountKeyFile" = "service-account-key-file";
+    "serviceClusterIpRange" = "service-cluster-ip-range";
+    "tlsCertFile" = "tls-cert-file";
+    "tlsKeyFile" = "tls-private-key-file";
+    "tokenAuthFile" = "token-auth-file";
+    "verbosity" = "v";
+    "webhookConfig" = "authentication-token-webhook-config-file";
+  };
+in
+{
+  # TODO: Remove in NixOS 24.05
+  imports =
+    let
+      base = ["services" "kubernetes" "apiserver"];
+    in
+      [
+        (mkRenamedOptionModule (base ++ ["extraSANs"]) ["services" "kubernetes" "pki" "apiServerExtraSANs"])
+      ] ++
+      (mapAttrsToList (n: v: mkRemovedOptionModule (base ++ [n]) v) removedOptions) ++
+      (mapAttrsToList (n: v: mkRenamedOptionModule (base ++ (optName n)) (base ++ ["settings" v])) renamedOptions);
+
+  ###### interface
+  options.services.kubernetes.apiserver = with types; {
+    enable = mkEnableOption (mdDoc "Kubernetes apiserver");
+
+    settings = mkOption {
+      description = ''
+        Configuration for kube-apiserver, see:
+          <https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver>.
+        All attrs defined here translates directly to flags of syntax `--<name>="<value>"`
+        which is provided as command line argument to the kube-apiserver binary.
+      '';
+      type = types.submodule {
+        freeformType = attrsOf (oneOf [
+          bool
+          float
+          int
+          (listOf str)
+          package
+          path
+          str
+        ]);
+      };
+    };
+  };
 
   ###### implementation
   config = mkMerge [
@@ -312,64 +106,7 @@ in
           serviceConfig = {
             Slice = "kubernetes.slice";
             ExecStart = ''${top.package}/bin/kube-apiserver \
-              --allow-privileged=${boolToString cfg.allowPrivileged} \
-              --authorization-mode=${concatStringsSep "," cfg.authorizationMode} \
-                ${optionalString (elem "ABAC" cfg.authorizationMode)
-                  "--authorization-policy-file=${
-                    pkgs.writeText "kube-auth-policy.jsonl"
-                    (concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.authorizationPolicy)
-                  }"
-                } \
-                ${optionalString (elem "Webhook" cfg.authorizationMode)
-                  "--authorization-webhook-config-file=${cfg.webhookConfig}"
-                } \
-              --bind-address=${cfg.bindAddress} \
-              ${optionalString (cfg.advertiseAddress != null)
-                "--advertise-address=${cfg.advertiseAddress}"} \
-              ${optionalString (cfg.clientCaFile != null)
-                "--client-ca-file=${cfg.clientCaFile}"} \
-              --disable-admission-plugins=${concatStringsSep "," cfg.disableAdmissionPlugins} \
-              --enable-admission-plugins=${concatStringsSep "," cfg.enableAdmissionPlugins} \
-              --etcd-servers=${concatStringsSep "," cfg.etcd.servers} \
-              ${optionalString (cfg.etcd.caFile != null)
-                "--etcd-cafile=${cfg.etcd.caFile}"} \
-              ${optionalString (cfg.etcd.certFile != null)
-                "--etcd-certfile=${cfg.etcd.certFile}"} \
-              ${optionalString (cfg.etcd.keyFile != null)
-                "--etcd-keyfile=${cfg.etcd.keyFile}"} \
-              ${optionalString (cfg.featureGates != [])
-                "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
-              ${optionalString (cfg.basicAuthFile != null)
-                "--basic-auth-file=${cfg.basicAuthFile}"} \
-              ${optionalString (cfg.kubeletClientCaFile != null)
-                "--kubelet-certificate-authority=${cfg.kubeletClientCaFile}"} \
-              ${optionalString (cfg.kubeletClientCertFile != null)
-                "--kubelet-client-certificate=${cfg.kubeletClientCertFile}"} \
-              ${optionalString (cfg.kubeletClientKeyFile != null)
-                "--kubelet-client-key=${cfg.kubeletClientKeyFile}"} \
-              ${optionalString (cfg.preferredAddressTypes != null)
-                "--kubelet-preferred-address-types=${cfg.preferredAddressTypes}"} \
-              ${optionalString (cfg.proxyClientCertFile != null)
-                "--proxy-client-cert-file=${cfg.proxyClientCertFile}"} \
-              ${optionalString (cfg.proxyClientKeyFile != null)
-                "--proxy-client-key-file=${cfg.proxyClientKeyFile}"} \
-              ${optionalString (cfg.runtimeConfig != "")
-                "--runtime-config=${cfg.runtimeConfig}"} \
-              --secure-port=${toString cfg.securePort} \
-              --api-audiences=${toString cfg.apiAudiences} \
-              --service-account-issuer=${toString cfg.serviceAccountIssuer} \
-              --service-account-signing-key-file=${cfg.serviceAccountSigningKeyFile} \
-              --service-account-key-file=${cfg.serviceAccountKeyFile} \
-              --service-cluster-ip-range=${cfg.serviceClusterIpRange} \
-              --storage-backend=${cfg.storageBackend} \
-              ${optionalString (cfg.tlsCertFile != null)
-                "--tls-cert-file=${cfg.tlsCertFile}"} \
-              ${optionalString (cfg.tlsKeyFile != null)
-                "--tls-private-key-file=${cfg.tlsKeyFile}"} \
-              ${optionalString (cfg.tokenAuthFile != null)
-                "--token-auth-file=${cfg.tokenAuthFile}"} \
-              ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \
-              ${cfg.extraOpts}
+              ${concatStringsSep " \\\n" (mapAttrsToList (n: v: ''--${n}="${top.lib.renderArg v}"'') cfg.settings)}
             '';
             WorkingDirectory = top.dataDir;
             User = "kubernetes";
@@ -378,7 +115,6 @@ in
             Restart = "on-failure";
             RestartSec = 5;
           };
-
           unitConfig = {
             StartLimitIntervalSec = 0;
           };
@@ -423,11 +159,11 @@ in
           hosts = [
                     "kubernetes.default.svc"
                     "kubernetes.default.svc.${top.addons.dns.clusterDomain}"
-                    cfg.advertiseAddress
+                    cfg.settings.advertise-address
                     top.masterAddress
                     apiserverServiceIP
                     "127.0.0.1"
-                  ] ++ cfg.extraSANs;
+                  ] ++ top.pki.apiServerExtraSANs;
           action = "systemctl restart kube-apiserver.service";
         };
         apiserverProxyClient = mkCert {
@@ -460,7 +196,7 @@ in
                     "etcd.local"
                     "etcd.${top.addons.dns.clusterDomain}"
                     top.masterAddress
-                    cfg.advertiseAddress
+                    cfg.settings.advertise-address
                   ];
           privateKeyOwner = "etcd";
           action = "systemctl restart etcd.service";

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -15,18 +15,6 @@ let
 in
 {
 
-  imports = [
-    (mkRenamedOptionModule [ "services" "kubernetes" "apiserver" "admissionControl" ] [ "services" "kubernetes" "apiserver" "enableAdmissionPlugins" ])
-    (mkRenamedOptionModule [ "services" "kubernetes" "apiserver" "address" ] ["services" "kubernetes" "apiserver" "bindAddress"])
-    (mkRemovedOptionModule [ "services" "kubernetes" "apiserver" "insecureBindAddress" ] "")
-    (mkRemovedOptionModule [ "services" "kubernetes" "apiserver" "insecurePort" ] "")
-    (mkRemovedOptionModule [ "services" "kubernetes" "apiserver" "publicAddress" ] "")
-    (mkRenamedOptionModule [ "services" "kubernetes" "etcd" "servers" ] [ "services" "kubernetes" "apiserver" "etcd" "servers" ])
-    (mkRenamedOptionModule [ "services" "kubernetes" "etcd" "keyFile" ] [ "services" "kubernetes" "apiserver" "etcd" "keyFile" ])
-    (mkRenamedOptionModule [ "services" "kubernetes" "etcd" "certFile" ] [ "services" "kubernetes" "apiserver" "etcd" "certFile" ])
-    (mkRenamedOptionModule [ "services" "kubernetes" "etcd" "caFile" ] [ "services" "kubernetes" "apiserver" "etcd" "caFile" ])
-  ];
-
   ###### interface
   options.services.kubernetes.apiserver = with lib.types; {
 

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -8,10 +8,6 @@ let
   cfg = top.controllerManager;
 in
 {
-  imports = [
-    (mkRenamedOptionModule [ "services" "kubernetes" "controllerManager" "address" ] ["services" "kubernetes" "controllerManager" "bindAddress"])
-    (mkRemovedOptionModule [ "services" "kubernetes" "controllerManager" "insecurePort" ] "")
-  ];
 
   ###### interface
   options.services.kubernetes.controllerManager = with lib.types; {

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -1,105 +1,64 @@
-{ config, lib, options, pkgs, ... }:
-
-with lib;
-
+{ config, lib, pkgs, ... }: with lib;
 let
   top = config.services.kubernetes;
-  otop = options.services.kubernetes;
   cfg = top.controllerManager;
+
+  # TODO: Remove in NixOS 24.05
+  removedOptions = {
+    "extraOpts" = "Use freeform settings";
+  };
+
+  # TODO: Remove in NixOS 24.05
+  optName = n: builtins.filter (f: f != []) (builtins.split "\\." n);
+
+  # TODO: Remove in NixOS 24.05
+  renamedOptions = {
+    "allocateNodeCIDRs" = "allocate-node-cidrs";
+    "bindAddress" = "bind-address";
+    "clusterCidr" = "cluster-cidr";
+    "featureGates" = "feature-gates";
+    "kubeconfig" = "kubeconfig";
+    "leaderElect" = "leader-elect";
+    "rootCaFile" = "root-ca-file";
+    "securePort" = "secure-port";
+    "serviceAccountKeyFile" = "service-account-private-key-file";
+    "tlsCertFile" = "tls-cert-file";
+    "tlsKeyFile" = "tls-private-key-file";
+    "verbosity" = "v";
+  };
 in
 {
+  # TODO: Remove in NixOS 24.05
+  imports =
+    let
+      base = ["services" "kubernetes" "controllerManager"];
+    in
+      (mapAttrsToList (n: v: mkRemovedOptionModule (base ++ [n]) v) removedOptions) ++
+      (mapAttrsToList (n: v: mkRenamedOptionModule (base ++ (optName n)) (base ++ ["settings" v])) renamedOptions);
 
   ###### interface
-  options.services.kubernetes.controllerManager = with lib.types; {
+  options.services.kubernetes.controllerManager = with types; {
+    enable = mkEnableOption (mdDoc "Kubernetes controller manager");
 
-    allocateNodeCIDRs = mkOption {
-      description = lib.mdDoc "Whether to automatically allocate CIDR ranges for cluster nodes.";
-      default = true;
-      type = bool;
-    };
-
-    bindAddress = mkOption {
-      description = lib.mdDoc "Kubernetes controller manager listening address.";
-      default = "127.0.0.1";
-      type = str;
-    };
-
-    clusterCidr = mkOption {
-      description = lib.mdDoc "Kubernetes CIDR Range for Pods in cluster.";
-      default = top.clusterCidr;
-      defaultText = literalExpression "config.${otop.clusterCidr}";
-      type = str;
-    };
-
-    enable = mkEnableOption (lib.mdDoc "Kubernetes controller manager");
-
-    extraOpts = mkOption {
-      description = lib.mdDoc "Kubernetes controller manager extra command line options.";
-      default = "";
-      type = separatedString " ";
-    };
-
-    featureGates = mkOption {
-      description = lib.mdDoc "List set of feature gates";
-      default = top.featureGates;
-      defaultText = literalExpression "config.${otop.featureGates}";
-      type = listOf str;
-    };
-
-    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes controller manager";
-
-    leaderElect = mkOption {
-      description = lib.mdDoc "Whether to start leader election before executing main loop.";
-      type = bool;
-      default = true;
-    };
-
-    rootCaFile = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes controller manager certificate authority file included in
-        service account's token secret.
+    settings = mkOption {
+      description = ''
+        Configuration for kube-controller-manager, see:
+          <https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager>.
+        All attrs defined here translates directly to flags of syntax `--<name>="<value>"`
+        which is provided as command line argument to the kube-controller-manager binary.
       '';
-      default = top.caFile;
-      defaultText = literalExpression "config.${otop.caFile}";
-      type = nullOr path;
+      type = types.submodule {
+        freeformType = attrsOf (oneOf [
+          bool
+          float
+          int
+          (listOf str)
+          package
+          path
+          str
+        ]);
+      };
     };
-
-    securePort = mkOption {
-      description = lib.mdDoc "Kubernetes controller manager secure listening port.";
-      default = 10252;
-      type = int;
-    };
-
-    serviceAccountKeyFile = mkOption {
-      description = lib.mdDoc ''
-        Kubernetes controller manager PEM-encoded private RSA key file used to
-        sign service account tokens
-      '';
-      default = null;
-      type = nullOr path;
-    };
-
-    tlsCertFile = mkOption {
-      description = lib.mdDoc "Kubernetes controller-manager certificate file.";
-      default = null;
-      type = nullOr path;
-    };
-
-    tlsKeyFile = mkOption {
-      description = lib.mdDoc "Kubernetes controller-manager private key file.";
-      default = null;
-      type = nullOr path;
-    };
-
-    verbosity = mkOption {
-      description = lib.mdDoc ''
-        Optional glog verbosity level for logging statements. See
-        <https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md>
-      '';
-      default = null;
-      type = nullOr int;
-    };
-
   };
 
   ###### implementation
@@ -113,27 +72,7 @@ in
         Restart = "on-failure";
         Slice = "kubernetes.slice";
         ExecStart = ''${top.package}/bin/kube-controller-manager \
-          --allocate-node-cidrs=${boolToString cfg.allocateNodeCIDRs} \
-          --bind-address=${cfg.bindAddress} \
-          ${optionalString (cfg.clusterCidr!=null)
-            "--cluster-cidr=${cfg.clusterCidr}"} \
-          ${optionalString (cfg.featureGates != [])
-            "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
-          --kubeconfig=${top.lib.mkKubeConfig "kube-controller-manager" cfg.kubeconfig} \
-          --leader-elect=${boolToString cfg.leaderElect} \
-          ${optionalString (cfg.rootCaFile!=null)
-            "--root-ca-file=${cfg.rootCaFile}"} \
-          --secure-port=${toString cfg.securePort} \
-          ${optionalString (cfg.serviceAccountKeyFile!=null)
-            "--service-account-private-key-file=${cfg.serviceAccountKeyFile}"} \
-          ${optionalString (cfg.tlsCertFile!=null)
-            "--tls-cert-file=${cfg.tlsCertFile}"} \
-          ${optionalString (cfg.tlsKeyFile!=null)
-            "--tls-private-key-file=${cfg.tlsKeyFile}"} \
-          ${optionalString (elem "RBAC" top.apiserver.authorizationMode)
-            "--use-service-account-credentials"} \
-          ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \
-          ${cfg.extraOpts}
+          ${concatStringsSep " \\\n" (mapAttrsToList (n: v: ''--${n}="${top.lib.renderArg v}"'') cfg.settings)}
         '';
         WorkingDirectory = top.dataDir;
         User = "kubernetes";
@@ -157,8 +96,6 @@ in
         action = "systemctl restart kube-controller-manager.service";
       };
     };
-
-    services.kubernetes.controllerManager.kubeconfig.server = mkDefault top.apiserverAddress;
   };
 
   meta.buildDocsInSandbox = false;

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -6,6 +6,13 @@ let
   cfg = config.services.kubernetes;
   opt = options.services.kubernetes;
 
+  renderArg = v:
+    if isList v
+    then concatStringsSep "," v
+    else if isBool v
+    then boolToString v
+    else toString v;
+
   defaultContainerdSettings = {
     version = 2;
     root = "/var/lib/containerd";
@@ -183,6 +190,7 @@ in {
         inherit mkCert;
         inherit mkKubeConfig;
         inherit mkKubeConfigOptions;
+        inherit renderArg;
       };
       type = types.attrs;
     };
@@ -215,20 +223,9 @@ in {
       services.etcd.enable = true; # Cannot mkDefault because of flannel default options
       services.kubernetes.kubelet = {
         enable = mkDefault true;
-        taints = mkIf (!(elem "node" cfg.roles)) {
-          master = {
-            key = "node-role.kubernetes.io/master";
-            value = "true";
-            effect = "NoSchedule";
-          };
-        };
+        settings.register-with-taints = mkIf (!(elem "node" cfg.roles))
+          "node-role.kubernetes.io/master=true:NoSchedule";
       };
-    })
-
-
-    (mkIf (all (el: el == "master") cfg.roles) {
-      # if this node is only a master make it unschedulable by default
-      services.kubernetes.kubelet.unschedulable = mkDefault true;
     })
 
     (mkIf (elem "node" cfg.roles) {
@@ -241,11 +238,40 @@ in {
       services.kubernetes.flannel.enable = mkDefault true;
       services.flannel.etcd.endpoints = mkDefault etcdEndpoints;
       services.kubernetes.easyCerts = mkDefault true;
+
+      # these are some defaults which were previously option defaults in nixpkgs
+      # they are kept here to make at least some easy/minimal configuration of a Kubernetes cluster possible
+      # and to not surprise users of this feature too much, yet
+      services.kubernetes.apiserver.settings = rec{
+        api-audiences = "api,${service-account-issuer}";
+        authorization-mode = ["RBAC" "Node"];
+        service-cluster-ip-range = "10.0.0.0/24";
+        service-account-issuer = "https://kubernetes.default.svc";
+      };
+
+      services.kubernetes.controllerManager.settings = {
+        allocate-node-cidrs = true;
+        cluster-cidr = cfg.clusterCidr;
+        use-service-account-credentials = true;
+      };
+
+      services.kubernetes.kubelet.settings = {
+        cgroup-driver = "systemd";
+      };
+
+      services.kubernetes.proxy.settings = {
+        cluster-cidr = cfg.clusterCidr;
+        hostname-override = cfg.kubelet.hostname;
+      };
+
+      services.kubernetes.addons.dns.clusterIp = concatStringsSep "." (
+        take 3 (splitString "." cfg.apiserver.settings.service-cluster-ip-range
+      )) + ".254";
     })
 
     (mkIf cfg.apiserver.enable {
       services.kubernetes.pki.etcClusterAdminKubeconfig = mkDefault "kubernetes/cluster-admin.kubeconfig";
-      services.kubernetes.apiserver.etcd.servers = mkDefault etcdEndpoints;
+      services.kubernetes.apiserver.settings.etcd-servers = mkDefault etcdEndpoints;
     })
 
     (mkIf cfg.kubelet.enable {
@@ -300,9 +326,9 @@ in {
       # dns addon is enabled by default
       services.kubernetes.addons.dns.enable = mkDefault true;
 
-      services.kubernetes.apiserverAddress = mkDefault ("https://${if cfg.apiserver.advertiseAddress != null
-                          then cfg.apiserver.advertiseAddress
-                          else "${cfg.masterAddress}:${toString cfg.apiserver.securePort}"}");
+      services.kubernetes.apiserverAddress = mkDefault ("https://${if cfg.apiserver.settings.advertise-address != null
+                          then cfg.apiserver.settings.advertise-address
+                          else "${cfg.masterAddress}:${toString cfg.apiserver.settings.secure-port}"}");
     })
   ];
 

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -102,11 +102,6 @@ let
   };
 in {
 
-  imports = [
-    (mkRemovedOptionModule [ "services" "kubernetes" "addons" "dashboard" ] "Removed due to it being an outdated version")
-    (mkRemovedOptionModule [ "services" "kubernetes" "verbose" ] "")
-  ];
-
   ###### interface
 
   options.services.kubernetes = {

--- a/nixos/modules/services/cluster/kubernetes/flannel.nix
+++ b/nixos/modules/services/cluster/kubernetes/flannel.nix
@@ -54,7 +54,7 @@ in
     };
 
     # give flannel some kubernetes rbac permissions if applicable
-    services.kubernetes.addonManager.bootstrapAddons = mkIf ((storageBackend == "kubernetes") && (elem "RBAC" top.apiserver.authorizationMode)) {
+    services.kubernetes.addonManager.bootstrapAddons = mkIf ((storageBackend == "kubernetes") && (elem "RBAC" top.apiserver.settings.authorization-mode)) {
 
       flannel-cr = {
         apiVersion = "rbac.authorization.k8s.io/v1";

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -1,11 +1,40 @@
-{ config, lib, options, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
 let
   top = config.services.kubernetes;
-  otop = options.services.kubernetes;
   cfg = top.kubelet;
+
+  # TODO: Remove in NixOS 24.05
+  removedOptions = {
+    "extraOpts" = "Use freeform settings";
+    "manifests" = "Build and set services.kubernetes.kubelet.settings.pod-manifest-path";
+    "unschedulable" = "Set services.kubernetes.kubelet.settings.register-with-tains manually";
+  };
+
+  # TODO: Remove in NixOS 24.05
+  optName = n: builtins.filter (f: f != []) (builtins.split "\\." n);
+
+  # TODO: Remove in NixOS 24.05
+  renamedOptions = {
+    "address" = "address";
+    "clusterDns" = "cluster-dns";
+    "clusterDomain" = "cluster-domain";
+    "clientCaFile" = "client-ca-file";
+    "containerRuntimeEndpoint" = "container-runtime-endpoint";
+    "featureGates" = "feature-gates";
+    "healthz.bind" = "healthz-bind-address";
+    "healthz.port" = "healthz-port";
+    "kubeconfig" = "kubeconfig";
+    "nodeIp" = "node-ip";
+    "registerNode" = "register-node";
+    "taints" = "register-with-taints";
+    "tlsCertFile" = "tls-cert-file";
+    "tlsKeyFile" = "tls-private-key-file";
+    "port" = "port";
+    "verbosity" = "v";
+  };
 
   cniConfig =
     if cfg.cni.config != [] && cfg.cni.configDir != null then
@@ -30,64 +59,18 @@ let
     };
     config.Cmd = ["/bin/pause"];
   };
-
-  kubeconfig = top.lib.mkKubeConfig "kubelet" cfg.kubeconfig;
-
-  manifestPath = "kubernetes/manifests";
-
-  taintOptions = with lib.types; { name, ... }: {
-    options = {
-      key = mkOption {
-        description = lib.mdDoc "Key of taint.";
-        default = name;
-        defaultText = literalMD "Name of this submodule.";
-        type = str;
-      };
-      value = mkOption {
-        description = lib.mdDoc "Value of taint.";
-        type = str;
-      };
-      effect = mkOption {
-        description = lib.mdDoc "Effect of taint.";
-        example = "NoSchedule";
-        type = enum ["NoSchedule" "PreferNoSchedule" "NoExecute"];
-      };
-    };
-  };
-
-  taints = concatMapStringsSep "," (v: "${v.key}=${v.value}:${v.effect}") (mapAttrsToList (n: v: v) cfg.taints);
 in
 {
+  # TODO: Remove in NixOS 24.05
+  imports =
+    let
+      base = ["services" "kubernetes" "kubelet"];
+    in
+      (mapAttrsToList (n: v: mkRemovedOptionModule (base ++ [n]) v) removedOptions) ++
+      (mapAttrsToList (n: v: mkRenamedOptionModule (base ++ (optName n)) (base ++ ["settings" v])) renamedOptions);
 
   ###### interface
   options.services.kubernetes.kubelet = with lib.types; {
-
-    address = mkOption {
-      description = lib.mdDoc "Kubernetes kubelet info server listening address.";
-      default = "0.0.0.0";
-      type = str;
-    };
-
-    clusterDns = mkOption {
-      description = lib.mdDoc "Use alternative DNS.";
-      default = "10.1.0.1";
-      type = str;
-    };
-
-    clusterDomain = mkOption {
-      description = lib.mdDoc "Use alternative domain.";
-      default = config.services.kubernetes.addons.dns.clusterDomain;
-      defaultText = literalExpression "config.${options.services.kubernetes.addons.dns.clusterDomain}";
-      type = str;
-    };
-
-    clientCaFile = mkOption {
-      description = lib.mdDoc "Kubernetes apiserver CA file for client authentication.";
-      default = top.caFile;
-      defaultText = literalExpression "config.${otop.caFile}";
-      type = nullOr path;
-    };
-
     cni = {
       packages = mkOption {
         description = lib.mdDoc "List of network plugin packages to install.";
@@ -128,71 +111,12 @@ in
       };
     };
 
-    containerRuntimeEndpoint = mkOption {
-      description = lib.mdDoc "Endpoint at which to find the container runtime api interface/socket";
-      type = str;
-      default = "unix:///run/containerd/containerd.sock";
-    };
-
     enable = mkEnableOption (lib.mdDoc "Kubernetes kubelet");
-
-    extraOpts = mkOption {
-      description = lib.mdDoc "Kubernetes kubelet extra command line options.";
-      default = "";
-      type = separatedString " ";
-    };
-
-    featureGates = mkOption {
-      description = lib.mdDoc "List set of feature gates";
-      default = top.featureGates;
-      defaultText = literalExpression "config.${otop.featureGates}";
-      type = listOf str;
-    };
-
-    healthz = {
-      bind = mkOption {
-        description = lib.mdDoc "Kubernetes kubelet healthz listening address.";
-        default = "127.0.0.1";
-        type = str;
-      };
-
-      port = mkOption {
-        description = lib.mdDoc "Kubernetes kubelet healthz port.";
-        default = 10248;
-        type = port;
-      };
-    };
 
     hostname = mkOption {
       description = lib.mdDoc "Kubernetes kubelet hostname override.";
       defaultText = literalExpression "config.networking.fqdnOrHostName";
       type = str;
-    };
-
-    kubeconfig = top.lib.mkKubeConfigOptions "Kubelet";
-
-    manifests = mkOption {
-      description = lib.mdDoc "List of manifests to bootstrap with kubelet (only pods can be created as manifest entry)";
-      type = attrsOf attrs;
-      default = {};
-    };
-
-    nodeIp = mkOption {
-      description = lib.mdDoc "IP address of the node. If set, kubelet will use this IP address for the node.";
-      default = null;
-      type = nullOr str;
-    };
-
-    registerNode = mkOption {
-      description = lib.mdDoc "Whether to auto register kubelet with API server.";
-      default = true;
-      type = bool;
-    };
-
-    port = mkOption {
-      description = lib.mdDoc "Kubernetes kubelet info server listening port.";
-      default = 10250;
-      type = port;
     };
 
     seedDockerImages = mkOption {
@@ -201,39 +125,25 @@ in
       type = listOf package;
     };
 
-    taints = mkOption {
-      description = lib.mdDoc "Node taints (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/).";
-      default = {};
-      type = attrsOf (submodule [ taintOptions ]);
-    };
-
-    tlsCertFile = mkOption {
-      description = lib.mdDoc "File containing x509 Certificate for HTTPS.";
-      default = null;
-      type = nullOr path;
-    };
-
-    tlsKeyFile = mkOption {
-      description = lib.mdDoc "File containing x509 private key matching tlsCertFile.";
-      default = null;
-      type = nullOr path;
-    };
-
-    unschedulable = mkOption {
-      description = lib.mdDoc "Whether to set node taint to unschedulable=true as it is the case of node that has only master role.";
-      default = false;
-      type = bool;
-    };
-
-    verbosity = mkOption {
-      description = lib.mdDoc ''
-        Optional glog verbosity level for logging statements. See
-        <https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md>
+    settings = mkOption {
+      description = ''
+        Configuration for kubelet, see:
+          <https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet>.
+        All attrs defined here translates directly to flags of syntax `--<name>="<value>"`
+        which is provided as command line argument to the kubelet binary.
       '';
-      default = null;
-      type = nullOr int;
+      type = types.submodule {
+        freeformType = attrsOf (oneOf [
+          bool
+          float
+          int
+          (listOf str)
+          package
+          path
+          str
+        ]);
+      };
     };
-
   };
 
   ###### implementation
@@ -287,41 +197,7 @@ in
           Restart = "on-failure";
           RestartSec = "1000ms";
           ExecStart = ''${top.package}/bin/kubelet \
-            --address=${cfg.address} \
-            --authentication-token-webhook \
-            --authentication-token-webhook-cache-ttl="10s" \
-            --authorization-mode=Webhook \
-            ${optionalString (cfg.clientCaFile != null)
-              "--client-ca-file=${cfg.clientCaFile}"} \
-            ${optionalString (cfg.clusterDns != "")
-              "--cluster-dns=${cfg.clusterDns}"} \
-            ${optionalString (cfg.clusterDomain != "")
-              "--cluster-domain=${cfg.clusterDomain}"} \
-            ${optionalString (cfg.featureGates != [])
-              "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
-            --hairpin-mode=hairpin-veth \
-            --healthz-bind-address=${cfg.healthz.bind} \
-            --healthz-port=${toString cfg.healthz.port} \
-            --hostname-override=${cfg.hostname} \
-            --kubeconfig=${kubeconfig} \
-            ${optionalString (cfg.nodeIp != null)
-              "--node-ip=${cfg.nodeIp}"} \
-            --pod-infra-container-image=pause \
-            ${optionalString (cfg.manifests != {})
-              "--pod-manifest-path=/etc/${manifestPath}"} \
-            --port=${toString cfg.port} \
-            --register-node=${boolToString cfg.registerNode} \
-            ${optionalString (taints != "")
-              "--register-with-taints=${taints}"} \
-            --root-dir=${top.dataDir} \
-            ${optionalString (cfg.tlsCertFile != null)
-              "--tls-cert-file=${cfg.tlsCertFile}"} \
-            ${optionalString (cfg.tlsKeyFile != null)
-              "--tls-private-key-file=${cfg.tlsKeyFile}"} \
-            ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \
-            --container-runtime-endpoint=${cfg.containerRuntimeEndpoint} \
-            --cgroup-driver=systemd \
-            ${cfg.extraOpts}
+            ${concatStringsSep " \\\n" (mapAttrsToList (n: v: ''--${n}="${top.lib.renderArg v}"'') cfg.settings)}
           '';
           WorkingDirectory = top.dataDir;
         };
@@ -332,6 +208,8 @@ in
 
       # Always include cni plugins
       services.kubernetes.kubelet.cni.packages = [pkgs.cni-plugins pkgs.cni-plugin-flannel];
+
+      services.kubernetes.kubelet.settings.hostname-override = mkDefault cfg.hostname;
 
       boot.kernelModules = ["br_netfilter" "overlay"];
 
@@ -354,26 +232,7 @@ in
           action = "systemctl restart kubelet.service";
         };
       };
-
-      services.kubernetes.kubelet.kubeconfig.server = mkDefault top.apiserverAddress;
     })
-
-    (mkIf (cfg.enable && cfg.manifests != {}) {
-      environment.etc = mapAttrs' (name: manifest:
-        nameValuePair "${manifestPath}/${name}.json" {
-          text = builtins.toJSON manifest;
-          mode = "0755";
-        }
-      ) cfg.manifests;
-    })
-
-    (mkIf (cfg.unschedulable && cfg.enable) {
-      services.kubernetes.kubelet.taints.unschedulable = {
-        value = "true";
-        effect = "NoSchedule";
-      };
-    })
-
   ];
 
   meta.buildDocsInSandbox = false;

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -58,13 +58,6 @@ let
   taints = concatMapStringsSep "," (v: "${v.key}=${v.value}:${v.effect}") (mapAttrsToList (n: v: v) cfg.taints);
 in
 {
-  imports = [
-    (mkRemovedOptionModule [ "services" "kubernetes" "kubelet" "applyManifests" ] "")
-    (mkRemovedOptionModule [ "services" "kubernetes" "kubelet" "cadvisorPort" ] "")
-    (mkRemovedOptionModule [ "services" "kubernetes" "kubelet" "allowPrivileged" ] "")
-    (mkRemovedOptionModule [ "services" "kubernetes" "kubelet" "networkPlugin" ] "")
-    (mkRemovedOptionModule [ "services" "kubernetes" "kubelet" "containerRuntime" ] "")
-  ];
 
   ###### interface
   options.services.kubernetes.kubelet = with lib.types; {

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -8,9 +8,6 @@ let
   cfg = top.proxy;
 in
 {
-  imports = [
-    (mkRenamedOptionModule [ "services" "kubernetes" "proxy" "address" ] ["services" "kubernetes" "proxy" "bindAddress"])
-  ];
 
   ###### interface
   options.services.kubernetes.proxy = with lib.types; {

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -1,56 +1,58 @@
-{ config, lib, options, pkgs, ... }:
-
-with lib;
-
+{ config, lib, pkgs, ... }: with lib;
 let
   top = config.services.kubernetes;
-  otop = options.services.kubernetes;
   cfg = top.proxy;
+
+  # TODO: Remove in NixOS 24.05
+  removedOptions = {
+    "extraOpts" = "Use freeform settings";
+  };
+
+  # TODO: Remove in NixOS 24.05
+  optName = n: builtins.filter (f: f != []) (builtins.split "\\." n);
+
+  # TODO: Remove in NixOS 24.05
+  renamedOptions = {
+    "bindAddress" = "bind-address";
+    "featureGates" = "feature-gates";
+    "hostname" = "hostname-override";
+    "kubeconfig" = "kubeconfig";
+    "verbosity" = "v";
+  };
 in
 {
+  # TODO: Remove in NixOS 24.05
+  imports =
+    let
+      base = ["services" "kubernetes" "proxy"];
+    in
+      (mapAttrsToList (n: v: mkRemovedOptionModule (base ++ [n]) v) removedOptions) ++
+      (mapAttrsToList (n: v: mkRenamedOptionModule (base ++ (optName n)) (base ++ ["settings" v])) renamedOptions);
 
   ###### interface
   options.services.kubernetes.proxy = with lib.types; {
 
-    bindAddress = mkOption {
-      description = lib.mdDoc "Kubernetes proxy listening address.";
-      default = "0.0.0.0";
-      type = str;
-    };
-
     enable = mkEnableOption (lib.mdDoc "Kubernetes proxy");
 
-    extraOpts = mkOption {
-      description = lib.mdDoc "Kubernetes proxy extra command line options.";
-      default = "";
-      type = separatedString " ";
-    };
-
-    featureGates = mkOption {
-      description = lib.mdDoc "List set of feature gates";
-      default = top.featureGates;
-      defaultText = literalExpression "config.${otop.featureGates}";
-      type = listOf str;
-    };
-
-    hostname = mkOption {
-      description = lib.mdDoc "Kubernetes proxy hostname override.";
-      default = config.networking.hostName;
-      defaultText = literalExpression "config.networking.hostName";
-      type = str;
-    };
-
-    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes proxy";
-
-    verbosity = mkOption {
-      description = lib.mdDoc ''
-        Optional glog verbosity level for logging statements. See
-        <https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md>
+    settings = mkOption {
+      description = ''
+        Configuration for kube-proxy, see:
+          <https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy>.
+        All attrs defined here translates directly to flags of syntax `--<name>="<value>"`
+        which is provided as command line argument to the kube-proxy binary.
       '';
-      default = null;
-      type = nullOr int;
+      type = types.submodule {
+        freeformType = attrsOf (oneOf [
+          bool
+          float
+          int
+          (listOf str)
+          package
+          path
+          str
+        ]);
+      };
     };
-
   };
 
   ###### implementation
@@ -63,15 +65,7 @@ in
       serviceConfig = {
         Slice = "kubernetes.slice";
         ExecStart = ''${top.package}/bin/kube-proxy \
-          --bind-address=${cfg.bindAddress} \
-          ${optionalString (top.clusterCidr!=null)
-            "--cluster-cidr=${top.clusterCidr}"} \
-          ${optionalString (cfg.featureGates != [])
-            "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
-          --hostname-override=${cfg.hostname} \
-          --kubeconfig=${top.lib.mkKubeConfig "kube-proxy" cfg.kubeconfig} \
-          ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \
-          ${cfg.extraOpts}
+          ${concatStringsSep " \\\n" (mapAttrsToList (n: v: ''--${n}="${top.lib.renderArg v}"'') cfg.settings)}
         '';
         WorkingDirectory = top.dataDir;
         Restart = "on-failure";
@@ -82,8 +76,6 @@ in
       };
     };
 
-    services.kubernetes.proxy.hostname = with config.networking; mkDefault hostName;
-
     services.kubernetes.pki.certs = {
       kubeProxyClient = top.lib.mkCert {
         name = "kube-proxy-client";
@@ -91,8 +83,6 @@ in
         action = "systemctl restart kube-proxy.service";
       };
     };
-
-    services.kubernetes.proxy.kubeconfig.server = mkDefault top.apiserverAddress;
   };
 
   meta.buildDocsInSandbox = false;

--- a/nixos/tests/kubernetes/base.nix
+++ b/nixos/tests/kubernetes/base.nix
@@ -51,13 +51,13 @@ let
               environment.systemPackages = [ wrapKubectl ];
               services.flannel.iface = "eth1";
               services.kubernetes = {
-                proxy.hostname = "${masterName}.${domain}";
+                proxy.settings.hostname-override = lib.mkForce "${masterName}.${domain}";
 
                 easyCerts = true;
                 inherit (machine) roles;
-                apiserver = {
-                  securePort = 443;
-                  advertiseAddress = master.ip;
+                apiserver.settings = {
+                  secure-port = 443;
+                  advertise-address = master.ip;
                 };
                 masterAddress = "${masterName}.${config.networking.domain}";
               };


### PR DESCRIPTION

## Description of changes

This PR removes 99% of all kubernetes module options in favor of the freeform syntax for configuring cli args for all the kubernetes components. Many of the options had default values which the `services.kubernetes.roles = [ ... ]` and _easyCerts_ auto-configuration and eventually the NixOS tests depended on. Now, the use of `services.kubernetes.roles` still sets some of these defaults, but it's done explicitly in `nixos/modules/services/cluster/kubernetes/default.nix`.

I wanted to change a lot more, but in the name of keeping this PR remotely reviewable, I'll stop here. First step is to get rid of many of the defaults and custom options which makes the module hard to maintain and offloading the choice of defaults to upstream. The "roles" smart-configuration might over time separate out into a nix-community repo or stay in-tree, but in either case it will be more distinctly separated - and perhaps more opinionated - than/from the raw configuration of base components. The in-tree NixOS tests still dogfood the "roles" feature.

### Subjective things up for discussion

- "roles" don't mkDefault settings, so users that benefit from partial auto-config will have to mkForce from now on. I personally think that's a good thing, because that will maybe cause/force more feedback/contribution to the module.

- "extraOpts" have died as well, so there's no way of appending verbatim command line args.

@saschagrunert @srhb I'd like to here your thoughts and possibly testing on this PR. I know that you might have some work to do to integrate this change (should it be merged) into your own configurations. Also, see my rel-note.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
