### PR TITLE
chromium: add widevine support on aarch64

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/glibc-no-relr-check.patch
+++ b/pkgs/applications/networking/browsers/chromium/glibc-no-relr-check.patch
@@ -1,0 +1,13 @@
+diff --git a/elf/dl-version.c b/elf/dl-version.c
+index 5b8693de04..c2bb39bc57 100644
+--- a/elf/dl-version.c
++++ b/elf/dl-version.c
+@@ -362,7 +362,7 @@ _dl_check_map_versions (struct link_map *map, int verbose, int trace_mode)
+   /* When there is a DT_VERNEED entry with libc.so on DT_NEEDED, issue
+      an error if there is a DT_RELR entry without GLIBC_ABI_DT_RELR
+      dependency.  */
+-  if (dyn != NULL
++  if (0 && dyn != NULL
+       && map->l_info[DT_NEEDED] != NULL
+       && map->l_info[DT_RELR] != NULL
+       && __glibc_unlikely (!map->l_dt_relr_ref))


### PR DESCRIPTION
## Description of changes

I packaged the arm64 build of widevine for chromium. The main weirdness here is widevine is built with DT_RELR relocations, which our version of glibc *does* support, but it checks for a particular symbol GLIBC_ABI_DT_RELR as a sort of compatibility flag. This widevine build doesn't have that flag, for what I understand to be ChromeOS reasons, so chromium fails to load the lib at startup. The fix I went with was to disable that check, as boldly copied from [here](https://thebrokenrail.com/2022/12/31/xfinity-stream-on-linux.html#how-do-i-actually-do-this). Another possibility would be to hand-patch that compatibility symbol into the widevine .so's, but I'm not sure where to start with that or how we'd carry that as a patch.

The main issue with this patch as it stands is by my understanding Hydra won't build/cache the patched glibc since it's not exposed anywhere, so users are stuck building glibc on their raspis or whatever. Alternatives that I know of would be to either expose the patched glibc as a package, or to just pull that patch into our glibc everywhere. My understanding is that wouldn't break anything (DT_RELR works the same way whether GLIBC_ABI_DT_RELR is present or not), but it's probably still more invasive than this warrants. I'd like to hear folks' thoughts on the best approach there.

The other issue is the widevine version/hash being inline when the other downloads are updateable through upstream-info.nix. I'm open to suggestions there.

Fixes https://github.com/NixOS/nixpkgs/issues/220828

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux - confirmed derivation unchanged
  - [x] aarch64-linux - confirmed working on netflix/hbo
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

