### PR TITLE
ocamlPackages.hack_parallel: fix for OCaml 5.0

### DIFF
--- a/pkgs/development/ocaml-modules/hack_parallel/default.nix
+++ b/pkgs/development/ocaml-modules/hack_parallel/default.nix
@@ -3,7 +3,6 @@
 buildDunePackage rec {
   pname = "hack_parallel";
   version = "1.0.1";
-  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
@@ -14,6 +13,23 @@ buildDunePackage rec {
   };
 
   patches = [ ./hack_parallel.patch ];
+
+  postPatch = ''
+    substituteInPlace src/third-party/hack_core/hack_caml.ml --replace 'include Pervasives' ""
+    substituteInPlace \
+      src/interface/hack_parallel_intf.mli \
+      src/procs/worker.ml \
+      src/third-party/hack_core/hack_core_list.ml \
+      src/third-party/hack_core/hack_result.ml* \
+      src/utils/collections/myMap.ml \
+      src/utils/daemon.ml* \
+      src/utils/exit_status.ml \
+      src/utils/hack_path.ml \
+      src/utils/measure.ml \
+      src/utils/timeout.ml \
+      --replace Pervasives. Stdlib.
+    substituteInPlace src/utils/sys_utils.ml --replace String.create Bytes.create
+  '';
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
