### PR TITLE
rpi-imager: 1.7.4 -> 1.7.5

### DIFF
--- a/pkgs/tools/misc/rpi-imager/default.nix
+++ b/pkgs/tools/misc/rpi-imager/default.nix
@@ -12,6 +12,7 @@
 , qttools
 , qtquickcontrols2
 , qtgraphicaleffects
+, nix-update-script
 }:
 
 stdenv.mkDerivation rec {
@@ -48,6 +49,10 @@ stdenv.mkDerivation rec {
     but that throws an error, as /sys/dev doesn't exist in the sandbox.
     This patch removes the check. */
   patches = [ ./lsblkCheckFix.patch ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     description = "Raspberry Pi Imaging Utility";

--- a/pkgs/tools/misc/rpi-imager/default.nix
+++ b/pkgs/tools/misc/rpi-imager/default.nix
@@ -13,6 +13,7 @@
 , qtquickcontrols2
 , qtgraphicaleffects
 , nix-update-script
+, enableTelemetry ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -30,6 +31,12 @@ stdenv.mkDerivation rec {
     cmake
     util-linux
     wrapQtAppsHook
+  ];
+
+  # Disable telemetry and update check.
+  cmakeFlags = lib.optionals (!enableTelemetry) [
+    "-DENABLE_CHECK_VERSION=OFF"
+    "-DENABLE_TELEMETRY=OFF"
   ];
 
   buildInputs = [

--- a/pkgs/tools/misc/rpi-imager/default.nix
+++ b/pkgs/tools/misc/rpi-imager/default.nix
@@ -1,31 +1,35 @@
-{ mkDerivation,
-  stdenv,
-  lib,
-  fetchFromGitHub,
-  cmake,
-  curl,
-  libarchive,
-  util-linux,
-  qtbase,
-  qtdeclarative,
-  qtsvg,
-  qttools,
-  qtquickcontrols2,
-  qtgraphicaleffects
+{ lib
+, stdenv
+, fetchFromGitHub
+, wrapQtAppsHook
+, cmake
+, util-linux
+, curl
+, libarchive
+, qtbase
+, qtdeclarative
+, qtsvg
+, qttools
+, qtquickcontrols2
+, qtgraphicaleffects
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "rpi-imager";
-  version = "1.7.4";
+  version = "1.7.5";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ahETmUhlPZ3jpxmzDK5pS6yLc6UxCJFOtWolAtSrDVQ=";
+    sha256 = "sha256-yB+H1zWL40KzxOrBuvg7nBC3zmWilsOgOW7ndiDWuDA=";
   };
 
-  nativeBuildInputs = [ cmake util-linux ];
+  nativeBuildInputs = [
+    cmake
+    util-linux
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     curl
@@ -47,7 +51,8 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "Raspberry Pi Imaging Utility";
-    homepage = "https://www.raspberrypi.org/software/";
+    homepage = "https://www.raspberrypi.com/software/";
+    changelog = "https://github.com/raspberrypi/rpi-imager/releases/tag/v${version}";
     downloadPage = "https://github.com/raspberrypi/rpi-imager/";
     license = licenses.asl20;
     maintainers = with maintainers; [ ymarkus ];

--- a/pkgs/tools/misc/rpi-imager/default.nix
+++ b/pkgs/tools/misc/rpi-imager/default.nix
@@ -50,6 +50,18 @@ stdenv.mkDerivation rec {
     This patch removes the check. */
   patches = [ ./lsblkCheckFix.patch ];
 
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Without this, the tests fail because they cannot create the QT Window
+    export QT_QPA_PLATFORM=offscreen
+    $out/bin/rpi-imager --version
+
+    runHook postInstallCheck
+  '';
+
   passthru = {
     updateScript = nix-update-script { };
   };

--- a/pkgs/tools/misc/rpi-imager/default.nix
+++ b/pkgs/tools/misc/rpi-imager/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/raspberrypi/rpi-imager/releases/tag/v${version}";
     downloadPage = "https://github.com/raspberrypi/rpi-imager/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ymarkus ];
+    maintainers = with maintainers; [ ymarkus anthonyroussel ];
     platforms = platforms.all;
     # does not build on darwin
     broken = stdenv.isDarwin;

--- a/pkgs/tools/misc/rpi-imager/lsblkCheckFix.patch
+++ b/pkgs/tools/misc/rpi-imager/lsblkCheckFix.patch
@@ -1,16 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3d7fc79..8ce72b9 100644
+index 170ce7a..063a137 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -229,11 +229,6 @@ else()
+@@ -332,11 +332,6 @@ else()
          if (NOT LSBLK)
              message(FATAL_ERROR "Unable to locate lsblk (used for disk enumeration)")
          endif()
 -
--        execute_process(COMMAND "${LSBLK}" "--json" RESULT_VARIABLE ret)
+-        execute_process(COMMAND "${LSBLK}" "--json" OUTPUT_QUIET RESULT_VARIABLE ret)
 -        if (ret EQUAL "1")
 -            message(FATAL_ERROR "util-linux package too old. lsblk does not support --json (used for disk enumeration)")
 -        endif()
      endif()
- 
+
      configure_file(


### PR DESCRIPTION
## Description of changes

See https://github.com/raspberrypi/rpi-imager/releases/tag/v1.7.5

Also:

* Lint imports
* Added missing wrapQtAppsHook nativeBuildInputs
* Added myself as package maintainer
* Fixed homepage link
* Added passthru.updateScript
* Added installCheck
* Disable telemetry by default (configurable through enableTelemetry)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
