### PR TITLE
zfs: add armv7 to supported platforms

### DIFF
--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -202,15 +202,15 @@ stdenv'.mkDerivation {
     changelog = "https://github.com/openzfs/zfs/releases/tag/zfs-${version}";
     license = lib.licenses.cddl;
 
-    # The case-block for TARGET_CPU has branches for only five CPU families,
+    # The case-block for TARGET_CPU has branches for only some CPU families,
     # which prevents ZFS from building on any other platform.  Since the NixOS
     # `boot.zfs.enabled` property is `readOnly`, excluding platforms where ZFS
     # does not build is the only way to produce a NixOS installer on such
     # platforms.
-    # https://github.com/openzfs/zfs/blob/6a6bd493988c75331deab06e5352a9bed035a87d/config/always-arch.m4#L16
+    # https://github.com/openzfs/zfs/blob/6723d1110f6daf93be93db74d5ea9f6b64c9bce5/config/always-arch.m4#L12
     platforms =
       with lib.systems.inspect.patterns;
-      map (p: p // isLinux) [ isx86_32 isx86_64 isPower isAarch64 isSparc ];
+      map (p: p // isLinux) ([ isx86_32 isx86_64 isPower isAarch64 isSparc ] ++ isArmv7);
 
     maintainers = with lib.maintainers; [ jcumming jonringer globin raitobezarius ];
     mainProgram = "zfs";


### PR DESCRIPTION
## Description of changes

`zfs` was restricted to a set of platforms in https://github.com/NixOS/nixpkgs/pull/194148. That platform list isn't quite right: ZFS builds for `armv7l-linux`, for example.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] armv7l-linux (cross)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
