### PR TITLE
cudaPackages.autoAddOpenGLRunpathHook: don't skip shared libraries

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/auto-add-opengl-runpath-hook.sh
+++ b/pkgs/development/compilers/cudatoolkit/auto-add-opengl-runpath-hook.sh
@@ -2,17 +2,21 @@
 # Run addOpenGLRunpath on all dynamically linked, ELF files
 echo "Sourcing auto-add-opengl-runpath-hook"
 
+elfHasDynamicSection() {
+    patchelf --print-rpath "$1" >& /dev/null
+}
+
 autoAddOpenGLRunpathPhase() (
   local outputPaths
   mapfile -t outputPaths < <(for o in $(getAllOutputNames); do echo "${!o}"; done)
   find "${outputPaths[@]}" -type f -executable -print0  | while IFS= read -rd "" f; do
     if isELF "$f"; then
       # patchelf returns an error on statically linked ELF files
-      if patchelf --print-interpreter "$f" >/dev/null 2>&1; then
+      if elfHasDynamicSection "$f" ; then
         echo "autoAddOpenGLRunpathHook: patching $f"
         addOpenGLRunpath "$f"
-      elif [ -n "${DEBUG-}" ]; then
-        echo "autoAddOpenGLRunpathHook: skipping ELF file $f"
+      elif (( "${NIX_DEBUG:-0}" >= 1 )) ; then
+        echo "autoAddOpenGLRunpathHook: skipping a statically-linked ELF file $f"
       fi
     fi
   done


### PR DESCRIPTION
## Description of changes


Hotfix for https://github.com/NixOS/nixpkgs/pull/245789#issuecomment-1687215040:

> I was wrong about [the] `.interp` [section of an ELF file]: only dynamically linked _executables_ [, as opposed to libraries,] got it, as far as I now understand
> 
> On the other hand, testing for `--print-rpath` (the `.dynamic` section [of the ELF]) gives:
> 
> ```
> ❯ patchelf --print-rpath /nix/store/yzi9jfm4faias1zmf91iwlrd90r433rz-cuda_cudart-11.8.89/lib/libcudart.so.11.8.89
> $ORIGIN
> ❯ # On a static binary:
> ❯ patchelf --print-rpath ./result/bin/wpa_supplicant
> patchelf: cannot find section '.dynamic'. The input file is most likely statically linked
> ```


## Things done

```
❯ nix build -f with-my-cuda.nix cudaPackages.cuda_cudart 
❯ patchelf --print-rpath result/lib/libcudart.so.11.0
/run/opengl-driver/lib:$ORIGIN
```


## Things NOT done

I didn't test if @de11n's original use-case (static libraries) is still handled correctly

We should write an automated test which would verify that the hook

- when used with a shared (i.e. dynamic) library in the outputs does actually prefix the runpath;
- when used with a static library and `NIX_DEBUG=1` does produce a message about the library presumed static, and does indeed leave the file intact;
- same for executables

We should also set up GPU-enabled tests, including one that would verify `torch.cuda.is_available()`