### PR TITLE
qcard: init at 0.7.1

### DIFF
--- a/pkgs/tools/networking/qcal/default.nix
+++ b/pkgs/tools/networking/qcal/default.nix
@@ -18,12 +18,12 @@ buildGoModule rec {
   # to that config file in the nix store
   preBuild = ''
     substituteInPlace helpers.go \
-      --replace " config-sample.json " " $out/share/config-sample.json "
+      --replace " config-sample.json " " $out/share/qcal/config-sample.json "
   '';
 
   postInstall = ''
-    mkdir -p $out/share
-    cp config-sample.json $out/share/
+    mkdir -p $out/share/qcal
+    cp config-sample.json $out/share/qcal/
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/qcard/default.nix
+++ b/pkgs/tools/networking/qcard/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+}:
+
+buildGoModule rec {
+  pname = "qcard";
+  version = "0.7.1";
+
+  src = fetchFromSourcehut {
+    owner = "~psic4t";
+    repo = "qcard";
+    rev = version;
+    hash = "sha256-OwmJSeAOZTX7jMhoLHSIJa0jR8zCadISQF/PqFqltRY=";
+  };
+
+  vendorHash = null;
+
+  # Replace "config-sample.json" in error message with the absolute path
+  # to that config file in the nix store
+  preBuild = ''
+    substituteInPlace helpers.go \
+      --replace " config-sample.json " " $out/share/qcard/config-sample.json "
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/qcard
+    cp config-sample.json $out/share/qcard/
+  '';
+
+  meta = {
+    description = "CLI addressbook application for CardDAV servers written in Go";
+    homepage = "https://git.sr.ht/~psic4t/qcard";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "qcard";
+    maintainers = with lib.maintainers; [ antonmosich ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27268,6 +27268,8 @@ with pkgs;
 
   qcal = callPackage ../tools/networking/qcal/default.nix { };
 
+  qcard = callPackage ../tools/networking/qcard { };
+
   rake = callPackage ../development/tools/build-managers/rake { };
 
   rakkess = callPackage ../development/tools/rakkess { };


### PR DESCRIPTION
## Description of changes
`qcard` is the sibling of qcal, which was added in #246058 . While qcal is for calendars, qcard manages, shows, edits and searches contacts.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
