### PR TITLE
ntpd-rs: init at 0.3.7

### DIFF
--- a/pkgs/tools/networking/ntpd-rs/default.nix
+++ b/pkgs/tools/networking/ntpd-rs/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ntpd-rs";
+  version = "0.3.7";
+
+  src = fetchFromGitHub {
+    owner = "pendulum-project";
+    repo = "ntpd-rs";
+    rev = "v${version}";
+    hash = "sha256-AUCzsveG9U+KxYO/4LGmyCPkR+w9pGDA/vTzMAGiVuI=";
+  };
+
+  cargoHash = "sha256-6FUVkr3uock43ZBHuMEVIZ5F8Oh8wMifh2EokMWv4hU=";
+
+  checkFlags = [
+    # doesn't find the testca
+    "--skip=keyexchange::tests::key_exchange_roundtrip"
+    # seems flaky
+    "--skip=algorithm::kalman::peer::tests::test_offset_steering_and_measurements"
+    # needs networking
+    "--skip=hwtimestamp::tests::get_hwtimestamp"
+  ];
+
+  postInstall = ''
+    install -vDt $out/lib/systemd/system pkg/common/ntpd-rs.service
+
+    for testprog in demobilize-server rate-limit-server nts-ke nts-ke-server peer-state simple-daemon; do
+      moveToOutput bin/$testprog "$tests"
+    done
+  '';
+
+  outputs = [ "out" "tests" ];
+
+  meta = with lib; {
+    description = "A full-featured implementation of the Network Time Protocol";
+    homepage = "https://tweedegolf.nl/en/pendulum";
+    changelog = "https://github.com/pendulum-project/ntpd-rs/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = with maintainers; [ fpletz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1884,6 +1884,8 @@ with pkgs;
 
   nominatim = callPackage ../servers/nominatim { };
 
+  ntpd-rs = callPackage ../tools/networking/ntpd-rs { };
+
   ocs-url = libsForQt5.callPackage ../tools/misc/ocs-url { };
 
   openbugs = pkgsi686Linux.callPackage ../applications/science/machine-learning/openbugs { };


### PR DESCRIPTION
## Description of changes

ntpd-rs is currently under heavy development. A NixOS module will follow, but I'll wait until things have stabilized upstream.

https://github.com/pendulum-project/ntpd-rs

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
