### PR TITLE
fortify-headers: 1.1alpine1 -> 1.1alpine3

### DIFF
--- a/pkgs/development/libraries/fortify-headers/default.nix
+++ b/pkgs/development/libraries/fortify-headers/default.nix
@@ -5,14 +5,14 @@
 
 stdenv.mkDerivation {
   pname = "fortify-headers";
-  version = "1.1alpine1";
+  version = "1.1alpine3";
 
   # upstream only accessible via git - unusable during bootstrap, hence
   # extract from the alpine package
   src = fetchurl {
-    url = "https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/fortify-headers-1.1-r1.apk";
+    url = "https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/fortify-headers-1.1-r3.apk";
     name = "fortify-headers.tar.gz";  # ensure it's extracted as a .tar.gz
-    hash = "sha256-A67NzUv+dldARY+MTaoVnezTg+Es8ZK/b7XOxA6KzpI=";
+    hash = "sha256-8A8JcKHIBgXpUuIP4zs3Q1yBs5jCGd5F3H2E8UN/S2g=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

The relevant changes in this bump are the addition of some patches fixing behaviour with clang. I think we're still going to have to patch fortify-headers further to make it more easily disable-able for clang (if not just disable it entirely for clang) but this is a start.

Have built a lot of `pkgsMusl` packages on nixos x86_64 with this.

cc @NixOS/static 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
