### PR TITLE
llvmPackages_15.libcxxabi: fix build on Linux and Darwin

### DIFF
--- a/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
-  ] ++ lib.optionals ((stdenv.hostPlatform.useLLVM or false) || !stdenv.hostPlatform.isDarwin) [
     # libcxxabi's CMake looks as though it treats -nostdlib++ as implying -nostdlib,
     # but that does not appear to be the case for example when building
     # pkgsLLVM.libcxxabi (which uses clangNoCompilerRtWithLibc).

--- a/pkgs/development/compilers/llvm/16/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/16/libcxxabi/default.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
-  ] ++ lib.optionals ((stdenv.hostPlatform.useLLVM or false) || !stdenv.hostPlatform.isDarwin) [
     # libcxxabi's CMake looks as though it treats -nostdlib++ as implying -nostdlib,
     # but that does not appear to be the case for example when building
     # pkgsLLVM.libcxxabi (which uses clangNoCompilerRtWithLibc).

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
-  ] ++ lib.optionals ((stdenv.hostPlatform.useLLVM or false) || !stdenv.hostPlatform.isDarwin) [
     # libcxxabi's CMake looks as though it treats -nostdlib++ as implying -nostdlib,
     # but that does not appear to be the case for example when building
     # pkgsLLVM.libcxxabi (which uses clangNoCompilerRtWithLibc).


### PR DESCRIPTION
## Description of changes

The previous change in https://github.com/NixOS/nixpkgs/pull/246577 broke `*-darwin`.
The previous fix in https://github.com/NixOS/nixpkgs/pull/251255 broke `*-linux`. 

This should fix LLVM for Linux and Darwin.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
