### PR TITLE
linuxPackages.{xpadneo, xone}: fix after simplifying sourceRoot

### DIFF
--- a/pkgs/os-specific/linux/xone/default.nix
+++ b/pkgs/os-specific/linux/xone/default.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  sourceRoot = src.name;
+  setSourceRoot = ''
+    export sourceRoot=$(pwd)/${src.name}
+  '';
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-rT2Mq40fE055FemDG7PBjt+cxgIHJG9tTjtw2nW6B98=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/hid-xpadneo/src";
+  setSourceRoot = ''
+    export sourceRoot=$(pwd)/${finalAttrs.src.name}/hid-xpadneo/src
+  '';
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
   buildInputs = [ bluez ];


### PR DESCRIPTION
This partially reverts commits 68be474e30887a66e0530edfc898b74fb5dd5d26 and 5a0f953d9ffe5c40df263ccccffa647a86729f5a.

@vcunat pointed out the above commits broke them in https://github.com/NixOS/nixpkgs/commit/5a0f953d9ffe5c40df263ccccffa647a86729f5a#commitcomment-125587480.