### PR TITLE
qemu-utils: copy from qemu_kvm, not qemu

### DIFF
--- a/pkgs/applications/virtualization/qemu/utils.nix
+++ b/pkgs/applications/virtualization/qemu/utils.nix
@@ -1,24 +1,24 @@
-{ stdenv, installShellFiles, qemu, removeReferencesTo }:
+{ stdenv, installShellFiles, qemu_kvm, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
   pname = "qemu-utils";
-  inherit (qemu) version;
+  inherit (qemu_kvm) version;
 
   nativeBuildInputs = [ installShellFiles ];
-  buildInputs = [ qemu ];
-  disallowedRequisites = [ qemu ];
+  buildInputs = [ qemu_kvm ];
+  disallowedRequisites = [ qemu_kvm ];
   unpackPhase = "true";
 
   installPhase = ''
     mkdir -p "$out/bin"
-    cp "${qemu}/bin/qemu-img" "$out/bin/qemu-img"
-    cp "${qemu}/bin/qemu-io"  "$out/bin/qemu-io"
-    cp "${qemu}/bin/qemu-nbd" "$out/bin/qemu-nbd"
-    ${removeReferencesTo}/bin/remove-references-to -t ${qemu} $out/bin/*
+    cp "${qemu_kvm}/bin/qemu-img" "$out/bin/qemu-img"
+    cp "${qemu_kvm}/bin/qemu-io"  "$out/bin/qemu-io"
+    cp "${qemu_kvm}/bin/qemu-nbd" "$out/bin/qemu-nbd"
+    ${removeReferencesTo}/bin/remove-references-to -t ${qemu_kvm} $out/bin/*
 
-    installManPage ${qemu}/share/man/man1/qemu-img.1.gz
-    installManPage ${qemu}/share/man/man8/qemu-nbd.8.gz
+    installManPage ${qemu_kvm}/share/man/man1/qemu-img.1.gz
+    installManPage ${qemu_kvm}/share/man/man8/qemu-nbd.8.gz
   '';
 
-  inherit (qemu) meta;
+  inherit (qemu_kvm) meta;
 }


### PR DESCRIPTION
## Description of changes

qemu_kvm is a much smaller build, so it's nicer if you're building qemu-utils specifically.  None of the tools depend on the emulation targets disabled in qemu_kvm.

The tools are copied, not linked, so we don't have to worry about potentially depending on both qemu_kvm and qemu in a bigger derivation, and qemu_kvm is already built by Hydra, so there's no increase in Hydra workload by using the variant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
