### PR TITLE
nixos/seatd: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15678,6 +15678,13 @@
     githubId = 2770647;
     name = "Simon Vandel Sillesen";
   };
+  sinanmohd = {
+    name = "Sinan Mohd";
+    email = "sinan@firemail.cc";
+    matrix = "@sinan:sinanmohd.com";
+    github = "sinanmohd";
+    githubId = 69694713;
+  };
   sioodmy = {
     name = "Antoni Sokołowski";
     github = "sioodmy";

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -22,6 +22,8 @@
 
 - [hddfancontrol](https://github.com/desbma/hddfancontrol), a service to regulate fan speeds based on hard drive temperature. Available as [services.hddfancontrol](#opt-services.hddfancontrol.enable).
 
+- [seatd](https://sr.ht/~kennylevinsen/seatd/), A minimal seat management daemon. Available as [services.seatd](#opt-services.seatd.enable).
+
 - [GoToSocial](https://gotosocial.org/), an ActivityPub social network server, written in Golang. Available as [services.gotosocial](#opt-services.gotosocial.enable).
 
 - [Typesense](https://github.com/typesense/typesense), a fast, typo-tolerant search engine for building delightful search experiences. Available as [services.typesense](#opt-services.typesense.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -461,6 +461,7 @@
   ./services/desktops/pipewire/pipewire.nix
   ./services/desktops/pipewire/wireplumber.nix
   ./services/desktops/profile-sync-daemon.nix
+  ./services/desktops/seatd.nix
   ./services/desktops/system-config-printer.nix
   ./services/desktops/system76-scheduler.nix
   ./services/desktops/telepathy.nix

--- a/nixos/modules/services/desktops/seatd.nix
+++ b/nixos/modules/services/desktops/seatd.nix
@@ -28,7 +28,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = with pkgs; [ seatd ];
+    environment.systemPackages = with pkgs; [ seatd sdnotify-wrapper ];
     users.groups.seat = lib.mkIf (cfg.group == "seat") {};
 
     systemd.services.seatd = {
@@ -39,8 +39,10 @@ in
       restartIfChanged = false;
 
       serviceConfig = {
-        Type = "simple";
-        ExecStart = "${pkgs.seatd.bin}/bin/seatd -u ${cfg.user} -g ${cfg.group} -l ${cfg.logLevel}";
+        Type = "notify";
+        NotifyAccess = "all";
+        SyslogIdentifier = "seatd";
+        ExecStart = "${pkgs.sdnotify-wrapper}/bin/sdnotify-wrapper ${pkgs.seatd.bin}/bin/seatd -n 1 -u ${cfg.user} -g ${cfg.group} -l ${cfg.logLevel}";
         RestartSec = 1;
         Restart = "always";
       };

--- a/nixos/modules/services/desktops/seatd.nix
+++ b/nixos/modules/services/desktops/seatd.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.seatd;
+  inherit (lib) mkEnableOption mkOption mdDoc types;
+in
+{
+  meta.maintainers = with lib.maintainers; [ sinanmohd ];
+
+  options.services.seatd = {
+    enable = mkEnableOption (mdDoc "seatd");
+
+    user = mkOption {
+      type = types.str;
+      default = "root";
+      description = mdDoc "User to own the seatd socket";
+    };
+    group = mkOption {
+      type = types.str;
+      default = "seat";
+      description = mdDoc "Group to own the seatd socket";
+    };
+    logLevel = mkOption {
+      type = types.enum [ "debug" "info" "error" "silent" ];
+      default = "info";
+      description = mdDoc "Logging verbosity";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ seatd ];
+    users.groups.seat = lib.mkIf (cfg.group == "seat") {};
+
+    systemd.services.seatd = {
+      description = "Seat management daemon";
+      documentation = [ "man:seatd(1)" ];
+
+      wantedBy = [ "multi-user.target" ];
+      restartIfChanged = false;
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.seatd.bin}/bin/seatd -u ${cfg.user} -g ${cfg.group} -l ${cfg.logLevel}";
+        RestartSec = 1;
+        Restart = "always";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -697,6 +697,7 @@ in {
   sddm = handleTest ./sddm.nix {};
   seafile = handleTest ./seafile.nix {};
   searx = handleTest ./searx.nix {};
+  seatd = handleTest ./seatd.nix {};
   service-runner = handleTest ./service-runner.nix {};
   sftpgo = runTest ./sftpgo.nix;
   sfxr-qt = handleTest ./sfxr-qt.nix {};

--- a/nixos/tests/seatd.nix
+++ b/nixos/tests/seatd.nix
@@ -1,0 +1,51 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+
+let
+  seatd-test = pkgs.writeShellApplication {
+    name = "seatd-client-pid";
+    text = ''
+      journalctl -u seatd --no-pager -b | while read -r line; do
+          case "$line" in
+          *"New client connected"*)
+              line="''${line##*pid: }"
+              pid="''${line%%,*}"
+              ;;
+          *"Opened client"*)
+              echo "$pid"
+              exit
+          esac
+      done;
+    '';
+  };
+in
+{
+  name = "seatd";
+  meta.maintainers = with lib.maintainers; [ sinanmohd ];
+
+  nodes.machine = { ... }: {
+    imports = [ ./common/user-account.nix ];
+    services.getty.autologinUser = "alice";
+    users.users.alice.extraGroups = [ "seat" "wheel" ];
+
+    fonts.enableDefaultPackages = true;
+    environment.systemPackages = with pkgs; [
+      dwl
+      foot
+      seatd-test
+    ];
+
+    programs.bash.loginShellInit = ''
+      [ "$(tty)" = "/dev/tty1" ] &&
+          dwl -s 'foot touch /tmp/foot_started'
+    '';
+
+    hardware.opengl.enable = true;
+    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+    services.seatd.enable = true;
+  };
+
+  testScript = ''
+    machine.wait_for_file("/tmp/foot_started")
+    machine.succeed("test $(seatd-client-pid) = $(pgrep dwl)")
+  '';
+})

--- a/pkgs/applications/misc/seatd/default.nix
+++ b/pkgs/applications/misc/seatd/default.nix
@@ -6,6 +6,7 @@
 , scdoc
 , stdenv
 , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
+, nixosTests
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dlibseat-builtin=enabled"
     "-Dserver=enabled"
   ];
+
+  passthru.tests.basic = nixosTests.seatd;
 
   meta = {
     description = "A minimal seat management daemon, and a universal seat management library";

--- a/pkgs/applications/misc/seatd/default.nix
+++ b/pkgs/applications/misc/seatd/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    description = "A universal seat management library";
+    description = "A minimal seat management daemon, and a universal seat management library";
     changelog = "https://git.sr.ht/~kennylevinsen/seatd/refs/${finalAttrs.version}";
     homepage = "https://sr.ht/~kennylevinsen/seatd/";
     license = lib.licenses.mit;


### PR DESCRIPTION
## Description of changes

add support for the seatd daemon, this allows wayland compositors like
hyprland, dwl, river, and sway to be ran without root privileges and polkit

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
