### PR TITLE
mcontrolcenter: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11931,6 +11931,13 @@
       fingerprint = "9E6A 25F2 C1F2 9D76 ED00  1932 1261 173A 01E1 0298";
     }];
   };
+  nadimkobeissi = {
+    name = "Nadim Kobeissi";
+    email = "nadim@symbolic.software";
+    github = "nadimkobeissi";
+    githubId = 9953;
+    matrix = "@nadimkobeissi:matrix.org";
+  };
   nadrieril = {
     email = "nadrieril@gmail.com";
     github = "Nadrieril";

--- a/pkgs/os-specific/linux/mcontrolcenter/default.nix
+++ b/pkgs/os-specific/linux/mcontrolcenter/default.nix
@@ -1,0 +1,2 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.libsForQt5.callPackage ./derivation.nix {}

--- a/pkgs/os-specific/linux/mcontrolcenter/derivation.nix
+++ b/pkgs/os-specific/linux/mcontrolcenter/derivation.nix
@@ -41,22 +41,20 @@ stdenv.mkDerivation (finalAttrs: rec {
   ];
 
   installPhase = ''
-    	install -Dm755 mcontrolcenter $out/bin/mcontrolcenter
-    	install -Dm755 helper/mcontrolcenter-helper $out/libexec/mcontrolcenter-helper
-    	install -Dm644  $src/resources/mcontrolcenter.svg $out/share/icons/hicolor/32x32/apps/mcontrolcenter.svg
-    	install -Dm644 $src/src/helper/mcontrolcenter-helper.conf $out/share/dbus-1/system.d/mcontrolcenter-helper.conf
-      mkdir -p $out/share/dbus-1/system-services
-      echo "[D-BUS Service]" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
-      echo "Name=mcontrolcenter.helper" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
-      echo "Exec=$out/libexec/mcontrolcenter-helper" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
-      echo "User=root" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+    install -Dm755 mcontrolcenter $out/bin/mcontrolcenter
+    install -Dm755 helper/mcontrolcenter-helper $out/libexec/mcontrolcenter-helper
+    install -Dm644  $src/resources/mcontrolcenter.svg $out/share/icons/hicolor/32x32/apps/mcontrolcenter.svg
+    install -Dm644 $src/src/helper/mcontrolcenter-helper.conf $out/share/dbus-1/system.d/mcontrolcenter-helper.conf
+    mkdir -p $out/share/dbus-1/system-services
+    echo "[D-BUS Service]" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+    echo "Name=mcontrolcenter.helper" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+    echo "Exec=$out/libexec/mcontrolcenter-helper" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+    echo "User=root" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
   '';
 
   meta = with lib; {
     homepage = "https://github.com/dmitry-s93/MControlCenter";
-    description = ''
-      An application that allows you to change the settings of MSI laptops running Linux.";
-    '';
+    description = "An application that allows you to change the settings of MSI laptops running Linux.";
     licencse = licenses.gpl3;
     platforms = with platforms; linux;
     # maintainers = [ maintainers.nadimkobeissi ];

--- a/pkgs/os-specific/linux/mcontrolcenter/derivation.nix
+++ b/pkgs/os-specific/linux/mcontrolcenter/derivation.nix
@@ -57,6 +57,6 @@ stdenv.mkDerivation (finalAttrs: rec {
     description = "An application that allows you to change the settings of MSI laptops running Linux.";
     licencse = licenses.gpl3;
     platforms = with platforms; linux;
-    # maintainers = [ maintainers.nadimkobeissi ];
+    maintainers = [ maintainers.nadimkobeissi ];
   };
 })

--- a/pkgs/os-specific/linux/mcontrolcenter/derivation.nix
+++ b/pkgs/os-specific/linux/mcontrolcenter/derivation.nix
@@ -1,0 +1,64 @@
+{ pkgs, lib, stdenv, qtbase, wrapQtAppsHook, qttools, makeDesktopItem, copyDesktopItems, fetchFromGitHub }:
+
+stdenv.mkDerivation (finalAttrs: rec {
+  pname = "mcontrolcenter";
+  version = "0.4.1";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "MControlCenter";
+      exec = "mcontrolcenter";
+      icon = "mcontrolcenter";
+      comment = finalAttrs.meta.description;
+      desktopName = "MControlCenter";
+      categories = [ "System" ];
+    })
+  ];
+
+  buildInputs = [
+    pkgs.cmake
+    qtbase
+  ];
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    qttools
+    copyDesktopItems
+  ];
+
+  src = fetchFromGitHub {
+    owner = "dmitry-s93";
+    repo = "MControlCenter";
+    rev = "f04ca9878f0ccfa5ea849a3bd17bcb79a5f52a0a";
+    hash = "sha256-SV78OVRGzy2zFLT3xqeUtbjlh81Z97PVao18P3h/8dI=";
+  };
+
+  patches = [ ./modprobe.patch ];
+
+  cmakeFlags = [
+    "-DENABLE_TESTING=OFF"
+    "-DENABLE_INSTALL=ON"
+  ];
+
+  installPhase = ''
+    	install -Dm755 mcontrolcenter $out/bin/mcontrolcenter
+    	install -Dm755 helper/mcontrolcenter-helper $out/libexec/mcontrolcenter-helper
+    	install -Dm644  $src/resources/mcontrolcenter.svg $out/share/icons/hicolor/32x32/apps/mcontrolcenter.svg
+    	install -Dm644 $src/src/helper/mcontrolcenter-helper.conf $out/share/dbus-1/system.d/mcontrolcenter-helper.conf
+      mkdir -p $out/share/dbus-1/system-services
+      echo "[D-BUS Service]" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+      echo "Name=mcontrolcenter.helper" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+      echo "Exec=$out/libexec/mcontrolcenter-helper" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+      echo "User=root" >> $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/dmitry-s93/MControlCenter";
+    description = ''
+      An application that allows you to change the settings of MSI laptops running Linux.";
+    '';
+    licencse = licenses.gpl3;
+    platforms = with platforms; linux;
+    # maintainers = [ maintainers.nadimkobeissi ];
+  };
+})

--- a/pkgs/os-specific/linux/mcontrolcenter/modprobe.patch
+++ b/pkgs/os-specific/linux/mcontrolcenter/modprobe.patch
@@ -1,0 +1,13 @@
+diff --git a/src/helper/helper.cpp b/src/helper/helper.cpp
+index 5c291c8..382c18f 100644
+--- a/src/helper/helper.cpp
++++ b/src/helper/helper.cpp
+@@ -57,7 +57,7 @@ bool Helper::isEcSysModuleLoaded() const {
+ bool Helper::loadEcSysModule() const {
+     fprintf(stderr, "%s\n", qPrintable("Trying to load the ec_sys kernel module"));
+     auto *process = new QProcess();
+-    process->start("sh", QStringList() << "-c" << "/usr/sbin/modprobe ec_sys write_support=1 2>&1");
++    process->start("sh", QStringList() << "-c" << "/run/current-system/sw/bin/modprobe ec_sys write_support=1 2>&1");
+     process->waitForFinished(1000);
+     if (QByteArray output = process->readAllStandardOutput(); output != "")
+         fprintf(stderr, "%s", qPrintable(output));


### PR DESCRIPTION
MControlCenter provides a relatively full-featured control panel for MSI laptops, written in Qt. It allows users to control MSI laptop power plans, fan speed, battery charging limits, keyboard backlight settings, USB power sharing and more.

The application comes with strong desktop integration: shortcuts, taskbar item, etc. etc. -- screenshots here:
https://github.com/dmitry-s93/MControlCenter/blob/main/README.md

This package has been previous requested by the NixOS community: https://github.com/NixOS/nixpkgs/issues/244881

The package comes with a patch that corrects MControlCenter's path to the `modprobe` binary, allowing it to automatically load the `ec_sys` kernel module (included with NixOS by default) with the right settings when launched.

This NixOS package has been fully tested on a NixOS Plasma5 desktop.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
