### PR TITLE
Relax or remove jupyterlab from some packages

### DIFF
--- a/pkgs/development/python-modules/anywidget/default.nix
+++ b/pkgs/development/python-modules/anywidget/default.nix
@@ -7,7 +7,6 @@
 , hatchling
 , importlib-metadata
 , ipywidgets
-, jupyterlab
 , psygnal
 , typing-extensions
 , watchfiles
@@ -25,10 +24,17 @@ buildPythonPackage rec {
     hash = "sha256-OUKxmYceEKURJeQTVI7oLT4SdZM90V7BoZf0UykkEV4=";
   };
 
+  # We do not need the jupyterlab build dependency, because we do not need to
+  # build any JS components; these are present already in the PyPI artifact.
+  #
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"jupyterlab==3.*"' ""
+  '';
+
   nativeBuildInputs = [
     hatch-jupyter-builder
     hatchling
-    jupyterlab
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/bqscales/default.nix
+++ b/pkgs/development/python-modules/bqscales/default.nix
@@ -13,7 +13,6 @@
 buildPythonPackage rec {
   pname = "bqscales";
   version = "0.3.1";
-
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
@@ -21,6 +20,19 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-C+/GLpqYpePngbn5W0MwvpdmVgFZF7aGHyKMgO5XM90=";
   };
+
+  # We relax dependencies here instead of pulling in a patch because upstream
+  # has released a new version using hatch-jupyter-builder, but it is not yet
+  # trivial to upgrade to that.
+  #
+  # Per https://github.com/bqplot/bqscales/issues/76, jupyterlab is not needed
+  # as a build dependency right now.
+  #
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"jupyterlab==3.*",' "" \
+      --replace 'jupyter_packaging~=' 'jupyter_packaging>='
+  '';
 
   nativeBuildInputs = [
     hatchling

--- a/pkgs/development/python-modules/ipycanvas/default.nix
+++ b/pkgs/development/python-modules/ipycanvas/default.nix
@@ -20,6 +20,16 @@ buildPythonPackage rec {
     hash = "sha256-+cOUBoG8ODgzkPjEbqXYRF1uEcbaZITDfYnfWuHawTE=";
   };
 
+  # We relax dependencies here instead of pulling in a patch because upstream
+  # has released a new version using hatch-jupyter-builder, but it is not yet
+  # trivial to upgrade to that.
+  #
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"jupyterlab==3.*",' "" \
+      --replace 'jupyter_packaging~=' 'jupyter_packaging>='
+  '';
+
   nativeBuildInputs = [ jupyter-packaging ];
 
   propagatedBuildInputs = [ ipywidgets numpy pillow ];

--- a/pkgs/development/python-modules/ipyniivue/default.nix
+++ b/pkgs/development/python-modules/ipyniivue/default.nix
@@ -21,7 +21,18 @@ buildPythonPackage rec {
     hash = "sha256-kym7949VI6C+62p3IOQ2QIzWnuSBcrmySb83oqUwhjI=";
   };
 
-  nativeBuildInputs = [ hatchling hatch-jupyter-builder ];
+  # We do not need the jupyterlab build dependency, because we do not need to
+  # build any JS components; these are present already in the PyPI artifact.
+  #
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"jupyterlab==3.*",' ""
+  '';
+
+  nativeBuildInputs = [
+    hatchling
+    hatch-jupyter-builder
+  ];
 
   propagatedBuildInputs = [ ipywidgets jupyter-ui-poll ];
 

--- a/pkgs/development/python-modules/ipyparallel/default.nix
+++ b/pkgs/development/python-modules/ipyparallel/default.nix
@@ -28,6 +28,14 @@ buildPythonPackage rec {
     hash = "sha256-o5ql75VgFwvw6a/typ/wReG5wYMsSTAzd+3Mkc6p+3c=";
   };
 
+  # We do not need the jupyterlab build dependency, because we do not need to
+  # build any JS components; these are present already in the PyPI artifact.
+  #
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"jupyterlab>=3.0.0,==3.*",' ""
+  '';
+
   nativeBuildInputs = [
     hatchling
   ];

--- a/pkgs/development/python-modules/ipytablewidgets/default.nix
+++ b/pkgs/development/python-modules/ipytablewidgets/default.nix
@@ -27,6 +27,15 @@ buildPythonPackage rec {
     hash = "sha256-14vIih+r/PHLxhgG29YtwuosSBLpewD2CluWpH2+pLc=";
   };
 
+  # Opened https://github.com/progressivis/ipytablewidgets/issues/3 to ask if
+  # jupyterlab can be updated upstream. (From commits, it looks like it was
+  # set to this version on purpose.) In the meantime, the build still works.
+  #
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'jupyterlab>=3.0.0,<3.7' 'jupyterlab>=3.0.0'
+  '';
+
   nativeBuildInputs = [
     jupyter-packaging
     jupyterlab


### PR DESCRIPTION
## Description of changes

Several packages declare in their pyproject.toml a dependency on jupyterlab v3. These builds now fail after https://github.com/NixOS/nixpkgs/pull/248866 due to stronger build dependency validation.

I'm pretty new to this ecosystem, so I did my best patching out the dependency when it seems unneeded and relaxing them when the build still seems to work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
