### PR TITLE
wl-clipboard: fix image data mime type detection

### DIFF
--- a/pkgs/tools/wayland/wl-clipboard/default.nix
+++ b/pkgs/tools/wayland/wl-clipboard/default.nix
@@ -7,6 +7,8 @@
 , wayland
 , wayland-protocols
 , wayland-scanner
+, xdg-utils
+, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -21,18 +23,24 @@ stdenv.mkDerivation rec {
   };
 
   strictDeps = true;
-  nativeBuildInputs = [ meson ninja pkg-config wayland-scanner ];
+  nativeBuildInputs = [ meson ninja pkg-config wayland-scanner makeWrapper ];
   buildInputs = [ wayland wayland-protocols ];
 
   mesonFlags = [
     "-Dfishcompletiondir=share/fish/vendor_completions.d"
   ];
 
+  # Fix for https://github.com/NixOS/nixpkgs/issues/251261
+  postInstall = lib.optionalString (!xdg-utils.meta.broken) ''
+    wrapProgram $out/bin/wl-copy \
+      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/bugaevc/wl-clipboard";
     description = "Command-line copy/paste utilities for Wayland";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ dywedir ];
+    maintainers = with maintainers; [ dywedir kashw2 ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

fixes: https://github.com/NixOS/nixpkgs/issues/251261

Adds:
-  the `xdg-utils` runtime dependency so that `wl-copy` can correctly determine the mime type of image data allowing it to work when pasting into an image editor.
- `postInstall` stage that wraps the `wl-copy` binary
- Myself as a maintainer of the package

tested this using the reproduction steps in the issue

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
