### PR TITLE
nixos/zfs: add keyScript option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -6,6 +6,8 @@
 
 - Support for WiFi6 (IEEE 802.11ax) and WPA3-SAE-PK was enabled in the `hostapd` package, along with a significant rework of the hostapd module.
 
+- ZFS now supports loading keys automatically at boot with the `boot.zfs.keyScripts` option.
+
 ## New Services {#sec-release-23.11-new-services}
 
 - [MCHPRS](https://github.com/MCHPR/MCHPRS), a multithreaded Minecraft server built for redstone. Available as [services.mchprs](#opt-services.mchprs.enable).
@@ -49,6 +51,9 @@
 - [systemd-sysupdate](https://www.freedesktop.org/software/systemd/man/systemd-sysupdate.html), atomically updates the host OS, container images, portable service images or other sources. Available as [systemd.sysupdate](opt-systemd.sysupdate).
 
 - [eris-server](https://codeberg.org/eris/eris-go). [ERIS](https://eris.codeberg.page/) is an encoding for immutable storage and this server provides block exchange as well as content decoding over HTTP and through a FUSE file-system. Available as [services.eris-server](#opt-services.eris-server.enable).
+
+- [clevis](https://github.com/latchset/clevis). Clevis is an automatic encryption framework, notable for it's full disk encryption capabilities. Available as [boot.initrd.clevis](#opt-boot.initrd.clevis.enable).
+
 
 ## Backward Incompatibilities {#sec-release-23.11-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1369,6 +1369,7 @@
   ./system/activation/bootspec.nix
   ./system/activation/top-level.nix
   ./system/boot/binfmt.nix
+  ./system/boot/clevis.nix
   ./system/boot/emergency-mode.nix
   ./system/boot/grow-partition.nix
   ./system/boot/initrd-network.nix

--- a/nixos/modules/system/boot/clevis.nix
+++ b/nixos/modules/system/boot/clevis.nix
@@ -1,0 +1,56 @@
+{config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  cfg = config.boot.initrd.clevis;
+  zfsKeyScript = ''
+  filesystem=$1
+
+  # check for zfs property latchset.clevis:decrypt = "yes"
+  zfs get -rH latchset.clevis:decrypt $filesystem | awk '{exit $3 != "yes"}' || { echo "Clevis decryption not enabled";  exit 1; }
+
+  # then load jwe from latchset.clevis:jwe, decrypt and pass to zfs load-keys
+  zfs get -rH latchset.clevis:jwe $filesystem | awk '{print $3}' | clevis decrypt | zfs load-key $filesystem
+  '';
+in
+{
+  imports = [];
+
+  options = {
+    boot.initrd.clevis.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Enable automatic unlocking of ZFS datasets using native encryption,
+        with a password secured by clevis.
+      '';
+    };
+
+    boot.initrd.clevis.package = mkOption {
+      type = types.package;
+      defaultText = "pkgs.clevis";
+      description = lib.mdDoc ''
+        Clevis package.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.enable) {
+    # TODO: assert systemd initrd
+    boot.initrd.clevis.package = mkDefault pkgs.clevis;
+
+    # Include clevis package in initrd
+    boot.initrd.systemd.storePaths = [
+      cfg.package
+      "${pkgs.jose}/bin/jose"
+      "${pkgs.tpm2-tools}/bin/tpm2_createprimary"
+      "${pkgs.tpm2-tools}/bin/tpm2_flushcontext"
+      "${pkgs.tpm2-tools}/bin/tpm2_load"
+      "${pkgs.tpm2-tools}/bin/tpm2_unseal"
+    ];
+    boot.initrd.systemd.extraBin.clevis = "${cfg.package}/bin/clevis";
+
+    boot.zfs.keyScripts = [zfsKeyScript];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds `boot.zfs.keyScripts` and `boot.initrd.clevis` options to automatically unlock zfs natively-encrypted partitions at boot.

## Motivation

Previously, dataset credentials were only able to be provided through a file on disk or a prompted password. This is problematic for systems which want to make use of tools such as [clevis](https://github.com/latchset/clevis) to bind datasets to TPMs.
Clevis is included in this PR as a reference example.
These changes introduce the concepet of key scripts, which are run before attempting an interactive password prompt and are able to unlock the dataset.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
