### PR TITLE
python311Packages.types-awscrt: init at 0.19.0, python311Packages.botocore-stubs: init at 1.31.34

### DIFF
--- a/pkgs/development/python-modules/botocore-stubs/default.nix
+++ b/pkgs/development/python-modules/botocore-stubs/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, poetry-core
+, pythonOlder
+, types-awscrt
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "botocore-stubs";
+  version = "1.31.34";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "botocore_stubs";
+    inherit version;
+    hash = "sha256-7HQvhmNqzyeHIgCYf+IGi6X7kmbOBBcKkOomtpjhVlQ=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    types-awscrt
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "botocore-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations and code completion for botocore";
+    homepage = "https://pypi.org/project/botocore-stubs/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/types-awscrt/default.nix
+++ b/pkgs/development/python-modules/types-awscrt/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, poetry-core
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "types-awscrt";
+  version = "0.19.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "types_awscrt";
+    inherit version;
+    hash = "sha256-6u9gQiz3FrSuIW8WS3TWecgrDZxT2zgKN96ymuVXmxs=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  pythonImportsCheck = [
+    "awscrt-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations and code completion for awscrt";
+    homepage = "https://github.com/youtype/types-awscrt";
+    changelog = "https://github.com/youtype/types-awscrt/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13118,6 +13118,8 @@ self: super: with self; {
 
   types-appdirs = callPackage ../development/python-modules/types-appdirs { };
 
+  types-awscrt = callPackage ../development/python-modules/types-awscrt { };
+
   types-beautifulsoup4 = callPackage ../development/python-modules/types-beautifulsoup4 { };
 
   types-colorama = callPackage ../development/python-modules/types-colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1525,6 +1525,8 @@ self: super: with self; {
 
   botocore = callPackage ../development/python-modules/botocore { };
 
+  botocore-stubs = callPackage ../development/python-modules/botocore-stubs { };
+
   botorch = callPackage ../development/python-modules/botorch { };
 
   bottle = callPackage ../development/python-modules/bottle { };


### PR DESCRIPTION
## Description of changes
Needed to fix `aws-sam-cli`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
