### PR TITLE
azure-cli: use overridePythonAttrs for overrides

### DIFF
--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -5,7 +5,7 @@ let
 
   overrideAzureMgmtPackage = package: version: extension: hash:
     # check to make sure overriding is even necessary
-    package.overrideAttrs(oldAttrs: rec {
+    package.overridePythonAttrs(oldAttrs: rec {
       inherit version;
 
       src = fetchPypi {


### PR DESCRIPTION
## Description of changes

It looks like azure-cli overrides the mgmt package versions, but it does so using `overrideAttrs` (which only affects the internal `stdenv.mkDerivation`) instead of `overridePythonAttrs` (which also affects the `buildPythonPackage` magic)

This indirectly fixes the azure-cli failure after #250560 where the extension was changed from `.zip` to `.tar.gz`, but azure-cli was forcing the old `.zip` `src`. Because it wasn't overriding the `buildPythonPackage` attrs, it didn't include `unzip` in `nativeBuildInputs`, since `buildPythonPackage` only adds it when the `src` that _it_ uses ends in `.zip` (and before this PR `azure-cli` was only changing the inner `mkDerivation` logic, after that would have happened)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).