### PR TITLE
python3.pkgs.jupytext: relax build dependencies

### DIFF
--- a/pkgs/development/python-modules/jupytext/default.nix
+++ b/pkgs/development/python-modules/jupytext/default.nix
@@ -14,7 +14,9 @@
 , pytestCheckHook
 , pythonOlder
 , pyyaml
+, setuptools
 , toml
+, wheel
 }:
 
 buildPythonPackage rec {
@@ -31,9 +33,23 @@ buildPythonPackage rec {
     hash = "sha256-M4BoST18sf1C1lwhFkp4a0B3fc0VKerwuVEIfwkD7i0=";
   };
 
-  buildInputs = [
+  # Follow https://github.com/mwouts/jupytext/pull/1119 to see if the patch
+  # relaxing jupyter_packaging version can be cleaned up.
+  #
+  # Follow https://github.com/mwouts/jupytext/pull/1077 to see when the patch
+  # relaxing jupyterlab version can be cleaned up.
+  #
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'jupyter_packaging~=' 'jupyter_packaging>=' \
+      --replace 'jupyterlab>=3,<=4' 'jupyterlab>=3'
+  '';
+
+  nativeBuildInputs = [
     jupyter-packaging
     jupyterlab
+    setuptools
+    wheel
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

After https://github.com/NixOS/nixpkgs/pull/248866, we have stronger build-time dependency validation, so this package needs its `jupyter-packaging` and `jupyterlab` dependencies relaxed.

The constraint in `jupyer-packaging` seems to be historical (and I submitted a PR upstream that will hopefully relax it in the future), while the constraint on `jupyterlab` seems to be only needed for a small subset of the functionality (per comments on https://github.com/mwouts/jupytext/pull/1068). (In any case, recent versions of both packages are already being used in the build; the constraint is just not being checked right now.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
