### PR TITLE
odoo: 15.0.20230317->15.020230816 fix broken fetcher

### DIFF
--- a/pkgs/applications/finance/odoo/default.nix
+++ b/pkgs/applications/finance/odoo/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchurl
+, fetchzip
 , python310
 , nodePackages
 , wkhtmltopdf
@@ -53,16 +53,11 @@ in python.pkgs.buildPythonApplication rec {
   format = "setuptools";
 
   # latest release is at https://github.com/odoo/docker/blob/master/16.0/Dockerfile
-  src = fetchurl {
-    url = "https://nightly.odoo.com/${odoo_version}/nightly/src/odoo_${version}.tar.gz";
+  src = fetchzip {
+    url = "https://nightly.odoo.com/${odoo_version}/nightly/src/odoo_${version}.zip";
     name = "${pname}-${version}";
-    hash = "sha256-DV5JBY+2gq5mUfcvN9S5xkd+ufgEBjvyvBY1X7pPFPk="; # odoo
+    hash = "sha256-pSycpYSiqJ6DKENvCWwLz+JaPUXT5dmaq8x4Aency60="; # odoo
   };
-
-  unpackPhase = ''
-    tar xfz $src
-    cd odoo*
-  '';
 
   # needs some investigation
   doCheck = false;

--- a/pkgs/applications/finance/odoo/odoo15.nix
+++ b/pkgs/applications/finance/odoo/odoo15.nix
@@ -109,7 +109,6 @@ in python.pkgs.buildPythonApplication rec {
   dontStrip = true;
 
   passthru = {
-    updateScript = ./update.sh;
     tests = { inherit (nixosTests) odoo15; };
   };
 

--- a/pkgs/applications/finance/odoo/odoo15.nix
+++ b/pkgs/applications/finance/odoo/odoo15.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchurl, python310, nodePackages, wkhtmltopdf
+{ stdenv, lib, fetchFromGitHub, fetchzip, python310, nodePackages, wkhtmltopdf
 , nixosTests }:
 
 let
@@ -38,7 +38,7 @@ let
   };
 
   odoo_version = "15.0";
-  odoo_release = "20230720";
+  odoo_release = "20230816";
 in python.pkgs.buildPythonApplication rec {
   pname = "odoo15";
   version = "${odoo_version}.${odoo_release}";
@@ -46,17 +46,11 @@ in python.pkgs.buildPythonApplication rec {
   format = "setuptools";
 
   # latest release is at https://github.com/odoo/docker/blob/master/15.0/Dockerfile
-  src = fetchurl {
-    url =
-      "https://nightly.odoo.com/${odoo_version}/nightly/src/odoo_${version}.tar.gz";
+  src = fetchzip {
+    url = "https://nightly.odoo.com/${odoo_version}/nightly/src/odoo_${version}.zip";
     name = "${pname}-${version}";
-    hash = "sha256-XH4cN2OrPvMjN3VcDJFxCacNxKkrN65jwhUN1dnGwgo="; # odoo
+    hash = "sha256-h81JA0o44DVtl/bZ52rGQfg54TigwQcNpcMjQbi0zIQ="; # odoo
   };
-
-  unpackPhase = ''
-    tar xfz $src
-    cd odoo*
-  '';
 
   # needs some investigation
   doCheck = false;

--- a/pkgs/applications/finance/odoo/update.sh
+++ b/pkgs/applications/finance/odoo/update.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused nix coreutils
+#!nix-shell -i bash -p curl gnused nix coreutils nix-prefetch
 
 set -euo pipefail
 
-DOCKER=$(curl -s https://raw.githubusercontent.com/odoo/docker/master/15.0/Dockerfile)
+DOCKER=$(curl -s https://raw.githubusercontent.com/odoo/docker/master/16.0/Dockerfile)
 
 get_var() {
   echo "$DOCKER" | grep -E "^[A-Z][A-Z][A-Z] ODOO_$1" | sed -r "s|^[A-Z]{3} ODOO_$1.||g"
@@ -22,6 +22,6 @@ fi
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-sed -ri "s| hash.+ # odoo| hash = \"$(nix-prefetch-url --type sha256 "https://nightly.odoo.com/${VERSION}/nightly/src/odoo_${latestVersion}.tar.gz")\"; # odoo|g" default.nix
+sed -ri "s| hash.+ # odoo| hash = \"$(nix-prefetch -q fetchzip --url "https://nightly.odoo.com/${VERSION}/nightly/src/odoo_${latestVersion}.zip")\"; # odoo|g" default.nix
 sed -ri "s| odoo_version.+| odoo_version = \"$VERSION\";|" default.nix
 sed -ri "s| odoo_release.+| odoo_release = \"$RELEASE\";|" default.nix


### PR DESCRIPTION


## Description of changes

Upstream seems to publish and retain `.zip` more consistently than `.tar.gz`, which caused the previous expression to break. This modifies the odoo package and updater script to use the `zip` sources.

## Things done

Switch from `fetchurl` to `fetchzip`.  Change update switch to use `nix-prefetch fetchzip`.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
