### PR TITLE
drogon: 1.8.3 -> 1.8.6

### DIFF
--- a/pkgs/development/libraries/drogon/default.nix
+++ b/pkgs/development/libraries/drogon/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "drogon";
-  version = "1.8.3";
+  version = "1.8.5";
 
   src = fetchFromGitHub {
     owner = "drogonframework";
     repo = "drogon";
     rev = "v${version}";
-    sha256 = "sha256-I3f/8TMGm1G4CFMJJLyiVYso9yTHjeLefS5eaGySvC4=";
+    sha256 = "sha256-VvN71A0Nhe/Zdi9M1YL5mxoaiMfd2bfV53dfMBuDZd8=";
     fetchSubmodules = true;
   };
 
@@ -43,18 +43,14 @@ stdenv.mkDerivation rec {
     # this part of the test would normally fail because it attempts to configure a CMake project that uses find_package on itself
     # this patch makes drogon and trantor visible to the test
     ./fix_find_package.patch
-
-    # see https://github.com/drogonframework/drogon/issues/1491
-    (fetchpatch {
-      url = "https://github.com/drogonframework/drogon/commit/7d87d7e0b264ce53aa5ee006fb022d3516c9d666.patch";
-      sha256 = "sha256-C4zH9oNMfhkaeVNvZuBuzu1v2vNgg/t+YPitbrmHg+Y=";
-    })
   ];
 
   # modifying PATH here makes drogon_ctl visible to the test
   installCheckPhase = ''
-    cd ..
-    PATH=$PATH:$out/bin bash test.sh
+    (
+      cd ..
+      PATH=$PATH:$out/bin bash test.sh
+    )
   '';
 
   doInstallCheck = true;

--- a/pkgs/development/libraries/drogon/default.nix
+++ b/pkgs/development/libraries/drogon/default.nix
@@ -7,14 +7,14 @@
 , redisSupport ? false, hiredis
 , mysqlSupport ? false, libmysqlclient, mariadb }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "drogon";
   version = "1.8.6";
 
   src = fetchFromGitHub {
     owner = "drogonframework";
     repo = "drogon";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-BYZoMesDquXaphZvnf2Vd/RuOC9jsOjZsGNbDmQ3u+c=";
     fetchSubmodules = true;
   };
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
-    "-DBUILD_TESTING=${if doInstallCheck then "ON" else "OFF"}"
+    "-DBUILD_TESTING=${if finalAttrs.finalPackage.doInstallCheck then "ON" else "OFF"}"
     "-DBUILD_EXAMPLES=OFF"
   ];
 
@@ -49,11 +49,13 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     (
       cd ..
-      PATH=$PATH:$out/bin bash test.sh
+      PATH=$PATH:$out/bin $SHELL test.sh
     )
   '';
 
-  doInstallCheck = true;
+  # this excludes you, pkgsStatic (cmake wants to run built binaries
+  # in the buildPhase)
+  doInstallCheck = stdenv.buildPlatform == stdenv.hostPlatform;
 
   meta = with lib; {
     homepage = "https://github.com/drogonframework/drogon";
@@ -62,4 +64,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ urlordjames ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/development/libraries/drogon/default.nix
+++ b/pkgs/development/libraries/drogon/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "drogon";
-  version = "1.8.5";
+  version = "1.8.6";
 
   src = fetchFromGitHub {
     owner = "drogonframework";
     repo = "drogon";
     rev = "v${version}";
-    sha256 = "sha256-VvN71A0Nhe/Zdi9M1YL5mxoaiMfd2bfV53dfMBuDZd8=";
+    sha256 = "sha256-BYZoMesDquXaphZvnf2Vd/RuOC9jsOjZsGNbDmQ3u+c=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Description of changes

~Looks like it _might_ resolve https://nvd.nist.gov/vuln/detail/CVE-2023-26137 (via https://github.com/drogonframework/drogon/pull/1703 in 1.8.5), but haven't got confirmation from upstream about that.~

Also fixed cross-compilation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
