### PR TITLE
modern-cpp-kafka: init at 2023.03.07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4424,6 +4424,15 @@
     githubId = 14034137;
     name = "Mostly Void";
   };
+  ditsuke = {
+    name = "Tushar";
+    email = "hello@ditsuke.com";
+    github = "ditsuke";
+    githubId = 72784348;
+    keys = [{
+      fingerprint = "8FD2 153F 4889 541A 54F1  E09E 71B6 C31C 8A5A 9D21";
+    }];
+  };
   djacu = {
     email = "daniel.n.baker@gmail.com";
     github = "djacu";

--- a/pkgs/by-name/mo/modern-cpp-kafka/package.nix
+++ b/pkgs/by-name/mo/modern-cpp-kafka/package.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, boost
+, rdkafka
+, gtest
+, rapidjson
+}:
+
+stdenv.mkDerivation rec {
+  pname = "modern-cpp-kafka";
+  version = "2023.03.07";
+
+  src = fetchFromGitHub {
+    repo = "modern-cpp-kafka";
+    owner = "morganstanley";
+    rev = "v${version}";
+    hash = "sha256-7hkwM1YbveQpDRqwMZ3MXM88LTwlAT7uB8NL0t409To=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-avoid-overwriting-library-paths.patch";
+      url = "https://github.com/morganstanley/modern-cpp-kafka/pull/221.patch";
+      hash = "sha256-UsQcMvJoRTn5kgXhmXOyqfW3n59kGKO596U2WjtdqAY=";
+    })
+    (fetchpatch {
+      name = "add-pkg-config-cmake-config.patch";
+      url = "https://github.com/morganstanley/modern-cpp-kafka/pull/222.patch";
+      hash = "sha256-OjoSttnpgEwSZjCVKc888xJb5f1Dulu/rQqoGmqXNM4=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ rdkafka ];
+
+  cmakeFlags = [
+    "-DLIBRDKAFKA_INCLUDE_DIR=${rdkafka.out}/include"
+    "-DGTEST_LIBRARY_DIR=${gtest.out}/lib"
+    "-DGTEST_INCLUDE_DIR=${gtest.dev}/include"
+    "-DRAPIDJSON_INCLUDE_DIRS=${rapidjson.out}/include"
+    "-DCMAKE_CXX_FLAGS=-Wno-uninitialized"
+  ];
+
+  checkInputs = [ gtest rapidjson ];
+
+  meta = with lib; {
+    description = "A C++ API for Kafka clients (i.e. KafkaProducer, KafkaConsumer, AdminClient)";
+    homepage = "https://github.com/morganstanley/modern-cpp-kafka";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ditsuke ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds a derivation for [modern-cpp-kafka](https://github.com/morganstanley/modern-cpp-kafka).

> **NOTE**
> ~~Using my fork that patches some cmake build setup temporarily. Won't be required once my [PR](https://github.com/morganstanley/modern-cpp-kafka/pull/221)
is accepted upstream. Alternatively I could apply my fixes as an inline-patch while still using the official repo.~~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
