### PR TITLE
python310Packages.patool: fix tests to be compatible with file 5.45

### DIFF
--- a/pkgs/development/python-modules/patool/default.nix
+++ b/pkgs/development/python-modules/patool/default.nix
@@ -1,6 +1,21 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook, p7zip,
-  cabextract, zip, lzip, zpaq, gnutar, gnugrep, diffutils, file,
-  gzip, bzip2, xz}:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pytestCheckHook
+, p7zip
+, cabextract
+, zip
+, lzip
+, zpaq
+, gnutar
+, gnugrep
+, diffutils
+, file
+, gzip
+, bzip2
+, xz
+}:
 
 # unrar is unfree, as well as 7z with unrar support, not including it (patool doesn't support unar)
 # it will still use unrar if present in the path
@@ -24,14 +39,30 @@ in
 buildPythonPackage rec {
   pname = "patool";
   version = "1.12";
+  format = "setuptools";
 
   #pypi doesn't have test data
   src = fetchFromGitHub {
     owner = "wummel";
     repo = pname;
     rev = "upstream/${version}";
-    sha256 = "0v4r77sm3yzh7y1whfwxmp01cchd82jbhvbg9zsyd2yb944imzjy";
+    hash = "sha256-Xv4aCUnLi+b1T29tuKRADTIWwK2dO8iDP/D7UfU5mWw=";
   };
+
+  patches = [
+    # https://github.com/wummel/patool/pull/63
+    (fetchpatch {
+      name = "apk-sometimes-has-mime-jar.patch";
+      url = "https://github.com/wummel/patool/commit/a9f3ee3d639a1065be024001e89c0b153511b16b.patch";
+      hash = "sha256-a4aWqHHc/cBs5T2QKZ08ky1K1tqKZEgqVmTmV11aTVE=";
+    })
+    # https://github.com/wummel/patool/pull/130
+    (fetchpatch {
+      name = "apk-sometimes-has-mime-android-package.patch";
+      url = "https://github.com/wummel/patool/commit/e8a1eea1d273b278a1b6f5029d2e21cb18bc9ffd.patch";
+      hash = "sha256-AVooVdU4FNIixUfwyrn39N2SDFHNs4CUYzS5Eey+DrU=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace patoolib/util.py \


### PR DESCRIPTION
## Description of changes

This should fix the current failure in staging-next (https://github.com/NixOS/nixpkgs/pull/250778) after an update to file in https://github.com/NixOS/nixpkgs/pull/247040.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
