### PR TITLE
python3.pkgs.jarowinkler: fix build dependencies

### DIFF
--- a/pkgs/development/python-modules/jarowinkler/default.nix
+++ b/pkgs/development/python-modules/jarowinkler/default.nix
@@ -8,6 +8,7 @@
 , rapidfuzz-capi
 , scikit-build
 , setuptools
+, wheel
 , jarowinkler-cpp
 , hypothesis
 , pytestCheckHook
@@ -16,10 +17,9 @@
 buildPythonPackage rec {
   pname = "jarowinkler";
   version = "1.2.3";
+  format = "pyproject";
 
   disabled = pythonOlder "3.6";
-
-  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "maxbachmann";
@@ -28,6 +28,14 @@ buildPythonPackage rec {
     hash = "sha256-j+ZabVsiVitNkTPhGjDg72XogjvPaL453lTW45ITm90=";
   };
 
+  # We cannot use Cython version 3.0.0 because the code in jarowinkler has not
+  # been adapted for https://github.com/cython/cython/issues/4280 yet
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'scikit-build==' 'scikit-build>=' \
+      --replace 'Cython==3.0.0a11' 'Cython'
+  '';
+
   nativeBuildInputs = [
     cmake
     cython
@@ -35,6 +43,7 @@ buildPythonPackage rec {
     rapidfuzz-capi
     scikit-build
     setuptools
+    wheel
   ];
 
   buildInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5333,7 +5333,9 @@ self: super: with self; {
 
   jaraco-text = callPackage ../development/python-modules/jaraco-text { };
 
-  jarowinkler = callPackage ../development/python-modules/jarowinkler { };
+  jarowinkler = callPackage ../development/python-modules/jarowinkler {
+    inherit (pkgs) cmake ninja;
+  };
 
   javaobj-py3 = callPackage ../development/python-modules/javaobj-py3 { };
 


### PR DESCRIPTION
## Description of changes

These changes are needed now that https://github.com/NixOS/nixpkgs/pull/248866 has been committed.

1. Relax scikit-build dependency in postPatch.
2. Allow using Cython 0.29 in postPatch because it does not support the final released version 3.0.0 of Cython yet.
3. Add wheel as an explicit build-time dependency (which will be required soon).
4. Pass in actual ninja and cmake instead of ninja and cmake Python modules. jarowinkler has a [custom build backend](https://github.com/maxbachmann/JaroWinkler/blob/main/_custom_build/backend.py) that can use them directly

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
