### PR TITLE
blackshades: 2.4.9 -> 2.5.1

### DIFF
--- a/pkgs/games/blackshades/default.nix
+++ b/pkgs/games/blackshades/default.nix
@@ -6,22 +6,22 @@
 , libGLU
 , libsndfile
 , openal
-, zig_0_9
+, zig_0_11
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "blackshades";
-  version = "2.4.9";
+  version = "2.5.1";
 
   src = fetchFromSourcehut {
     owner = "~cnx";
     repo = "blackshades";
     rev = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-Hg+VcWI28GzY/CPm1lUftP0RGztOnzizrKJQVTmeJ9I=";
+    hash = "sha256-qdpXpuXHr9w2XMfgOVveWv3JoqdJHVB8TCqZdyaw/DM=";
   };
 
-  nativeBuildInputs = [ zig_0_9.hook ];
+  nativeBuildInputs = [ zig_0_11.hook ];
 
   buildInputs = [
     glfw
@@ -34,6 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://sr.ht/~cnx/blackshades";
     description = "A psychic bodyguard FPS";
+    changelog = "https://git.sr.ht/~cnx/blackshades/refs/${finalAttrs.version}";
+    mainProgram = "blackshades";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ McSinyx viric ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
## Description of changes

[Compatibility update for the latest Zig compiler with a few bug fixes](https://git.sr.ht/~cnx/blackshades/refs/2.5.1)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).