### PR TITLE
electrum: 4.4.5 -> 4.4.6

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "4.4.5";
+  version = "4.4.6";
 
   libsecp256k1_name =
     if stdenv.isLinux then "libsecp256k1.so.{v}"
@@ -28,7 +28,7 @@ let
     owner = "spesmilo";
     repo = "electrum";
     rev = version;
-    sha256 = "sha256-R5jFxqaKnqQ+WNp4l0u34wMFxlbIsQ+9qDQxiQEu6kM=";
+    sha256 = "sha256-nd435CgF0a6JOni/OXcxkciVCR1aQqzfGfDSg1gPQ8Q=";
 
     postFetch = ''
       mv $out ./all
@@ -44,7 +44,7 @@ python3.pkgs.buildPythonApplication {
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "sha256-rTQcnEfHaFrLvPnI1IZl9uk2D0NFLn0PSaGsI9KyLr4=";
+    sha256 = "sha256-BxxC1xVKToUjgBo4mEeK9Tdhbd/+doHcTTJsXDtaELg=";
   };
 
   postUnpack = ''


### PR DESCRIPTION
## Description of changes
https://github.com/spesmilo/electrum/blob/master/RELEASE-NOTES
### Release 4.4.6 (August 18, 2023)
 * Lightning:
   - fix: cannot sweep from channel after local-force-close, if using
     imported channel backup (#8536). Fixing this required adding a
     new field (local_payment_pubkey) to the channel backup
     import/export format and bumping its version number
     (v0->v1). Both v0 and v1 can be imported, and we only export v1
     backups. When you force close a channel, the GUI will prompt you
     to save a backup. In that case, you must export the backup using
     the updated Electrum, and not rely on a backup made with an older
     release of Electrum.  Note that if you request a force close from
     the remote node or co-op close, you do not need to save a channel
     backup.
   - fix: we would sometimes attempt sending MPP even if not supported
     by the invoice (2cf6173c)
 * QML GUI:
   - fix lnurl-pay when config.BTC_AMOUNTS_ADD_THOUSANDS_SEP is True
     (5b4df759)
 * Hardware wallets:
   - Trezor: support longer than 9 character PIN codes (#8526)
   - Jade: support more custom-built DIY Jade devices (#8546)
 * Builds/binaries:
   - include AppStream metainfo.xml in tarballs (#8501)
 * fix: exceptions in some callbacks got lost and not logged (3e6580b9)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
