### PR TITLE
tlp: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/tools/misc/tlp/default.nix
+++ b/pkgs/tools/misc/tlp/default.nix
@@ -24,13 +24,13 @@
 , networkmanager
 }: stdenv.mkDerivation rec {
   pname = "tlp";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "linrunner";
     repo = "TLP";
     rev = version;
-    sha256 = "sha256-hHel3BVMzTYfE59kxxADnm8tqtUFntqS3RzmJSZlWjM=";
+    hash = "sha256-XAyko2MxFyo5RyioaexhoFAR3E+I3t/8vD2K3WYNmsI=";
   };
 
   # XXX: See patch files for relevant explanations.
@@ -127,6 +127,7 @@
     description = "Advanced Power Management for Linux";
     homepage =
       "https://linrunner.de/en/tlp/docs/tlp-linux-advanced-power-management.html";
+    changelog = "https://github.com/linrunner/TLP/releases/tag/${version}";
     platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar lovesegfault ];
     license = licenses.gpl2Plus;

--- a/pkgs/tools/misc/tlp/patches/0001-makefile-correctly-sed-paths.patch
+++ b/pkgs/tools/misc/tlp/patches/0001-makefile-correctly-sed-paths.patch
@@ -15,14 +15,14 @@ The reason DESTDIR is used at all, as opposed to the more appropriate
 PREFIX, is covered in the nix formula, and is (also) due to the Makefile
 being a bit "different."
 ---
- Makefile | 18 +++++++++---------
- 1 file changed, 9 insertions(+), 9 deletions(-)
+ Makefile | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index e9bbab4..ab05720 100644
+index 8042517..1c436ad 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -51,19 +51,19 @@ _TPACPIBAT = $(DESTDIR)$(TPACPIBAT)
+@@ -57,20 +57,20 @@ _TPACPIBAT = $(DESTDIR)$(TPACPIBAT)
  
  SED = sed \
  	-e "s|@TLPVER@|$(TLPVER)|g" \
@@ -40,9 +40,11 @@ index e9bbab4..ab05720 100644
  	-e "s|@TLP_CONFDIR@|$(TLP_CONFDIR)|g" \
 -	-e "s|@TLP_CONFDEF@|$(TLP_CONFDEF)|g" \
 -	-e "s|@TLP_CONFREN@|$(TLP_CONFREN)|g" \
+-	-e "s|@TLP_CONFDPR@|$(TLP_CONFDPR)|g" \
 -	-e "s|@TLP_CONF@|$(TLP_CONF)|g" \
 +	-e "s|@TLP_CONFDEF@|$(_CONFDEF)|g" \
 +	-e "s|@TLP_CONFREN@|$(_CONFREN)|g" \
++	-e "s|@TLP_CONFDPR@|$(_CONFDPR)|g" \
 +	-e "s|@TLP_CONF@|$(_CONF)|g" \
  	-e "s|@TLP_RUN@|$(TLP_RUN)|g"   \
  	-e "s|@TLP_VAR@|$(TLP_VAR)|g"   \
@@ -52,5 +54,5 @@ index e9bbab4..ab05720 100644
  INFILES = \
  	tlp \
 -- 
-2.33.0
+2.41.0
 

--- a/pkgs/tools/misc/tlp/patches/0002-reintroduce-tlp-sleep-service.patch
+++ b/pkgs/tools/misc/tlp/patches/0002-reintroduce-tlp-sleep-service.patch
@@ -13,17 +13,15 @@ systemd itself to not use the hook scripts. As per the manual:
 > they should rather use the Inhibitor interface[1].
 ---
  Makefile             |  6 +++---
- tlp-sleep            | 11 -----------
  tlp-sleep.service.in | 19 +++++++++++++++++++
- 3 files changed, 22 insertions(+), 14 deletions(-)
- delete mode 100644 tlp-sleep
+ 2 files changed, 22 insertions(+), 3 deletions(-)
  create mode 100644 tlp-sleep.service.in
 
 diff --git a/Makefile b/Makefile
-index ab05720..075b42f 100644
+index 1c436ad..fd5211b 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -76,6 +76,7 @@ INFILES = \
+@@ -84,6 +84,7 @@ INFILES = \
  	tlp.rules \
  	tlp-readconfs \
  	tlp-run-on \
@@ -31,15 +29,15 @@ index ab05720..075b42f 100644
  	tlp.service \
  	tlp-stat \
  	tlp.upstart \
-@@ -106,7 +107,6 @@ SHFILES = \
+@@ -115,7 +116,6 @@ SHFILES = \
  	tlp-rdw-udev.in \
  	tlp-rf.in \
  	tlp-run-on.in \
 -	tlp-sleep \
  	tlp-sleep.elogind \
  	tlp-stat.in \
- 	tlp-usb-udev.in
-@@ -159,7 +159,7 @@ ifneq ($(TLP_NO_INIT),1)
+ 	tlp-usb-udev.in \
+@@ -172,7 +172,7 @@ ifneq ($(TLP_NO_INIT),1)
  endif
  ifneq ($(TLP_WITH_SYSTEMD),0)
  	install -D -m 644 tlp.service $(_SYSD)/tlp.service
@@ -48,7 +46,7 @@ index ab05720..075b42f 100644
  endif
  ifneq ($(TLP_WITH_ELOGIND),0)
  	install -D -m 755 tlp-sleep.elogind $(_ELOD)/49-tlp-sleep
-@@ -216,7 +216,7 @@ uninstall-tlp:
+@@ -240,7 +240,7 @@ uninstall-tlp:
  	rm $(_ULIB)/rules.d/85-tlp.rules
  	rm -f $(_SYSV)/tlp
  	rm -f $(_SYSD)/tlp.service
@@ -83,5 +81,5 @@ index 0000000..79c202c
 +[Install]
 +WantedBy=sleep.target
 -- 
-2.33.0
+2.41.0
 


### PR DESCRIPTION

## Description of changes
Slightly modify the patches to apply cleanly.

Changelog: https://github.com/linrunner/TLP/releases/tag/1.6.0
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
