### PR TITLE
waybar: enable experimental features

### DIFF
--- a/pkgs/applications/misc/waybar/default.nix
+++ b/pkgs/applications/misc/waybar/default.nix
@@ -44,6 +44,7 @@
 
 , cavaSupport ? true
 , evdevSupport ? true
+, experimentalPatches ? true
 , hyprlandSupport ? true
 , inputSupport ? true
 , jackSupport ? true
@@ -162,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
     "tests" = runTests;
     "upower_glib" = upowerSupport;
     "wireplumber" = wireplumberSupport;
-  });
+  }) ++ lib.optional experimentalPatches (lib.mesonBool "experimental" true);
 
   preFixup = lib.optionalString withMediaPlayer ''
     cp $src/resources/custom_modules/mediaplayer.py $out/bin/waybar-mediaplayer.py


### PR DESCRIPTION
This addresses my concerns in https://github.com/NixOS/nixpkgs/pull/250551 by doing the following:

- Adds an experimentalPatches option to waybar to optionally enable experimental features of waybar, such as but (probably) not limited to wlr/workspaces

- Adds a waybar-experimental package that comes with experimentalPatches enabled, mainly to allow caching by hydra instead of forcing users to build it themselves

Without experimentalPatches (a.k.a experimental meson flag), users are forced into using `hyprland/workspaces` which is, at the moment, a below par replacement to previously standard `wlr/workspaces`. Additionally, if a single waybar configuration is shared between two separated wlroots compositors the users also left without a viable solution.


Ideally we would want to enable experimental patches by default because *why wouldn't we?* but I assumed it would be against some obscure nixpkgs idiom I haven't heard about.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
