### PR TITLE
salt: fix duplicate scripts in wheel

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , python3
+, fetchpatch
 , fetchPypi
 , openssl
   # Many Salt modules require various Python modules to be installed,
@@ -11,28 +12,20 @@
 python3.pkgs.buildPythonApplication rec {
   pname = "salt";
   version = "3006.2";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-+I0aJeIw2co9/eE9rdRmB6KxdQq1WoY1nFpCUedx8Wc=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
-    distro
-    jinja2
-    jmespath
-    looseversion
-    markupsafe
-    msgpack
-    packaging
-    psutil
-    pycryptodomex
-    pyyaml
-    pyzmq
-    requests
-  ] ++ extraInputs;
-
   patches = [
+    # https://github.com/saltstack/salt/pull/63795
+    (fetchpatch {
+      name = "remove-duplicate-scripts.patch";
+      url = "https://github.com/saltstack/salt/commit/6b9463836e70e40409dbf653f01aa94ef869dfe7.patch";
+      hash = "sha256-VcVdKC8EH4qoWHtq6eEPl8OviR4eA2k/S2lWNQbubJw=";
+    })
     ./fix-libcrypto-loading.patch
   ];
 
@@ -50,6 +43,21 @@ python3.pkgs.buildPythonApplication rec {
     substituteInPlace "requirements/zeromq.txt" \
       --replace 'pyzmq==25.0.2 ; sys_platform == "win32"' ""
   '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    distro
+    jinja2
+    jmespath
+    looseversion
+    markupsafe
+    msgpack
+    packaging
+    psutil
+    pycryptodomex
+    pyyaml
+    pyzmq
+    requests
+  ] ++ extraInputs;
 
   # Don't use fixed dependencies on Darwin
   USE_STATIC_REQUIREMENTS = "0";


### PR DESCRIPTION
## Description of changes

The build fails now in staging since https://github.com/NixOS/nixpkgs/pull/248866 was merged. We use [`installer`](https://installer.pypa.io/en/stable/cli/installer/) to install Python wheels instead of `pip`, and it complains when a wheel contains duplicate scripts. To fix this, we can pull in https://github.com/saltstack/salt/pull/63795 from upstream.

I also moved the `propagatedBuildInputs` section to below the patch sections. I think it makes more sense this way.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
