### PR TITLE
Revert "python3Packages.pillow & python3Packages.pillow-simd: Fix cross compilation"

### DIFF
--- a/pkgs/development/python-modules/pillow-simd/default.nix
+++ b/pkgs/development/python-modules/pillow-simd/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, buildPythonPackage, fetchFromGitHub, isPyPy, isPy3k
 , olefile, freetype, libjpeg, zlib, libtiff, libwebp, libxcrypt, tcl, lcms2
 , libxcb, tk, libX11, openjpeg, libimagequant, pyroma, numpy, defusedxml
-, pytestCheckHook, setuptools
+, pytestCheckHook
 }@args:
 
 import ../pillow/generic.nix (rec {

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -6,7 +6,7 @@
 , fetchpatch
 , isPyPy
 , defusedxml, olefile, freetype, libjpeg, zlib, libtiff, libwebp, libxcrypt, tcl, lcms2, tk, libX11
-, libxcb, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook, setuptools
+, libxcb, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
 # for passthru.tests
 , imageio, matplotlib, pilkit, pydicom, reportlab
 }@args:

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -39,8 +39,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook pyroma numpy ];
 
-  nativeBuildInputs = [ setuptools ];
-
   buildInputs = [ freetype libjpeg openjpeg libimagequant zlib libtiff libwebp libxcrypt tcl lcms2 ]
     ++ lib.optionals (lib.versionAtLeast version "7.1.0") [ libxcb ]
     ++ lib.optionals (isPyPy) [ tk libX11 ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#249136

This PR caused over [13k rebuilds](https://gist.github.com/GrahamcOfBorg/fe7b707ecd078a881325b5583eb6f8b4) in total without justification for direct merge to master.