### PR TITLE
create_ap: add dynamicConfigScripts option

### DIFF
--- a/nixos/modules/services/networking/create_ap.nix
+++ b/nixos/modules/services/networking/create_ap.nix
@@ -4,7 +4,16 @@ with lib;
 
 let
   cfg = config.services.create_ap;
-  configFile = pkgs.writeText "create_ap.conf" (generators.toKeyValue { } cfg.settings);
+  makeConfigFile = pkgs.writeShellScript "make-create-ap-conf" ''
+      set -euo pipefail
+
+      create_ap_config_file=/run/create_ap/create_ap.conf
+      rm -rf "$create_ap_config_file"
+      cat > "$create_ap_config_file" <<EOF
+      ${(generators.toKeyValue { } cfg.settings)}
+      EOF
+      ${concatMapStrings (script: "${script} \"$create_ap_config_file\"\n") (attrValues cfg.dynamicConfigScripts)}
+  '';
 in {
   options = {
     services.create_ap = {
@@ -24,6 +33,28 @@ in {
           PASSPHRASE = "12345678";
         };
       };
+      dynamicConfigScripts = mkOption {
+        default = {};
+        type = types.attrsOf types.path;
+        example = literalExpression ''
+          {
+            exampleDynamicConfig = pkgs.writeShellScript "dynamic-config" '''
+              CREATE_AP_CONFIG=$1
+
+              cat >> "$CREATE_AP_CONFIG" << EOF
+              # Add some dynamically generated statements here
+              EOF
+            ''';
+          }
+        '';
+        description = mdDoc ''
+          All of these scripts will be executed in lexicographical order before create_ap
+          is started, right after the global segment was generated and may dynamically
+          append global options to the generated configuration file.
+
+          The first argument will point to the configuration file that you may append to.
+        '';
+      };
     };
   };
 
@@ -34,11 +65,12 @@ in {
         wantedBy = [ "multi-user.target" ];
         description = "Create AP Service";
         after = [ "network.target" ];
-        restartTriggers = [ configFile ];
+        preStart = lib.concatStringsSep "\n"  [ makeConfigFile ];
         serviceConfig = {
-          ExecStart = "${pkgs.linux-wifi-hotspot}/bin/create_ap --config ${configFile}";
+          ExecStart = "${pkgs.linux-wifi-hotspot}/bin/create_ap --config /run/create_ap/create_ap.conf";
           KillSignal = "SIGINT";
           Restart = "on-failure";
+          RuntimeDirectory = "create_ap";
         };
       };
     };


### PR DESCRIPTION
## Description of changes

In the same spirit as the [`hostapd` service dynamic configuration files option](https://github.com/NixOS/nixpkgs/blob/697d1792311b1389836a94e7b466577fa11d241f/nixos/modules/services/networking/hostapd.nix#L265), this adds a new option to the `create_ap` service to allow dynamic customization of the `create_ap.conf` file.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
