### PR TITLE
jack-passthrough: init at 2021-9-25

### DIFF
--- a/pkgs/applications/audio/jack-passthrough/default.nix
+++ b/pkgs/applications/audio/jack-passthrough/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, libjack2
+, meson
+, ninja
+, fmt_9
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jack-passthrough";
+  version = "2021-9-25";
+
+  # https://github.com/guysherman/jack-passthrough
+  src = fetchFromGitHub {
+    owner = "guysherman";
+    repo = finalAttrs.pname;
+    rev = "aad03b7c5ccc4a4dcb8fa38c49aa64cb9d628660";
+    hash = "sha256-9IsNaLW5dYAqiwe+vX0+D3oIKFP2TIfy1q1YaqmS6wE=";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [ fmt_9 libjack2 ];
+
+  meta = with lib; {
+    description = "A simple app to help with JACK apps that behave strangely.";
+    longDescription = ''
+      Creates a JACK passthrough client with an arbitrary name and number of
+      ports. Common uses include tricking stubborn applications into creating
+      more ports than they normally would or to prevent them from
+      auto-connecting to certain things.
+    '';
+    # license unknown: https://github.com/guysherman/jack-passthrough/issues/2
+    license = licenses.unfree;
+    maintainers = [ maintainers.PowerUser64 ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32962,6 +32962,8 @@ with pkgs;
 
   jack_oscrolloscope = callPackage ../applications/audio/jack-oscrolloscope { };
 
+  jack-passthrough = callPackage ../applications/audio/jack-passthrough { };
+
   jack_rack = callPackage ../applications/audio/jack-rack { };
 
   jackmeter = callPackage ../applications/audio/jackmeter { };


### PR DESCRIPTION
## Description of changes

This pull request adds [jack-passthrough](https://github.com/guysherman/jack-passthrough), a tool for wrangling odd JACK clients.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
