### PR TITLE
swaynotificationcenter: backport PR 296

### DIFF
--- a/pkgs/applications/misc/swaynotificationcenter/001-backport-pr296.patch
+++ b/pkgs/applications/misc/swaynotificationcenter/001-backport-pr296.patch
@@ -1,0 +1,50 @@
+diff --git a/src/functions.vala b/src/functions.vala
+index cf7fefc..9b4d82a 100644
+--- a/src/functions.vala
++++ b/src/functions.vala
+@@ -102,10 +102,7 @@ namespace SwayNotificationCenter {
+ 
+         public static string get_style_path (owned string ? custom_path,
+                                              bool only_system = false) {
+-            string[] paths = {
+-                // Fallback location. Specified in postinstall.py
+-                "/usr/local/etc/xdg/swaync/style.css"
+-            };
++            string[] paths = {};
+             if (custom_path != null && custom_path.length > 0) {
+                 // Replaces the home directory relative path with a absolute path
+                 if (custom_path.get (0) == '~') {
+@@ -123,7 +120,9 @@ namespace SwayNotificationCenter {
+                 paths += Path.build_path (Path.DIR_SEPARATOR.to_string (),
+                                           path, "swaync/style.css");
+             }
+-
++            // Fallback location. Specified in postinstall.py. Mostly for Debian
++            paths += "/usr/local/etc/xdg/swaync/style.css";
++            
+             string path = "";
+             foreach (string try_path in paths) {
+                 if (File.new_for_path (try_path).query_exists ()) {
+@@ -140,10 +139,7 @@ namespace SwayNotificationCenter {
+         }
+ 
+         public static string get_config_path (owned string ? custom_path) {
+-            string[] paths = {
+-                // Fallback location. Specified in postinstall.py
+-                "/usr/local/etc/xdg/swaync/config.json"
+-            };
++            string[] paths = {};
+             if (custom_path != null && custom_path.length > 0) {
+                 // Replaces the home directory relative path with a absolute path
+                 if (custom_path.get (0) == '~') {
+@@ -158,7 +154,9 @@ namespace SwayNotificationCenter {
+                 paths += Path.build_path (Path.DIR_SEPARATOR.to_string (),
+                                           path, "swaync/config.json");
+             }
+-
++            // Fallback location. Specified in postinstall.py. Mostly for Debian
++            paths += "/usr/local/etc/xdg/swaync/config.json";
++ 
+             string path = "";
+             foreach (string try_path in paths) {
+                 if (File.new_for_path (try_path).query_exists ()) {

--- a/pkgs/applications/misc/swaynotificationcenter/default.nix
+++ b/pkgs/applications/misc/swaynotificationcenter/default.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation (finalAttrs: rec {
     hash = "sha256-mwwSTs4d9jUXUy33nSYJCRFlpH6naCmbRUSpfVacMBE=";
   };
 
+  patches = [
+    ./001-backport-pr296.patch
+  ];
+
   nativeBuildInputs = [
     bash-completion
     # cmake # currently conflicts with meson
@@ -70,6 +74,8 @@ stdenv.mkDerivation (finalAttrs: rec {
   postPatch = ''
     chmod +x build-aux/meson/postinstall.py
     patchShebangs build-aux/meson/postinstall.py
+
+    substituteInPlace src/functions.vala --replace /usr/local/etc $out/etc
   '';
 
   passthru.tests.version = testers.testVersion {


### PR DESCRIPTION
## Description of changes
 
Backport PR 296 from upstream to fix the loading of default config and style files

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
