### PR TITLE
python3Packages.pyssim: unbreak after recent pillow bump

### DIFF
--- a/pkgs/development/python-modules/pyssim/default.nix
+++ b/pkgs/development/python-modules/pyssim/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, numpy, scipy, pillow }:
+{ lib, buildPythonPackage, fetchFromGitHub, numpy, scipy, pillow, fetchpatch }:
 
 buildPythonPackage rec {
   pname = "pyssim";
@@ -13,6 +13,18 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "sha256-VvxQTvDTDms6Ccyclbf9P0HEQksl5atPPzHuH8yXTmc=";
   };
+
+  patches = [
+    # "Replace Image.ANTIALIAS with Image.LANCZOS"
+    # Image.ANTIALIAS has been removed in Pillow 10.0.0,
+    # the version currently in nixpkgs,
+    # and Image.LANCZOS is a drop-in since Pillow 2.7.0.
+    # https://github.com/jterrace/pyssim/pull/45
+    (fetchpatch {
+      url = "https://github.com/jterrace/pyssim/commit/db4296c12ca9c027eb9cd61b52195a78dfcc6711.patch";
+      hash = "sha256-wNp47EFtjXv6jIFX25IErXg83ksmGRNFKNeMFS+tP6s=";
+    })
+  ];
 
   # Tests are copied from .travis.yml
   checkPhase = ''


### PR DESCRIPTION
## Description of changes

`pyssim`, a dependency of `sitespeed-io`, did break due to the recent pillow update as part of the usual python updates in staging.

Caught when running `nixpkgs-review` in https://github.com/NixOS/nixpkgs/pull/251400#pullrequestreview-1596636436

`Image.LANCZOS` is a drop-in replacement for `Image.ANTIALIAS`. See https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants

Pillow bump: bdf1a96570808dc9e11cfbb1ffa5b8a7ff001e2d (#244135)

https://hydra.nixos.org/build/230653960

If someone wants to upstream this patch, feel free to do so.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
