### PR TITLE
halide: 15.0.1 -> 16.0.0

### DIFF
--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -18,13 +18,13 @@ assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 
 stdenv.mkDerivation rec {
   pname = "halide";
-  version = "15.0.1";
+  version = "16.0.0";
 
   src = fetchFromGitHub {
     owner = "halide";
     repo = "Halide";
     rev = "v${version}";
-    sha256 = "sha256-mnZ6QMqDr48bH2W+andGZj2EhajXKApjuW6B50xtzx0=";
+    sha256 = "sha256-lJQrXkJgBmGb/QMSxwuPkkHOSgEDowLWzIolp1km2Y8=";
   };
 
   cmakeFlags = [

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -27,6 +27,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-lJQrXkJgBmGb/QMSxwuPkkHOSgEDowLWzIolp1km2Y8=";
   };
 
+  postPatch = ''
+    # See https://github.com/halide/Halide/issues/7785
+    substituteInPlace 'src/runtime/HalideRuntime.h' \
+      --replace '#if defined(__x86_64__) || defined(__i386__) || defined(__arm__) || defined(__aarch64__)
+    #define HALIDE_CPP_COMPILER_HAS_FLOAT16' \
+                '#if defined(__x86_64__) || defined(__i386__)
+    #define HALIDE_CPP_COMPILER_HAS_FLOAT16'
+  '';
+
   cmakeFlags = [
     "-DWARNINGS_AS_ERRORS=OFF"
     "-DWITH_PYTHON_BINDINGS=OFF"

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -34,8 +34,11 @@ stdenv.mkDerivation rec {
     #define HALIDE_CPP_COMPILER_HAS_FLOAT16' \
                 '#if defined(__x86_64__) || defined(__i386__)
     #define HALIDE_CPP_COMPILER_HAS_FLOAT16'
-
-    # AvailabilityVersions.h is part of Apple SDK, and we do not want to depend on it
+  ''
+  # Note: on x86_64-darwin, clang fails to find AvailabilityVersions.h, so we remove it.
+  # Halide uses AvailabilityVersions.h and TargetConditionals.h to determine whether
+  # ::aligned_alloc is available. For us, it isn't.
+  + lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
     substituteInPlace 'src/runtime/HalideBuffer.h' \
       --replace '#ifdef __APPLE__
     #include <AvailabilityVersions.h>
@@ -43,7 +46,7 @@ stdenv.mkDerivation rec {
     #endif' \
                 ' ' \
       --replace 'TARGET_OS_OSX && (__MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_15)' \
-                '0' \
+                '1' \
       --replace 'TARGET_OS_IPHONE && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_14_0)' \
                 '0'
   '';

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -67,11 +67,8 @@ stdenv.mkDerivation rec {
 
   # Note: disable mullapudi2016_fibonacci because it requires too much
   # parallelism for remote builders
-  ctestArgs = "--output-on-failure -E 'mullapudi2016_fibonacci'";
-  checkPhase = ''
-    runHook preCheck
-    ctest ${ctestArgs}
-    runHook postCheck
+  preCheck = ''
+    checkFlagsArray+=("ARGS=-E 'mullapudi2016_fibonacci'")
   '';
 
   # Note: only openblas and not atlas part of this Nix expression

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -57,6 +57,10 @@ stdenv.mkDerivation rec {
     "-DTARGET_WEBASSEMBLY=OFF"
     # Disable performance tests since they may fail on busy machines
     "-DWITH_TEST_PERFORMANCE=OFF"
+    # Disable fuzzing tests -- this has become the default upstream after the
+    # v16 release (See https://github.com/halide/Halide/commit/09c5d1d19ec8e6280ccbc01a8a12decfb27226ba)
+    # These tests also fail to compile on Darwin because of some missing command line options...
+    "-DWITH_TEST_FUZZ=OFF"
   ];
 
   doCheck = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8648,7 +8648,7 @@ with pkgs;
   halibut = callPackage ../tools/typesetting/halibut { };
 
   halide = callPackage ../development/compilers/halide {
-    llvmPackages = llvmPackages_14;
+    llvmPackages = llvmPackages_16;
   };
 
   harePackages = recurseIntoAttrs (callPackage ../development/compilers/hare { });


### PR DESCRIPTION
This PR supersedes  #241047.

## Description of changes

Link to the upstream release: https://github.com/halide/Halide/releases/tag/v16.0.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
