### PR TITLE
python3.pkgs.python-lsp-server: relax jedi dependency constraint

### DIFF
--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -4,6 +4,7 @@
 , buildPythonPackage
 , docstring-to-markdown
 , fetchFromGitHub
+, fetchpatch
 , flake8
 , flaky
 , jedi
@@ -28,6 +29,7 @@
 , ujson
 , websockets
 , whatthepatch
+, wheel
 , yapf
 }:
 
@@ -45,13 +47,22 @@ buildPythonPackage rec {
     hash = "sha256-plciPUROFileVULGBZpwUTkW2NZVHy4Nuf4+fSjd8nM=";
   };
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  patches = [
+    # https://github.com/python-lsp/python-lsp-server/pull/416
+    (fetchpatch {
+      name = "bump-jedi-upper-pin-to-0.20.patch";
+      url = "https://github.com/python-lsp/python-lsp-server/commit/f33a93afc8c3a0f16751f9e1f6601a37967fd7df.patch";
+      hash = "sha256-lBpzXxjlQp2ig0z2DRJw+jQZ5eRLIOJYjGrzfgvknDA=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace "--cov-report html --cov-report term --junitxml=pytest.xml" "" \
       --replace "--cov pylsp --cov test" ""
   '';
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   pythonRelaxDeps = [
     "autopep8"
@@ -65,6 +76,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     pythonRelaxDepsHook
     setuptools-scm
+    wheel
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

This will be needed so that builds continue working on staging-next after https://github.com/NixOS/nixpkgs/commit/39fc433514bb0fcf121be187b873bf2565df74a7. In particular, `pyls-flake8` and `python-lsp-black` seem to require relaxing this so that their tests pass (for some reason).

We could also add `jedi` to `pythonRelaxDeps` but I guess my personal preference is to pull in patches when they exist on upstream. When upstream releases a version with the patch, it is easier to trace and clean up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
