### PR TITLE
python310Packages.cookiecutter: improve derivation, enable tests

### DIFF
--- a/pkgs/development/python-modules/cookiecutter/patch-test-paths.diff
+++ b/pkgs/development/python-modules/cookiecutter/patch-test-paths.diff
@@ -1,0 +1,138 @@
+diff --git a/tests/test-generate-files-permissions/input{{cookiecutter.permissions}}/script.sh b/tests/test-generate-files-permissions/input{{cookiecutter.permissions}}/script.sh
+index 0402dbb..ec0cb29 100755
+--- a/tests/test-generate-files-permissions/input{{cookiecutter.permissions}}/script.sh
++++ b/tests/test-generate-files-permissions/input{{cookiecutter.permissions}}/script.sh
+@@ -1,3 +1,3 @@
+-#!/bin/bash
++#!@bash@
+ 
+ # some bash script
+diff --git a/tests/test-pyshellhooks/hooks/post_gen_project.sh b/tests/test-pyshellhooks/hooks/post_gen_project.sh
+index d244dce..61cbf53 100755
+--- a/tests/test-pyshellhooks/hooks/post_gen_project.sh
++++ b/tests/test-pyshellhooks/hooks/post_gen_project.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@bash@
+ 
+ echo 'post generation hook';
+ touch 'shell_post.txt'
+diff --git a/tests/test-pyshellhooks/hooks/pre_gen_project.sh b/tests/test-pyshellhooks/hooks/pre_gen_project.sh
+index 351b6af..3a7e383 100755
+--- a/tests/test-pyshellhooks/hooks/pre_gen_project.sh
++++ b/tests/test-pyshellhooks/hooks/pre_gen_project.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@bash@
+ 
+ echo 'post generation hook';
+ touch 'shell_pre.txt'
+diff --git a/tests/test-shellhooks/hooks/post_gen_project.sh b/tests/test-shellhooks/hooks/post_gen_project.sh
+index d244dce..61cbf53 100755
+--- a/tests/test-shellhooks/hooks/post_gen_project.sh
++++ b/tests/test-shellhooks/hooks/post_gen_project.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@bash@
+ 
+ echo 'post generation hook';
+ touch 'shell_post.txt'
+diff --git a/tests/test-shellhooks/hooks/pre_gen_project.sh b/tests/test-shellhooks/hooks/pre_gen_project.sh
+index 8eae15f..380e9fb 100755
+--- a/tests/test-shellhooks/hooks/pre_gen_project.sh
++++ b/tests/test-shellhooks/hooks/pre_gen_project.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@bash@
+ 
+ echo 'pre generation hook';
+ touch 'shell_pre.txt'
+diff --git a/tests/test_generate_hooks.py b/tests/test_generate_hooks.py
+index a57e0db..1184977 100644
+--- a/tests/test_generate_hooks.py
++++ b/tests/test_generate_hooks.py
+@@ -125,7 +125,7 @@ def test_run_failing_hook_removes_output_directory():
+     hook_path = os.path.join(hooks_path, 'pre_gen_project.py')
+ 
+     with Path(hook_path).open('w') as f:
+-        f.write("#!/usr/bin/env python\n")
++        f.write("#!@python@\n")
+         f.write("import sys; sys.exit(1)\n")
+ 
+     with pytest.raises(FailedHookException) as excinfo:
+@@ -154,7 +154,7 @@ def test_run_failing_hook_preserves_existing_output_directory():
+     hook_path = os.path.join(hooks_path, 'pre_gen_project.py')
+ 
+     with Path(hook_path).open('w') as f:
+-        f.write("#!/usr/bin/env python\n")
++        f.write("#!@python@\n")
+         f.write("import sys; sys.exit(1)\n")
+ 
+     os.mkdir('inputhooks')
+diff --git a/tests/test_hooks.py b/tests/test_hooks.py
+index 9abd66a..3c44aa0 100644
+--- a/tests/test_hooks.py
++++ b/tests/test_hooks.py
+@@ -22,7 +22,7 @@ def make_test_repo(name, multiple_hooks=False):
+     Path(template, 'README.rst').write_text("foo\n===\n\nbar\n")
+ 
+     with Path(hook_dir, 'pre_gen_project.py').open('w') as f:
+-        f.write("#!/usr/bin/env python\n")
++        f.write("#!@python@\n")
+         f.write("# -*- coding: utf-8 -*-\n")
+         f.write("from __future__ import print_function\n")
+         f.write("\n")
+@@ -41,7 +41,7 @@ def make_test_repo(name, multiple_hooks=False):
+         post = 'post_gen_project.sh'
+         filename = os.path.join(hook_dir, post)
+         with Path(filename).open('w') as f:
+-            f.write("#!/bin/bash\n")
++            f.write("#!@bash@\n")
+             f.write("\n")
+             f.write("echo 'post generation hook';\n")
+             f.write("touch 'shell_post.txt'\n")
+@@ -61,7 +61,7 @@ def make_test_repo(name, multiple_hooks=False):
+             pre = 'pre_gen_project.sh'
+             filename = os.path.join(hook_dir, pre)
+             with Path(filename).open('w') as f:
+-                f.write("#!/bin/bash\n")
++                f.write("#!@bash@\n")
+                 f.write("\n")
+                 f.write("echo 'post generation hook';\n")
+                 f.write("touch 'shell_pre.txt'\n")
+@@ -189,7 +189,7 @@ class TestExternalHooks:
+                 f.write("echo. >{{cookiecutter.file}}\n")
+         else:
+             with Path(hook_path).open('w') as fh:
+-                fh.write("#!/bin/bash\n")
++                fh.write("#!@bash@\n")
+                 fh.write("\n")
+                 fh.write("echo 'post generation hook';\n")
+                 fh.write("touch 'shell_post.txt'\n")
+@@ -222,7 +222,7 @@ class TestExternalHooks:
+         tests_dir = os.path.join(self.repo_path, 'input{{hooks}}')
+ 
+         with Path(hook_path).open('w') as f:
+-            f.write("#!/usr/bin/env python\n")
++            f.write("#!@python@\n")
+             f.write("import sys; sys.exit(1)\n")
+ 
+         with utils.work_in(self.repo_path):
+@@ -239,7 +239,7 @@ def dir_with_hooks(tmp_path):
+ 
+     pre_hook_content = textwrap.dedent(
+         """
+-        #!/usr/bin/env python
++        #!@python@
+         # -*- coding: utf-8 -*-
+         print('pre_gen_project.py~')
+         """
+@@ -249,7 +249,7 @@ def dir_with_hooks(tmp_path):
+ 
+     post_hook_content = textwrap.dedent(
+         """
+-        #!/usr/bin/env python
++        #!@python@
+         # -*- coding: utf-8 -*-
+         print('post_gen_project.py~')
+         """


### PR DESCRIPTION
## Description of changes

Follow up from https://github.com/NixOS/nixpkgs/pull/247059.

Here's a list of changes:

1. Formatted the argument list at the top.
2. Add "format = setuptools" explicitly to help with https://github.com/NixOS/nixpkgs/issues/124051.
3. Enable tests (except one) and patch some "/bin/bash" and "/bin/env python" paths in test files.
4. Remove `jinja2-time`, which is no longer a dependency since v2.2.0.
5. Update homepage link (the repo was moved to a new organization).
6. Remove safety and pre-commit, which are not needed dependencies to run just the unit / integration tests (even though they are in test_requirements.txt).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
