### PR TITLE
cfspeedtest: init at 1.1.2

### DIFF
--- a/pkgs/tools/networking/cfspeedtest/default.nix
+++ b/pkgs/tools/networking/cfspeedtest/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cfspeedtest";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "code-inflation";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-uQe9apG4SdFEUT2aOrzF2C8bbrl0fOiqnMZrWDQvbxk=";
+  };
+
+  cargoSha256 = "sha256-wJmLUPXGSg90R92iW9R02r3E3e7XU1gJwd8IqIC+QMA=";
+
+  meta = with lib; {
+    description = "Unofficial CLI for speed.cloudflare.com";
+    homepage = "https://github.com/code-inflation/cfspeedtest";
+    license = with licenses; [ mit ];
+    broken = stdenv.isDarwin;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1699,6 +1699,8 @@ with pkgs;
 
   cf-vault = callPackage ../tools/admin/cf-vault { };
 
+  cfspeedtest = callPackage ../tools/networking/cfspeedtest { };
+
   cfonts = callPackage ../tools/misc/cfonts { };
 
   bikeshed = python3Packages.callPackage ../applications/misc/bikeshed { };


### PR DESCRIPTION
## Description of changes

Repo: https://github.com/code-inflation/cfspeedtest

Example usage:
```
╭ zeph  ~/code/nixpkgs/cmpkgs 6sec 997ms
╰─▶ nix build .#legacyPackages.x86_64-linux.cfspeedtest
warning: Git tree '/home/cole/code/nixpkgs/cmpkgs' is dirty

╭ zeph  ~/code/nixpkgs/cmpkgs 1min 577ms
╰─▶ ./result/bin/cfspeedtest
Starting Cloudflare speed test
City: Topeka
Country: US
Ip: 72.209.157.122
Asn: 22773
Colo: DFW
latency test    [==============================]
Avg GET request latency 31.94 ms (RTT excluding server processing time)

Download 100KB  [==============================]  217.33 mbit/s | 100KB in    3ms -> status: 200 OK
Download 1MB    [==============================]  557.26 mbit/s |   1MB in   14ms -> status: 200 OK
Download 10MB   [==============================]  588.01 mbit/s |  10MB in  136ms -> status: 200 OK
Upload 100KB    [==============================]   15.48 mbit/s | 100KB in   51ms -> status: 200 OK
Upload 1MB      [==============================]   11.42 mbit/s |   1MB in  700ms -> status: 200 OK
Upload 10MB     [==============================]   11.37 mbit/s |  10MB in 7037ms -> status: 200 OK

Summary Statistics
Type     Payload |  min/max/avg in mbit/s
Download  100KB  |  min 25.09   max 233.08  avg 182.01
Download  1MB    |  min 135.59  max 575.61  avg 491.48
Download  10MB   |  min 417.01  max 596.38  avg 513.49
Upload    100KB  |  min 6.40    max 15.48   avg 11.27
Upload    1MB    |  min 11.30   max 26.55   avg 13.38
Upload    10MB   |  min 11.08   max 11.45   avg 11.32

```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
