### PR TITLE
Remove service result check for oci-containers; fixes #249332

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -284,8 +284,8 @@ let
     );
 
     preStop = if cfg.backend == "podman"
-      then "[ $SERVICE_RESULT = success ] || podman stop --ignore --cidfile=/run/podman-${escapedName}.ctr-id"
-      else "[ $SERVICE_RESULT = success ] || ${cfg.backend} stop ${name}";
+      then "podman stop --ignore --cidfile=/run/podman-${escapedName}.ctr-id"
+      else "${cfg.backend} stop ${name}";
     postStop =  if cfg.backend == "podman"
       then "podman rm -f --ignore --cidfile=/run/podman-${escapedName}.ctr-id"
       else "${cfg.backend} rm -f ${name} || true";


### PR DESCRIPTION
## Description of changes
Remove service result check

## Explanation
The container would only be stopped when the service result was not "success" because of short circuit of `||`.
This would cause the monitoring process to be killed together with the rest of the cgroup. Killing the monitoring process could cause container processes to crash and coredump. No check is present in the systemd units generated by `podman systemd generate`. The check is not needed because the stop action is not run if the unit fails to start.