### PR TITLE
hddfancontrol: license and metadata tweaks

### DIFF
--- a/nixos/modules/services/hardware/hddfancontrol.nix
+++ b/nixos/modules/services/hardware/hddfancontrol.nix
@@ -8,7 +8,7 @@ in
 {
   options = {
 
-    services.hddfancontrol.enable = lib.mkEnableOption "hddfancontrol daemon";
+    services.hddfancontrol.enable = lib.mkEnableOption (lib.mdDoc "hddfancontrol daemon");
 
     services.hddfancontrol.disks = lib.mkOption {
       type = with types; listOf path;
@@ -58,7 +58,6 @@ in
       systemd.packages = [pkgs.hddfancontrol];
 
       systemd.services.hddfancontrol = {
-        enable = true;
         wantedBy = [ "multi-user.target" ];
         environment.HDDFANCONTROL_ARGS = lib.escapeShellArgs args;
       };

--- a/pkgs/tools/system/hddfancontrol/default.nix
+++ b/pkgs/tools/system/hddfancontrol/default.nix
@@ -28,7 +28,7 @@ python3Packages.buildPythonPackage rec {
   meta = with lib; {
     description = "Dynamically control fan speed according to hard drive temperature on Linux";
     homepage = "https://github.com/desbma/hddfancontrol";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ benley ];
   };
 }


### PR DESCRIPTION
## Description of changes

Followup to https://github.com/NixOS/nixpkgs/pull/239801#pullrequestreview-1498132501

- tweak license field
- tag services.hddfancontrol.enable as markdown
- remove redundant `enable = true` default

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
