### PR TITLE
glog: disable logging tests on aarch64-darwin

### DIFF
--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation rec {
     let
       excludedTests = lib.optionals stdenv.isDarwin [
         "mock-log"
+      ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+        "logging"   # works around segfaults on aarch64-darwin for now
       ];
       excludedTestsRegex = lib.optionalString (excludedTests != [ ]) "(${lib.concatStringsSep "|" excludedTests})";
     in


### PR DESCRIPTION
## Description of changes

This is the failure on Hydra:

```
[ RUN      ] SafeFNMatch.logging
[       OK ] SafeFNMatch.logging (0 ms)
[----------] 1 test from SafeFNMatch (0 ms total)

[----------] 1 test from Strerror
[ RUN      ] Strerror.logging
[       OK ] Strerror.logging (0 ms)
[----------] 1 test from Strerror (0 ms total)

[----------] 2 tests from DVLog
[ RUN      ] DVLog.Basic
[       OK ] DVLog.Basic (0 ms)
[ RUN      ] DVLog.V0

      Start  4: signalhandler
 4/16 Test  #4: signalhandler ....................   Passed    0.17 sec
      Start  5: stacktrace
 5/16 Test  #5: stacktrace .......................   Passed    0.16 sec
      Start  6: stl_logging
 6/16 Test  #6: stl_logging ......................   Passed    0.15 sec
      Start  7: symbolize
 7/16 Test  #7: symbolize ........................   Passed    0.14 sec
      Start  8: cmake_package_config_init
 8/16 Test  #8: cmake_package_config_init ........   Passed    0.03 sec
      Start  9: cmake_package_config_generate
 9/16 Test  #9: cmake_package_config_generate ....   Passed    0.45 sec
      Start 10: cmake_package_config_build
10/16 Test #10: cmake_package_config_build .......   Passed    0.49 sec
      Start 11: cmake_package_config_cleanup
11/16 Test #11: cmake_package_config_cleanup .....   Passed    0.01 sec
      Start 12: cleanup_init
12/16 Test #12: cleanup_init .....................   Passed    0.01 sec
      Start 14: cleanup_immediately
13/16 Test #14: cleanup_immediately ..............   Passed    3.29 sec
      Start 15: cleanup_with_absolute_prefix
14/16 Test #15: cleanup_with_absolute_prefix .....   Passed    3.34 sec
      Start 16: cleanup_with_relative_prefix
15/16 Test #16: cleanup_with_relative_prefix .....   Passed    6.35 sec
      Start 13: cleanup_logdir
16/16 Test #13: cleanup_logdir ...................   Passed    0.02 sec

88% tests passed, 2 tests failed out of 16

Total Test time (real) =  15.49 sec

The following tests FAILED:
          1 - logging_custom_prefix (SEGFAULT)
          3 - logging (SEGFAULT)
Errors while running CTest
```

Apologies that this might not be the best way to disable the test, but I couldn't figure out how to get the filter to work. This should suffice to get this package and its dependents to pass on staging-next (https://github.com/NixOS/nixpkgs/pull/250778) right now, so I'd like to merge it as is. Happy to iterate on this and apply any feedback.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
