### PR TITLE
vcpkg: init at 2023.10.19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6834,6 +6834,12 @@
     githubId = 6893840;
     name = "Yacine Hmito";
   };
+  gracicot = {
+    email = "gracicot42@gmail.com";
+    github = "gracicot";
+    githubId = 2906673;
+    name = "Guillaume Racicot";
+  };
   graham33 = {
     email = "graham@grahambennett.org";
     github = "graham33";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6939,6 +6939,11 @@
     githubId = 21156405;
     name = "GuangTao Zhang";
   };
+  guekka = {
+    github = "Guekka";
+    githubId = 39066502;
+    name = "Guekka";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";

--- a/pkgs/by-name/cm/cmakerc/package.nix
+++ b/pkgs/by-name/cm/cmakerc/package.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "cmrc";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "vector-of-bool";
+    repo = "cmrc";
+    rev = finalAttrs.version;
+    hash = "sha256-++16WAs2K9BKk8384yaSI/YD1CdtdyXVBIjGhqi4JIk=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install CMakeRC.cmake -DT $out/share/cmakerc/cmakerc-config.cmake
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A Resource Compiler in a Single CMake Script";
+    homepage = "https://github.com/vector-of-bool/cmrc";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ guekka ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/vc/vcpkg-tool/change-lock-location.patch
+++ b/pkgs/by-name/vc/vcpkg-tool/change-lock-location.patch
@@ -1,0 +1,14 @@
+diff --git a/src/vcpkg/vcpkgpaths.cpp b/src/vcpkg/vcpkgpaths.cpp
+index 3f588c21..e6f2bbed 100644
+--- a/src/vcpkg/vcpkgpaths.cpp
++++ b/src/vcpkg/vcpkgpaths.cpp
+@@ -579,7 +579,8 @@ namespace vcpkg
+                 if (!args.do_not_take_lock)
+                 {
+                     std::error_code ec;
+-                    const auto vcpkg_root_file = root / ".vcpkg-root";
++                    fs.create_directories(Path{"/tmp/vcpkg"}, VCPKG_LINE_INFO);
++                    const auto vcpkg_root_file = Path{"/tmp/vcpkg"} / Hash::get_string_sha256(root.c_str());
+                     if (args.wait_for_lock.value_or(false))
+                     {
+                         file_lock_handle = fs.take_exclusive_file_lock(vcpkg_root_file, ec);

--- a/pkgs/by-name/vc/vcpkg-tool/package.nix
+++ b/pkgs/by-name/vc/vcpkg-tool/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cacert
+, cmake
+, cmakerc
+, fmt
+, git
+, gzip
+, makeWrapper
+, meson
+, ninja
+, openssh
+, python3
+, zip
+, zstd
+, extraRuntimeDeps ? []
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vcpkg-tool";
+  version = "2023-10-18";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vcpkg-tool";
+    rev = finalAttrs.version;
+    hash = "sha256-Hm+GSKov9A6tmN10BHOTVy8aWkLOJNBMOQJNm4HnWuI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    cmakerc
+    fmt
+    ninja
+    makeWrapper
+  ];
+
+  patches = [
+    ./change-lock-location.patch
+  ];
+
+  cmakeFlags = [
+    "-DVCPKG_DEPENDENCY_EXTERNAL_FMT=ON"
+    "-DVCPKG_DEPENDENCY_CMAKERC=ON"
+  ];
+
+  postFixup = let
+    # These are the most common binaries used by vcpkg
+    # Extra binaries can be added via overlay when needed
+    runtimeDeps = [
+      cacert
+      cmake
+      git
+      gzip
+      meson
+      ninja
+      openssh
+      python3
+      zip
+      zstd
+    ] ++ extraRuntimeDeps;
+  in ''
+    wrapProgram $out/bin/vcpkg --prefix PATH ${lib.makeBinPath runtimeDeps}
+  '';
+
+  meta = {
+    description = "Components of microsoft/vcpkg's binary";
+    homepage = "https://github.com/microsoft/vcpkg-tool";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ guekka gracicot ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -1,0 +1,51 @@
+{ fetchFromGitHub
+, stdenvNoCC
+, lib
+, vcpkg-tool
+, writeShellScript
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "vcpkg";
+  version = "2023.10.19";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vcpkg";
+    rev = finalAttrs.version;
+    hash = "sha256-u+4vyOphnowoaZgfkCbzF7Q4tuz2GN1bHylaKw352Lc=";
+  };
+
+  installPhase = let
+    # vcpkg needs two directories to write to that is independent of installation directory.
+    # Since vcpkg already creates $HOME/.vcpkg/ we use that to create a root where vcpkg can write into.
+    vcpkgScript = writeShellScript "vcpkg" ''
+      vcpkg_writable_path="$HOME/.vcpkg/root/"
+
+      VCPKG_ROOT="@out@/share/vcpkg" ${vcpkg-tool}/bin/vcpkg \
+        --x-downloads-root="$vcpkg_writable_path"/downloads \
+        --x-buildtrees-root="$vcpkg_writable_path"/buildtrees \
+        --x-packages-root="$vcpkg_writable_path"/packages \
+        "$@"
+      '';
+    in ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/share/vcpkg/scripts/buildsystems
+      cp --preserve=mode -r ./{docs,ports,triplets,scripts,.vcpkg-root,versions,LICENSE.txt} $out/share/vcpkg/
+      substitute ${vcpkgScript} $out/bin/vcpkg --subst-var-by out $out
+      chmod +x $out/bin/vcpkg
+      ln -s $out/bin/vcpkg $out/share/vcpkg/vcpkg
+      touch $out/share/vcpkg/vcpkg.disable-metrics
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "C++ Library Manager";
+    homepage = "https://vcpkg.io/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ guekka gracicot ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -822,6 +822,10 @@ with pkgs;
 
   sea-orm-cli = callPackage ../development/tools/sea-orm-cli { };
 
+  vcpkg-tool = callPackage ../by-name/vc/vcpkg-tool/package.nix {
+    fmt = fmt_10;
+  };
+
   r3ctl = qt5.callPackage ../tools/misc/r3ctl { };
 
   ptouch-print = callPackage ../misc/ptouch-print { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/151096

This PR packages vcpkg, a C++ package manager: https://vcpkg.io/

The goal of this package is to make vcpkg usable inside a nix environment as developer environment, and behave as closely as possible to other package managers such as pip and npm.

To have reproducible packages that uses vcpkg to be built, we would need a tool such as `vcpkg2nix`, but projects that work with vcpkg can normally skip vcpkg and uses packages from nix directly.

I will kindly ask for some help to make this PR ready to merge, I really intent to make this an official package but I'm not sure what's left to be done, and how to test the package.

This is based on the work of @Guekka 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
