### PR TITLE
QGIS 3.28 -> QGIS 3.32.2

### DIFF
--- a/pkgs/applications/gis/qgis/fix-qsci.patch
+++ b/pkgs/applications/gis/qgis/fix-qsci.patch
@@ -1,0 +1,14 @@
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 38aca73dc57..7e56f92ced3 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -355,7 +355,7 @@ if(WITH_QSCIAPI)
+   add_custom_command(
+     OUTPUT "${QGIS_PYTHON_PAP_FILE}"
+     DEPENDS "${QGIS_PYTHON_API_FILE}"
+-    COMMAND ${_python} "${APIS_SRC_DIR}/generate_console_pap.py" -platform offscreen "${QGIS_PYTHON_PAP_FILE}" "${APIS_SRC_DIR}" "${APIS_OUT_DIR}"
++    COMMAND ${_python} "${APIS_SRC_DIR}/generate_console_pap.py" -platform offscreen "${QGIS_PYTHON_PAP_FILE}" "${APIS_SRC_DIR}" "${APIS_OUT_DIR}"
+     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+     COMMENT "Generating pap file for console auto-completion" VERBATIM)
+ 
+

--- a/pkgs/applications/gis/qgis/set-pyqt-package-dirs-ltr.patch
+++ b/pkgs/applications/gis/qgis/set-pyqt-package-dirs-ltr.patch
@@ -39,13 +39,13 @@ index 69e41c1fe9..5456c3d59b 100644
      ENDIF(_qsci_metadata)
  
      IF(QSCI_MOD_VERSION_STR)
--      SET(QSCI_SIP_DIR "${PYQT_SIP_DIR}")
+-      SET(QSCI_SIP_DIR "${PYQT5_SIP_DIR}")
 +      SET(QSCI_SIP_DIR "@qsciPackageDir@/PyQt5/bindings")
        SET(QSCI_FOUND TRUE)
      ENDIF(QSCI_MOD_VERSION_STR)
 
 diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
-index 38aca73dc57..7e56f92ced3 100644
+index 4cd19c3af4..668cc6a5e6 100644
 --- a/python/CMakeLists.txt
 +++ b/python/CMakeLists.txt
 @@ -206,7 +206,7 @@ if (WITH_GUI)

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -73,7 +73,7 @@ let
     six
   ];
 in mkDerivation rec {
-  version = "3.28.7";
+  version = "3.28.8";
   pname = "qgis-ltr-unwrapped";
 
   src = fetchFromGitHub {
@@ -124,7 +124,7 @@ in mkDerivation rec {
 
   patches = [
     (substituteAll {
-      src = ./set-pyqt-package-dirs.patch;
+      src = ./set-pyqt-package-dirs-ltr.patch;
       pyQt5PackageDir = "${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}";
       qsciPackageDir = "${py.pkgs.qscintilla-qt5}/${py.pkgs.python.sitePackages}";
     })
@@ -150,6 +150,7 @@ in mkDerivation rec {
     wrapProgram $out/bin/qgis \
       "''${gappsWrapperArgs[@]}" \
       --prefix PATH : ${lib.makeBinPath [ grass ]}
+    ln -s qgis $out/bin/qgis-ltr
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Enables the latest versions of QGIS to build again, but with QSCIAPI scintilla bindings disabled.
For context see also https://github.com/NixOS/nixpkgs/issues/248239

## Description of changes

This PR partially addresses some of the issues described in https://github.com/NixOS/nixpkgs/issues/248239.
In particular it re-enables building the latest version of QGIS which is currently stuck behind the LTR version (3.28.x) - it should be on 3.32.2.

In order to make the build work, I fixed a few paths to PyQt dependencies and I disabled the WITH_QSCIAPI flag until such time as we can properly resolve the scintilla bindings to build.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

CC:

@imincik
@sikmir
@nh2
@willcohen

To test out these changes locally:


> cd nixpkgs
> nix build .#qgis  --print-out-paths
> nix build .#qgis-ltr  --print-out-paths

Launch QGIS LTR explicitly:

> qgis-ltr

Launch QGIS Latest explicitly:

> qgis-latest