### PR TITLE
python311Packages.keyrings-cryptfile: 1.3.4 -> 1.3.9

### DIFF
--- a/pkgs/development/python-modules/keyrings-cryptfile/default.nix
+++ b/pkgs/development/python-modules/keyrings-cryptfile/default.nix
@@ -1,8 +1,7 @@
 { lib
+, argon2-cffi
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
-, argon2-cffi
 , keyring
 , pycryptodome
 , pytestCheckHook
@@ -10,26 +9,22 @@
 }:
 
 buildPythonPackage rec {
-  pname = "keyrings.cryptfile";
-  # NOTE: newer releases are bugged/incompatible
-  # https://github.com/frispete/keyrings.cryptfile/issues/15
-  version = "1.3.4";
+  pname = "keyrings-cryptfile";
+  version = "1.3.9";
+  format = "setuptools";
+
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-jW+cKMm+xef8C+fl0CGe+6SEkYBHDjFX2/kLCZ62j6c=";
+    pname = "keyrings.cryptfile";
+    inherit version;
+    hash = "sha256-fCpFPKuZhUJrjCH3rVSlfkn/joGboY4INAvYgBrPAJE=";
   };
 
-  patches = [
-    # upstream setup.cfg has an option that is not supported
-    ./fix-testsuite.patch
-    # change of API in keyrings.testing
-    (fetchpatch {
-      url = "https://github.com/frispete/keyrings.cryptfile/commit/6fb9e45f559b8b69f7a0a519c0bece6324471d79.patch";
-      hash = "sha256-1878pMO9Ed1zs1pl+7gMjwx77HbDHdE1CryN8TPfPdU=";
-    })
-  ];
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "-s --cov=keyrings/cryptfile" ""
+  '';
 
   propagatedBuildInputs = [
     argon2-cffi
@@ -46,13 +41,14 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    "test_set_properties"
-    "UncryptedFileKeyringTestCase"
+    # FileNotFoundError: [Errno 2] No such file or directory: '/build/...
+    "test_versions"
   ];
 
   meta = with lib; {
     description = "Encrypted file keyring backend";
     homepage = "https://github.com/frispete/keyrings.cryptfile";
+    changelog = "https://github.com/frispete/keyrings.cryptfile/blob/v${version}/CHANGES.md";
     license = licenses.mit;
     maintainers = teams.chia.members;
   };


### PR DESCRIPTION
Changelog: https://github.com/frispete/keyrings.cryptfile/blob/v1.3.9/CHANGES.md

## Description of changes
Fix build (https://hydra.nixos.org/build/232275749)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
