### PR TITLE
healthchecks: add DB, DB_NAME and support for several _FILE options

### DIFF
--- a/nixos/modules/services/web-apps/healthchecks.nix
+++ b/nixos/modules/services/web-apps/healthchecks.nix
@@ -107,6 +107,8 @@ in
         We add two variables to this list inside the packages `local_settings.py.`
         - STATIC_ROOT to set a state directory for dynamically generated static files.
         - SECRET_KEY_FILE to read SECRET_KEY from a file at runtime and keep it out of /nix/store.
+        - EMAIL_HOST_PASSWORD_FILE to read EMAIL_HOST_PASSWORD from a file at runtime and keep it
+          out of /nix/store.
       '';
       type = types.submodule (settings: {
         freeformType = types.attrsOf types.str;
@@ -162,6 +164,12 @@ in
               else "hc"
             '';
             description = lib.mdDoc "Database name.";
+          };
+
+          EMAIL_HOST_PASSWORD_FILE = mkOption {
+            type = types.str;
+            default = "";
+            description = lib.mdDoc "Path to a file containing the email password.";
           };
         };
       });

--- a/nixos/modules/services/web-apps/healthchecks.nix
+++ b/nixos/modules/services/web-apps/healthchecks.nix
@@ -104,11 +104,16 @@ in
         See <https://healthchecks.io/docs/self_hosted_configuration/>
         for a full documentation of settings.
 
-        We add two variables to this list inside the packages `local_settings.py.`
-        - STATIC_ROOT to set a state directory for dynamically generated static files.
-        - SECRET_KEY_FILE to read SECRET_KEY from a file at runtime and keep it out of /nix/store.
-        - EMAIL_HOST_PASSWORD_FILE to read EMAIL_HOST_PASSWORD from a file at runtime and keep it
-          out of /nix/store.
+        We add additional variables to this list inside the packages `local_settings.py.`
+        - `STATIC_ROOT` to set a state directory for dynamically generated static files.
+        - `SECRET_KEY_FILE` to read `SECRET_KEY` from a file at runtime and keep it out of
+          /nix/store.
+        - `_FILE` variants for several values that hold sensitive information in
+          [Healthchecks configuration](https://healthchecks.io/docs/self_hosted_configuration/) so
+          that they also can be read from a file and kept out of /nix/store. To see which values
+          have support for a `_FILE` variant, run:
+          - `nix-instantiate --eval --expr '(import <nixpkgs> {}).healthchecks.secrets'`
+          - or `nix eval 'nixpkgs#healthchecks.secrets'` if the flake support has been enabled.
       '';
       type = types.submodule (settings: {
         freeformType = types.attrsOf types.str;
@@ -164,12 +169,6 @@ in
               else "hc"
             '';
             description = lib.mdDoc "Database name.";
-          };
-
-          EMAIL_HOST_PASSWORD_FILE = mkOption {
-            type = types.str;
-            default = "";
-            description = lib.mdDoc "Path to a file containing the email password.";
           };
         };
       });

--- a/pkgs/servers/web-apps/healthchecks/default.nix
+++ b/pkgs/servers/web-apps/healthchecks/default.nix
@@ -39,20 +39,36 @@ py.pkgs.buildPythonApplication rec {
     whitenoise
   ];
 
+  secrets = [
+    "DB_PASSWORD"
+    "DISCORD_CLIENT_SECRET"
+    "EMAIL_HOST_PASSWORD"
+    "LINENOTIFY_CLIENT_SECRET"
+    "MATRIX_ACCESS_TOKEN"
+    "PD_APP_ID"
+    "PUSHBULLET_CLIENT_SECRET"
+    "PUSHOVER_API_TOKEN"
+    "S3_SECRET_KEY"
+    "SECRET_KEY"
+    "SLACK_CLIENT_SECRET"
+    "TELEGRAM_TOKEN"
+    "TRELLO_APP_KEY"
+    "TWILIO_AUTH"
+  ];
+
   localSettings = writeText "local_settings.py" ''
     import os
 
     STATIC_ROOT = os.getenv("STATIC_ROOT")
 
-    SECRET_KEY_FILE = os.getenv("SECRET_KEY_FILE")
-    if SECRET_KEY_FILE:
-        with open(SECRET_KEY_FILE, "r") as file:
-            SECRET_KEY = file.readline()
-
-    EMAIL_HOST_PASSWORD_FILE = os.getenv("EMAIL_HOST_PASSWORD_FILE")
-    if EMAIL_HOST_PASSWORD_FILE:
-        with open(EMAIL_HOST_PASSWORD_FILE, "r") as file:
-            EMAIL_HOST_PASSWORD = file.readline()
+    ${lib.concatLines (map
+      (secret: ''
+        ${secret}_FILE = os.getenv("${secret}_FILE")
+        if ${secret}_FILE:
+            with open(${secret}_FILE, "r") as file:
+                ${secret} = file.readline()
+      '')
+      secrets)}
   '';
 
   installPhase = ''

--- a/pkgs/servers/web-apps/healthchecks/default.nix
+++ b/pkgs/servers/web-apps/healthchecks/default.nix
@@ -41,11 +41,18 @@ py.pkgs.buildPythonApplication rec {
 
   localSettings = writeText "local_settings.py" ''
     import os
+
     STATIC_ROOT = os.getenv("STATIC_ROOT")
+
     SECRET_KEY_FILE = os.getenv("SECRET_KEY_FILE")
     if SECRET_KEY_FILE:
         with open(SECRET_KEY_FILE, "r") as file:
             SECRET_KEY = file.readline()
+
+    EMAIL_HOST_PASSWORD_FILE = os.getenv("EMAIL_HOST_PASSWORD_FILE")
+    if EMAIL_HOST_PASSWORD_FILE:
+        with open(EMAIL_HOST_PASSWORD_FILE, "r") as file:
+            EMAIL_HOST_PASSWORD = file.readline()
   '';
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

Added few additional options to services.healthchecks.settings:
- `DB`: with `sqlite` as default
- `DB_NAME`: with correct defaults based on `DB` value
- `_FILE` variants for several values that hold sensitive information in [Healthchecks configuration](https://healthchecks.io/docs/self_hosted_configuration/).

See the commit messages for more details.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
