### PR TITLE
yazi: init at 0.1.3

### DIFF
--- a/pkgs/applications/file-managers/yazi/default.nix
+++ b/pkgs/applications/file-managers/yazi/default.nix
@@ -1,0 +1,73 @@
+{ rustPlatform
+, fetchFromGitHub
+, lib
+
+, makeWrapper
+, stdenv
+, Foundation
+
+, withFile ? true
+, file
+, withJq ? true
+, jq
+, withPoppler ? true
+, poppler_utils
+, withUnar ? true
+, unar
+, withFfmpegthumbnailer ? true
+, ffmpegthumbnailer
+, withFd ? true
+, fd
+, withRipgrep ? true
+, ripgrep
+, withFzf ? true
+, fzf
+, withZoxide ? true
+, zoxide
+
+, nix-update-script
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "yazi";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "sxyazi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-IUE2846AltYyEefkavCJOEak9mW0wygojWsucwUEgh4=";
+  };
+
+  cargoHash = "sha256-wwtdaReb+teXf+VDwqAqCbSy2qWI11IRlcygmWdaqF4=";
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = lib.optionals stdenv.isDarwin [ Foundation ];
+
+  postInstall = with lib;
+    let
+      runtimePaths = [ ]
+        ++ optional withFile file
+        ++ optional withJq jq
+        ++ optional withPoppler poppler_utils
+        ++ optional withUnar unar
+        ++ optional withFfmpegthumbnailer ffmpegthumbnailer
+        ++ optional withFd fd
+        ++ optional withRipgrep ripgrep
+        ++ optional withFzf fzf
+        ++ optional withZoxide zoxide;
+    in
+    ''
+      wrapProgram $out/bin/yazi \
+         --prefix PATH : "${makeBinPath runtimePaths}"
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Blazing fast terminal file manager written in Rust, based on async I/O";
+    homepage = "https://github.com/sxyazi/yazi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ xyenon matthiasbeyer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -42031,4 +42031,6 @@ with pkgs;
   wttrbar = callPackage ../applications/misc/wttrbar { };
 
   wpm = callPackage ../applications/misc/wpm { };
+
+  yazi = callPackage ../applications/file-managers/yazi { inherit (darwin.apple_sdk.frameworks) Foundation; };
 }


### PR DESCRIPTION
## Description of changes

[Yazi - ⚡️ Blazing Fast Terminal File Manager](https://github.com/sxyazi/yazi)

https://github.com/NixOS/nixpkgs/issues/250564

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
