### PR TITLE
nixos/keycloak: Add systemd startup notification

### DIFF
--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -466,7 +466,8 @@ in
       confFile = pkgs.writeText "keycloak.conf" (keycloakConfig filteredConfig);
       keycloakBuild = cfg.package.override {
         inherit confFile;
-        plugins = cfg.package.enabledPlugins ++ cfg.plugins;
+        plugins = cfg.package.enabledPlugins ++ cfg.plugins ++
+                  (with cfg.package.plugins; [quarkus-systemd-notify quarkus-systemd-notify-deployment]);
       };
     in
     mkIf cfg.enable
@@ -638,6 +639,8 @@ in
               RuntimeDirectory = "keycloak";
               RuntimeDirectoryMode = "0700";
               AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+              Type = "notify";  # Requires quarkus-systemd-notify plugin
+              NotifyAccess = "all";
             };
             script = ''
               set -o errexit -o pipefail -o nounset -o errtrace

--- a/pkgs/servers/keycloak/all-plugins.nix
+++ b/pkgs/servers/keycloak/all-plugins.nix
@@ -1,4 +1,4 @@
-{ callPackage }:
+{ callPackage, fetchMavenArtifact }:
 
 {
   scim-for-keycloak = callPackage ./scim-for-keycloak {};
@@ -6,4 +6,20 @@
   keycloak-discord = callPackage ./keycloak-discord {};
   keycloak-metrics-spi = callPackage ./keycloak-metrics-spi {};
   keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth {};
+
+  # These could theoretically be used by something other than Keycloak, but
+  # there are no other quarkus apps in nixpkgs (as of 2023-08-21)
+  quarkus-systemd-notify = (fetchMavenArtifact {
+    groupId = "io.quarkiverse.systemd.notify";
+    artifactId = "quarkus-systemd-notify";
+    version = "1.0.1";
+    hash = "sha256-3I4j22jyIpokU4kdobkt6cDsALtxYFclA+DV+BqtmLY=";
+  }).passthru.jar;
+
+  quarkus-systemd-notify-deployment = (fetchMavenArtifact {
+    groupId = "io.quarkiverse.systemd.notify";
+    artifactId = "quarkus-systemd-notify-deployment";
+    version = "1.0.1";
+    hash = "sha256-xHxzBxriSd/OU8gEcDG00VRkJYPYJDfAfPh/FkQe+zg=";
+  }).passthru.jar;
 }


### PR DESCRIPTION
## Description of changes

This makes it possible for other systemd units to depend on keycloak.service using `after` and `wants` relationships, and systemd will actually wait for Keycloak to finish its initialization before starting any dependent units.  This can be important for services like oauth2-proxy, which (when configured to use Keycloak as its auth provider) will fail to start until Keycloak's `.well-known/openid-configuration` endpoint is available.

Note that the existing nixos test for keycloak automatically covers this new functionality, because the systemd unit would fail to start with `Type = notify` unless the new systemd plugin works correctly.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).