### PR TITLE
cloc: add basic install check

### DIFF
--- a/pkgs/tools/misc/cloc/default.nix
+++ b/pkgs/tools/misc/cloc/default.nix
@@ -1,8 +1,9 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper, perlPackages }:
 
-stdenv.mkDerivation rec {
+let version = "1.98";
+in stdenv.mkDerivation {
   pname = "cloc";
-  version = "1.98";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "AlDanial";
@@ -26,6 +27,28 @@ stdenv.mkDerivation rec {
   makeFlags = [ "prefix=" "DESTDIR=$(out)" "INSTALL=install" ];
 
   postFixup = "wrapProgram $out/bin/cloc --prefix PERL5LIB : $PERL5LIB";
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    echo -n 'checking --version...'
+    $out/bin/cloc --version | grep '${version}' > /dev/null
+    echo ' ok'
+
+    cat > test.nix <<EOF
+    {a, b}: {
+      test = a
+        + b;
+    }
+    EOF
+
+    echo -n 'checking lines in test.nix...'
+    $out/bin/cloc --quiet --csv test.nix | grep '1,Nix,0,0,4' > /dev/null
+    echo ' ok'
+
+    runHook postInstallCheck
+  '';
 
   meta = {
     description = "A program that counts lines of source code";


### PR DESCRIPTION
## Description of changes

Adds a basic install check for cloc. Verifies that --version is as expected and a basic file count works.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).