### PR TITLE
Set meta.mainProgram for grimshot, pulsemixer, unzip, vlock

### DIFF
--- a/pkgs/applications/window-managers/sway/contrib.nix
+++ b/pkgs/applications/window-managers/sway/contrib.nix
@@ -73,6 +73,7 @@ grimshot = stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A helper for screenshots within sway";
     maintainers = with maintainers; [ evils ];
+    mainProgram = "grimshot";
   };
 };
 

--- a/pkgs/misc/screensavers/vlock/default.nix
+++ b/pkgs/misc/screensavers/vlock/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ ];
     platforms = platforms.linux;
+    mainProgram = "vlock";
   };
 }

--- a/pkgs/tools/archivers/unzip/default.nix
+++ b/pkgs/tools/archivers/unzip/default.nix
@@ -102,5 +102,6 @@ stdenv.mkDerivation rec {
     description = "An extraction utility for archives compressed in .zip format";
     license = lib.licenses.free; # http://www.info-zip.org/license.html
     platforms = lib.platforms.all;
+    mainProgram = "unzip";
   };
 }

--- a/pkgs/tools/audio/pulsemixer/default.nix
+++ b/pkgs/tools/audio/pulsemixer/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = [ maintainers.woffs ];
     platforms = platforms.all;
+    mainProgram = "pulsemixer";
   };
 }


### PR DESCRIPTION
## Description of changes

Adds `meta.mainPackage` on the following derivations: `grimshot`, `pulsemixer`, `unzip`, and `vlock`.

Since recently, `lib.getExe` warns when that metadata is missing, rather than assume the derivation's main program is eponymous.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
