### PR TITLE
xfce.xfce4-terminal: 1.0.4 -> 1.1.0

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
@@ -1,17 +1,38 @@
-{ lib, mkXfceDerivation, gtk3, libxfce4ui, vte, xfconf, pcre2, libxslt, docbook_xml_dtd_45, docbook_xsl, nixosTests }:
+{ lib
+, mkXfceDerivation
+, glib
+, gtk3
+, libxfce4ui
+, vte
+, xfconf
+, pcre2
+, libxslt
+, docbook_xml_dtd_45
+, docbook_xsl
+, nixosTests
+}:
 
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-terminal";
-  version = "1.0.4";
+  version = "1.1.0";
 
-  sha256 = "sha256-eCb6KB9fFPuYzNLUm/yYrh+0D60ISzasnv/myStImEI=";
+  sha256 = "sha256-ilxiP1Org5/uSQOzfRgODmouH0BmK3CmCJj1kutNuII=";
 
-  nativeBuildInputs = [ libxslt docbook_xml_dtd_45 docbook_xsl ];
+  nativeBuildInputs = [
+    libxslt
+    docbook_xml_dtd_45
+    docbook_xsl
+  ];
 
-  buildInputs = [ gtk3 libxfce4ui vte xfconf pcre2 ];
-
-  env.NIX_CFLAGS_COMPILE = "-I${libxfce4ui.dev}/include/xfce4";
+  buildInputs = [
+    glib
+    gtk3
+    libxfce4ui
+    vte
+    xfconf
+    pcre2
+  ];
 
   passthru.tests.test = nixosTests.terminal-emulators.xfce4-terminal;
 


### PR DESCRIPTION

## Description of changes

https://github.com/xfce-mirror/xfce4-terminal/compare/xfce4-terminal-1.0.4...xfce4-terminal-1.1.0

- Explicitly add glib.
- Format with nixpkgs-fmt.
- Clean up unneeded NIX_CFLAGS_COMPILE.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
