### PR TITLE
stag-audio-tagger: init at 1.0.0

### DIFF
--- a/pkgs/applications/audio/stag/default.nix
+++ b/pkgs/applications/audio/stag/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, ncurses
+, taglib
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "stag";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "smabie";
+    repo = "stag";
+    rev = "v${version}";
+    hash = "sha256-IWb6ZbPlFfEvZogPh8nMqXatrg206BTV2DYg7BMm7R4=";
+  };
+
+  buildInputs = [
+    ncurses
+    taglib
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv stag $out/bin/stag
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Public domain utf8 curses based audio file tagger";
+    homepage = "https://github.com/smabie/stag";
+    license = with licenses; [ publicDomain ];
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6305,6 +6305,8 @@ with pkgs;
 
   stacs = callPackage ../tools/security/stacs { };
 
+  stag-audio-tagger = callPackage ../applications/audio/stag { };
+
   stagit = callPackage ../development/tools/stagit { };
 
   starboard = callPackage ../applications/networking/cluster/starboard { };


### PR DESCRIPTION
## Description of changes

Adds this nice ncurses tui for managing id3 tags and more to nixpkgs, there's a naming collision with an existing ncurses program called `stag` which is why I've named it `stag-audio-tagger`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
