### PR TITLE
burpsuite: 2023.7.2 -> 2023.10.2.4, add Professional Edition

### DIFF
--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -1,14 +1,15 @@
 { lib, fetchurl, jdk, buildFHSEnv, unzip, makeDesktopItem }:
 let
-  version = "2023.7.2";
+  version = "2023.9.4";
 
   src = fetchurl {
     name = "burpsuite.jar";
     urls = [
+      "https://portswigger-cdn.net/burp/releases/download?product=community&version=${version}&type=Jar"
       "https://portswigger.net/burp/releases/download?productId=100&version=${version}&type=Jar"
       "https://web.archive.org/web/https://portswigger.net/burp/releases/download?productId=100&version=${version}&type=Jar"
     ];
-    hash = "sha256-mpOG8sx+L+/kwgB3X9ALOvq+Rx1GC3JE2G7yVt1iQYg=";
+    hash = "sha256-OqtbimeWDZDePKvH0SKvfZxAXKhqFIQ49rdj7vkPckU=";
   };
 
   name = "burpsuite-${version}";
@@ -69,11 +70,11 @@ buildFHSEnv {
       exploiting security vulnerabilities.
     '';
     homepage = "https://portswigger.net/burp/";
-    downloadPage = "https://portswigger.net/burp/freedownload";
+    downloadPage = "https://portswigger.net/burp/communitydownload";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     platforms = jdk.meta.platforms;
     hydraPlatforms = [ ];
-    maintainers = with maintainers; [ bennofs ];
+    maintainers = with maintainers; [ arcayr bennofs ];
   };
 }

--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -1,15 +1,25 @@
-{ lib, fetchurl, jdk, buildFHSEnv, unzip, makeDesktopItem }:
+{ lib, fetchurl, jdk, buildFHSEnv, unzip, makeDesktopItem, proEdition ? false }:
 let
   version = "2023.9.4";
+
+  product = if proEdition then {
+    productName = "pro";
+    productDesktop = "Burp Suite Professional Edition";
+    hash = "sha256-5n7xT+uWRoh1HREu62EcMBlK10ihTM5Gz+9yJl2jtiE=";
+  } else {
+    productName = "community";
+    productDesktop = "Burp Suite Community Edition";
+    hash = "sha256-OqtbimeWDZDePKvH0SKvfZxAXKhqFIQ49rdj7vkPckU=";
+  };
 
   src = fetchurl {
     name = "burpsuite.jar";
     urls = [
-      "https://portswigger-cdn.net/burp/releases/download?product=community&version=${version}&type=Jar"
-      "https://portswigger.net/burp/releases/download?productId=100&version=${version}&type=Jar"
-      "https://web.archive.org/web/https://portswigger.net/burp/releases/download?productId=100&version=${version}&type=Jar"
+      "https://portswigger-cdn.net/burp/releases/download?product=${product.productName}&version=${version}&type=Jar"
+      "https://portswigger.net/burp/releases/download?product=${product.productName}&version=${version}&type=Jar"
+      "https://web.archive.org/web/https://portswigger.net/burp/releases/download?product=${product.productName}&version=${version}&type=Jar"
     ];
-    hash = "sha256-OqtbimeWDZDePKvH0SKvfZxAXKhqFIQ49rdj7vkPckU=";
+    hash = product.hash;
   };
 
   name = "burpsuite-${version}";
@@ -18,7 +28,7 @@ let
     name = "burpsuite";
     exec = name;
     icon = name;
-    desktopName = "Burp Suite Community Edition";
+    desktopName = product.productDesktop;
     comment = description;
     categories = [ "Development" "Security" "System" ];
   };
@@ -57,7 +67,7 @@ buildFHSEnv {
   extraInstallCommands = ''
     mv "$out/bin/${name}" "$out/bin/burpsuite" # name includes the version number
     mkdir -p "$out/share/pixmaps"
-    ${lib.getBin unzip}/bin/unzip -p ${src} resources/Media/icon64community.png > "$out/share/pixmaps/burpsuite.png"
+    ${lib.getBin unzip}/bin/unzip -p ${src} resources/Media/icon64${product.productName}.png > "$out/share/pixmaps/burpsuite.png"
     cp -r ${desktopItem}/share/applications $out/share
   '';
 
@@ -70,7 +80,6 @@ buildFHSEnv {
       exploiting security vulnerabilities.
     '';
     homepage = "https://portswigger.net/burp/";
-    downloadPage = "https://portswigger.net/burp/communitydownload";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
     platforms = jdk.meta.platforms;

--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -22,12 +22,12 @@ let
     hash = product.hash;
   };
 
-  name = "burpsuite-${version}";
+  pname = "burpsuite";
   description = "An integrated platform for performing security testing of web applications";
-  desktopItem = makeDesktopItem rec {
+  desktopItem = makeDesktopItem {
     name = "burpsuite";
-    exec = name;
-    icon = name;
+    exec = pname;
+    icon = pname;
     desktopName = product.productDesktop;
     comment = description;
     categories = [ "Development" "Security" "System" ];
@@ -35,7 +35,7 @@ let
 
 in
 buildFHSEnv {
-  inherit name;
+  inherit pname version;
 
   runScript = "${jdk}/bin/java -jar ${src}";
 
@@ -65,7 +65,6 @@ buildFHSEnv {
   ];
 
   extraInstallCommands = ''
-    mv "$out/bin/${name}" "$out/bin/burpsuite" # name includes the version number
     mkdir -p "$out/share/pixmaps"
     ${lib.getBin unzip}/bin/unzip -p ${src} resources/Media/icon64${product.productName}.png > "$out/share/pixmaps/burpsuite.png"
     cp -r ${desktopItem}/share/applications $out/share

--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -1,15 +1,15 @@
 { lib, fetchurl, jdk, buildFHSEnv, unzip, makeDesktopItem, proEdition ? false }:
 let
-  version = "2023.9.4";
+  version = "2023.10.1.1";
 
   product = if proEdition then {
     productName = "pro";
     productDesktop = "Burp Suite Professional Edition";
-    hash = "sha256-5n7xT+uWRoh1HREu62EcMBlK10ihTM5Gz+9yJl2jtiE=";
+    hash = "sha256-xyEQVrfI9CS6div7vZuluKkIm36B9XqKZ9rH+1DjeD4=";
   } else {
     productName = "community";
     productDesktop = "Burp Suite Community Edition";
-    hash = "sha256-OqtbimeWDZDePKvH0SKvfZxAXKhqFIQ49rdj7vkPckU=";
+    hash = "sha256-lV1V92sxCiZ7AGjUNJHO9fkh3aUgt0+oISh7efBaOUA=";
   };
 
   src = fetchurl {

--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -1,15 +1,15 @@
 { lib, fetchurl, jdk, buildFHSEnv, unzip, makeDesktopItem, proEdition ? false }:
 let
-  version = "2023.10.1.1";
+  version = "2023.10.2.4";
 
   product = if proEdition then {
     productName = "pro";
     productDesktop = "Burp Suite Professional Edition";
-    hash = "sha256-xyEQVrfI9CS6div7vZuluKkIm36B9XqKZ9rH+1DjeD4=";
+    hash = "sha256-H5/nxVvAoGzRIAOchv9tAYyFgrodh7XugCTn2oUV9Tw=";
   } else {
     productName = "community";
     productDesktop = "Burp Suite Community Edition";
-    hash = "sha256-lV1V92sxCiZ7AGjUNJHO9fkh3aUgt0+oISh7efBaOUA=";
+    hash = "sha256-en+eay+XL09Vk6H011fYvxGluMAndedtqCo4dQZvbBM=";
   };
 
   src = fetchurl {


### PR DESCRIPTION
## Description of changes
Bump Burp Suite from 2023.7.2 to 2023.10.2.4, and adds the ability to install the Professional Edition of Burp Suite by overriding the `proEdition` argument to `true`.

Some of upstream's URLs now redirect from the word "free" to "community". They have been amended as part of this update.

A list of upstream changes since the last version in nixpkgs, from [https://portswigger.net/burp/releases](https://portswigger.net/burp/releases):
* 2023.10.2.4: We have upgraded Burp's built-in browser to 118.0.5993.117 for Mac / Linux and 118.0.5993.90 for Windows. For more information, see the [Chromium release notes](https://chromereleases.googleblog.com/2023/10/stable-channel-update-for-desktop_24.html).
* 2023.10.2.3: We have upgraded Burp's built-in browser to 118.0.5993.88 for Mac / Linux and 118.0.5993.88/.89 for Windows. This update contains a security fix. For more information, see the [Chromium release notes](https://chromereleases.googleblog.com/2023/10/stable-channel-update-for-desktop_17.html).
* 2023.10.2.2:  This release introduces new functionality for BChecks, including the ability to test your checks from within the editor and create definitions from a blank template. We have also added a notes feature to Repeater tabs. 
* 2023.10.1.2: We have upgraded Burp's built-in browser to 117.0.5938.132 for Mac, Linux, and Windows. This update contains security fixes. For more information, see the [Chromium release notes](https://chromereleases.googleblog.com/2023/09/stable-channel-update-for-desktop_27.html).
* 2023.10.1.1: This release includes the introduction of user activity logging, and a number of other improvements.
* 2023.9.4: We have upgraded Burp's built-in browser to [116.0.5845.140 for Mac and Linux and 116.0.5845.140/.141 for Windows](https://chromereleases.googleblog.com/2023/08/stable-channel-update-for-desktop_29.html). This update contains  security fixes.
* 2023.9.3: This release introduces the ability to unpack Brotli-compressed messages in the Proxy and Repeater tools, and adds Organizer functionality to the Montoya API.
* 2023.9.2: This release upgrades Burp's built-in browser and fixes a bug when scanning [GraphQL](https://portswigger.net/web-security/graphql) APIs.
* 2023.9.1: This release introduces new Repeater functionality based on the techniques discussed in James Kettle's talk "Smashing the State Machine: The True Potential of Web Race Conditions", first presented at Black Hat USA 2023. Repeater's new single-packet attack feature nullifies network jitter, enabling you to send multiple requests in parallel. These requests are synchronized to arrive within a very small time window, making it much simpler to test for race conditions.
* 2023.8.1: We have upgraded Burp's built-in browser to [115.0.5790.170 for Mac and Linux and 115.0.5790.170/.171 for Windows](https://chromereleases.googleblog.com/2023/08/stable-channel-update-for-desktop.html). This update contains multiple high-severity security fixes.
* 2023.7.3: We have upgraded Burp's built-in browser to [115.0.5790.170 for Mac and Linux and 115.0.5790.170/.171 for Windows](https://chromereleases.googleblog.com/2023/08/stable-channel-update-for-desktop.html). This update contains multiple high-severity security fixes.

## Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>burpsuite</li>
  </ul>
</details>
