### PR TITLE
ccoctl: init at 4.13.0

### DIFF
--- a/pkgs/applications/networking/cluster/ccoctl/default.nix
+++ b/pkgs/applications/networking/cluster/ccoctl/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+}:
+buildGoModule {
+  pname = "ccoctl";
+  version = "4.13.0";
+
+  # When updating, pin `rev` to latest commit in the `4.x` release branch.
+  src = fetchFromGitHub {
+    owner = "openshift";
+    repo = "cloud-credential-operator";
+    rev = "0621fcaf818f57ab05602259c1eb14db07b68dce";
+    hash = "sha256-zWOIRfltCOvkYpk9flvS7pBtfeLhBGwAJNe6WfrEd9c=";
+  };
+
+  # Dependencies are vendored in the repository.
+  vendorHash = null;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  subPackages = [ "cmd/ccoctl" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd ccoctl \
+      --bash <($out/bin/ccoctl completion bash) \
+      --fish <($out/bin/ccoctl completion fish) \
+      --zsh <($out/bin/ccoctl completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "Manage cloud provider credentials as Kubernetes CRDs";
+    homepage = "https://github.com/openshift/cloud-credential-operator";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ stehessel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30918,6 +30918,8 @@ with pkgs;
 
   cbc = callPackage ../applications/science/math/cbc { };
 
+  ccoctl = callPackage ../applications/networking/cluster/ccoctl { };
+
   cddiscid = callPackage ../applications/audio/cd-discid {
     inherit (darwin) IOKit;
   };


### PR DESCRIPTION
## Description of changes

`ccoctl` is a CLI tool to setup cloud provider credentials on OpenShift clusters. https://github.com/openshift/cloud-credential-operator

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
