### PR TITLE
get_iplayer: removed unnecessary dependencies

### DIFF
--- a/pkgs/applications/misc/get_iplayer/default.nix
+++ b/pkgs/applications/misc/get_iplayer/default.nix
@@ -7,8 +7,6 @@
 , perl
 , atomicparsley
 , ffmpeg
-, flvstreamer
-, rtmpdump
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -25,7 +23,7 @@ perlPackages.buildPerlPackage rec {
   nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.isDarwin shortenPerlShebang;
   buildInputs = [ perl ];
   propagatedBuildInputs = with perlPackages; [
-    HTMLParser HTTPCookies LWP LWPProtocolHttps XMLLibXML XMLSimple Mojolicious
+    LWP LWPProtocolHttps XMLLibXML Mojolicious
   ];
 
   preConfigure = "touch Makefile.PL";
@@ -36,7 +34,7 @@ perlPackages.buildPerlPackage rec {
     runHook preInstall
     mkdir -p $out/bin $out/share/man/man1
     cp get_iplayer $out/bin
-    wrapProgram $out/bin/get_iplayer --suffix PATH : ${lib.makeBinPath [ atomicparsley ffmpeg flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
+    wrapProgram $out/bin/get_iplayer --suffix PATH : ${lib.makeBinPath [ atomicparsley ffmpeg ]} --prefix PERL5LIB : $PERL5LIB
     cp get_iplayer.1 $out/share/man/man1
     runHook postInstall
   '';
@@ -46,9 +44,9 @@ perlPackages.buildPerlPackage rec {
   '';
 
   meta = with lib; {
-    description = "Downloads TV and radio from BBC iPlayer";
+    description = "Downloads TV and radio programmes from BBC iPlayer and BBC Sounds";
     license = licenses.gpl3Plus;
-    homepage = "https://squarepenguin.co.uk/";
+    homepage = "https://github.com/get-iplayer/get_iplayer";
     platforms = platforms.all;
     maintainers = with maintainers; [ rika jgarcia ];
   };


### PR DESCRIPTION
## Description of changes

Removed unnecessary dependencies as described below

flvstreamer: not used by get_iplayer
rtmpdump: not used by get_iplayer
perlPackages:
HTMLParser: pulled in by LWP
HTMLCookies: pulled in by LWP
XMLSimple: not used by get_iplayer

Also updated meta.description and meta.homepage - old site is defunct.

No dependents or package tests defined. Basic test with Docker to exercise all dependencies:

```
$ docker run --rm -it -v $(pwd)/nixpkgs:/nixpkgs nixos/nix
docker> cd /nixpkgs
docker> nix-build -A get_iplayer
docker> ./result/bin/get_iplayer --refresh
docker> ./result/bin/get_iplayer --get 1 --stop 120 --subtitles
docker> ls -l *.mp4 *.srt
docker> exit
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
