### PR TITLE
python310Packages.radian: 0.6.6 -> 0.6.7

### DIFF
--- a/pkgs/development/python-modules/radian/default.nix
+++ b/pkgs/development/python-modules/radian/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "radian";
-  version = "0.6.6";
+  version = "0.6.7";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -27,13 +27,12 @@ buildPythonPackage rec {
     owner = "randy3k";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-zA7R9UIB0hOWev10Y4oySIKeIxTOo0V6Q3Fxe+FeHSU=";
+    hash = "sha256-MEstbQj1dOcrukgDvMwL330L9INEZcIupebrSYMOrZk=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner"' "" \
-      --replace '0.3.39,<0.4.0' '0.3.39'
+      --replace '"pytest-runner"' ""
   '';
 
   nativeBuildInputs = [
@@ -58,6 +57,8 @@ buildPythonPackage rec {
     jedi
     git
   ];
+
+  makeWrapperArgs = [ "--set R_HOME ${R}/lib/R" ];
 
   preCheck = ''
     export HOME=$TMPDIR

--- a/pkgs/development/r-modules/wrapper-radian.nix
+++ b/pkgs/development/r-modules/wrapper-radian.nix
@@ -26,8 +26,7 @@ runCommand (radian.name + "-wrapper") {
   };
 } (''
   makeWrapper "${radian}/bin/radian" "$out/bin/radian" \
-    --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE" \
-    --set "R_HOME" "${R}/lib/R"
+    --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE"
 '' + lib.optionalString wrapR ''
   cd ${R}/bin
   for exe in *; do


### PR DESCRIPTION
## Description of changes

Bumped radian to 0.6.7 and set `R_HOME` explicitly. Also changed radianWrapper because `R_HOME` is now set in the package itself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
