### PR TITLE
python3.pkgs.cmsis-pack-manager: fix install using pypa installer

### DIFF
--- a/pkgs/development/python-modules/cmsis-pack-manager/default.nix
+++ b/pkgs/development/python-modules/cmsis-pack-manager/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchPypi
+, fetchFromGitHub
 , rustPlatform
 , cffi
 , libiconv
@@ -15,17 +15,20 @@
 }:
 
 buildPythonPackage rec {
-  pname = "cmsis_pack_manager";
+  pname = "cmsis-pack-manager";
   version = "0.5.2";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-sVfyz9D7/0anIp0bEPp1EJkERDbNJ3dCcydLbty1KsQ=";
+  src = fetchFromGitHub {
+    owner = "pyocd";
+    repo = "cmsis-pack-manager";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-PeyJf3TGUxv8/MKIQUgWrenrK4Hb+4cvtDA2h3r6kGg=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    sha256 = "dO4qw5Jx0exwb4RuOhu6qvGxQZ+LayHtXDHZKADLTEI=";
+    hash = "sha256-dO4qw5Jx0exwb4RuOhu6qvGxQZ+LayHtXDHZKADLTEI=";
   };
 
   nativeBuildInputs = [ rustPlatform.cargoSetupHook rustPlatform.maturinBuildHook ];
@@ -35,10 +38,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ appdirs pyyaml ];
   nativeCheckInputs = [ hypothesis jinja2 pytestCheckHook unzip ];
 
-  format = "pyproject";
-
+  # remove cmsis_pack_manager source directory so that binaries can be imported
+  # from the installed wheel instead
   preCheck = ''
-    unzip $dist/*.whl cmsis_pack_manager/cmsis_pack_manager/native.so
+    rm -r cmsis_pack_manager
   '';
 
   disabledTests = [


### PR DESCRIPTION
## Description of changes

After https://github.com/NixOS/nixpkgs/pull/248866 was committed, we now use [`installer`](https://installer.pypa.io/en/stable/) instead of `pip` to install wheels. As reported in https://github.com/pyocd/cmsis-pack-manager/issues/207, we cannot install this from the PyPI artifact: for some reason, the wheel that is created has duplicated files in the archive, and `installer` does not like it.

This isn't a problem when installing from the GitHub sources.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
