### PR TITLE
parrot: init at 1.6.0

### DIFF
--- a/pkgs/applications/audio/parrot/default.nix
+++ b/pkgs/applications/audio/parrot/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, cmake
+, ffmpeg
+, libopus
+, makeBinaryWrapper
+, nix-update-script
+, openssl
+, pkg-config
+, stdenv
+, yt-dlp
+, Security
+}:
+let
+  version = "1.6.0";
+in
+rustPlatform.buildRustPackage {
+  pname = "parrot";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "aquelemiguel";
+    repo = "parrot";
+    rev = "v${version}";
+    hash = "sha256-f6YAdsq2ecsOCvk+A8wsUu+ywQnW//gCAkVLF0HTn8c=";
+  };
+
+  cargoHash = "sha256-e4NHgwoNkZ0//rugHrP0gU3pntaMeBJsV/YSzJfD8r4=";
+
+  nativeBuildInputs = [ cmake makeBinaryWrapper pkg-config ];
+
+  buildInputs = [ libopus openssl ]
+    ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  postInstall = ''
+    wrapProgram $out/bin/parrot \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg yt-dlp ]}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A hassle-free Discord music bot";
+    homepage = "https://github.com/aquelemiguel/parrot";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gerg-l ];
+    mainProgram = "parrot";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11663,6 +11663,10 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
+  parrot = callPackage ../applications/audio/parrot {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   patchutils = callPackage ../tools/text/patchutils { };
 
   patchutils_0_3_3 = callPackage ../tools/text/patchutils/0.3.3.nix { };


### PR DESCRIPTION
## Description of changes
Added parrot a discord music bot written in rust
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
