### PR TITLE
pre-commit: fixing import bug for built-in hooks

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -32,6 +32,7 @@ buildPythonApplication rec {
 
   patches = [
     ./languages-use-the-hardcoded-path-to-python-binaries.patch
+    ./system-hooks-use-calling-environment-paths.patch
     ./hook-tmpl.patch
     ./pygrep-pythonpath.patch
   ];
@@ -104,11 +105,24 @@ buildPythonApplication rec {
     deactivate
   '';
 
-  # Propagating dependencies leaks them through $PYTHONPATH which causes issues
-  # when used in nix-shell.
+
   postFixup = ''
+    # Propagating inputs causes them to show up in $PYTHONPATH in a nix shell,
+    # this is problematic because they might conflict with the user's dependencies,
+    # so we remove them.
     rm $out/nix-support/propagated-build-inputs
+
+    # the wrapper script modifies PATH and PYTHONPATH to point into the nix store
+    # this prevents 'system' type hooks from referencing the calling environment
+    # save untainted copies of that environment for such cases
+    sed -i '2i\export "OUTER_PYTHONPATH=$PYTHONPATH"' $out/bin/pre-commit
+    sed -i '2i\export "OUTER_PATH=$PATH"' $out/bin/pre-commit
   '';
+
+  # Pre-commit also has built-in hooks which it needs to import from the nix store
+  # we hid them from user devshells by removing propated-build-inputs, but now we
+  # need to restore them for pre-commit's use (but only inside of the wrapper).
+  makeWrapperArgs = ''--set PYTHONPATH $PYTHONPATH'';
 
   disabledTests = [
     # ERROR: The install method you used for conda--probably either `pip install conda`
@@ -178,8 +192,8 @@ buildPythonApplication rec {
     "pre_commit"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = pre-commit;
+  passthru.tests = callPackage ./tests.nix {
+    inherit git pre-commit;
   };
 
   meta = with lib; {

--- a/pkgs/tools/misc/pre-commit/system-hooks-use-calling-environment-paths.patch
+++ b/pkgs/tools/misc/pre-commit/system-hooks-use-calling-environment-paths.patch
@@ -1,0 +1,94 @@
+diff --git a/pre_commit/all_languages.py b/pre_commit/all_languages.py
+index 476bad9..742172a 100644
+--- a/pre_commit/all_languages.py
++++ b/pre_commit/all_languages.py
+@@ -21,6 +21,7 @@ from pre_commit.languages import rust
+ from pre_commit.languages import script
+ from pre_commit.languages import swift
+ from pre_commit.languages import system
++from pre_commit.languages import meta
+ 
+ 
+ languages: dict[str, Language] = {
+@@ -44,6 +45,7 @@ languages: dict[str, Language] = {
+     'script': script,
+     'swift': swift,
+     'system': system,
++    'meta': meta,
+     # TODO: fully deprecate `python_venv`
+     'python_venv': python,
+ }
+diff --git a/pre_commit/clientlib.py b/pre_commit/clientlib.py
+index d0651ca..008307b 100644
+--- a/pre_commit/clientlib.py
++++ b/pre_commit/clientlib.py
+@@ -265,8 +265,8 @@ META_HOOK_DICT = cfgv.Map(
+     'Hook', 'id',
+     cfgv.Required('id', cfgv.check_string),
+     cfgv.Required('id', cfgv.check_one_of(tuple(k for k, _ in _meta))),
+-    # language must be system
+-    cfgv.Optional('language', cfgv.check_one_of({'system'}), 'system'),
++    # language must be meta
++    cfgv.Optional('language', cfgv.check_one_of({'meta'}), 'meta'),
+     # entry cannot be overridden
+     NotAllowed('entry', cfgv.check_any),
+     *(
+diff --git a/pre_commit/lang_base.py b/pre_commit/lang_base.py
+index 4a993ea..eba8f3e 100644
+--- a/pre_commit/lang_base.py
++++ b/pre_commit/lang_base.py
+@@ -130,6 +130,27 @@ def no_install(
+ def no_env(prefix: Prefix, version: str) -> Generator[None, None, None]:
+     yield
+ 
++@contextlib.contextmanager
++def outer_env(prefix: Prefix, version: str) -> Generator[None, None, None]:
++
++
++    # access the non-nix-modified environment
++    # which was captured pre-modifications by the wrapper script
++    # which was configured by the postFixup hook here:
++    # nixpkgs/pkgs/tools/misc/pre-commit/default.nix
++    backups = {}
++    for var in ["PATH", "PYTHONPATH"]:
++        val = os.environ.get(var)
++        outer_val = os.environ.get("OUTER_" + var)
++        if outer_val:
++            backups[var] = val
++            os.environ[var] = outer_val
++
++    yield
++
++    # restore the nix-modified environment
++    for k, v in backups.items():
++        os.environ[k] = v
+ 
+ def target_concurrency() -> int:
+     if 'PRE_COMMIT_NO_CONCURRENCY' in os.environ:
+diff --git a/pre_commit/languages/meta.py b/pre_commit/languages/meta.py
+new file mode 100644
+index 0000000..f6ad688
+--- /dev/null
++++ b/pre_commit/languages/meta.py
+@@ -0,0 +1,10 @@
++from __future__ import annotations
++
++from pre_commit import lang_base
++
++ENVIRONMENT_DIR = None
++get_default_version = lang_base.basic_get_default_version
++health_check = lang_base.basic_health_check
++install_environment = lang_base.no_install
++in_env = lang_base.no_env
++run_hook = lang_base.basic_run_hook
+diff --git a/pre_commit/languages/system.py b/pre_commit/languages/system.py
+index f6ad688..d8237e7 100644
+--- a/pre_commit/languages/system.py
++++ b/pre_commit/languages/system.py
+@@ -6,5 +6,5 @@ ENVIRONMENT_DIR = None
+ get_default_version = lang_base.basic_get_default_version
+ health_check = lang_base.basic_health_check
+ install_environment = lang_base.no_install
+-in_env = lang_base.no_env
++in_env = lang_base.outer_env
+ run_hook = lang_base.basic_run_hook

--- a/pkgs/tools/misc/pre-commit/tests.nix
+++ b/pkgs/tools/misc/pre-commit/tests.nix
@@ -1,0 +1,37 @@
+{ git
+, pre-commit
+, runCommand
+, testers
+}: {
+  check-meta-hooks = runCommand "check-meta-hooks" {
+    nativeBuildInputs = [ git pre-commit ];
+  } ''
+    cd "$(mktemp --directory)"
+    export HOME="$PWD"
+    cat << 'EOF' > .pre-commit-config.yaml
+    repos:
+      - repo: local
+        hooks:
+          - id: echo
+            name: echo
+            entry: echo
+            files: \.yaml$
+            language: system
+      - repo: meta
+        hooks:
+          - id: check-hooks-apply
+          - id: check-useless-excludes
+          - id: identity
+    EOF
+    git config --global user.email "you@example.com"
+    git config --global user.name "Your Name"
+    git init --initial-branch=main
+    git add .
+    pre-commit run --all-files
+    touch $out
+  '';
+
+  version = testers.testVersion {
+    package = pre-commit;
+  };
+}


### PR DESCRIPTION
## Context

Pre-commit has built-in ["meta" hooks](https://github.com/pre-commit/pre-commit/tree/main/pre_commit/meta_hooks).  If they are isolated from pre-commit itself, they don't work.

https://github.com/NixOS/nixpkgs/pull/235123 prevented pre-commit's dependencies from propagating into devshells. This was necessary because those dependencies were clobbering others in the devshell definition.

This increased isolation broke the "meta" hooks.  A workaround emerged (see comments below) which involved configuring the pre-commit wrapper script to always run with its PYTHONPATH set such that the pre-commit internals are accessible.

The workaround clutters up the devshell definition, and it needlessly exposes `system` type hooks to pre-commit internals. Really, only the `meta` type hooks need to see pre-commit internals.

## Description of changes

This PR patches pre-commit so that it treats `meta` and `system` hook types separately, ensuring that pre-commit itself (via `PYTHONPATH`) is available only to the `meta` hooks.  This allows users to just add `pkgs.pre-commit` to their devshell without thinking about `PYTHONPATH` at all.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
