### PR TITLE
mozc: init at unstable-2024-02-09, fcitx5-mozc: 2.26.4220.102 -> unstable-2024-02-09

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -937,6 +937,11 @@ lib.mapAttrs mkLicense ({
     url = "https://license.coscl.org.cn/MulanPSL2";
   };
 
+  naist-2003 = {
+    spdxId = "NAIST-2003";
+    fullName = "Nara Institute of Science and Technology License (2003)";
+  };
+
   nasa13 = {
     spdxId = "NASA-1.3";
     fullName = "NASA Open Source Agreement 1.3";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14344,6 +14344,11 @@
     githubId = 96225281;
     name = "Mustafa Çalışkan";
   };
+  musjj = {
+    name = "musjj";
+    github = "musjj";
+    githubId = 72612857;
+  };
   mvisonneau = {
     name = "Maxime VISONNEAU";
     email = "maxime@visonneau.fr";

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -10,6 +10,16 @@
 , qtwayland
 , ruby
 , wrapQtAppsHook
+, dictionaries ? [
+    "alt-cannadic"
+    "edict2"
+    "jawiki"
+    "neologd"
+    "personal-names"
+    "place-names"
+    "skk-jisyo"
+    "sudachidict"
+  ]
 }:
 
 buildBazelPackage {
@@ -176,20 +186,12 @@ buildBazelPackage {
 
         [[ -e mozcdic-ut.txt ]] && rm mozcdic-ut.txt
 
-        dicts=(
-          alt-cannadic
-          edict2
-          jawiki
-          neologd
-          personal-names
-          place-names
-          skk-jisyo
-          sudachidict
+        dictionaries=(
+          ${lib.escapeShellArgs dictionaries}
         )
-
-        for dict in "''${dicts[@]}"; do
-          tar -xf ../../mozcdic-ut-$dict/mozcdic-ut-$dict.txt.tar.bz2
-          cat mozcdic-ut-$dict.txt >>mozcdic-ut.txt
+        for name in "''${dictionaries[@]}"; do
+          tar -xf ../../mozcdic-ut-$name/mozcdic-ut-$name.txt.tar.bz2
+          cat mozcdic-ut-$name.txt >>mozcdic-ut.txt
         done
 
         ruby remove_duplicate_ut_entries.rb mozcdic-ut.txt

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -7,6 +7,7 @@
 , pkg-config
 , python3
 , qtbase
+, qtwayland
 , ruby
 , wrapQtAppsHook
 }:
@@ -117,7 +118,7 @@ buildBazelPackage {
     wrapQtAppsHook
   ];
 
-  buildInputs = [ qtbase ];
+  buildInputs = [ qtbase qtwayland ];
 
   preBuild = ''
     cd mozc/src

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -89,12 +89,11 @@ buildBazelPackage {
     })
     (fetchurl rec {
       name = "jawiki";
-      url = "https://dumps.wikimedia.org/${name}/20230820/${name}-20230820-all-titles-in-ns0.gz";
+      url = "https://dumps.wikimedia.org/${name}/20240120/${name}-20240120-all-titles-in-ns0.gz";
       recursiveHash = true;
-      hash = "sha256-pOK4ThhOaup4t896Wx9jfsKSmWlQYn4Yy4pTiiwAFIs=";
+      hash = "sha256-Mp7ya2tM6E0IKE6kOYSlRx6gZBS/DK1zAwyT6jvZxrY=";
       downloadToTemp = true;
       postFetch = ''
-        mkdir -p $out
         mv $downloadedFile $out/${name}.gz
       '';
     })

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -231,7 +231,9 @@ buildBazelPackage {
       gpl2Only # mozcdic-ut-alt-cannadic.txt
       gpl2Plus # mozcdic-ut-skk-jisyo.txt
       mit # wil
+      naist-2003 # IPAdic
       publicDomain # src/data/test/stress_test, mozcdic-ut-place-names.txt, jp-zip-codes, Okinawa dictionary
+      unicode-30 # src/data/unicode, breakpad
     ];
     maintainers = with maintainers; [ musjj ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -14,7 +14,7 @@
 
 buildBazelPackage {
   pname = "mozc";
-  version = "unstable-2023-08-18";
+  version = "unstable-2024-02-09";
 
   srcs = [
     (fetchFromGitHub rec {
@@ -22,71 +22,71 @@ buildBazelPackage {
       repo = "mozc";
       name = repo;
       fetchSubmodules = true;
-      rev = "89c70080d0102e8ed23cae6c05b535dedf506de4";
-      hash = "sha256-SSAu9gYTfEbfgORSDyqS0Z02bJDCAEy7nYC3ZcjL8gM=";
+      rev = "c2fcbf6515c5884437977de46187c16a8cb7bb50";
+      hash = "sha256-AcIN5sWPBe4JotAUYv1fytgQw+mJzdFhKuVPLR48soA=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "merge-ut-dictionaries";
       name = repo;
-      rev = "dbf3e9ccd711be39749cbf38baee99adbb2bad6f";
-      hash = "sha256-7CfIr7hJChBWFVynCVqw5KYh/lIjl277fqQQ4AuJ7x4=";
+      rev = "a3d6fc4005aff2092657ebca98b9de226e1c617f";
+      hash = "sha256-UK29ACZUK9zGfzW7C85uMw2aF5Gk+0aDeUdNV71PY+0=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-alt-cannadic";
       name = repo;
-      rev = "f59287e569db3e226378380a34e71275654b46d0";
-      hash = "sha256-a9U6mGlGAxbywILeAaWKbt7BFWRPFS+UZvUhliFUseY=";
+      rev = "4e548e6356b874c76e8db438bf4d8a0b452f2435";
+      hash = "sha256-4gzqVoCIhC0k3mh0qbEr8yYttz9YR0fItkFNlu7cYOY=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-edict2";
       name = repo;
-      rev = "e0cbf7d3192b1cdd38629a720b295bcbd67cd8bd";
-      hash = "sha256-jj5eBcmWxLxKC/Q720BPuzxJc9x1Y2RvY0kJfBJkIfE=";
+      rev = "b2eec665b81214082d61acee1c5a1b5b115baf1a";
+      hash = "sha256-LIpGt6xB8dLUnazbJHZk6EH1/ZyAHMIn1m6Qpr2dsHs=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-jawiki";
       name = repo;
-      rev = "be4da36c087e56a3aa5f835f8d9e810fc1a060ba";
-      hash = "sha256-WkP/RugY28TqNwTjbi2V5BsRVLwUIIvOX6zGJmdIDEk=";
+      rev = "6e08b8c823f3d2d09064ad2080e7a16552a7b473";
+      hash = "sha256-0YwAinlcI6yojCdW1MpLgMZfyYV7gk9Q+Wlu4lR3Hrg=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-neologd";
       name = repo;
-      rev = "90e59c7707a5fe250c992c10c6ceb08a7ce7e652";
-      hash = "sha256-zY7K/J4OzBTQHrj8sF4s8xPqakoWHHMxWrvnvHT6oxE=";
+      rev = "bf9d0d217107f2fb2e7d1a26648ef429d9fdcd27";
+      hash = "sha256-e0iM5fohwpNNhPl9CjkD753/Rgatg7GdwN0NSvlN94c=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-personal-names";
       name = repo;
-      rev = "0e51584283f759cb6bfac1f19eda92c2c524eed4";
-      hash = "sha256-8cJmSp7rGxSHy+TElFpkXmNvMxYLw2yiAYJJb2AUyyE=";
+      rev = "8a500f82c553936cbdd33b85955120e731069d44";
+      hash = "sha256-pMyYvl5S0+U++MO5m9rmbtxDzAmO4Xs8sFewOUGqgUA=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-place-names";
       name = repo;
-      rev = "478004504981e094af407f4fbd64cd65cf2d85dd";
-      hash = "sha256-3BwK+RuZMl5+femxQXNhDF/NE3qfX6u/+imqL2Uqd8I=";
+      rev = "a847a02e0137ab9e2fdbbaaf120826f870408ca6";
+      hash = "sha256-B0kW8Wa/nCT4KEYl2Rz6gQcj0Po3GxU6i42unHhgZeU=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-skk-jisyo";
       name = repo;
-      rev = "43518e6ea033681580a515281668c85eb74a5b14";
-      hash = "sha256-05T//ulsS5HvOKPdOEG87/Yp8GgzOB2X3wG8Sds3uUU=";
+      rev = "ee94f6546ce52edfeec0fd203030f52d4d99656f";
+      hash = "sha256-RXxO878ZBkxenrdo7cFom5NjM0m7CdYQk0dFu/HPp/Y=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-sudachidict";
       name = repo;
-      rev = "1b5ad7cb51325fc9b42732887fede29d6a02bb07";
-      hash = "sha256-E4kq3YnxdYRFlv4KLSvf4NRoPhWXL8c89JIvqsjuy3o=";
+      rev = "55f61c3fca81dec661c36c73eb29b2631c8ed618";
+      hash = "sha256-gNnBcuVU1M7rllfZXIrLg7WYUhKqPJsUjR8Scnq3Fw8=";
     })
     (fetchurl rec {
       name = "jawiki";
@@ -103,8 +103,8 @@ buildBazelPackage {
       owner = "musjj";
       repo = "jp-zip-codes";
       name = repo;
-      rev = "be9cd2ac888a34eba30a425c43a7e54f5187a649";
-      hash = "sha256-02CE/DJnqNXUF0OH3ptq2sb8UbtqKjLKx7Hf0izq+X4=";
+      rev = "cfbb54655223d8e2cea6fedbaef202919d8d62fe";
+      hash = "sha256-ZvZL/6yTE6JrBu4ja7HvyBUKWUAIL0jULii5Im+zmLQ=";
     })
   ];
 
@@ -159,7 +159,7 @@ buildBazelPackage {
       rm -rf $bazelOut/external/qt_linux
     '';
 
-    sha256 = "sha256-qvUkld0DJePrXFX5OJ/ZOp2KIF1AjU0I8EbOeSiZLEY=";
+    sha256 = "sha256-gpRLwbYHPW2o9LkOhO10sOVhtXZr7MPfMRdJympwPyk=";
   };
 
   buildAttrs = {

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -217,16 +217,15 @@ buildBazelPackage {
     description = "The Open Source edition of Google Japanese Input bundled with the UT dictionary";
     homepage = "https://github.com/google/mozc";
     license = with licenses; [
-      asl20
-      bsd2
-      bsd3
-      cc-by-sa-30
-      cc-by-sa-40
-      gpl2Only
-      ipa
-      mit
-      mspl
-      publicDomain
+      asl20 # abseil-cpp, merge-ut-dictionaries, mozcdic-ut-alt-cannadic, mozcdic-ut-edict2, mozcdic-ut-jawiki, mozcdic-ut-neologd, mozcdic-ut-personal-names, mozcdic-ut-place-names, mozcdic-ut-skk-jisyo, mozcdic-ut-sudachidict
+      bsd2 # japanese-usage-dictionary
+      bsd3 # mozc, breakpad, gtest, gyp, japanese-usage-dictionary, protobuf, id.def
+      cc-by-sa-30 # jawiki-latest-all-titles, mozcdic-ut-jawiki.txt, jawiki
+      cc-by-sa-40 # mozcdic-ut-edict2.txt
+      gpl2Only # mozcdic-ut-alt-cannadic.txt
+      gpl2Plus # mozcdic-ut-skk-jisyo.txt
+      mit # wil
+      publicDomain # src/data/test/stress_test, mozcdic-ut-place-names.txt, jp-zip-codes
     ];
     maintainers = with maintainers; [ musjj ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -94,7 +94,8 @@ buildBazelPackage {
       hash = "sha256-Mp7ya2tM6E0IKE6kOYSlRx6gZBS/DK1zAwyT6jvZxrY=";
       downloadToTemp = true;
       postFetch = ''
-        mv $downloadedFile $out/${name}.gz
+        mkdir -p "$out"
+        install -Dm444 "$downloadedFile" "$out/${name}.gz"
       '';
     })
     (fetchFromGitHub rec {
@@ -200,13 +201,11 @@ buildBazelPackage {
     installPhase = ''
       runHook preInstall
 
-      mkdir -p $out/share/licenses/mozc
-      cp ../LICENSE $out/share/licenses/mozc/LICENSE
-      cp data/installer/credits_en.html $out/share/licenses/mozc/Submodules
+      install -Dm444 -t $out/share/licenses/mozc ../LICENSE
+      install -Dm444 -t $out/share/licenses/mozc/Submodules data/installer/credits_en.html
 
-      mkdir -p $out/lib/mozc
-      cp bazel-bin/server/mozc_server $out/lib/mozc/mozc_server
-      cp bazel-bin/gui/tool/mozc_tool $out/lib/mozc/mozc_tool
+      install -Dm555 -t $out/lib/mozc bazel-bin/server/mozc_server
+      install -Dm555 -t $out/lib/mozc bazel-bin/gui/tool/mozc_tool
 
       runHook postInstall
     '';

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -157,7 +157,7 @@ buildBazelPackage {
       rm -rf $bazelOut/external/qt_linux
     '';
 
-    sha256 = "sha256-TNeU39pmUXBn0NC5Zwu9p4I86LhT432whrhM63UPQ7U=";
+    sha256 = "sha256-qvUkld0DJePrXFX5OJ/ZOp2KIF1AjU0I8EbOeSiZLEY=";
   };
 
   buildAttrs = {

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -231,7 +231,7 @@ buildBazelPackage {
       gpl2Only # mozcdic-ut-alt-cannadic.txt
       gpl2Plus # mozcdic-ut-skk-jisyo.txt
       mit # wil
-      publicDomain # src/data/test/stress_test, mozcdic-ut-place-names.txt, jp-zip-codes
+      publicDomain # src/data/test/stress_test, mozcdic-ut-place-names.txt, jp-zip-codes, Okinawa dictionary
     ];
     maintainers = with maintainers; [ musjj ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -1,0 +1,234 @@
+{ bazel
+, buildBazelPackage
+, fetchFromGitHub
+, fetchurl
+, glibcLocales
+, lib
+, pkg-config
+, python3
+, qtbase
+, ruby
+, wrapQtAppsHook
+}:
+
+buildBazelPackage {
+  pname = "mozc";
+  version = "unstable-2023-08-18";
+
+  srcs = [
+    (fetchFromGitHub rec {
+      owner = "google";
+      repo = "mozc";
+      name = repo;
+      fetchSubmodules = true;
+      rev = "89c70080d0102e8ed23cae6c05b535dedf506de4";
+      hash = "sha256-SSAu9gYTfEbfgORSDyqS0Z02bJDCAEy7nYC3ZcjL8gM=";
+    })
+    (fetchFromGitHub rec {
+      owner = "utuhiro78";
+      repo = "merge-ut-dictionaries";
+      name = repo;
+      rev = "dbf3e9ccd711be39749cbf38baee99adbb2bad6f";
+      hash = "sha256-7CfIr7hJChBWFVynCVqw5KYh/lIjl277fqQQ4AuJ7x4=";
+    })
+    (fetchFromGitHub rec {
+      owner = "utuhiro78";
+      repo = "mozcdic-ut-alt-cannadic";
+      name = repo;
+      rev = "f59287e569db3e226378380a34e71275654b46d0";
+      hash = "sha256-a9U6mGlGAxbywILeAaWKbt7BFWRPFS+UZvUhliFUseY=";
+    })
+    (fetchFromGitHub rec {
+      owner = "utuhiro78";
+      repo = "mozcdic-ut-edict2";
+      name = repo;
+      rev = "e0cbf7d3192b1cdd38629a720b295bcbd67cd8bd";
+      hash = "sha256-jj5eBcmWxLxKC/Q720BPuzxJc9x1Y2RvY0kJfBJkIfE=";
+    })
+    (fetchFromGitHub rec {
+      owner = "utuhiro78";
+      repo = "mozcdic-ut-jawiki";
+      name = repo;
+      rev = "be4da36c087e56a3aa5f835f8d9e810fc1a060ba";
+      hash = "sha256-WkP/RugY28TqNwTjbi2V5BsRVLwUIIvOX6zGJmdIDEk=";
+    })
+    (fetchFromGitHub rec {
+      owner = "utuhiro78";
+      repo = "mozcdic-ut-neologd";
+      name = repo;
+      rev = "90e59c7707a5fe250c992c10c6ceb08a7ce7e652";
+      hash = "sha256-zY7K/J4OzBTQHrj8sF4s8xPqakoWHHMxWrvnvHT6oxE=";
+    })
+    (fetchFromGitHub rec {
+      owner = "utuhiro78";
+      repo = "mozcdic-ut-personal-names";
+      name = repo;
+      rev = "0e51584283f759cb6bfac1f19eda92c2c524eed4";
+      hash = "sha256-8cJmSp7rGxSHy+TElFpkXmNvMxYLw2yiAYJJb2AUyyE=";
+    })
+    (fetchFromGitHub rec {
+      owner = "utuhiro78";
+      repo = "mozcdic-ut-place-names";
+      name = repo;
+      rev = "478004504981e094af407f4fbd64cd65cf2d85dd";
+      hash = "sha256-3BwK+RuZMl5+femxQXNhDF/NE3qfX6u/+imqL2Uqd8I=";
+    })
+    (fetchFromGitHub rec {
+      owner = "utuhiro78";
+      repo = "mozcdic-ut-skk-jisyo";
+      name = repo;
+      rev = "43518e6ea033681580a515281668c85eb74a5b14";
+      hash = "sha256-05T//ulsS5HvOKPdOEG87/Yp8GgzOB2X3wG8Sds3uUU=";
+    })
+    (fetchFromGitHub rec {
+      owner = "utuhiro78";
+      repo = "mozcdic-ut-sudachidict";
+      name = repo;
+      rev = "1b5ad7cb51325fc9b42732887fede29d6a02bb07";
+      hash = "sha256-E4kq3YnxdYRFlv4KLSvf4NRoPhWXL8c89JIvqsjuy3o=";
+    })
+    (fetchurl rec {
+      name = "jawiki";
+      url = "https://dumps.wikimedia.org/${name}/20230820/${name}-20230820-all-titles-in-ns0.gz";
+      recursiveHash = true;
+      hash = "sha256-pOK4ThhOaup4t896Wx9jfsKSmWlQYn4Yy4pTiiwAFIs=";
+      downloadToTemp = true;
+      postFetch = ''
+        mkdir -p $out
+        mv $downloadedFile $out/${name}.gz
+      '';
+    })
+    (fetchFromGitHub rec {
+      owner = "musjj";
+      repo = "jp-zip-codes";
+      name = repo;
+      rev = "be9cd2ac888a34eba30a425c43a7e54f5187a649";
+      hash = "sha256-02CE/DJnqNXUF0OH3ptq2sb8UbtqKjLKx7Hf0izq+X4=";
+    })
+  ];
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    glibcLocales
+    pkg-config
+    python3
+    ruby
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [ qtbase ];
+
+  preBuild = ''
+    cd mozc/src
+  '';
+
+  LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+  LC_ALL = "en_US.UTF-8";
+
+  inherit bazel;
+  removeRulesCC = false;
+  dontAddBazelOpts = true;
+
+  bazelFlags = [
+    "--config"
+    "oss_linux"
+    "--compilation_mode"
+    "opt"
+  ];
+
+  bazelTargets = [
+    "server:mozc_server"
+    "gui/tool:mozc_tool"
+  ];
+
+  fetchAttrs = {
+    postPatch = ''
+      substituteInPlace mozc/src/WORKSPACE.bazel \
+        --replace \
+          'url = "https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip"' \
+          "url = \"file://$PWD/jp-zip-codes/ken_all.zip\"" \
+        --replace \
+          'url = "https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip"' \
+          "url = \"file://$PWD/jp-zip-codes/jigyosyo.zip\""
+    '';
+
+    preInstall = ''
+      rm -rf $bazelOut/external/qt_linux
+    '';
+
+    sha256 = "sha256-TNeU39pmUXBn0NC5Zwu9p4I86LhT432whrhM63UPQ7U=";
+  };
+
+  buildAttrs = {
+    postPatch = ''
+      sed -ri -e "s|^(LINUX_MOZC_SERVER_DIR = ).+|\1\"$out/lib/mozc\"|" mozc/src/config.bzl
+
+      (
+        cd merge-ut-dictionaries/src
+
+        sed -i -e "s|https://raw.githubusercontent.com/google/mozc/master|../../mozc|" remove_duplicate_ut_entries.rb
+
+        sed -i -e '/wget/d' count_word_hits.rb
+        sed -i -e "s|^filename = \"jawiki-.*|filename = \"../../jawiki/jawiki.gz\"|" count_word_hits.rb
+
+        [[ -e mozcdic-ut.txt ]] && rm mozcdic-ut.txt
+
+        dicts=(
+          alt-cannadic
+          edict2
+          jawiki
+          neologd
+          personal-names
+          place-names
+          skk-jisyo
+          sudachidict
+        )
+
+        for dict in "''${dicts[@]}"; do
+          tar -xf ../../mozcdic-ut-$dict/mozcdic-ut-$dict.txt.tar.bz2
+          cat mozcdic-ut-$dict.txt >>mozcdic-ut.txt
+        done
+
+        ruby remove_duplicate_ut_entries.rb mozcdic-ut.txt
+        ruby count_word_hits.rb
+        ruby apply_word_hits.rb mozcdic-ut.txt
+
+        cat mozcdic-ut.txt >>../../mozc/src/data/dictionary_oss/dictionary00.txt
+      )
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/licenses/mozc
+      cp ../LICENSE $out/share/licenses/mozc/LICENSE
+      cp data/installer/credits_en.html $out/share/licenses/mozc/Submodules
+
+      mkdir -p $out/lib/mozc
+      cp bazel-bin/server/mozc_server $out/lib/mozc/mozc_server
+      cp bazel-bin/gui/tool/mozc_tool $out/lib/mozc/mozc_tool
+
+      runHook postInstall
+    '';
+  };
+
+  meta = with lib; {
+    description = "The Open Source edition of Google Japanese Input bundled with the UT dictionary";
+    homepage = "https://github.com/google/mozc";
+    license = with licenses; [
+      asl20
+      bsd2
+      bsd3
+      cc-by-sa-30
+      cc-by-sa-40
+      gpl2Only
+      ipa
+      mit
+      mspl
+      publicDomain
+    ];
+    maintainers = with maintainers; [ musjj ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -219,7 +219,11 @@ buildBazelPackage {
     description = "The Open Source edition of Google Japanese Input bundled with the UT dictionary";
     homepage = "https://github.com/google/mozc";
     license = with licenses; [
-      asl20 # abseil-cpp, merge-ut-dictionaries, mozcdic-ut-alt-cannadic, mozcdic-ut-edict2, mozcdic-ut-jawiki, mozcdic-ut-neologd, mozcdic-ut-personal-names, mozcdic-ut-place-names, mozcdic-ut-skk-jisyo, mozcdic-ut-sudachidict
+      asl20 # abseil-cpp, merge-ut-dictionaries, mozcdic-ut-alt-cannadic,
+            # mozcdic-ut-edict2, mozcdic-ut-jawiki, mozcdic-ut-neologd,
+            # mecab-ipadic-neologd, mozcdic-ut-personal-names,
+            # mozcdic-ut-place-names, mozcdic-ut-skk-jisyo,
+            # mozcdic-ut-sudachidict
       bsd2 # japanese-usage-dictionary
       bsd3 # mozc, breakpad, gtest, gyp, japanese-usage-dictionary, protobuf, id.def
       cc-by-sa-30 # jawiki-latest-all-titles, mozcdic-ut-jawiki.txt, jawiki

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -124,8 +124,9 @@ buildBazelPackage {
     cd mozc/src
   '';
 
-  LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
-  LC_ALL = "en_US.UTF-8";
+  # Required so that the ruby scripts can work
+  env.LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+  env.LC_ALL = "en_US.UTF-8";
 
   inherit bazel;
   removeRulesCC = false;

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -1,16 +1,17 @@
-{ bazel_6
-, buildBazelPackage
-, fetchFromGitHub
-, fetchurl
-, glibcLocales
-, lib
-, pkg-config
-, python3
-, qtbase
-, qtwayland
-, ruby
-, wrapQtAppsHook
-, dictionaries ? [
+{
+  bazel_6,
+  buildBazelPackage,
+  fetchFromGitHub,
+  fetchurl,
+  glibcLocales,
+  lib,
+  pkg-config,
+  python3,
+  qtbase,
+  qtwayland,
+  ruby,
+  wrapQtAppsHook,
+  dictionaries ? [
     "alt-cannadic"
     "edict2"
     "jawiki"
@@ -19,7 +20,7 @@
     "place-names"
     "skk-jisyo"
     "sudachidict"
-  ]
+  ],
 }:
 
 buildBazelPackage {
@@ -123,7 +124,10 @@ buildBazelPackage {
     wrapQtAppsHook
   ];
 
-  buildInputs = [ qtbase qtwayland ];
+  buildInputs = [
+    qtbase
+    qtwayland
+  ];
 
   preBuild = ''
     cd mozc/src
@@ -210,11 +214,12 @@ buildBazelPackage {
     description = "The Open Source edition of Google Japanese Input bundled with the UT dictionary";
     homepage = "https://github.com/google/mozc";
     license = with licenses; [
-      asl20 # abseil-cpp, merge-ut-dictionaries, mozcdic-ut-alt-cannadic,
-            # mozcdic-ut-edict2, mozcdic-ut-jawiki, mozcdic-ut-neologd,
-            # mecab-ipadic-neologd, mozcdic-ut-personal-names,
-            # mozcdic-ut-place-names, mozcdic-ut-skk-jisyo,
-            # mozcdic-ut-sudachidict
+      # abseil-cpp, merge-ut-dictionaries, mozcdic-ut-alt-cannadic,
+      # mozcdic-ut-edict2, mozcdic-ut-jawiki, mozcdic-ut-neologd,
+      # mecab-ipadic-neologd, mozcdic-ut-personal-names,
+      # mozcdic-ut-place-names, mozcdic-ut-skk-jisyo,
+      # mozcdic-ut-sudachidict
+      asl20
       bsd2 # japanese-usage-dictionary
       bsd3 # mozc, breakpad, gtest, gyp, japanese-usage-dictionary, protobuf, id.def
       cc-by-sa-30 # jawiki-latest-all-titles, mozcdic-ut-jawiki.txt, jawiki

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -24,7 +24,7 @@
 
 buildBazelPackage {
   pname = "mozc";
-  version = "unstable-2024-02-09";
+  version = "unstable-2024-07-29";
 
   srcs = [
     (fetchFromGitHub rec {
@@ -32,89 +32,85 @@ buildBazelPackage {
       repo = "mozc";
       name = repo;
       fetchSubmodules = true;
-      rev = "c2fcbf6515c5884437977de46187c16a8cb7bb50";
-      hash = "sha256-AcIN5sWPBe4JotAUYv1fytgQw+mJzdFhKuVPLR48soA=";
+      rev = "5e6abfe1853b080766def432b746a9bed79e54b0";
+      hash = "sha256-w0bjoMmq8gL7DSehEG7cKqp5e4kNOXnCYLW31Zl9FRs=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "merge-ut-dictionaries";
       name = repo;
-      rev = "a3d6fc4005aff2092657ebca98b9de226e1c617f";
-      hash = "sha256-UK29ACZUK9zGfzW7C85uMw2aF5Gk+0aDeUdNV71PY+0=";
+      rev = "1f1cdcf545b952f84fdad78d58c0db7a662b592d";
+      hash = "sha256-BrjHLTomoaF/DHmxUEFVzyTWBXfB+LUtt5b/MiuZ8EU=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-alt-cannadic";
       name = repo;
-      rev = "4e548e6356b874c76e8db438bf4d8a0b452f2435";
-      hash = "sha256-4gzqVoCIhC0k3mh0qbEr8yYttz9YR0fItkFNlu7cYOY=";
+      rev = "50fee0397b87fe508f9edd45bac56f5290d8ce66";
+      hash = "sha256-KKUj3d9yR2kTTTFbroZQs+OZR4KUyAUYE/X3z9/vQvM=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-edict2";
       name = repo;
-      rev = "b2eec665b81214082d61acee1c5a1b5b115baf1a";
-      hash = "sha256-LIpGt6xB8dLUnazbJHZk6EH1/ZyAHMIn1m6Qpr2dsHs=";
+      rev = "b2112277d0d479b9218f42772356da3601b3e8cf";
+      hash = "sha256-DIIp8FooWxyHMrQmq+2KUGEmYHKy+H6NtHrvRldxXqc=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-jawiki";
       name = repo;
-      rev = "6e08b8c823f3d2d09064ad2080e7a16552a7b473";
-      hash = "sha256-0YwAinlcI6yojCdW1MpLgMZfyYV7gk9Q+Wlu4lR3Hrg=";
+      rev = "29dd6d3202119d88a2356a11300b7b338f5cb950";
+      hash = "sha256-tgg9fOFnRypJjb9jWoTOOu4kbCdzNDry3/fpy5Tms9s=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-neologd";
       name = repo;
-      rev = "bf9d0d217107f2fb2e7d1a26648ef429d9fdcd27";
-      hash = "sha256-e0iM5fohwpNNhPl9CjkD753/Rgatg7GdwN0NSvlN94c=";
+      rev = "b7035b88db25ad1a933f05a33f193711c6c3b2db";
+      hash = "sha256-JPTrWaDtdNs/Z0uLRwaS8Qc/l4/Y7NtwLanivyefXnk=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-personal-names";
       name = repo;
-      rev = "8a500f82c553936cbdd33b85955120e731069d44";
-      hash = "sha256-pMyYvl5S0+U++MO5m9rmbtxDzAmO4Xs8sFewOUGqgUA=";
+      rev = "5df5cedaef3b55c509cacfbf3e97ded852535a1b";
+      hash = "sha256-zTJVhbZEIG+xiRWAPsK9faxxxnKeHIt/gc7HuAXqOl4=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-place-names";
       name = repo;
-      rev = "a847a02e0137ab9e2fdbbaaf120826f870408ca6";
-      hash = "sha256-B0kW8Wa/nCT4KEYl2Rz6gQcj0Po3GxU6i42unHhgZeU=";
+      rev = "5c2167541200528d8b25214c52be7a4c3dd3b89b";
+      hash = "sha256-GUfze7iSRQiMPExr6tZ3fvO6W+cfU1I4MwXyZzgNrig=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-skk-jisyo";
       name = repo;
-      rev = "ee94f6546ce52edfeec0fd203030f52d4d99656f";
-      hash = "sha256-RXxO878ZBkxenrdo7cFom5NjM0m7CdYQk0dFu/HPp/Y=";
+      rev = "7300f19e6a3f27334ed7af64589de8782549a13f";
+      hash = "sha256-LJ1rP+uyh8K3IWCgKMDYt0EwEDiQqQL+wBdQCFbZM/k=";
     })
     (fetchFromGitHub rec {
       owner = "utuhiro78";
       repo = "mozcdic-ut-sudachidict";
       name = repo;
-      rev = "55f61c3fca81dec661c36c73eb29b2631c8ed618";
-      hash = "sha256-gNnBcuVU1M7rllfZXIrLg7WYUhKqPJsUjR8Scnq3Fw8=";
+      rev = "a754f1fff5fded62cc066aa6be0ab0169059a144";
+      hash = "sha256-WzhWNpqtiG9TtFHEOSbHG1mbb4ak0zCkO13g9ZWqyBE=";
     })
-    (fetchurl rec {
-      name = "jawiki";
-      url = "https://dumps.wikimedia.org/${name}/20240120/${name}-20240120-all-titles-in-ns0.gz";
-      recursiveHash = true;
-      hash = "sha256-Mp7ya2tM6E0IKE6kOYSlRx6gZBS/DK1zAwyT6jvZxrY=";
-      downloadToTemp = true;
-      postFetch = ''
-        mkdir -p "$out"
-        install -Dm444 "$downloadedFile" "$out/${name}.gz"
-      '';
+    (fetchFromGitHub rec {
+      owner = "musjj";
+      repo = "jawiki-archive";
+      name = repo;
+      rev = "d205f63665e351ea853edc72157f14daa22a227f";
+      hash = "sha256-Jj2vH8UMhgSzWv+RnOipnVNSdeOF6jttcLN/kVYa4D4=";
     })
     (fetchFromGitHub rec {
       owner = "musjj";
       repo = "jp-zip-codes";
       name = repo;
-      rev = "cfbb54655223d8e2cea6fedbaef202919d8d62fe";
-      hash = "sha256-ZvZL/6yTE6JrBu4ja7HvyBUKWUAIL0jULii5Im+zmLQ=";
+      rev = "995d7cce9ae68a31efe4b5882137dd67ac26f7ff";
+      hash = "sha256-VnzczwIbYPUpWpWLMm2TYGqiDxzZaDDKs7xh4F3xA0E=";
     })
   ];
 
@@ -124,7 +120,6 @@ buildBazelPackage {
     glibcLocales
     pkg-config
     python3
-    ruby
     wrapQtAppsHook
   ];
 
@@ -133,10 +128,6 @@ buildBazelPackage {
   preBuild = ''
     cd mozc/src
   '';
-
-  # Required so that the ruby scripts can work
-  env.LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
-  env.LC_ALL = "en_US.UTF-8";
 
   bazel = bazel_6;
   removeRulesCC = false;
@@ -169,7 +160,7 @@ buildBazelPackage {
       rm -rf $bazelOut/external/qt_linux
     '';
 
-    sha256 = "sha256-gpRLwbYHPW2o9LkOhO10sOVhtXZr7MPfMRdJympwPyk=";
+    sha256 = "sha256-EiRTuK6J9vgnw9HQwSpeGQcOp4AcTBluFYjjr69ILv4=";
   };
 
   buildAttrs = {
@@ -179,10 +170,10 @@ buildBazelPackage {
       (
         cd merge-ut-dictionaries/src
 
-        sed -i -e "s|https://raw.githubusercontent.com/google/mozc/master|../../mozc|" remove_duplicate_ut_entries.rb
+        sed -i -e "s|https://raw.githubusercontent.com/google/mozc/master/src|file://$PWD/../../mozc/src|" remove_duplicate_ut_entries.py
 
-        sed -i -e '/wget/d' count_word_hits.rb
-        sed -i -e "s|^filename = \"jawiki-.*|filename = \"../../jawiki/jawiki.gz\"|" count_word_hits.rb
+        sed -i -e '/wget/d' count_word_hits.py
+        sed -i -e "s|^file_name = \"jawiki-latest-all-titles-in-ns0.gz\"|file_name = \"../../jawiki-archive/jawiki-latest-all-titles-in-ns0.gz\"|" count_word_hits.py
 
         [[ -e mozcdic-ut.txt ]] && rm mozcdic-ut.txt
 
@@ -194,9 +185,9 @@ buildBazelPackage {
           cat mozcdic-ut-$name.txt >>mozcdic-ut.txt
         done
 
-        ruby remove_duplicate_ut_entries.rb mozcdic-ut.txt
-        ruby count_word_hits.rb
-        ruby apply_word_hits.rb mozcdic-ut.txt
+        python remove_duplicate_ut_entries.py mozcdic-ut.txt
+        python count_word_hits.py
+        python apply_word_hits.py mozcdic-ut.txt
 
         cat mozcdic-ut.txt >>../../mozc/src/data/dictionary_oss/dictionary00.txt
       )

--- a/pkgs/development/libraries/mozc/default.nix
+++ b/pkgs/development/libraries/mozc/default.nix
@@ -1,4 +1,4 @@
-{ bazel
+{ bazel_6
 , buildBazelPackage
 , fetchFromGitHub
 , fetchurl
@@ -138,7 +138,7 @@ buildBazelPackage {
   env.LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
   env.LC_ALL = "en_US.UTF-8";
 
-  inherit bazel;
+  bazel = bazel_6;
   removeRulesCC = false;
   dontAddBazelOpts = true;
 

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -102,6 +102,7 @@ buildBazelPackage {
       install -Dm644 outlined/properties.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-properties.svg
       install -Dm644 outlined/tool.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-tool.svg
 
+      # These are relative symlinks, they will always resolve to files within $out
       ln -s org.fcitx.Fcitx5.fcitx-mozc.png $out/share/icons/hicolor/128x128/apps/fcitx-mozc.png
       ln -s org.fcitx.Fcitx5.fcitx-mozc-alpha-full.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-alpha-full.svg
       ln -s org.fcitx.Fcitx5.fcitx-mozc-alpha-half.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-alpha-half.svg

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -69,38 +69,38 @@ buildBazelPackage {
     installPhase = ''
       runHook preInstall
 
-      install -Dm644 ../LICENSE $out/share/licenses/fcitx5-mozc/LICENSE
-      install -Dm644 data/installer/credits_en.html $out/share/licenses/fcitx5-mozc/Submodules
+      install -Dm444 ../LICENSE $out/share/licenses/fcitx5-mozc/LICENSE
+      install -Dm444 data/installer/credits_en.html $out/share/licenses/fcitx5-mozc/Submodules
 
-      install -Dm755 bazel-bin/unix/fcitx5/fcitx5-mozc.so $out/lib/fcitx5/fcitx5-mozc.so
-      install -Dm644 unix/fcitx5/mozc-addon.conf $out/share/fcitx5/addon/mozc.conf
-      install -Dm644 unix/fcitx5/mozc.conf $out/share/fcitx5/inputmethod/mozc.conf
+      install -Dm555 bazel-bin/unix/fcitx5/fcitx5-mozc.so $out/lib/fcitx5/fcitx5-mozc.so
+      install -Dm444 unix/fcitx5/mozc-addon.conf $out/share/fcitx5/addon/mozc.conf
+      install -Dm444 unix/fcitx5/mozc.conf $out/share/fcitx5/inputmethod/mozc.conf
 
       for pofile in unix/fcitx5/po/*.po; do
         filename=$(basename $pofile)
         lang=''${filename/.po/}
         mofile=''${pofile/.po/.mo}
         msgfmt $pofile -o $mofile
-        install -Dm644 $mofile $out/share/locale/$lang/LC_MESSAGES/fcitx5-mozc.mo
+        install -Dm444 $mofile $out/share/locale/$lang/LC_MESSAGES/fcitx5-mozc.mo
       done
 
       msgfmt --xml -d unix/fcitx5/po/ --template unix/fcitx5/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml.in -o unix/fcitx5/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml
-      install -Dm644 unix/fcitx5/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml $out/share/metainfo/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml
+      install -Dm444 unix/fcitx5/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml $out/share/metainfo/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml
 
       cd bazel-bin/unix
 
       unzip -o icons.zip
 
-      install -Dm644 mozc.png $out/share/icons/hicolor/128x128/apps/org.fcitx.Fcitx5.fcitx-mozc.png
-      install -Dm644 alpha_full.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-alpha-full.svg
-      install -Dm644 alpha_half.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-alpha-half.svg
-      install -Dm644 direct.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-direct.svg
-      install -Dm644 hiragana.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-hiragana.svg
-      install -Dm644 katakana_full.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-katakana-full.svg
-      install -Dm644 katakana_half.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-katakana-half.svg
-      install -Dm644 outlined/dictionary.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-dictionary.svg
-      install -Dm644 outlined/properties.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-properties.svg
-      install -Dm644 outlined/tool.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-tool.svg
+      install -Dm444 mozc.png $out/share/icons/hicolor/128x128/apps/org.fcitx.Fcitx5.fcitx-mozc.png
+      install -Dm444 alpha_full.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-alpha-full.svg
+      install -Dm444 alpha_half.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-alpha-half.svg
+      install -Dm444 direct.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-direct.svg
+      install -Dm444 hiragana.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-hiragana.svg
+      install -Dm444 katakana_full.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-katakana-full.svg
+      install -Dm444 katakana_half.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-katakana-half.svg
+      install -Dm444 outlined/dictionary.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-dictionary.svg
+      install -Dm444 outlined/properties.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-properties.svg
+      install -Dm444 outlined/tool.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-tool.svg
 
       # These are relative symlinks, they will always resolve to files within $out
       ln -s org.fcitx.Fcitx5.fcitx-mozc.png $out/share/icons/hicolor/128x128/apps/fcitx-mozc.png

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -62,7 +62,7 @@ buildBazelPackage {
       rm -rf $bazelOut/external/fcitx5
     '';
 
-    sha256 = "sha256-sWFzlUZvEj3oG7s0l2BhkCsaebbEL2onX2zeTFo/TDE=";
+    sha256 = "sha256-Ix9l9XPySNShThxubBVqHAHSNA/Lp6bJiMP1kVBqNZo=";
   };
 
   buildAttrs = {

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -1,128 +1,138 @@
-{ lib, clangStdenv, fetchFromGitHub, fetchurl, fetchpatch
-, python3Packages, ninja, pkg-config, protobuf, zinnia, qt5, fcitx5
-, jsoncpp, gtest, which, gtk2, unzip, abseil-cpp, breakpad, nixosTests }:
-let
-  inherit (python3Packages) python gyp six;
-  utdic = fetchurl {
-    url = "https://osdn.net/downloads/users/39/39056/mozcdic-ut-20220904.tar.bz2";
-    sha256 = "sha256-pmLBCcw2Zsirzl1PjYkviRIZoyfUz5rpESeABDxuhtU=";
-  };
-  japanese_usage_dictionary = fetchFromGitHub {
-    owner = "hiroyuki-komatsu";
-    repo = "japanese-usage-dictionary";
-    rev = "e5b3425575734c323e1d947009dd74709437b684";
-    sha256 = "0pyrpz9c8nxccwpgyr36w314mi8h132cis8ijvlqmmhqxwsi30hm";
-  };
-  zipcode_rel = "202011";
-  jigyosyo = fetchurl {
-    url = "https://osdn.net/projects/ponsfoot-aur/storage/mozc/jigyosyo-${zipcode_rel}.zip";
-    sha256 = "j7MkNtd4+QTi91EreVig4/OV0o5y1+KIjEJBEmLK/mY=";
-  };
-  x-ken-all = fetchurl {
-    url =
-      "https://osdn.net/projects/ponsfoot-aur/storage/mozc/x-ken-all-${zipcode_rel}.zip";
-    sha256 = "ExS0Cg3rs0I9IOVbZHLt8UEfk8/LmY9oAHPVVlYuTPw=";
-  };
+{ bazel
+, buildBazelPackage
+, fcitx5
+, fetchFromGitHub
+, gettext
+, lib
+, mozc
+, nixosTests
+, pkg-config
+, python3
+, unzip
+}:
 
-in clangStdenv.mkDerivation {
+buildBazelPackage {
   pname = "fcitx5-mozc";
-  version = "2.26.4220.102";
+  version = "unstable-2023-08-18";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "mozc";
-    rev = "1882e33b61673b66d63277f82b4c80ae4e506c10";
-    sha256 = "R+w0slVFpqtt7PIr1pyupJjRoQsABVZiMdZ9fKGKAqw=";
+    fetchSubmodules = true;
+    rev = "198608e08393dd26a81cd091e4916dfbc4196e5e";
+    hash = "sha256-6hTFCohmz+ijwWLQu65kKpiihs7XKqph3/JDwQjSHBw=";
   };
 
-  nativeBuildInputs = [ gyp ninja python pkg-config qt5.wrapQtAppsHook six which unzip ];
+  sourceRoot = "source/src";
 
-  buildInputs = [ protobuf zinnia qt5.qtbase fcitx5 abseil-cpp jsoncpp gtest gtk2 ];
-
-  patches = [
-    # Support linking system abseil-cpp
-    (fetchpatch {
-      url = "https://salsa.debian.org/debian/mozc/-/raw/debian/sid/debian/patches/0007-Update-src-base-absl.gyp.patch";
-      sha256 = "UiS0UScDKyAusXOhc7Bg8dF8ARQQiVTylEhAOxqaZt8=";
-    })
-
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    python3
+    unzip
   ];
 
-  postUnpack = ''
-    unzip ${x-ken-all} -d $sourceRoot/src/
-    unzip ${jigyosyo} -d $sourceRoot/src/
-    mkdir $TMPDIR/unpack
-    tar xf ${utdic} -C $TMPDIR/unpack
-    cat $TMPDIR/unpack/mozcdic-ut-20220904/mozcdic-ut-20220904.txt >> $sourceRoot/src/data/dictionary_oss/dictionary00.txt
+  buildInputs = [
+    mozc
+    fcitx5
+  ];
 
-    rmdir $sourceRoot/src/third_party/breakpad/
-    ln -s ${breakpad} $sourceRoot/src/third_party/breakpad
-    rmdir $sourceRoot/src/third_party/gtest/
-    ln -s ${gtest} $sourceRoot/src/third_party/gtest
-    rmdir $sourceRoot/src/third_party/gyp/
-    ln -s ${gyp} $sourceRoot/src/third_party/gyp
-    rmdir $sourceRoot/src/third_party/japanese_usage_dictionary/
-    ln -s ${japanese_usage_dictionary} $sourceRoot/src/third_party/japanese_usage_dictionary
+  postPatch = ''
+    sed -i -e 's|^\(LINUX_MOZC_SERVER_DIR = \).\+|\1"${mozc}/lib/mozc"|' config.bzl
   '';
 
-  # Copied from https://github.com/archlinux/svntogit-community/blob/packages/fcitx5-mozc/trunk/PKGBUILD
-  configurePhase = ''
-    cd src
-    export GYP_DEFINES="document_dir=$out/share/doc/mozc use_libzinnia=1 use_libprotobuf=1 use_libabseil=1"
+  inherit bazel;
+  removeRulesCC = false;
+  dontAddBazelOpts = true;
 
-    # disable fcitx4
-    rm unix/fcitx/fcitx.gyp
+  bazelFlags = [
+    "--config"
+    "oss_linux"
+    "--compilation_mode"
+    "opt"
+  ];
 
-    # gen zip code seed
-    PYTHONPATH="$PWD:$PYTHONPATH" python dictionary/gen_zip_code_seed.py --zip_code="x-ken-all.csv" --jigyosyo="JIGYOSYO.CSV" >> data/dictionary_oss/dictionary09.txt
+  bazelTargets = [
+    "unix/fcitx5:fcitx5-mozc.so"
+    "unix/icons"
+  ];
 
-    # use libstdc++ instead of libc++
-    sed "/stdlib=libc++/d;/-lc++/d" -i gyp/common.gypi
+  fetchAttrs = {
+    preInstall = ''
+      rm -rf $bazelOut/external/fcitx5
+    '';
 
-    # run gyp
-    python build_mozc.py gyp --gypdir=${gyp}/bin --server_dir=$out/lib/mozc
-  '';
+    sha256 = "sha256-sWFzlUZvEj3oG7s0l2BhkCsaebbEL2onX2zeTFo/TDE=";
+  };
 
-  buildPhase = ''
-    runHook preBuild
+  buildAttrs = {
+    installPhase = ''
+      runHook preInstall
 
-    python build_mozc.py build -c Release \
-      server/server.gyp:mozc_server \
-      gui/gui.gyp:mozc_tool \
-      unix/fcitx5/fcitx5.gyp:fcitx5-mozc
+      install -Dm644 ../LICENSE $out/share/licenses/fcitx5-mozc/LICENSE
+      install -Dm644 data/installer/credits_en.html $out/share/licenses/fcitx5-mozc/Submodules
 
-    runHook postBuild
-  '';
+      install -Dm755 bazel-bin/unix/fcitx5/fcitx5-mozc.so $out/lib/fcitx5/fcitx5-mozc.so
+      install -Dm644 unix/fcitx5/mozc-addon.conf $out/share/fcitx5/addon/mozc.conf
+      install -Dm644 unix/fcitx5/mozc.conf $out/share/fcitx5/inputmethod/mozc.conf
 
-  installPhase = ''
-    runHook preInstall
+      for pofile in unix/fcitx5/po/*.po; do
+        filename=$(basename $pofile)
+        lang=''${filename/.po/}
+        mofile=''${pofile/.po/.mo}
+        msgfmt $pofile -o $mofile
+        install -Dm644 $mofile $out/share/locale/$lang/LC_MESSAGES/fcitx5-mozc.mo
+      done
 
-    export PREFIX=$out
-    export _bldtype=Release
-    ../scripts/install_server
-    install -d $out/share/licenses/fcitx5-mozc
-    head -n 29 server/mozc_server.cc > $out/share/licenses/fcitx5-mozc/LICENSE
-    install -m644 data/installer/*.html $out/share/licenses/fcitx5-mozc/
-    install -d $out/share/fcitx5/addon
-    install -d $out/share/fcitx5/inputmethod
-    install -d $out/lib/fcitx5
-    ../scripts/install_fcitx5
+      msgfmt --xml -d unix/fcitx5/po/ --template unix/fcitx5/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml.in -o unix/fcitx5/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml
+      install -Dm644 unix/fcitx5/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml $out/share/metainfo/org.fcitx.Fcitx5.Addon.Mozc.metainfo.xml
 
-    runHook postInstall
-  '';
+      cd bazel-bin/unix
 
-  preFixup = ''
-    wrapQtApp $out/lib/mozc/mozc_tool
-  '';
+      unzip -o icons.zip
+
+      install -Dm644 mozc.png $out/share/icons/hicolor/128x128/apps/org.fcitx.Fcitx5.fcitx-mozc.png
+      install -Dm644 alpha_full.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-alpha-full.svg
+      install -Dm644 alpha_half.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-alpha-half.svg
+      install -Dm644 direct.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-direct.svg
+      install -Dm644 hiragana.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-hiragana.svg
+      install -Dm644 katakana_full.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-katakana-full.svg
+      install -Dm644 katakana_half.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-katakana-half.svg
+      install -Dm644 outlined/dictionary.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-dictionary.svg
+      install -Dm644 outlined/properties.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-properties.svg
+      install -Dm644 outlined/tool.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-tool.svg
+
+      ln -s org.fcitx.Fcitx5.fcitx-mozc.png $out/share/icons/hicolor/128x128/apps/fcitx-mozc.png
+      ln -s org.fcitx.Fcitx5.fcitx-mozc-alpha-full.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-alpha-full.svg
+      ln -s org.fcitx.Fcitx5.fcitx-mozc-alpha-half.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-alpha-half.svg
+      ln -s org.fcitx.Fcitx5.fcitx-mozc-direct.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-direct.svg
+      ln -s org.fcitx.Fcitx5.fcitx-mozc-hiragana.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-hiragana.svg
+      ln -s org.fcitx.Fcitx5.fcitx-mozc-katakana-full.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-katakana-full.svg
+      ln -s org.fcitx.Fcitx5.fcitx-mozc-katakana-half.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-katakana-half.svg
+      ln -s org.fcitx.Fcitx5.fcitx-mozc-dictionary.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-dictionary.svg
+      ln -s org.fcitx.Fcitx5.fcitx-mozc-properties.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-properties.svg
+      ln -s org.fcitx.Fcitx5.fcitx-mozc-tool.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-tool.svg
+
+      runHook postInstall
+    '';
+  };
 
   passthru.tests = {
     inherit (nixosTests) fcitx5;
   };
 
   meta = with lib; {
-    description = "Fcitx5 Module of A Japanese Input Method for Chromium OS, Windows, Mac and Linux (the Open Source Edition of Google Japanese Input)";
+    description = "Mozc - a Japanese Input Method Editor designed for multi-platform";
     homepage = "https://github.com/fcitx/mozc";
-    license = licenses.bsd3;
+    license = with licenses; [
+      asl20
+      bsd2
+      bsd3
+      ipa
+      mit
+      mspl
+      publicDomain
+    ];
     maintainers = with maintainers; [ berberman govanify ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -91,28 +91,20 @@ buildBazelPackage {
 
       unzip -o icons.zip
 
-      install -Dm444 mozc.png $out/share/icons/hicolor/128x128/apps/org.fcitx.Fcitx5.fcitx-mozc.png
-      install -Dm444 alpha_full.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-alpha-full.svg
-      install -Dm444 alpha_half.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-alpha-half.svg
-      install -Dm444 direct.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-direct.svg
-      install -Dm444 hiragana.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-hiragana.svg
-      install -Dm444 katakana_full.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-katakana-full.svg
-      install -Dm444 katakana_half.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-katakana-half.svg
-      install -Dm444 outlined/dictionary.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-dictionary.svg
-      install -Dm444 outlined/properties.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-properties.svg
-      install -Dm444 outlined/tool.svg $out/share/icons/hicolor/scalable/apps/org.fcitx.Fcitx5.fcitx-mozc-tool.svg
-
       # These are relative symlinks, they will always resolve to files within $out
+
+      install -Dm444 mozc.png $out/share/icons/hicolor/128x128/apps/org.fcitx.Fcitx5.fcitx-mozc.png
       ln -s org.fcitx.Fcitx5.fcitx-mozc.png $out/share/icons/hicolor/128x128/apps/fcitx-mozc.png
-      ln -s org.fcitx.Fcitx5.fcitx-mozc-alpha-full.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-alpha-full.svg
-      ln -s org.fcitx.Fcitx5.fcitx-mozc-alpha-half.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-alpha-half.svg
-      ln -s org.fcitx.Fcitx5.fcitx-mozc-direct.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-direct.svg
-      ln -s org.fcitx.Fcitx5.fcitx-mozc-hiragana.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-hiragana.svg
-      ln -s org.fcitx.Fcitx5.fcitx-mozc-katakana-full.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-katakana-full.svg
-      ln -s org.fcitx.Fcitx5.fcitx-mozc-katakana-half.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-katakana-half.svg
-      ln -s org.fcitx.Fcitx5.fcitx-mozc-dictionary.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-dictionary.svg
-      ln -s org.fcitx.Fcitx5.fcitx-mozc-properties.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-properties.svg
-      ln -s org.fcitx.Fcitx5.fcitx-mozc-tool.svg $out/share/icons/hicolor/scalable/apps/fcitx-mozc-tool.svg
+
+      rm {mozc,dictionary,properties,tool}.svg
+      for svg in *.svg outlined/*.svg; do
+        name=$(basename -- ''${svg//_/-})
+        path=$out/share/icons/hicolor/scalable/apps
+        prefix=org.fcitx.Fcitx5.fcitx-mozc
+
+        install -Dm444 $svg $path/$prefix-$name
+        ln -s $prefix-$name $path/fcitx-mozc-$name
+      done
 
       runHook postInstall
     '';

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -126,13 +126,12 @@ buildBazelPackage {
     description = "Mozc - a Japanese Input Method Editor designed for multi-platform";
     homepage = "https://github.com/fcitx/mozc";
     license = with licenses; [
-      asl20
-      bsd2
-      bsd3
-      ipa
-      mit
-      mspl
-      publicDomain
+      asl20 # abseil-cpp
+      bsd3 # mozc, breakpad, gtest, gyp, japanese-usage-dictionary, protobuf
+      mit # wil
+      naist-2003 # IPAdic
+      publicDomain # src/data/test/stress_test, Okinawa dictionary
+      unicode-30 # src/data/unicode, breakpad
     ];
     maintainers = with maintainers; [ berberman govanify ];
     platforms = platforms.linux;

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -13,14 +13,14 @@
 
 buildBazelPackage {
   pname = "fcitx5-mozc";
-  version = "unstable-2023-08-18";
+  version = "unstable-2024-02-09";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "mozc";
     fetchSubmodules = true;
-    rev = "198608e08393dd26a81cd091e4916dfbc4196e5e";
-    hash = "sha256-6hTFCohmz+ijwWLQu65kKpiihs7XKqph3/JDwQjSHBw=";
+    rev = "c687b82fccd443917359a5c2a7b9b1c5fd3737c9";
+    hash = "sha256-lXEW7F7ctI7kNdKEjdeYHbyeF8hf6C5AohoWVIfDbjM=";
   };
 
   sourceRoot = "source/src";
@@ -62,7 +62,7 @@ buildBazelPackage {
       rm -rf $bazelOut/external/fcitx5
     '';
 
-    sha256 = "sha256-Ix9l9XPySNShThxubBVqHAHSNA/Lp6bJiMP1kVBqNZo=";
+    sha256 = "sha256-nJbxmF5zbPO7HrFDeI5Ur42ID0M4pqGZoxEF+CBRQ/E=";
   };
 
   buildAttrs = {

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -1,4 +1,4 @@
-{ bazel
+{ bazel_6
 , buildBazelPackage
 , fcitx5
 , fetchFromGitHub
@@ -41,7 +41,7 @@ buildBazelPackage {
     sed -i -e 's|^\(LINUX_MOZC_SERVER_DIR = \).\+|\1"${mozc}/lib/mozc"|' config.bzl
   '';
 
-  inherit bazel;
+  bazel = bazel_6;
   removeRulesCC = false;
   dontAddBazelOpts = true;
 

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -13,14 +13,14 @@
 
 buildBazelPackage {
   pname = "fcitx5-mozc";
-  version = "unstable-2024-02-09";
+  version = "unstable-2024-07-31";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "mozc";
     fetchSubmodules = true;
-    rev = "c687b82fccd443917359a5c2a7b9b1c5fd3737c9";
-    hash = "sha256-lXEW7F7ctI7kNdKEjdeYHbyeF8hf6C5AohoWVIfDbjM=";
+    rev = "57e67f2a25e4c0861e0e422da0c7d4c232d89fcc";
+    hash = "sha256-1EZjEbMl+LRipH5gEgFpaKP8uEKPfupHmiiTNJc/T1k=";
   };
 
   sourceRoot = "source/src";
@@ -62,7 +62,7 @@ buildBazelPackage {
       rm -rf $bazelOut/external/fcitx5
     '';
 
-    sha256 = "sha256-nJbxmF5zbPO7HrFDeI5Ur42ID0M4pqGZoxEF+CBRQ/E=";
+    sha256 = "sha256-rrRp/v1pty7Py80/6I8rVVQvkeY72W+nlixUeYkjp+o=";
   };
 
   buildAttrs = {
@@ -93,17 +93,26 @@ buildBazelPackage {
 
       # These are relative symlinks, they will always resolve to files within $out
 
-      install -Dm444 mozc.png $out/share/icons/hicolor/128x128/apps/org.fcitx.Fcitx5.fcitx-mozc.png
-      ln -s org.fcitx.Fcitx5.fcitx-mozc.png $out/share/icons/hicolor/128x128/apps/fcitx-mozc.png
+      install -Dm444 mozc.png $out/share/icons/hicolor/128x128/apps/org.fcitx.Fcitx5.fcitx_mozc.png
+      ln -s org.fcitx.Fcitx5.fcitx_mozc.png $out/share/icons/hicolor/128x128/apps/fcitx_mozc.png
 
-      rm {mozc,dictionary,properties,tool}.svg
-      for svg in *.svg outlined/*.svg; do
-        name=$(basename -- ''${svg//_/-})
+      for svg in \
+        alpha_full.svg \
+        alpha_half.svg \
+        direct.svg \
+        hiragana.svg \
+        katakana_full.svg \
+        katakana_half.svg \
+        outlined/dictionary.svg \
+        outlined/properties.svg \
+        outlined/tool.svg
+      do
+        name=$(basename -- $svg)
         path=$out/share/icons/hicolor/scalable/apps
-        prefix=org.fcitx.Fcitx5.fcitx-mozc
+        prefix=org.fcitx.Fcitx5.fcitx_mozc
 
-        install -Dm444 $svg $path/$prefix-$name
-        ln -s $prefix-$name $path/fcitx-mozc-$name
+        install -Dm444 $svg $path/$prefix_$name
+        ln -s $prefix_$name $path/fcitx_mozc_$name
       done
 
       runHook postInstall

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7621,11 +7621,7 @@ with pkgs;
 
   fcitx5-bamboo = callPackage ../tools/inputmethods/fcitx5/fcitx5-bamboo.nix { };
 
-  fcitx5-mozc = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-mozc.nix {
-    abseil-cpp = abseil-cpp.override {
-      cxxStandard = "17";
-    };
-  };
+  fcitx5-mozc = callPackage ../tools/inputmethods/fcitx5/fcitx5-mozc.nix { };
 
   fcitx5-skk = qt6Packages.callPackage ../tools/inputmethods/fcitx5/fcitx5-skk.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7615,6 +7615,8 @@ with pkgs;
 
   chewing-editor = libsForQt5.callPackage ../applications/misc/chewing-editor { };
 
+  mozc = qt6Packages.callPackage ../development/libraries/mozc { };
+
   fcitx5 = callPackage ../tools/inputmethods/fcitx5 { };
 
   fcitx5-bamboo = callPackage ../tools/inputmethods/fcitx5/fcitx5-bamboo.nix { };


### PR DESCRIPTION
## Description of changes

This upgrades `mozc` to the latest version (the last version was over 2 years old and suffers from some issues). Consequently, with the deprecation of the GYP I chose to move to the new Bazel build system.

I'm really unfamiliar with Bazel, so I'd really appreciate it if anyone with experience can help check if everything's alright, especially in terms of reproducibility.

I also choose to modularize `mozc` as a library, so that other packagers can re-use it if they want to.

AUR packages I used for reference:

- https://aur.archlinux.org/packages/mozc-ut
- https://aur.archlinux.org/packages/fcitx5-mozc-ut

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
