### PR TITLE
tools/misc/smc - updated to version 7.6.0

### DIFF
--- a/pkgs/tools/misc/smc/default.nix
+++ b/pkgs/tools/misc/smc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "smc";
-  version = "6.6.3";
+  version = "7.6.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/smc/smc/${lib.replaceStrings ["."] ["_"] version}/smc_${lib.replaceStrings ["."] ["_"] version}.tgz";
-    sha256 = "1gv0hrgdl4wp562virpf9sib6pdhapwv4zvwbl0d5f5xyx04il11";
+    url = "mirror://sourceforge/project/smc/SMC%20${version}/smc_${lib.replaceStrings ["."] ["_"] version}.tgz";
+    sha256 = "2e1db2884a01370e58b1d78758a9e9478f68a3129ac7801a56baed26852ed5d2";
   };
 
   # Prebuilt Java package.
@@ -18,9 +18,8 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/share/java"
 
     cp bin/Smc.jar "$out/share/java/"
-    cp -r examples/ docs/ tools/ README.txt LICENSE.txt "$out/share/smc/"
+    cp -r docs/ tools/ README.txt LICENSE.txt "$out/share/smc/"
     cp -r lib/* "$out/share/smc/lib/"
-    cp misc/smc.ico "$out/share/icons/"
 
     cat > "$out/bin/smc" << EOF
     #!${runtimeShell}


### PR DESCRIPTION
## Description of changes

Nix package for The State Machine Compiler was updated to build version 7.6.0 of SMC.

## Things done

Only minor changes to build newer version of SMC, some tweaks of download paths, versions, etc. Nothing serious.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
