### PR TITLE
python3Packages.pytest-testinfra: 8.1.0 → 9.0.0

### DIFF
--- a/pkgs/development/python-modules/pytest-testinfra/default.nix
+++ b/pkgs/development/python-modules/pytest-testinfra/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "pytest-testinfra";
-  version = "8.1.0";
+  version = "9.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-m0CCi1j7esK/8pzBRlk0rfQ08Q3VoQj2BTXe5SZgpj0=";
+    hash = "sha256-UxGzaeBUaSD85GTDv5RbVevnWhJ1aPbWFelLiJE0AUk=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   ];
 
   # markers don't get added when docker is not available (leads to warnings):
-  # https://github.com/pytest-dev/pytest-testinfra/blob/8.1.0/test/conftest.py#L228
+  # https://github.com/pytest-dev/pytest-testinfra/blob/9.0.0/test/conftest.py#L223
   preCheck = ''
     export HOME=$(mktemp -d)
     sed -i '54imarkers = \


### PR DESCRIPTION
## Description of changes
[Changelog](https://github.com/pytest-dev/pytest-testinfra/releases/tag/9.0.0)

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
