### PR TITLE
libopencm3: init at unstable-2023-08-16

### DIFF
--- a/pkgs/development/embedded/libopencm3/default.nix
+++ b/pkgs/development/embedded/libopencm3/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, writeText
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libopencm3";
+  version = "unstable-2023-08-16";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "32a169207775d6c53c536d46b78ecf8eca3fdd18";
+    hash = "sha256-8lE63woxooREL0r+AE0/2qozyIA+HFipoDu1dLOLzqA=";
+  };
+
+  nativeBuildInputs = [ python3 ];
+
+  postPatch = ''
+    patchShebangs scripts/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/include/
+    cp -r include/libopencm3/ include/libopencmsis/ $out/include/
+    install -Dm444 lib/*.a lib/*.ld -t $out/lib/
+    # Install some more files to make it actually useful
+    # FHS violation, I know...
+    install -Dm444 mk/* -t $out/mk/
+    install -Dm444 ld/devices.data ld/linker.ld.S -t $out/ld/
+    install -Dm555 scripts/genlink.py -t $out/scripts/
+    runHook postInstall
+  '';
+
+  setupHook = writeText "setup-hook.sh" ''
+    addOpencm3Dir () {
+      export MAKEFLAGS+=" OPENCM3_DIR=@out@"
+    }
+    addEnvHooks "$hostOffset" addOpencm3Dir
+  '';
+
+  passthru.updateScript = unstableGitUpdater { url = src.gitRepoUrl; };
+
+  meta = with lib; {
+    description = "Open-source lowlevel hardware library for various ARM Cortex-M microcontrollers";
+    longDescription = ''
+      Libopencm3 packaged for easy integration with Nixpkgs. A nix-shell can be launched with:
+
+        nix-shell -E '(import <nixpkgs> { }).pkgsCross.arm-embedded.callPackage ({ mkShell, libopencm3 }: mkShell { buildInputs = [ libopencm3 ]; }) { }'
+
+      If you prefer using it as source code, use ${pname}.src instead.
+    '';
+    homepage = "https://libopencm3.org/";
+    license = licenses.lgpl3;
+    platforms = [ "arm-none" ];
+    maintainers = with maintainers; [ chuangzhu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23356,6 +23356,8 @@ with pkgs;
 
   libopenaptx = callPackage ../development/libraries/libopenaptx { };
 
+  libopencm3 = callPackage ../development/embedded/libopencm3 { };
+
   libopenglrecorder = callPackage ../development/libraries/libopenglrecorder { };
 
   libopus = callPackage ../development/libraries/libopus { };


### PR DESCRIPTION
## Description of changes

Libopencm3 is a low level peripheral library for various ARM Cortex-M microcontrollers. Though it's primarily used as git submodules, several distros, such as Arch Linux and FreeBSD, have packaged it. It is especially a good idea to package this into Nixpkgs so embedded development can benefit from Nixpkgs' awesome cross compilation support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux.pkgsCross.arm-embedded
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Tested building a simple blinky program for STM32F103
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
