### PR TITLE
texlive: transform into overridable scope and extract generic interface

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, fetchpatch, buildPackages
-, bin, combine, pkgs
+, bin, combine, pkgs, src, version
 , zlib, libiconv, libpng, libX11
 , freetype, gd, libXaw, icu, ghostscript, libXpm, libXmu, libXext
 , perl, perlPackages, python3Packages, pkg-config
@@ -7,7 +7,7 @@
 , brotli, cairo, pixman, xorg, clisp, biber, woff2, xxHash
 , makeWrapper, shortenPerlShebang, useFixedHashes, asymptote
 , biber-ms
-}:
+}@args:
 
 # Useful resource covering build options:
 # http://tug.org/texlive/doc/tlbuild.html
@@ -15,21 +15,14 @@
 let
   withSystemLibs = map (libname: "--with-system-${libname}");
 
-  year = toString ((import ./tlpdb.nix)."00texlive.config").year;
-  version = year; # keep names simple for now
+  version = toString args.version.texliveYear; # keep names simple for now
 
   # detect and stop redundant rebuilds that may occur when building new fixed hashes
   assertFixedHash = name: src:
     if ! useFixedHashes || src ? outputHash then src else throw "The TeX Live package '${src.pname}' must have a fixed hash before building '${name}'.";
 
   common = {
-    src = fetchurl {
-      urls = [
-        "http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/${year}/texlive-${year}0321-source.tar.xz"
-              "ftp://tug.ctan.org/pub/tex/historic/systems/texlive/${year}/texlive-${year}0321-source.tar.xz"
-      ];
-      hash = "sha256-X/o0heUessRJBJZFD8abnXvXy55TNX2S20vNT9YXm1Y=";
-    };
+    inherit src;
 
     prePatch = ''
       for i in texk/kpathsea/mktex*; do
@@ -77,7 +70,7 @@ let
 in rec { # un-indented
 
 inherit (common) cleanBrokenLinks;
-texliveYear = year;
+texliveYear = version;
 
 
 core = stdenv.mkDerivation rec {

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, fetchpatch, buildPackages
-, texlive
+, bin, combine, pkgs
 , zlib, libiconv, libpng, libX11
 , freetype, gd, libXaw, icu, ghostscript, libXpm, libXmu, libXext
 , perl, perlPackages, python3Packages, pkg-config
@@ -93,8 +93,8 @@ core = stdenv.mkDerivation rec {
   ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     # configure: error: tangle was not found but is required when cross-compiling.
     # dev (himktables) is used when building hitex to generate the additional source file hitables.c
-    texlive.bin.core
-    texlive.bin.core.dev
+    bin.core
+    bin.core.dev
   ];
 
   buildInputs = [
@@ -196,7 +196,7 @@ core = stdenv.mkDerivation rec {
 };
 
 
-inherit (core-big) metafont mflua metapost luatex luahbtex luajittex xetex;
+inherit (bin.core-big) metafont mflua metapost luatex luahbtex luajittex xetex;
 core-big = stdenv.mkDerivation { #TODO: upmendex
   pname = "texlive-core-big.bin";
   inherit version;
@@ -394,7 +394,7 @@ pygmentex = python3Packages.buildPythonApplication rec {
   inherit (src) version;
   format = "other";
 
-  src = assertFixedHash pname (lib.head (builtins.filter (p: p.tlType == "run") texlive.pygmentex.pkgs));
+  src = assertFixedHash pname (lib.head (builtins.filter (p: p.tlType == "run") pkgs.pygmentex.pkgs));
 
   propagatedBuildInputs = with python3Packages; [ pygments chardet ];
 
@@ -475,7 +475,7 @@ xdvi = stdenv.mkDerivation {
 
 xpdfopen = stdenv.mkDerivation {
   pname = "texlive-xpdfopen.bin";
-  inherit (lib.head texlive.xpdfopen.pkgs) version;
+  inherit (lib.head pkgs.xpdfopen.pkgs) version;
 
   inherit (common) src;
 
@@ -510,7 +510,7 @@ xindy = stdenv.mkDerivation {
 
   nativeBuildInputs = [
     pkg-config perl
-    (texlive.combine { inherit (texlive) scheme-basic cyrillic ec; })
+    (combine { inherit (pkgs) scheme-basic cyrillic ec; })
   ];
   buildInputs = [ clisp libiconv perl ];
 

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -1,6 +1,6 @@
 { lib, buildEnv, runCommand, writeText, makeWrapper, libfaketime, makeFontsConf
 , perl, bash, coreutils, gnused, gnugrep, gawk, ghostscript
-, bin, tl }:
+, bin, pkgs }:
 # combine =
 args@{
   pkgFilter ? (pkg: pkg.tlType == "run" || pkg.tlType == "bin" || pkg.pname == "core"
@@ -49,7 +49,7 @@ let
     paths = lib.catAttrs "outPath" pkgList.nonbin;
 
     # mktexlsr
-    nativeBuildInputs = [ (lib.last tl."texlive.infra".pkgs) ];
+    nativeBuildInputs = [ (lib.last pkgs."texlive.infra".pkgs) ];
 
     postBuild = # generate ls-R database
     ''
@@ -107,9 +107,9 @@ in (buildEnv {
   nativeBuildInputs = [
     makeWrapper
     libfaketime
-    (lib.last tl."texlive.infra".pkgs) # mktexlsr
-    (lib.last tl.texlive-scripts.pkgs) # fmtutil, updmap
-    (lib.last tl.texlive-scripts-extra.pkgs) # texlinks
+    (lib.last pkgs."texlive.infra".pkgs) # mktexlsr
+    (lib.last pkgs.texlive-scripts.pkgs) # fmtutil, updmap
+    (lib.last pkgs.texlive-scripts-extra.pkgs) # texlinks
     perl
   ];
 

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -75,83 +75,82 @@ let
         inherit tlpdb;
       };
     in  {
+      inherit callPackage;
 
-    inherit callPackage;
+      tlpdb = {
+        # nested in an attribute set to prevent them from appearing in search
+        nix = tlpdbNix;
+        xz = tlpdbxz;
+      };
 
-    tlpdb = {
-      # nested in an attribute set to prevent them from appearing in search
-      nix = tlpdbNix;
-      xz = tlpdbxz;
-    };
+      bin = assert assertions; callPackage ./bin.nix { };
 
-    bin = assert assertions; callPackage ./bin.nix { };
+      combine = assert assertions; callPackage ./combine.nix { };
 
-    combine = assert assertions; callPackage ./combine.nix { };
+      pkgs = let
+        buildTeXLivePackage = callPackage ./build-texlive-package.nix { texliveBinaries = self.bin; };
 
-    pkgs = let
-      buildTeXLivePackage = callPackage ./build-texlive-package.nix { texliveBinaries = self.bin; };
+        overrides = callPackage ./tlpdb-overrides.nix { tlpdbxz = self.tlpdb.xz; };
 
-      overrides = callPackage ./tlpdb-overrides.nix { tlpdbxz = self.tlpdb.xz; };
+        overriddenTlpdb = overrides tlpdb;
 
-      overriddenTlpdb = overrides tlpdb;
+        makePackageSet = tlpdb:
+          lib.mapAttrs (pname: { revision, extraRevision ? "", ... }@args:
+            buildTeXLivePackage (args
+              # NOTE: the fixed naming scheme must match generate-fixed-hashes.nix
+              // { inherit mirrors pname; fixedHashes = fixedHashes."${pname}-${toString revision}${extraRevision}" or { }; }
+              // lib.optionalAttrs (args ? deps) { deps = map (n: self.pkgs.${n}) (args.deps or [ ]); })
+          ) tlpdb;
 
-      makePackageSet = tlpdb:
-        lib.mapAttrs (pname: { revision, extraRevision ? "", ... }@args:
-          buildTeXLivePackage (args
-            # NOTE: the fixed naming scheme must match generate-fixed-hashes.nix
-            // { inherit mirrors pname; fixedHashes = fixedHashes."${pname}-${toString revision}${extraRevision}" or { }; }
-            // lib.optionalAttrs (args ? deps) { deps = map (n: self.pkgs.${n}) (args.deps or [ ]); })
-        ) tlpdb;
-
-    in lib.makeOverridable makePackageSet overriddenTlpdb;
+      in lib.makeOverridable makePackageSet overriddenTlpdb;
 
 
-    # Pre-defined combined packages for TeX Live schemes,
-    # to make nix-env usage more comfortable and build selected on Hydra.
-    combined = with lib;
-      let
-        # these license lists should be the sorted union of the licenses of the packages the schemes contain.
-        # The correctness of this collation is tested by tests.texlive.licenses
-        licenses = with lib.licenses; {
-          scheme-basic = [ free gfl gpl1Only gpl2 gpl2Plus knuth lgpl21 lppl1 lppl13c mit ofl publicDomain ];
-          scheme-context = [ bsd2 bsd3 cc-by-sa-40 free gfl gfsl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21
-            lppl1 lppl13c mit ofl publicDomain x11 ];
-          scheme-full = [ artistic1-cl8 artistic2 asl20 bsd2 bsd3 bsdOriginal cc-by-10 cc-by-40 cc-by-sa-10 cc-by-sa-20
-            cc-by-sa-30 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth
-            lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
-          scheme-gust = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl2
-            gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
-          scheme-infraonly = [ gpl2 gpl2Plus lgpl21 ];
-          scheme-medium = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-20 cc-by-sa-30 cc-by-sa-40 cc0 fdl13Only
-            free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a lppl13c mit ofl
-            publicDomain x11 ];
-          scheme-minimal = [ free gpl1Only gpl2 gpl2Plus knuth lgpl21 lppl1 lppl13c mit ofl publicDomain ];
-          scheme-small = [ asl20 cc-by-40 cc-by-sa-40 cc0 fdl13Only free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus knuth
-            lgpl2 lgpl21 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
-          scheme-tetex = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-10 cc-by-sa-20 cc-by-sa-30 cc-by-sa-40 cc0
-            fdl13Only free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a
-            lppl13c mit ofl publicDomain x11];
-        };
-      in recurseIntoAttrs (
-      mapAttrs
-        (pname: attrs:
-          addMetaAttrs rec {
-            description = "TeX Live environment for ${pname}";
-            platforms = lib.platforms.all;
-            maintainers = with lib.maintainers;  [ veprbl ];
-            license = licenses.${pname};
+      # Pre-defined combined packages for TeX Live schemes,
+      # to make nix-env usage more comfortable and build selected on Hydra.
+      combined = with lib;
+        let
+          # these license lists should be the sorted union of the licenses of the packages the schemes contain.
+          # The correctness of this collation is tested by tests.texlive.licenses
+          licenses = with lib.licenses; {
+            scheme-basic = [ free gfl gpl1Only gpl2 gpl2Plus knuth lgpl21 lppl1 lppl13c mit ofl publicDomain ];
+            scheme-context = [ bsd2 bsd3 cc-by-sa-40 free gfl gfsl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21
+              lppl1 lppl13c mit ofl publicDomain x11 ];
+            scheme-full = [ artistic1-cl8 artistic2 asl20 bsd2 bsd3 bsdOriginal cc-by-10 cc-by-40 cc-by-sa-10 cc-by-sa-20
+              cc-by-sa-30 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth
+              lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
+            scheme-gust = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-40 cc0 fdl13Only free gfl gfsl gpl1Only gpl2
+              gpl2Plus gpl3 gpl3Plus knuth lgpl2 lgpl21 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
+            scheme-infraonly = [ gpl2 gpl2Plus lgpl21 ];
+            scheme-medium = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-20 cc-by-sa-30 cc-by-sa-40 cc0 fdl13Only
+              free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a lppl13c mit ofl
+              publicDomain x11 ];
+            scheme-minimal = [ free gpl1Only gpl2 gpl2Plus knuth lgpl21 lppl1 lppl13c mit ofl publicDomain ];
+            scheme-small = [ asl20 cc-by-40 cc-by-sa-40 cc0 fdl13Only free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus knuth
+              lgpl2 lgpl21 lppl1 lppl12 lppl13a lppl13c mit ofl publicDomain x11 ];
+            scheme-tetex = [ artistic1-cl8 asl20 bsd2 bsd3 cc-by-40 cc-by-sa-10 cc-by-sa-20 cc-by-sa-30 cc-by-sa-40 cc0
+              fdl13Only free gfl gpl1Only gpl2 gpl2Plus gpl3 gpl3Plus isc knuth lgpl2 lgpl21 lgpl3 lppl1 lppl12 lppl13a
+              lppl13c mit ofl publicDomain x11];
+          };
+        in recurseIntoAttrs (
+        mapAttrs
+          (pname: attrs:
+            addMetaAttrs rec {
+              description = "TeX Live environment for ${pname}";
+              platforms = lib.platforms.all;
+              maintainers = with lib.maintainers;  [ veprbl ];
+              license = licenses.${pname};
+            }
+            (self.combine {
+              ${pname} = attrs;
+              extraName = "combined" + lib.removePrefix "scheme" pname;
+              extraVersion = with version; if final then "-final" else ".${year}${month}${day}";
+            })
+          )
+          { inherit (self.pkgs)
+              scheme-basic scheme-context scheme-full scheme-gust scheme-infraonly
+              scheme-medium scheme-minimal scheme-small scheme-tetex;
           }
-          (self.combine {
-            ${pname} = attrs;
-            extraName = "combined" + lib.removePrefix "scheme" pname;
-            extraVersion = with version; if final then "-final" else ".${year}${month}${day}";
-          })
-        )
-        { inherit (self.pkgs)
-            scheme-basic scheme-context scheme-full scheme-gust scheme-infraonly
-            scheme-medium scheme-minimal scheme-small scheme-tetex;
-        }
-    );
+      );
   };
 
   texlive = makeScopeWithSplicing' {

--- a/pkgs/tools/typesetting/tex/texlive/stable.nix
+++ b/pkgs/tools/typesetting/tex/texlive/stable.nix
@@ -1,0 +1,30 @@
+{ callPackage, lib, fetchurl, useFixedHashes ? true, fetchpatch }:
+lib.makeOverridable callPackage ./. rec {
+  version = {
+    texliveYear = 2022;
+    final = true;
+  };
+
+  mirrors = with version; [
+    # tlnet-final snapshot; used when texlive.tlpdb is frozen
+    # the TeX Live yearly freeze typically happens in mid-March
+    "http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/${toString texliveYear}/tlnet-final"
+    "ftp://tug.org/texlive/historic/${toString texliveYear}/tlnet-final"
+    # mostly just kept to prevent rebuilds :)
+    "https://texlive.info/tlnet-archive/2023/03/19/tlnet"
+  ];
+
+  src = with version; fetchurl {
+    urls = [
+      "http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/${toString texliveYear}/texlive-${toString texliveYear}0321-source.tar.xz"
+      "ftp://tug.ctan.org/pub/tex/historic/systems/texlive/${toString texliveYear}/texlive-${toString texliveYear}0321-source.tar.xz"
+    ];
+    hash = "sha256-X/o0heUessRJBJZFD8abnXvXy55TNX2S20vNT9YXm1Y=";
+  };
+
+  tlpdb = import ./tlpdb.nix;
+  tlpdbxzHash = "sha256-vm7DmkH/h183pN+qt1p1wZ6peT2TcMk/ae0nCXsCoMw=";
+
+  fixedHashes = lib.optionalAttrs useFixedHashes (import ./fixed-hashes.nix);
+  inherit useFixedHashes;
+}

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -1,4 +1,4 @@
-{ lib, tlpdb, bin, tlpdbxz, tl
+{ lib, tlpdb, bin, tlpdbxz, pkgs
 , installShellFiles
 , coreutils, findutils, gawk, getopt, ghostscript_headless, gnugrep
 , gnumake, gnupg, gnused, gzip, ncurses, perl, python3, ruby, zip
@@ -134,7 +134,7 @@ in lib.recursiveUpdate orig rec {
 
   texlive-scripts.binlinks = {
     mktexfmt = "fmtutil";
-    texhash = (lib.last tl."texlive.infra".pkgs) + "/bin/mktexlsr";
+    texhash = (lib.last pkgs."texlive.infra".pkgs) + "/bin/mktexlsr";
   };
 
   texlive-scripts-extra.binlinks = {
@@ -391,14 +391,14 @@ in lib.recursiveUpdate orig rec {
     license = [ "gpl2Plus" ] ++ lib.toList bin.core.meta.license.shortName ++ orig."texlive.infra".license or [ ];
 
     scriptsFolder = "texlive";
-    extraBuildInputs = [ coreutils gnused gnupg (lib.last tl.kpathsea.pkgs) (perl.withPackages (ps: with ps; [ Tk ])) ];
+    extraBuildInputs = [ coreutils gnused gnupg (lib.last pkgs.kpathsea.pkgs) (perl.withPackages (ps: with ps; [ Tk ])) ];
 
     # make tlmgr believe it can use kpsewhich to evaluate TEXMFROOT
     postFixup = ''
       substituteInPlace "$out"/bin/tlmgr \
         --replace 'if (-r "$bindir/$kpsewhichname")' 'if (1)'
       sed -i '2i$ENV{PATH}='"'"'${lib.makeBinPath [ gnupg ]}'"'"' . ($ENV{PATH} ? ":$ENV{PATH}" : '"'''"');' "$out"/bin/tlmgr
-      sed -i '2iPATH="${lib.makeBinPath [ coreutils gnused (lib.last tl.kpathsea.pkgs) ]}''${PATH:+:$PATH}"' "$out"/bin/mktexlsr
+      sed -i '2iPATH="${lib.makeBinPath [ coreutils gnused (lib.last pkgs.kpathsea.pkgs) ]}''${PATH:+:$PATH}"' "$out"/bin/mktexlsr
     '';
 
     # add minimal texlive.tlpdb

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5373,7 +5373,12 @@ with pkgs;
   texFunctions = callPackage ../tools/typesetting/tex/nix pkgs;
 
   # TeX Live; see https://nixos.org/nixpkgs/manual/#sec-language-texlive
-  texlive = recurseIntoAttrs (callPackage ../tools/typesetting/tex/texlive { });
+  texlive = recurseIntoAttrs
+    # callPackage is not used here in order not to override the override-attribute
+    # from makeOverridable in stable.nix
+    (import ../tools/typesetting/tex/texlive/stable.nix {
+    inherit (__splicedPackages) callPackage lib fetchurl fetchpatch;
+  });
 
   fop = callPackage ../tools/typesetting/fop {
     jdk = openjdk8;


### PR DESCRIPTION
## Description of changes

This includes all the preparation neccessary to add texlive-2023 ( #236382 ) and builds upon #250621 and #248746.

Unfortunately I wasn't really able to divide this into smaller independent chunks that can be merged separately, but I think it should be possible to comprehend the changes when looking at them commit-by-commit.

This should also not cause any rebuilds.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
