### PR TITLE
tomato-c: init at unstable-2023-08-21

### DIFF
--- a/pkgs/applications/misc/tomato-c/default.nix
+++ b/pkgs/applications/misc/tomato-c/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, libnotify
+, makeWrapper
+, mpv
+, ncurses
+, pkg-config
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tomato-c";
+  version = "unstable-2023-08-21";
+
+  src = fetchFromGitHub {
+    owner = "gabrielzschmitz";
+    repo = "Tomato.C";
+    rev = "6e43e85aa15f3d96811311a3950eba8ce9715634";
+    hash = "sha256-RpKkQ7xhM2XqfZdXra0ju0cTBL3Al9NMVQ/oleFydDs=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "sudo " ""
+    substituteInPlace notify.c \
+      --replace "/usr/local" "${placeholder "out"}"
+    substituteInPlace util.c \
+      --replace "/usr/local" "${placeholder "out"}"
+    substituteInPlace tomato.desktop \
+      --replace "/usr/local" "${placeholder "out"}"
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    libnotify
+    mpv
+    ncurses
+  ];
+
+  installFlags = [
+    "PREFIX=${placeholder "out"}"
+    "CPPFLAGS=$NIX_CFLAGS_COMPILE"
+    "LDFLAGS=$NIX_LDFLAGS"
+  ];
+
+  postFixup = ''
+    for file in $out/bin/*; do
+      wrapProgram $file \
+        --prefix PATH : ${lib.makeBinPath [ libnotify mpv ]}
+    done
+  '';
+
+  strictDeps = true;
+
+  meta = {
+    homepage = "https://github.com/gabrielzschmitz/Tomato.C";
+    description = " A pomodoro timer written in pure C";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ AndersonTorres ];
+    mainProgram = "tomato";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -192,6 +192,8 @@ with pkgs;
     meta.platforms = lib.platforms.linux;
   } ../build-support/setup-hooks/auto-patchelf.sh;
 
+  tomato-c = callPackage ../applications/misc/tomato-c { };
+
   appflowy = callPackage ../applications/office/appflowy { };
 
   appimageTools = callPackage ../build-support/appimage { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/250219

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
