### PR TITLE
audio-bridge: init at 2023-08-22

### DIFF
--- a/pkgs/applications/audio/audio-bridge/default.nix
+++ b/pkgs/applications/audio/audio-bridge/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, alsa-lib
+, libjack2
+, cmake
+, lv2
+, pkg-config
+, tree
+}:
+
+stdenv.mkDerivation rec {
+  pname = "audio-bridge";
+  version = "2023-08-22";
+
+  src = fetchFromGitHub {
+    owner = "falkTX";
+    repo = pname;
+    rev = "b85ef510dfca27e48fb7c86030b0ad854aaf63f3";
+    hash = "sha256-mVIJT7v85JM6qJVBwdAWINlX1kOYJfos03mf+W7qipY=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config tree];
+  buildInputs = [ alsa-lib libjack2 lv2 cmake ];
+
+  installPhase = ''
+  mkdir -p "$out"/{bin,lib/lv2}
+  cp -r audio-bridge.lv2 "$out"/lib/lv2
+  cp jack-audio-bridge "$out"/bin
+  '';
+
+  # enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Connect additional ALSA devices to JACK";
+    homepage = "https://github.com/falkTX/audio-bridge";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ PowerUser64 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1642,6 +1642,8 @@ with pkgs;
 
   audible-cli = callPackage ../tools/misc/audible-cli { };
 
+  audio-bridge = callPackage ../applications/audio/audio-bridge { };
+
   audiobookshelf = callPackage ../servers/audiobookshelf { };
 
   auditwheel = callPackage ../tools/package-management/auditwheel { };


### PR DESCRIPTION
## Description of changes

This adds [audio-bridge](https://github.com/falkTX/audio-bridge), an up-and-coming audio utility from falkTX. This application is still in very active development and hasn't seen its first release yet, so we should wait to merge this, but I'm putting it out here now anyway.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
