### PR TITLE
[staging-next] python3Packages.python3-saml: skip (more) tests with expired test data

### DIFF
--- a/pkgs/development/python-modules/python3-saml/default.nix
+++ b/pkgs/development/python-modules/python3-saml/default.nix
@@ -29,6 +29,9 @@ buildPythonPackage rec {
       url = "https://github.com/SAML-Toolkits/python3-saml/commit/bd65578e5a21494c89320094c61c1c77250bea33.diff";
       hash = "sha256-9Trew6R5JDjtc0NRGoklqMVDEI4IEqFOdK3ezyBU6gI=";
     })
+    # skip tests with expired test data
+    # upstream issue: https://github.com/SAML-Toolkits/python3-saml/issues/373
+    ./skip-broken-tests.patch
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/python3-saml/skip-broken-tests.patch
+++ b/pkgs/development/python-modules/python3-saml/skip-broken-tests.patch
@@ -1,0 +1,28 @@
+diff --git a/tests/src/OneLogin/saml2_tests/response_test.py b/tests/src/OneLogin/saml2_tests/response_test.py
+index fbe714f..bbed3c2 100644
+--- a/tests/src/OneLogin/saml2_tests/response_test.py
++++ b/tests/src/OneLogin/saml2_tests/response_test.py
+@@ -562,6 +562,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
+         response_2 = OneLogin_Saml2_Response(settings, xml_2)
+         self.assertTrue(response_2.check_one_condition())
+ 
++    @unittest.skip("test data expired")
+     def testCheckOneAuthnStatement(self):
+         """
+         Tests the check_one_authnstatement method of SamlResponse
+@@ -970,6 +971,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
+         with self.assertRaisesRegex(Exception, 'Could not validate timestamp: expired. Check system clock.'):
+             response_2.is_valid(self.get_request_data(), raise_exceptions=True)
+ 
++    @unittest.skip("test data expired")
+     def testIsInValidNoStatement(self):
+         """
+         Tests the is_valid method of the OneLogin_Saml2_Response
+@@ -1080,6 +1082,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
+         with self.assertRaisesRegex(Exception, 'Found an Attribute element with duplicated Name'):
+             response.get_attributes()
+ 
++    @unittest.skip("test data expired")
+     def testIsInValidDestination(self):
+         """
+         Tests the is_valid method of the OneLogin_Saml2_Response class


### PR DESCRIPTION
## Description of changes

Pretty sure there's no better way to do this. *sigh*

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
