### PR TITLE
ocamlPackages.ppxlib: 0.28.0 → 0.30.0

### DIFF
--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -1,4 +1,5 @@
-{ lib, buildDunePackage, cstruct, sexplib, ppxlib, stdlib-shims
+{ lib, buildDunePackage, cstruct, sexplib, ppxlib
+, ocaml-migrate-parsetree-2
 , ounit, cppo, ppx_sexp_conv, cstruct-unix, cstruct-sexp
 }:
 
@@ -11,11 +12,10 @@ else
     inherit (cstruct) version src meta;
 
     minimalOCamlVersion = "4.08";
-    duneVersion = "3";
 
-    propagatedBuildInputs = [ cstruct ppxlib sexplib stdlib-shims ];
+    propagatedBuildInputs = [ cstruct ppxlib sexplib ];
 
     doCheck = true;
     nativeCheckInputs = [ cppo ];
-    checkInputs = [ ounit ppx_sexp_conv cstruct-sexp cstruct-unix ];
+    checkInputs = [ ounit ppx_sexp_conv cstruct-sexp cstruct-unix ocaml-migrate-parsetree-2 ];
   }

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -3,7 +3,7 @@
   if lib.versionAtLeast ocaml.version "4.07"
   then if lib.versionAtLeast ocaml.version "4.08"
   then if lib.versionAtLeast ocaml.version "4.11"
-  then "0.28.0" else "0.24.0" else "0.15.0" else "0.13.0"
+  then "0.30.0" else "0.24.0" else "0.15.0" else "0.13.0"
 , ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
 , stdlib-shims, ocaml-migrate-parsetree-2
 }:
@@ -59,6 +59,10 @@ let param = {
     sha256 = "sha256-2Hrl+aCBIGMIypZICbUKZq646D0lSAHouWdUSLYM83c=";
     min_version = "4.07";
     max_version = "5.1";
+  };
+  "0.30.0" = {
+    sha256 = "sha256-3UpjvenSm0mBDgTXZTk3yTLxd6lByg4ZgratU6xEIRA=";
+    min_version = "4.07";
   };
 }."${version}"; in
 

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -13,34 +13,37 @@ let param = {
     sha256 = "sha256-pct57oO7qAMEtlvEfymFOCvviWaLG0b5/7NzTC8vdSE=";
     max_version = "4.10";
     useDune2 = false;
-    useOMP2 = false;
+    OMP = [ ocaml-migrate-parsetree ];
   };
   "0.13.0" = {
     sha256 = "sha256-geHz0whQDg5/YQjVsN2iuHlkClwh7z3Eqb2QOBzuOdk=";
     max_version = "4.11";
     useDune2 = false;
-    useOMP2 = false;
+    OMP = [ ocaml-migrate-parsetree ];
   };
   "0.15.0" = {
     sha256 = "sha256-C2MNf410qJmlXMJxiLXOA+c1qT8H6gwt5WUy2P2TszA=";
     min_version = "4.07";
     max_version = "4.12";
-    useOMP2 = false;
+    OMP = [ ocaml-migrate-parsetree ];
   };
   "0.18.0" = {
     sha256 = "sha256-nUg8NkZ64GHHDfcWbtFGXq3MNEKu+nYPtcVDm/gEfcM=";
     min_version = "4.07";
     max_version = "4.12";
+    OMP = [ ocaml-migrate-parsetree-2 ];
   };
   "0.22.0" = {
     sha256 = "sha256-PuuR4DlmZiKEoyIuYS3uf0+it2N8U9lXLSp0E0u5bXo=";
     min_version = "4.07";
     max_version = "4.13";
+    OMP = [ ocaml-migrate-parsetree-2 ];
   };
   "0.22.2" = {
     sha256 = "sha256-0Oih69xiILFXTXqSbwCEYMURjM73m/mgzgJC80z/Ilo=";
     min_version = "4.07";
     max_version = "4.14";
+    OMP = [ ocaml-migrate-parsetree-2 ];
   };
   "0.23.0" = {
     sha256 = "sha256-G1g2wYa51aFqz0falPOWj08ItRm3cpzYao/TmXH+EuU=";
@@ -50,10 +53,12 @@ let param = {
   "0.24.0" = {
     sha256 = "sha256-d2YCfC7ND1s7Rg6SEqcHCcZ0QngRPrkfMXxWxB56kMg=";
     min_version = "4.07";
+    max_version = "5.1";
   };
   "0.28.0" = {
     sha256 = "sha256-2Hrl+aCBIGMIypZICbUKZq646D0lSAHouWdUSLYM83c=";
     min_version = "4.07";
+    max_version = "5.1";
   };
 }."${version}"; in
 
@@ -75,9 +80,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [
     ocaml-compiler-libs
-    (if param.useOMP2 or true
-     then ocaml-migrate-parsetree-2
-     else ocaml-migrate-parsetree)
+  ] ++ (param.OMP or []) ++ [
     ppx_derivers
     stdio
     stdlib-shims


### PR DESCRIPTION
## Description of changes

Compatibility with latest OCaml (5.1).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
