### PR TITLE
lief, python3Packages.lief: 0.12.3 -> 0.13.2

### DIFF
--- a/pkgs/development/libraries/lief/default.nix
+++ b/pkgs/development/libraries/lief/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = "https://lief.quarkslab.com/";
     license = [ licenses.asl20 ];
     platforms = with platforms; linux ++ darwin;
-    maintainers = [ maintainers.lassulus ];
+    maintainers = with maintainers; [ lassulus genericnerdyusername ];
   };
 }

--- a/pkgs/development/libraries/lief/default.nix
+++ b/pkgs/development/libraries/lief/default.nix
@@ -3,26 +3,28 @@
 , fetchFromGitHub
 , python
 , cmake
+, ninja
 }:
 
 let
-  pyEnv = python.withPackages (ps: [ ps.setuptools ]);
+  pyEnv = python.withPackages (ps: [ ps.setuptools ps.tomli ps.pip ps.setuptools ]);
 in
 stdenv.mkDerivation rec {
   pname = "lief";
-  version = "0.12.3";
+  version = "0.13.2";
 
   src = fetchFromGitHub {
     owner = "lief-project";
     repo = "LIEF";
     rev = version;
-    sha256 = "sha256-wZgv4AFc7DrMCyxMLKQxO1mUTDAU4klK8aZAySqGJoY=";
+    sha256 = "sha256-lH4SqwPB2Jp/wUI2Cll67PQbHbwMqpNuLy/ei8roiHg=";
   };
 
   outputs = [ "out" "py" ];
 
   nativeBuildInputs = [
     cmake
+    ninja
   ];
 
   # Not a propagatedBuildInput because only the $py output needs it; $out is
@@ -31,33 +33,16 @@ stdenv.mkDerivation rec {
     python
   ];
 
-  dontUseCmakeConfigure = true;
-
-  buildPhase = ''
-    runHook preBuild
-
-    substituteInPlace setup.py \
-      --replace 'cmake_args = []' "cmake_args = [ \"-DCMAKE_INSTALL_PREFIX=$prefix\" ]"
-    ${pyEnv.interpreter} setup.py --sdk build --parallel=$NIX_BUILD_CORES
-
-    runHook postBuild
+  postBuild = ''
+    pushd /build/source/api/python
+    ${pyEnv.interpreter} setup.py build --parallel=$NIX_BUILD_CORES
+    popd
   '';
 
-  # I was unable to find a way to build the library itself and have it install
-  # to $out, while also installing the Python bindings to $py without building
-  # the project twice (using cmake), so this is the best we've got. It uses
-  # something called CPack to create the tarball, but it's not obvious to me
-  # *how* that happens, or how to intercept it to just get the structured
-  # library output.
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out $py/nix-support
-    echo "${python}" >> $py/nix-support/propagated-build-inputs
-    tar xf build/*.tar.gz --directory $out --strip-components 1
+  postInstall = ''
+    pushd /build/source/api/python
     ${pyEnv.interpreter} setup.py install --skip-build --root=/ --prefix=$py
-
-    runHook postInstall
+    popd
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Fix build and update for lief.

Closes #249419.

@Lassulus 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
