### PR TITLE
fontmatrix: 0.6.0-qt5 -> 0.9.100

### DIFF
--- a/pkgs/applications/graphics/fontmatrix/default.nix
+++ b/pkgs/applications/graphics/fontmatrix/default.nix
@@ -1,21 +1,21 @@
-{ lib, mkDerivation, fetchpatch, fetchFromGitHub, cmake, qttools, qtwebkit }:
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, qttools
+, qtwebkit
+}:
 
 mkDerivation rec {
   pname = "fontmatrix";
-  version = "0.6.0";
+  version = "0.9.100";
 
   src = fetchFromGitHub {
-    owner = "fcoiffie";
+    owner = "fontmatrix";
     repo = "fontmatrix";
-    rev = "1ff8382d8c85c18d9962918f461341ff4fe21993";
-    sha256 = "0yx1gbsjj9ddq1kiqplif1w5x5saw250zbmhmd4phqmaqzr60w0h";
+    rev = "v${version}";
+    sha256 = "sha256-DtajGhx79DiecglXHja9q/TKVq8Jl2faQdA5Ib/yT88=";
   };
-
-  # Add missing QAction include
-  patches = [ (fetchpatch {
-    url = "https://github.com/fcoiffie/fontmatrix/commit/dc6de8c414ae21516b72daead79c8db88309b102.patch";
-    sha256 = "092860fdyf5gq67jqfxnlgwzjgpizi6j0njjv3m62aiznrhig7c8";
-  })];
 
   buildInputs = [ qttools qtwebkit ];
 

--- a/pkgs/applications/graphics/fontmatrix/default.nix
+++ b/pkgs/applications/graphics/fontmatrix/default.nix
@@ -21,8 +21,6 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  hardeningDisable = [ "format" ];
-
   meta = with lib; {
     description = "Fontmatrix is a free/libre font explorer for Linux, Windows and Mac";
     homepage = "https://github.com/fontmatrix/fontmatrix";

--- a/pkgs/applications/graphics/fontmatrix/default.nix
+++ b/pkgs/applications/graphics/fontmatrix/default.nix
@@ -2,7 +2,7 @@
 
 mkDerivation rec {
   pname = "fontmatrix";
-  version = "0.6.0-qt5";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "fcoiffie";


### PR DESCRIPTION
Diff: https://github.com/fcoiffie/fontmatrix/compare/1ff8382d8c85c18d9962918f461341ff4fe21993...v0.6.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
