### PR TITLE
linux-wifi-hotspot: remove TKIP usage in create_ap

### DIFF
--- a/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
+++ b/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , which
 , pkg-config
 , glib
@@ -50,6 +51,15 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" ];
 
+  # Since TKIP is deprecated in hostapd, we need to modify create_ap to not use it
+  # See: https://github.com/NixOS/nixpkgs/commit/4bec3f204362fa22a0740c8a572ffef3b322596d
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/lakinduakash/linux-wifi-hotspot/commit/32fdb2bf2d3a34847270598682dec57cc3caf424.patch";
+      hash = "sha256-HUuJLOk7luQQ6xU5XKfGlV+YtLfYnFx2P6ZJF/1M7VE=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace ./src/scripts/Makefile \
       --replace "etc" "$out/etc"
@@ -59,13 +69,6 @@ stdenv.mkDerivation rec {
       --replace "/usr" "$out"
     substituteInPlace ./src/scripts/policies/polkit.policy \
       --replace "/usr" "$out"
-  '';
-
-  # Since TKIP is deprecated in hostapd, we need to modify create_ap to not use it
-  # See: https://github.com/NixOS/nixpkgs/commit/4bec3f204362fa22a0740c8a572ffef3b322596d
-  preBuild = ''
-    substituteInPlace ./src/scripts/create_ap \
-      --replace "wpa_pairwise=TKIP CCMP" "wpa_pairwise=CCMP"
   '';
 
   makeFlags = [

--- a/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
+++ b/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
@@ -61,6 +61,13 @@ stdenv.mkDerivation rec {
       --replace "/usr" "$out"
   '';
 
+  # Since TKIP is deprecated in hostapd, we need to modify create_ap to not use it
+  # See: https://github.com/NixOS/nixpkgs/commit/4bec3f204362fa22a0740c8a572ffef3b322596d
+  preBuild = ''
+    substituteInPlace ./src/scripts/create_ap \
+      --replace "wpa_pairwise=TKIP CCMP" "wpa_pairwise=CCMP"
+  '';
+
   makeFlags = [
     "PREFIX=${placeholder "out"}"
   ];


### PR DESCRIPTION
## Description of changes

Since [TKIP is now deprecated in hostapd](https://github.com/NixOS/nixpkgs/commit/4bec3f204362fa22a0740c8a572ffef3b322596d), the `create_ap` script in `linux-wifi-hotspot` needs to be updated to not use it.

## Things done

Changes were built and tested on aarch64-linux.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
