### PR TITLE
osslsigncode: 2.5 -> 2.6

### DIFF
--- a/pkgs/development/tools/osslsigncode/default.nix
+++ b/pkgs/development/tools/osslsigncode/default.nix
@@ -2,37 +2,24 @@
 , stdenv
 , fetchFromGitHub
 , cmake
-, fetchpatch
 , pkg-config
+, python3
 , curl
 , openssl
 }:
 
 stdenv.mkDerivation rec {
   pname = "osslsigncode";
-  version = "2.5";
+  version = "2.6";
 
   src = fetchFromGitHub {
     owner = "mtrojnar";
     repo = pname;
     rev = version;
-    sha256 = "sha256-33uT9PFD1YEIMzifZkpbl2EAoC98IsM72K4rRjDfh8g=";
+    sha256 = "sha256-Lt99RO/pTEtksIuulkKTm48+1xUKZOHrnlbDZGi3VWk=";
   };
 
-  patches = [
-    # Cygwin patch is prereq for Darwin fix applying -- committed to master after 2.5 release
-    (fetchpatch {
-      url = "https://github.com/mtrojnar/osslsigncode/commit/1c678bf926b78c947b14c46c3ce88e06268c738e.patch";
-      sha256 = "sha256-vOBMGIJ3PHJTvmsXRRfAUJRi7P929PcfmrUiRuM0pf4=";
-    })
-    # Fix build on Darwin when clang not identified as Apple (https://github.com/mtrojnar/osslsigncode/pull/247)
-    (fetchpatch {
-      url = "https://github.com/charles-dyfis-net/osslsigncode/commit/b2ed89b35c8a26faa7eb6515fecaff3c4c5f7fed.patch";
-      sha256 = "sha256-FGKZK/IzHbbkTzSoAtpC75z79d5+qQvvJrjEDY31WJ0=";
-    })
-  ];
-
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config python3 ];
 
   buildInputs = [ curl openssl ];
 


### PR DESCRIPTION
## Description of changes
The two patches got upstreamed into 2.6 and are no longer necessary.

This fixes PKCS#11 signers on Nix as it restores the ability to specify a full path to the PKCS#11 engine shared object.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
