### PR TITLE
python3.pkgs.ruamel-base: add pythonNamespaces to remove nspkg.pth file

### DIFF
--- a/pkgs/development/python-modules/ruamel-base/default.nix
+++ b/pkgs/development/python-modules/ruamel-base/default.nix
@@ -18,6 +18,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ruamel.base" ];
 
+  pythonNamespaces = [ "ruamel" ];
+
   meta = with lib; {
     description = "Common routines for ruamel packages";
     homepage = "https://sourceforge.net/projects/ruamel-base/";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The Python package ruamel-* [uses legacy namespace](https://sourceforge.net/p/ruamel-base/code/ci/default/tree/setup.py#l328) which produces `ruamel.*-1.0.0-py3.10-nspkg.pth` file. This causes wrapped python applications importting `ruamel.yaml` throw a `ModuleNotFoundError` when `$PYTHONPATH` is also set to contain ruamel packages. Although I don't understand the cause, this maybe related to 
https://github.com/pypa/setuptools/discussions/3991.

For example, in a simple `devShell` with only [ansible-lint](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/tools/admin/ansible/lint.nix) package, running `ansible-lint` command gives `ModuleNotFoundError: No module named 'ruamel.yaml'`. You can try it by running `nix develop github:KiruyaMomochi/nix-ruamel-lab` and then run `ansible-lint`.

This issue does not occurs with ruamel-yaml 0.17.21 ([update commit](https://github.com/NixOS/nixpkgs/commit/5330b05d9952aad7606d5c0658d65faf1955c659)), because both the ruamel-base and ruamel-yaml contains .pth file. The former .pth file is overridden by the latter.

This PR fixes the problem by adding `pythonNamespaces` to all ruamel-* packages. This triggers `pythonNamespacesHook`, so that [all the .pth files are removed](https://github.com/NixOS/nixpkgs/blob/05ba191efbec39d62027ba883cf220d33197de39/pkgs/development/interpreters/python/hooks/python-namespaces-hook.sh#L35) in these packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

