### PR TITLE
python310Packages.fasm: init at 0.0.2.post100

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6756,6 +6756,12 @@
     githubId = 22756350;
     name = "Emile Hansmaennel";
   };
+  hansfbaier = {
+    email = "hansfbaier@gmail.com";
+    github = "hansfbaier";
+    githubId = 148607;
+    name = "Hans Florian Baier";
+  };
   hansjoergschurr = {
     email = "commits@schurr.at";
     github = "hansjoergschurr";

--- a/pkgs/development/python-modules/fasm/default.nix
+++ b/pkgs/development/python-modules/fasm/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "fasm";
+  version = "0.0.2.post100";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3b840a6b1184b5f1568635b1adab28147947522707d41ceba02d5ed0a0877279";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/chipsalliance/fasm/";
+    description = "FPGA Assembly (FASM) Parser and Generator ";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hansfbaier ];
+  };
+}

--- a/pkgs/development/python-modules/fasm/default.nix
+++ b/pkgs/development/python-modules/fasm/default.nix
@@ -1,24 +1,98 @@
+# https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/python.section.md
+# https://aur.archlinux.org/packages/python-fasm-git
+
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, pythonOlder
+, cmake
+, textx
+, cython
+, fetchpatch
 }:
 
+let
+  fetchPatchFromAur = { name, sha256 }:
+    fetchpatch {
+      inherit name sha256;
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/${name}?h=python-fasm-git";
+    };
+in
 buildPythonPackage rec {
-  pname = "fasm";
-  version = "0.0.2.post100";
+  name = "fasm";
+  version = "0.0.2.r98.g9a73d70";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-O4QKaxGEtfFWhjWxrasoFHlHUicH1BzroC1e0KCHcnk=";
+  src = fetchFromGitHub {
+    inherit name;
+    owner = "chipsalliance";
+    repo = "fasm";
+    rev = "9a73d70c53fbc7e9202191120836a961c97c0868";
+    hash = "sha256-oC6vSpI9u8gEA2C85k00WdXzpH5GxeqtfNqqMduW5Jg=";
   };
 
+  patches = map fetchPatchFromAur [
+    {
+      name = "0001-cmake-install-parse_fasm.so.patch";
+      sha256 = "sha256-ZEq/hTXjCIkVkWhgCYWtRe3wftdYMNwhNC4KNnBI2Dc=";
+    }
+    {
+      name = "0002-cmake-install-tags.py-properly.patch";
+      sha256 = "sha256-OK5nXWsAzKK5ZreUCZy0maqWKrB0rpv8c2tA8zTE4U4=";
+    }
+    {
+      name = "0003-fix-setup.py-compute-install-directory-before-outsid.patch";
+      sha256 = "sha256-XBbEHi4uXiS5rCl+0aiTkQ0q/+npgyr8zHabRMMiybI=";
+    }
+    {
+      name = "0004-setup.py-don-t-build-everything-twice.patch";
+      sha256 = "sha256-TI8Ku+UIgnMNU4L4W09cSA0BC7kohXn+qGYki/EkQWA=";
+    }
+    {
+      name = "0005-cmake-allow-overriding-ANTLR_EXECUTABLE.patch";
+      sha256 = "sha256-11HnqV7nUDL3IztA9B2KnsEy1JaGzOOea269tmaLIzs=";
+    }
+    {
+      name = "0006-cmake-explicitly-link-test-with-gtest.patch";
+      sha256 = "sha256-hy0sL5INTPkkA8fdPxrw4zQA5KsSfhRIrT1HuP1BrVI=";
+    }
+    {
+      name = "0007-ANTLR4-4.10-compatibility.patch";
+      sha256 = "sha256-ZctDyp+a0m/Yr6b/Z42DBQvrKwF95GRrYaCbsFBtEz0=";
+    }
+    {
+      name = "0008-cmake-use-native-gtest.patch";
+      sha256 = "sha256-dYIjVrq+awCPblp6fV/VaTRsef7ibib+qP0ioh3dZ14=";
+    }
+    {
+      name = "0009-Use-cmake-directly-instead-of-letting-setup.py-try-t.patch";
+      sha256 = "sha256-/Ay+XjTE7MPcQg5yeo7zuKE2T/tE/P1sIMxgRYeSWNI=";
+    }
+  ];
+
+
+  nativeBuildInputs = [
+    cmake
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    textx
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  # Broken upstream.
+  # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-fasm-git#n76
+  doCheck = false;
+
   meta = with lib; {
+    changelog = "https://github.com/chipsalliance/fasm/releases/tag/${version}";
     homepage = "https://github.com/chipsalliance/fasm/";
     description = "FPGA Assembly (FASM) Parser and Generator";
     license = licenses.asl20;
-    maintainers = with maintainers; [ hansfbaier ];
+    maintainers = with maintainers; [ jleightcap hansfbaier ];
   };
 }

--- a/pkgs/development/python-modules/fasm/default.nix
+++ b/pkgs/development/python-modules/fasm/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3b840a6b1184b5f1568635b1adab28147947522707d41ceba02d5ed0a0877279";
+    hash = "sha256-O4QKaxGEtfFWhjWxrasoFHlHUicH1BzroC1e0KCHcnk=";
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/fasm/default.nix
+++ b/pkgs/development/python-modules/fasm/default.nix
@@ -1,8 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
 
 buildPythonPackage rec {
   pname = "fasm";
   version = "0.0.2.post100";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -11,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/chipsalliance/fasm/";
-    description = "FPGA Assembly (FASM) Parser and Generator ";
+    description = "FPGA Assembly (FASM) Parser and Generator";
     license = licenses.asl20;
     maintainers = with maintainers; [ hansfbaier ];
   };


### PR DESCRIPTION
## Description of changes

added nix packaging for fasm
This PR depends on https://github.com/NixOS/nixpkgs/pull/251333/commits
If somebody else wants to maintain this, please change the maintainer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

