### PR TITLE
pythonPackages.paddleocr: init at 2.7.0.1

### DIFF
--- a/pkgs/development/python-modules/paddleocr/default.nix
+++ b/pkgs/development/python-modules/paddleocr/default.nix
@@ -1,0 +1,111 @@
+{ lib
+, buildPythonPackage
+, pythonRelaxDepsHook
+, fetchFromGitHub
+, attrdict
+, beautifulsoup4
+, cython
+, fire
+, fonttools
+, lmdb
+, lxml
+, numpy
+, opencv4
+, openpyxl
+, pdf2docx
+, pillow
+, premailer
+, pyclipper
+, pymupdf
+, python-docx
+, rapidfuzz
+, scikit-image
+, shapely
+, tqdm
+, paddlepaddle
+, lanms-neo
+, polygon3
+}:
+
+let
+  version = "2.7.0.1";
+in
+buildPythonPackage {
+  pname = "paddleocr";
+  inherit version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "PaddlePaddle";
+    repo = "PaddleOCR";
+    rev = "254786752a2659e184822b4b2de5637a05236590";
+    hash = "sha256-M/Fpk9swX9Gds7o5poM9Iv6LOhKoZNbe0Wv9JNMPOU0=";
+  };
+
+  patches = [
+    # The `ppocr.data.imaug` re-exports the `IaaAugment` and `CopyPaste`
+    # classes. These classes depend on the `imgaug` package which is
+    # unmaintained and has been removed from nixpkgs.
+    #
+    # The image OCR feature of PaddleOCR doesn't use these classes though, so
+    # they work even after stripping the the `IaaAugment` and `CopyPaste`
+    # exports. It probably breaks some of the OCR model creation tooling that
+    # PaddleOCR provides, however.
+    ./remove-import-imaug.patch
+  ];
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  # trying to relax only pymupdf makes the whole build fail
+  pythonRelaxDeps = true;
+  pythonRemoveDeps = [
+    "imgaug"
+    "visualdl"
+    "opencv-python"
+    "opencv-contrib-python"
+  ];
+
+  propagatedBuildInputs = [
+    attrdict
+    beautifulsoup4
+    cython
+    fire
+    fonttools
+    lmdb
+    lxml
+    numpy
+    opencv4
+    openpyxl
+    pdf2docx
+    pillow
+    premailer
+    pyclipper
+    pymupdf
+    python-docx
+    rapidfuzz
+    scikit-image
+    shapely
+    tqdm
+    paddlepaddle
+    lanms-neo
+    polygon3
+  ];
+
+  # TODO: The tests depend, among possibly other things, on `cudatoolkit`.
+  # But Cudatoolkit fails to install.
+  # preCheck = "export HOME=$TMPDIR";
+  # nativeCheckInputs = with pkgs; [ which cudatoolkit ];
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/PaddlePaddle/PaddleOCR";
+    license = licenses.asl20;
+    description = "Multilingual OCR toolkits based on PaddlePaddle";
+    longDescription = ''
+      PaddleOCR aims to create multilingual, awesome, leading, and practical OCR
+      tools that help users train better models and apply them into practice.
+    '';
+    changelog = "https://github.com/PaddlePaddle/PaddleOCR/releases/tag/v${version}";
+    maintainers = with maintainers; [ happysalada ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+}

--- a/pkgs/development/python-modules/paddleocr/remove-import-imaug.patch
+++ b/pkgs/development/python-modules/paddleocr/remove-import-imaug.patch
@@ -1,0 +1,20 @@
+diff --git a/ppocr/data/imaug/__init__.py b/ppocr/data/imaug/__init__.py
+index 121582b4..a6987c75 100644
+--- a/ppocr/data/imaug/__init__.py
++++ b/ppocr/data/imaug/__init__.py
+@@ -16,7 +16,6 @@ from __future__ import division
+ from __future__ import print_function
+ from __future__ import unicode_literals
+ 
+-from .iaa_augment import IaaAugment
+ from .make_border_map import MakeBorderMap
+ from .make_shrink_map import MakeShrinkMap
+ from .random_crop_data import EastRandomCropData, RandomCropImgMask
+@@ -30,7 +29,6 @@ from .rec_img_aug import BaseDataAugmentation, RecAug, RecConAug, RecResizeImg,
+     RFLRecResizeImg, SVTRRecAug
+ from .ssl_img_aug import SSLRotateResize
+ from .randaugment import RandAugment
+-from .copy_paste import CopyPaste
+ from .ColorJitter import ColorJitter
+ from .operators import *
+ from .label_ops import *

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1197,6 +1197,8 @@ self: super: with self; {
 
   paddle2onnx = callPackage ../development/python-modules/paddle2onnx { };
 
+  paddleocr = callPackage ../development/python-modules/paddleocr { };
+
   paddlepaddle = callPackage ../development/python-modules/paddlepaddle { };
 
   pulumi = callPackage ../development/python-modules/pulumi { inherit (pkgs) pulumi; };


### PR DESCRIPTION
## Description of changes

This should be the last PR to package paddleocr
a couple of comments to explain some weird things.
I've found this commit that updates the version to the latest
https://github.com/PaddlePaddle/PaddleOCR/commit/254786752a2659e184822b4b2de5637a05236590
I've used it as the reference. I was wondering if I should include a changelog given that the version is not released on github, in the end I added the changelog in the hope that other versions will be published on github.

trying to relax only pymupdf (in any casing , so also PyMuPDF) did not work, so in the end I had to put relaxdeps = true.

@Avaq thanks a lot for posting the original PR, I've broken it down in 3 different ones to be sure to merge the individual ones. (there were a bit more changes that were uninteresting, you can always go and check if you are interested).

@natsukium let me know if I forgot anything of course. (if you have time).

continuation of https://github.com/NixOS/nixpkgs/pull/249297

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
