### PR TITLE
python3.pkgs.pypiserver: add pip dependency and audit tests

### DIFF
--- a/pkgs/development/python-modules/pypiserver/default.nix
+++ b/pkgs/development/python-modules/pypiserver/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , passlib
+, pip
 , pytestCheckHook
 , pythonOlder
 , setuptools
@@ -9,6 +10,7 @@
 , twine
 , watchdog
 , webtest
+, wheel
 }:
 
 buildPythonPackage rec {
@@ -26,11 +28,13 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
+    setuptools
     setuptools-git
+    wheel
   ];
 
   propagatedBuildInputs = [
-    setuptools
+    pip
   ];
 
   passthru.optional-dependencies = {
@@ -42,12 +46,21 @@ buildPythonPackage rec {
     ];
   };
 
+  __darwinAllowLocalNetworking = true;
+
+  # Tests need these permissions in order to use the FSEvents API on macOS.
+  sandboxProfile = ''
+    (allow mach-lookup (global-name "com.apple.FSEvents"))
+  '';
+
   preCheck = ''
     export HOME=$TMPDIR
   '';
 
   nativeCheckInputs = [
+    pip
     pytestCheckHook
+    setuptools
     twine
     webtest
   ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
@@ -57,11 +70,6 @@ buildPythonPackage rec {
     "test_hash_algos"
     "test_pip_install_authed_succeeds"
     "test_pip_install_open_succeeds"
-    "test_pip_install_authed_fails"
-    # Tests want to tests upload
-    "upload"
-    "register"
-    "test_partial_authed_open_download"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
## Description of changes

This started failing (on staging) after https://github.com/NixOS/nixpkgs/pull/248866 because `pip` is a dependency of this package but is no longer present in the environment.

In addition to adding it, we also add a few other missing build-time dependencies, verified that a few tests that used to fail now pass, and added a sandbox profile so that tests pass on Darwin with the sandbox enabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
