### PR TITLE
discount: fixup dylib paths on darwin

### DIFF
--- a/pkgs/tools/text/discount/default.nix
+++ b/pkgs/tools/text/discount/default.nix
@@ -26,7 +26,10 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   postFixup = lib.optionalString stdenv.isDarwin ''
-    install_name_tool -id $out/lib/libmarkdown.dylib $out/lib/libmarkdown.dylib
+    install_name_tool -id "$out/lib/libmarkdown.dylib" "$out/lib/libmarkdown.dylib"
+    for exe in $out/bin/*; do
+      install_name_tool -change libmarkdown.dylib "$out/lib/libmarkdown.dylib" "$exe"
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

The binaries in the `discount` package on Darwin can't locate the `libmarkdown.dylib` in the nix store. This results in errors like so:

``` % nix-shell -p discount
% mkd2html
dyld: Library not loaded: libmarkdown.dylib
  Referenced from: /nix/store/j9x0wsp7wjyii7fn2qppprrs1i05klrs-discount-2.2.7b/bin/mkd2html
  Reason: image not found
Abort trap: 6
```

Similar to other darwin definitions, the solution is to use postFixup to shell out to `install_name_tool` and patch the executables with the store path to the dynamic library.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
