### PR TITLE
vmware-workstation: 17.0.0 -> 17.0.2

### DIFF
--- a/pkgs/applications/virtualization/vmware-workstation/default.nix
+++ b/pkgs/applications/virtualization/vmware-workstation/default.nix
@@ -32,14 +32,14 @@
 
 let
   # macOS - versions
-  fusionVersion = "13.0.0";
-  fusionBuild = "20802013";
+  fusionVersion = "13.0.2";
+  fusionBuild = "21581413";
   unlockerVersion = "3.0.4";
 
   # macOS - ISOs
   darwinIsoSrc = fetchurl {
-    url = "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/${fusionVersion}/${fusionBuild}/x86/core/com.vmware.fusion.zip.tar";
-    sha256 = "sha256-cSboek+nhkVj8rjdic6yzWQfjXiiLlch6gBWn73BzRU=";
+    url = "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/${fusionVersion}/${fusionBuild}/universal/core/com.vmware.fusion.zip.tar";
+    sha256 = "sha256-8IaEQn1+e+WtjRX9Aopbi6tVTNt9RVyGrpaARtVH6j0=";
   };
 
   # macOS - Unlocker
@@ -71,8 +71,8 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vmware-workstation";
-  version = "17.0.0";
-  build = "20800274";
+  version = "17.0.2";
+  build = "21581411";
 
   buildInputs = [
     libxslt
@@ -100,8 +100,8 @@ stdenv.mkDerivation rec {
     ++ lib.optionals enableMacOSGuests [ gnutar unzip ];
 
   src = fetchurl {
-    url = "https://download3.vmware.com/software/WKST-1700-LX/VMware-Workstation-Full-${version}-${build}.x86_64.bundle";
-    sha256 = "sha256-kBTocGb1tg5i+dvWmOaPfPUHxrWcX8/obeKqRGR+mRA=";
+    url = "https://download3.vmware.com/software/WKST-${builtins.replaceStrings ["."] [""] version}-LX/VMware-Workstation-Full-${version}-${build}.x86_64.bundle";
+    sha256 = "sha256-9ONh+uvL4YGNGxbpPX1mWO8P4oKPUpwzTsKKBJNxHMc=";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
## Description of changes
Just a small bump.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

