### PR TITLE
box64: Post-0.2.4 refactoring

### DIFF
--- a/pkgs/applications/emulators/box64/default.nix
+++ b/pkgs/applications/emulators/box64/default.nix
@@ -8,20 +8,19 @@
 , withDynarec ? stdenv.hostPlatform.isAarch64
 , runCommand
 , hello-x86_64
-, box64
 }:
 
 # Currently only supported on ARM
 assert withDynarec -> stdenv.hostPlatform.isAarch64;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "box64";
   version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "ptitSeb";
-    repo = pname;
-    rev = "v${version}";
+    repo = "box64";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-iCZv/WvqZkH6i23fSLA/p0nG5/CgzjyU5glVgje4c3w=";
   };
 
@@ -79,7 +78,7 @@ stdenv.mkDerivation rec {
       rev-prefix = "v";
     };
     tests.hello = runCommand "box64-test-hello" {
-      nativeBuildInputs = [ box64 hello-x86_64 ];
+      nativeBuildInputs = [ finalAttrs.finalPackage ];
     } ''
       # There is no actual "Hello, world!" with any of the logging enabled, and with all logging disabled it's hard to
       # tell what problems the emulator has run into.
@@ -94,4 +93,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ gador OPNA2608 ];
     platforms = [ "x86_64-linux" "aarch64-linux" "riscv64-linux" "powerpc64le-linux" ];
   };
-}
+})

--- a/pkgs/applications/emulators/box64/default.nix
+++ b/pkgs/applications/emulators/box64/default.nix
@@ -5,13 +5,13 @@
 , gitUpdater
 , cmake
 , python3
-, withDynarec ? stdenv.hostPlatform.isAarch64
+, withDynarec ? (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64)
 , runCommand
 , hello-x86_64
 }:
 
-# Currently only supported on ARM
-assert withDynarec -> stdenv.hostPlatform.isAarch64;
+# Currently only supported on ARM & RISC-V
+assert withDynarec -> (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "box64";
@@ -46,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DARM64=${lib.boolToString stdenv.hostPlatform.isAarch64}"
     "-DRV64=${lib.boolToString stdenv.hostPlatform.isRiscV64}"
     "-DPPC64LE=${lib.boolToString (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian)}"
+    "-DLARCH64=${lib.boolToString stdenv.hostPlatform.isLoongArch64}"
   ] ++ lib.optionals stdenv.hostPlatform.isx86_64 [
     # x86_64 has no arch-specific mega-option, manually enable the options that apply to it
     "-DLD80BITS=ON"
@@ -53,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ [
     # Arch dynarec
     "-DARM_DYNAREC=${lib.boolToString (withDynarec && stdenv.hostPlatform.isAarch64)}"
+    "-DRV64_DYNAREC=${lib.boolToString (withDynarec && stdenv.hostPlatform.isRiscV64)}"
   ];
 
   installPhase = ''
@@ -98,6 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     maintainers = with maintainers; [ gador OPNA2608 ];
     mainProgram = "box64";
-    platforms = [ "x86_64-linux" "aarch64-linux" "riscv64-linux" "powerpc64le-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "riscv64-linux" "powerpc64le-linux" "loongarch64-linux" "mips64el-linux" ];
   };
 })

--- a/pkgs/applications/emulators/box64/default.nix
+++ b/pkgs/applications/emulators/box64/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , gitUpdater
 , cmake
 , python3
@@ -23,6 +24,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-iCZv/WvqZkH6i23fSLA/p0nG5/CgzjyU5glVgje4c3w=";
   };
+
+  patches = [
+    # Fix crash due to regression in SDL1 AudioCallback signature in 0.2.4
+    # Remove when version > 0.2.4
+    (fetchpatch {
+      name = "0001-box64-Fixed_signature_of_SDL1_AudioCallback.patch";
+      url = "https://github.com/ptitSeb/box64/commit/5fabd602aea1937e3c5ce58843504c2492b8c0ec.patch";
+      hash = "sha256-dBdKijTljCFtSJ2smHrbjH/ok0puGw4YEy/kluLl4AQ=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Description of changes

Various adjustments, following the [recent bump](https://github.com/NixOS/nixpkgs/pull/250877).

- Fetch a patch to fix a regression in SDL1 coverage
- Migrate from `rec` attrset to `finalAttrs` function mkDerivation pattern
- A minor refactor of how the CMake flags are ordered & filled in, when the check phases are run (require built binaries to be executable locally) to fix cross, and an addition of `meta.mainProgram`
- Some additions regarding more exotic platforms
  - RISC-V received dynarec support in 0.2.4, added handling for it & enabled it by default.
    I lack the hardware to test it, but it cross-compiles for me.
  - Added `loongarch64-linux` and `mips64el-linux` to supported platforms, at least on paper. LA64 is explicitly supported with one of the "mega-options", 64-bit little-endian MIPS by virtue of fitting the upstream target description: `non-x86_64 Linux systems, like ARM (host system needs to be 64-bit little-endian)`.
    The cross-compiler toolchain for both of these targets seems to be broken right now so I can't verify if these build.

I'd appreciate *any* suggestions on how to automatically compose `meta.platforms`. The only unwieldy solution could come up with includes duplicating code from `lib/systems/doubles.nix`, due to there being no `64bit` platforms list:
```nix
# Supported on 64-bit, little-endian, Linux hosts
platforms = map lib.systems.parse.doubleFromSystem
  (lib.lists.filter lib.systems.inspect.predicates.is64bit
    (map lib.systems.parse.mkSystemFromString
      (lib.lists.intersectLists lib.platforms.linux lib.platforms.littleEndian)));
```

This *does* give me the correct list of platforms, but feels too ugly to commit. :sweat_smile:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
