### PR TITLE
ride: init at 4.5.4097

### DIFF
--- a/pkgs/by-name/ri/ride/mk.patch
+++ b/pkgs/by-name/ri/ride/mk.patch
@@ -1,0 +1,34 @@
+diff --git a/mk b/mk
+index a5baa0f8..37cac28e 100755
+--- a/mk
++++ b/mk
+@@ -25,7 +25,7 @@ const rm = (x) => {
+ };
+ const pj = JSON.parse(rf('package.json'));
+ // v:version string - "x.y.z" where z is the number of commits since the beginning of the project
+-const v = `${pj.version.replace(/\.0$/, '')}.${sh('git rev-list --count HEAD')}`;
++const v = "@version@";
+ const isDyalogBuild = /^dyalog/.test(pj.name);
+ const tasks = { };
+ 
+@@ -36,8 +36,8 @@ const b = (f) => {
+   const vi = {
+     versionInfo: {
+       version: v,
+-      date: sh('git show -s HEAD --pretty=format:%ci'),
+-      rev: sh('git rev-parse HEAD'),
++      date: 'unknown',
++      rev: 'nixpkgs',
+     },
+   };
+   wf('_/version.js', `D=${JSON.stringify(vi)}`);
+@@ -50,6 +50,9 @@ const incl = new RegExp('^$'
+   + '|^/style($|/(fonts|img)|.*\\.css$)');
+ const pkg = (x, y, f) => {
+   rq('electron-packager')({
++    asar: true,
++    electronZipDir: "local-cache",
++    electronVersion: "@electron_version@",
+     dir: '.',
+     platform: x,
+     arch: y,

--- a/pkgs/by-name/ri/ride/package.nix
+++ b/pkgs/by-name/ri/ride/package.nix
@@ -1,0 +1,152 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  substituteAll,
+  jq,
+  moreutils,
+  zip,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  electron_27,
+}:
+
+let
+  platformInfos = {
+    "x86_64-linux" = {
+      zipSuffix = "linux-x64";
+      buildCmd = "linux";
+    };
+    "x86_64-darwin" = {
+      zipSuffix = "darwin-x64";
+      buildCmd = "osx";
+    };
+    "aarch64-darwin" = {
+      zipSuffix = "darwin-arm64";
+      buildCmd = "osxarm";
+    };
+  };
+
+  platformInfo = platformInfos.${stdenv.system};
+
+  # Electron 27 is the latest version that works as of RIDE version 4.5.4097
+  electron = electron_27;
+in
+buildNpmPackage rec {
+  pname = "ride";
+  version = "4.5.4097";
+
+  src = fetchFromGitHub {
+    owner = "Dyalog";
+    repo = "ride";
+    rev = "v${version}";
+    hash = "sha256-xR+HVC1JVrPkgPhIJZxdTVG52+QbanmD1c/uO5l84oc=";
+  };
+
+  npmDepsHash = "sha256-EG3pZkjDGBI2dDaQZ6351+oU4xfHd6HNB8eD7ErpYIg=";
+
+  patches = [
+    # Fix info in the "about" page, set electron version, set local-cache as zipdir
+    (substituteAll {
+      src = ./mk.patch;
+      version = version;
+      electron_version = electron.version;
+    })
+  ];
+
+  postPatch = ''
+    # Remove spectron (it would download electron-chromedriver binaries)
+    ${jq}/bin/jq 'del(.devDependencies.spectron)' package.json | ${moreutils}/bin/sponge package.json
+
+    pushd style
+
+    # Remove non-deterministic glob ordering
+    sed -i "/\*\*/d" layout.less light-theme.less dark-theme.less
+
+    # Individually include all files that were previously globbed
+    shopt -s globstar
+    for file in less/layout/**/*.less; do
+      echo "@import '$file';" >> layout.less
+    done
+    for file in less/colour/**/*.less; do
+      echo "@import '$file';" >> light-theme.less
+      echo "@import '$file';" >> dark-theme.less
+    done
+    shopt -u globstar
+
+    popd
+  '';
+
+  nativeBuildInputs = [
+    zip
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  npmBuildFlags = platformInfo.buildCmd;
+
+  # This package uses electron-packager instead of electron-builder
+  # Here, we create a local cache of electron zip-files, so electron-packager can copy from it
+  postConfigure = ''
+    mkdir local-cache
+    cp -r --no-preserve=all ${electron}/libexec/electron electron
+    pushd electron
+    zip -qr ../local-cache/electron-v${electron.version}-${platformInfo.zipSuffix}.zip *
+    popd
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 D.png $out/share/icons/hicolor/64x64/apps/ride.png
+    install -Dm644 D.svg $out/share/icons/hicolor/scalable/apps/ride.svg
+
+    pushd _/ride*/*
+
+    install -Dm644 ThirdPartyNotices.txt -t $out/share/doc/ride
+
+    mkdir -p $out/share/ride
+    cp -r locales resources{,.pak} $out/share/ride
+    makeWrapper ${lib.getExe electron} $out/bin/ride \
+      --add-flags $out/share/ride/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --inherit-argv0
+
+    popd
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ride";
+      exec = "ride";
+      icon = "ride";
+      desktopName = "RIDE";
+      categories = [
+        "Development"
+        "IDE"
+      ];
+      comment = meta.description;
+      terminal = false;
+    })
+  ];
+
+  meta = {
+    broken = stdenv.isDarwin;
+    changelog = "https://github.com/Dyalog/ride/releases/tag/${src.rev}";
+    description = "Remote IDE for Dyalog APL";
+    homepage = "https://github.com/Dyalog/ride";
+    license = lib.licenses.mit;
+    mainProgram = "ride";
+    maintainers = with lib.maintainers; [
+      tomasajt
+      markus1189
+    ];
+    platforms = lib.attrNames platformInfos;
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds 1 package: `ride`

This name is quite simple so another option could be `dyalog-ride`.

Homepage: https://github.com/dyalog/ride


RIDE is a **Remote** IDE for Dyalog, so Dyalog is not a hard dependency of RIDE.
The package `dyalog` can be found in Nixpkgs, so you can use that for testing out the program.

For testing: In the startup window click on the arrow in the top-right corner and put "dyalog" as the executable path (the names of the binaries in `dyalog`.

----

Outside of Nixpkgs, RIDE would detect the installed versions of Dyalog (`/opt/mdyalog`).
We could patch this so that it lists the interpreters specified in an attribute. The issue with that is that when the interpreter's store path changes, the old interpreters nix path will remain in the interpreter selection box, and you would have to select the updated interpreter from the dropdown. 
We could patch this also, so that if its a `/nix/store/` path, it gets cleared if it isn't specified in the attribute.

Anyways, that's outside of the scope of this PR

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
