### PR TITLE
zerotierone: 1.10.6 -> 1.12.0

### DIFF
--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -2,10 +2,8 @@
 , stdenv
 , rustPlatform
 , fetchFromGitHub
-
 , buildPackages
 , cargo
-, iproute2
 , lzo
 , openssl
 , pkg-config
@@ -16,13 +14,13 @@
 
 let
   pname = "zerotierone";
-  version = "1.10.6";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "zerotier";
     repo = "ZeroTierOne";
     rev = version;
-    sha256 = "sha256-mapFKeF+8jMGkxSuHaw5oUdTdSQgAdxEwF/S6iyVLbY=";
+    sha256 = "sha256-O1KRclWyLu23cbnz97CDExmE3Gv8yaK8IoFKM2Ix4y0=";
   };
 
 in stdenv.mkDerivation {
@@ -62,8 +60,6 @@ in stdenv.mkDerivation {
     lzo
     openssl
     zlib
-  ] ++ lib.optional stdenv.isLinux [
-    iproute2
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Also removes obsolete iproute2 dependency

## Description of changes

ZeroTier 1.12 changelog: https://github.com/zerotier/ZeroTierOne/releases/tag/1.12.0

Major changes: improved time to recovery on sleep/wake and default route changes, and export of Prometheus-compatible metrics

## Things done

Updated version + SHA-256 values, removed obsolete `iproute2` dependency

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
