### PR TITLE
nixos/sddm: avoid systemd-tmpfiles-clean removing user's $XAUTHORITY

### DIFF
--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -267,6 +267,7 @@ in
 
     environment.systemPackages = [ sddm ];
     services.dbus.packages = [ sddm ];
+    systemd.tmpfiles.packages = [ sddm ];
 
     # We're not using the upstream unit, so copy these: https://github.com/sddm/sddm/blob/develop/services/sddm.service.in
     systemd.services.display-manager.after = [


### PR DESCRIPTION
## Description of changes

Include SDDM's shipped `systemd-tmpfiles` configuration file(s) in the ones used by NixOS.

### Motivation

At some point (at or prior to SDDM v20, I think), SDDM started storing the `$XAUTHORITY` files it passes to user sessions under `/tmp/xauth_*`, which is unfortunate, because files under `/tmp` are cleaned up by systemd's default `/etc/tmpfiles.d/tmp.conf` once they're more than 10 days old. The result is that long-running X sessions under SDDM eventually get broken:
```
Aug 23 18:33:02 dreamlogic systemd[1]: Starting Cleanup of Temporary Directories...
Aug 23 18:33:02 dreamlogic systemd[1]: systemd-tmpfiles-clean.service: Deactivated successfully.
Aug 23 18:33:02 dreamlogic systemd[1]: Finished Cleanup of Temporary Directories.
Aug 23 18:33:02 dreamlogic systemd[1]: run-credentials-systemd\x2dtmpfiles\x2dclean.service.mount: Deactivated successfully.
Aug 23 18:33:03 dreamlogic xsession[47394]: Authorization required, but no authorization protocol specified
Aug 23 18:33:04 dreamlogic xsession[47394]: Authorization required, but no authorization protocol specified
Aug 23 18:33:05 dreamlogic xsession[47394]: Authorization required, but no authorization protocol specified
Aug 23 18:33:05 dreamlogic xsession[47394]: Authorization required, but no authorization protocol specified
Aug 23 18:33:05 dreamlogic xsession[47394]: Authorization required, but no authorization protocol specified
```

However, SDDM includes its own `/etc/tmpfiles.d/sddm.conf` file, which (among other things) tells `systemd-tmpfiles` to *only* remove `/tmp/xauth_*` files on bootup (to clean-up files from a previous boot), preventing this from happening.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- ~~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~~
- ~~Tested basic functionality of all binary files (usually in `./result/bin/`)~~
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - ~~(Module updates) Added a release notes entry if the change is significant~~
  - ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

-----

As an aside: if you're on a running system that has been affected by this, and want to recover it *without* restarting X, there's a slightly janky way to achieve this. First, find the X process (check `systemctl status display-manager`, if there's multiple X processes listed I believe the correct one is the first one), look at its arguments, and note down the path given to the `-auth` arg. Then, pass that path to `xauth merge`, e.g. `sudo xauth merge /run/sddm/xauth_FOObar`, and finally change the ownership of your newly-created `$XAUTHORITY` with `sudo chown $(id -u):nogroup $XAUTHORITY`.