### PR TITLE
quark-goldleaf: init at 1.0.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -240,6 +240,7 @@
   ./programs/proxychains.nix
   ./programs/qdmr.nix
   ./programs/qt5ct.nix
+  ./programs/quark-goldleaf.nix
   ./programs/regreet.nix
   ./programs/rog-control-center.nix
   ./programs/rust-motd.nix

--- a/nixos/modules/programs/quark-goldleaf.nix
+++ b/nixos/modules/programs/quark-goldleaf.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.quark-goldleaf;
+in
+{
+  options = {
+    programs.quark-goldleaf = {
+      enable = lib.mkEnableOption "quark-goldleaf with udev rules applied";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.quark-goldleaf ];
+    services.udev.packages = [ pkgs.quark-goldleaf ];
+  };
+
+  meta.maintainers = pkgs.quark-goldleaf.meta.maintainers;
+}

--- a/pkgs/by-name/qu/quark-goldleaf/99-quark-goldleaf.rules
+++ b/pkgs/by-name/qu/quark-goldleaf/99-quark-goldleaf.rules
@@ -1,0 +1,2 @@
+# Nintendo Switch HOS
+SUBSYSTEM=="usb", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="3000", MODE="0666"

--- a/pkgs/by-name/qu/quark-goldleaf/fix-maven-plugin-versions.patch
+++ b/pkgs/by-name/qu/quark-goldleaf/fix-maven-plugin-versions.patch
@@ -1,0 +1,88 @@
+diff --git a/pom.xml b/pom.xml
+index 5a683ca..be71e5d 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -104,7 +105,7 @@
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-compiler-plugin</artifactId>
+-                <version>3.1</version>
++                <version>3.11.0</version>
+                 <configuration>
+                     <source>1.8</source>
+                     <target>1.8</target>
+@@ -113,7 +114,7 @@
+             
+             <plugin>
+                 <artifactId>maven-jar-plugin</artifactId>
+-                <version>2.4</version>
++                <version>3.3.0</version>
+                 <executions>
+                     <execution>
+                         <id>default-jar</id>
+@@ -134,7 +135,7 @@
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-assembly-plugin</artifactId>
+-                <version>3.1.0</version>
++                <version>3.6.0</version>
+                 <configuration>
+                     <finalName>Quark</finalName>
+                     <appendAssemblyId>false</appendAssemblyId>
+@@ -157,6 +158,56 @@
+                     </execution>
+                 </executions>
+             </plugin>
++
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-enforcer-plugin</artifactId>
++                <version>3.3.0</version>
++                <executions>
++                    <execution>
++                        <id>require-all-plugin-versions-to-be-set</id>
++                        <phase>validate</phase>
++                        <goals>
++                            <goal>enforce</goal>
++                        </goals>
++                        <configuration>
++                            <rules>
++                                <requirePluginVersions />
++                            </rules>
++                        </configuration>
++                    </execution>
++                </executions>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-deploy-plugin</artifactId>
++                <version>3.1.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-resources-plugin</artifactId>
++                <version>3.3.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-site-plugin</artifactId>
++                <version>4.0.0-M9</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-install-plugin</artifactId>
++                <version>3.1.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-clean-plugin</artifactId>
++                <version>3.3.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-surefire-plugin</artifactId>
++                <version>3.1.2</version>
++            </plugin>
+         </plugins>
+     </build>
+ 

--- a/pkgs/by-name/qu/quark-goldleaf/package.nix
+++ b/pkgs/by-name/qu/quark-goldleaf/package.nix
@@ -1,0 +1,114 @@
+{ lib
+, jdk
+, maven
+, fetchFromGitHub
+, fetchpatch
+, makeDesktopItem
+, copyDesktopItems
+, imagemagick
+, wrapGAppsHook
+, gtk3
+}:
+
+let
+  jdk' = jdk.override { enableJavaFX = true; };
+  maven' = maven.override { jdk = jdk'; };
+in
+maven'.buildMavenPackage rec {
+  pname = "quark-goldleaf";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "XorTroll";
+    repo = "Goldleaf";
+    rev = version;
+    hash = "sha256-gagIQGOiygJ0Onm0SrkbFWaovqWX2WJNx7LpSRheCLM=";
+  };
+
+  sourceRoot = "${src.name}/Quark";
+
+  patches = [
+    ./fix-maven-plugin-versions.patch
+    ./remove-pom-jfx.patch
+    (fetchpatch {
+      name = "fix-config-path.patch";
+      url = "https://github.com/XorTroll/Goldleaf/commit/714ecc2755df9c1252615ad02cafff9c0311a739.patch";
+      hash = "sha256-4j+6uLIOdltZ4XIb3OtOzZg9ReH9660gZMMNQpHnn4o=";
+      relative = "Quark";
+    })
+  ];
+
+  mvnHash = "sha256-gA3HsQZFa2POP9cyJLb1l8t3hrJYzDowhJU+5Xl79p4=";
+
+  # set fixed build timestamp for deterministic jar
+  mvnParameters = "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z";
+
+  nativeBuildInputs = [
+    imagemagick # for icon conversion
+    copyDesktopItems
+    wrapGAppsHook
+  ];
+
+  buildInputs = [ gtk3 ];
+
+  # don't double-wrap
+  dontWrapGApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ${./99-quark-goldleaf.rules} $out/etc/udev/rules.d/99-quark-goldleaf.rules
+    install -Dm644 target/Quark.jar $out/share/java/quark-goldleaf.jar
+
+    for size in 16 24 32 48 64 128; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert -resize "$size"x"$size" src/main/resources/Icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/quark-goldleaf.png
+    done
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    # This is in postFixup because gappsWrapperArgs are generated during preFixup
+    makeWrapper ${jdk'}/bin/java $out/bin/quark-goldleaf \
+        "''${gappsWrapperArgs[@]}" \
+        --add-flags "-jar $out/share/java/quark-goldleaf.jar"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "quark-goldleaf";
+      exec = "quark-goldleaf";
+      icon = "quark-goldleaf";
+      desktopName = "Quark";
+      comment = meta.description;
+      terminal = false;
+      categories = [ "Utility" "FileTransfer" ];
+      keywords = [ "nintendo" "switch" "goldleaf" ];
+    })
+  ];
+
+  meta = {
+    changelog = "https://github.com/XorTroll/Goldleaf/releases/tag/${src.rev}";
+    description = "A GUI tool for transfering files between a computer and a Nintendo Switch running Goldleaf";
+    homepage = "https://github.com/XorTroll/Goldleaf#quark-and-remote-browsing";
+    longDescription = ''
+      ${meta.description}
+
+      For the program to work properly, you will have to install Nintendo Switch udev rules.
+
+      You can either do this by enabling the NixOS module:
+
+      `programs.quark-goldleaf.enable = true;`
+
+      or by adding the package manually to udev packages:
+
+      `services.udev.packages = [ pkgs.quark-goldleaf ];
+    '';
+    license = lib.licenses.gpl3Only;
+    mainProgram = "quark-goldleaf";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+}
+

--- a/pkgs/by-name/qu/quark-goldleaf/remove-pom-jfx.patch
+++ b/pkgs/by-name/qu/quark-goldleaf/remove-pom-jfx.patch
@@ -1,0 +1,93 @@
+diff --git a/pom.xml b/pom.xml
+index 51ce56b..44dcd09 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -15,72 +15,6 @@
+   </properties>
+ 
+     <dependencies>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-controls</artifactId>
+-            <version>17</version>
+-            <classifier>linux</classifier>
+-            <scope>compile</scope>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-controls</artifactId>
+-            <version>17</version>
+-            <classifier>win</classifier>
+-            <scope>compile</scope>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-controls</artifactId>
+-            <version>17</version>
+-            <classifier>mac</classifier>
+-            <scope>compile</scope>
+-        </dependency>
+-
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-fxml</artifactId>
+-            <version>17</version>
+-            <classifier>linux</classifier>
+-            <scope>compile</scope> 
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-fxml</artifactId>
+-            <version>17</version>
+-            <classifier>win</classifier>
+-            <scope>compile</scope> 
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-fxml</artifactId>
+-            <version>17</version>
+-            <classifier>mac</classifier>
+-            <scope>compile</scope> 
+-        </dependency>
+-
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-graphics</artifactId>
+-            <version>17</version>
+-            <classifier>linux</classifier>
+-            <scope>compile</scope>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-graphics</artifactId>
+-            <version>17</version>
+-            <classifier>win</classifier>
+-            <scope>compile</scope>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-graphics</artifactId>
+-            <version>17</version>
+-            <classifier>mac</classifier>
+-            <scope>compile</scope>
+-        </dependency>
+-
+         <dependency>
+             <groupId>org.usb4java</groupId>
+             <artifactId>usb4java-javax</artifactId>
+@@ -123,15 +57,6 @@
+                 </executions>
+             </plugin>
+             
+-            <plugin>
+-                <groupId>org.openjfx</groupId>
+-                <artifactId>javafx-maven-plugin</artifactId>
+-                <version>0.0.8</version>
+-                <configuration>
+-                    <mainClass>xortroll.goldleaf.quark.Main</mainClass>
+-                </configuration>
+-            </plugin>
+-
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
## Description of changes

This PR adds 1 package: `quark-goldleaf`
and 1 nixos module: `programs.quark-goldleaf`

This package is used for sending files between a PC and the Nintendo Switch

The actual program's name is `Quark`, however as there is already a package called `quark`.
I called this one `quark-goldleaf`, as this program was made for communicating with Goldleaf.

Link to Goldleaf's repo: https://github.com/XorTroll/Goldleaf/

The PR also adds a `udev` rule which allows the Nintendo Switch to be detected by Quark.

I found that if you disconnect and then reconnect the Nintendo Switch, only by using `MODE="0666"` will it work without rebooting the PC.

---

I saw that there have been some problems regarding deterministic builds with other maven packages.

After some research, I found that reproducible builds were first added in `maven-assembly-plugin:3.2.0` ([link](https://github.com/apache/maven-assembly-plugin/commit/d5e01847897324ba5fa2f7bfa9e025ef2f1444ed))
Also, had to set the `project.build.outputTimestamp`.
It seems like this did the job, as doing `nix build .#quark-goldleaf --rebuild` didn't complain anymore.

---

I overrode the `maven`'s `jdk` to include the nix-provided `javafx`, so that I could remove the mentions of `javafx` from `pom.xml`. This way the maven deps hash doesn't differ between platforms.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
