### PR TITLE
nixosTests.os-prober: add bintools to the VM

### DIFF
--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -76,6 +76,7 @@ in {
       # nixos-rebuild needs must be included in the VM.
       system.extraDependencies = with pkgs;
         [
+          bintools
           brotli
           brotli.dev
           brotli.lib


### PR DESCRIPTION
## Description of changes

```
machine # warning: error: unable to download 'https://ftpmirror.gnu.org/bash/bash-5.2.tar.gz': Couldn't resolve host name (6); retrying in 329 ms machine # warning: error: unable to download 'https://ftpmirror.gnu.org/bash/bash-5.2.tar.gz': Couldn't resolve host name (6); retrying in 530 ms machine # warning: error: unable to download 'https://ftpmirror.gnu.org/bash/bash-5.2.tar.gz': Couldn't resolve host name (6); retrying in 1066 ms machine # warning: error: unable to download 'https://ftpmirror.gnu.org/bash/bash-5.2.tar.gz': Couldn't resolve host name (6); retrying in 2544 ms machine # [ 1283.199545] GUEST-test1[1465]: [  414.478221] stage-1-init: [Wed Aug 23 13:26:29 UTC 2023] + loadkmap machine # error:
machine #        … writing file '/nix/store/v28dv6l0qk3j382kp40bksa1v6h7dx9p-bash-5.2.tar.gz'
machine #
machine #        error: unable to download 'https://ftpmirror.gnu.org/bash/bash-5.2.tar.gz': Couldn't resolve host name (6)
machine # error: builder for '/nix/store/5jrd75v747s76s16zxk59384xfcjqn58-bash-5.2.tar.gz.drv' failed with exit code 1
machine # error: 1 dependencies of derivation '/nix/store/0cgj4m2h51hjhmz5h4440pd73kv5lm5v-bash-5.2-p15.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/d2x66i0dfv9w81gl1w3nbkn0nz7mawaz-bash-5.2-p15.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/lcz1v3h1nsbyz2fp7xkp113jvyjqq0sx-bash-5.2-p15.drv' failed to build
machine # building '/nix/store/20d5pi1a5i9jj041i0gvr9zcs7bjbw46-binutils-2.40.tar.bz2.drv'...
machine # error: 1 dependencies of derivation '/nix/store/zb0ykvcllgc8l9ki38fdv9n8xp3rnphb-gcc-12.3.0.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/7kxjnzmc79sickp7hiyp8v169idyw8f2-gettext-0.21.1.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/wp7hpglhgwljl3fsfyx8caaakh4a1r72-xgcc-12.3.0.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/f7glbcn7n59k22b911bx1vyy13g4bdxh-binutils-2.40.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/q7yvprjmnqprx743ikkcz4kqx2mjdas4-binutils-wrapper-2.40.drv' failed to build
machine # building '/nix/store/vks3aqqal1rjvrsbj61nl1yh7r5shhdh-builder.pl.drv'...
machine # error: 1 dependencies of derivation '/nix/store/qmdff14r0l31mzx8al7h1kp9h5pck5wr-extra-utils.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/rdlk4188b2jp4ac38w94qazdaxk6sga9-stage-1-init.sh.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/rq15acvd6hcr52a5dlmk1p7mlyzjack0-initrd-linux-6.1.46.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/h1rch2zqjacijnn0szq2hgwmd6v1r1ld-nixos-system-nixos-23.11pre-git.drv' failed to build
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
