### PR TITLE
plasma-desktop: add no-discover-shortcut.patch

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-desktop/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-desktop/default.nix
@@ -127,6 +127,7 @@ mkDerivation {
     ./hwclock-path.patch
     ./tzdir.patch
     ./kcm-access.patch
+    ./no-discover-shortcut.patch
   ];
   CXXFLAGS =
     [

--- a/pkgs/desktops/plasma-5/plasma-desktop/no-discover-shortcut.patch
+++ b/pkgs/desktops/plasma-5/plasma-desktop/no-discover-shortcut.patch
@@ -1,0 +1,13 @@
+diff --git a/applets/taskmanager/package/contents/config/main.xml b/applets/taskmanager/package/contents/config/main.xml
+index 6bb27695d..25e621810 100644
+--- a/applets/taskmanager/package/contents/config/main.xml
++++ b/applets/taskmanager/package/contents/config/main.xml
+@@ -85,7 +85,7 @@
+     </entry>
+     <entry name="launchers" type="StringList">
+       <label>The list of launcher tasks on the widget. Usually .desktop file or executable URLs. Special URLs such as preferred://browser that expand to default applications are supported.</label>
+-      <default>applications:systemsettings.desktop,applications:org.kde.discover.desktop,preferred://filemanager,preferred://browser</default>
++      <default>applications:systemsettings.desktop,preferred://filemanager,preferred://browser</default>
+     </entry>
+     <entry name="middleClickAction" type="Enum">
+       <label>What to do on middle-mouse click on a task button.</label>


### PR DESCRIPTION
## Description of changes

This commit removes shortcuts to KDE Discover from the default menus of the default Plasma Desktop installation in NixOS. Right now, in for example the [official NixOS 23.05 Plasma Desktop ISO](https://channels.nixos.org/nixos-23.05/latest-nixos-plasma5-x86_64-linux.iso) (as well as other installation vectors), a broken KDE Discover link is included in the default toolbar and other places, leading to a worse user experience, since NixOS intentionally does not ship the Plasma Desktop with KDE Discover.

Confirmed working through building an ISO.

### Before
Booting [latest-nixos-plasma5-x86_64-linux.iso](https://channels.nixos.org/nixos-unstable/latest-nixos-plasma5-x86_64-linux.iso):
![Screenshot_20230827_101542](https://github.com/NixOS/nixpkgs/assets/9953/b016f5b8-4f89-430a-99ca-0f2b1d37e47c)


### After
Booting an image with the local changes included in this pull requestto test locally:
```
NIX_PATH=localdev=/home/nadim/Code/nixos/nixpkgs/nixos nix-build '<localdev>' -A config.system.build.isoImage -I nixos-config=installation-cd-graphical-plasma5.nix
```

![Screenshot_20230827_110456](https://github.com/NixOS/nixpkgs/assets/9953/5827d5d5-df28-4d5d-92e8-c01cac60c396)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
