### PR TITLE
olive-editor: 2023-03-20 -> 2023-06-12

### DIFF
--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -37,10 +37,6 @@ stdenv.mkDerivation {
   # https://github.com/olive-editor/olive/issues/2200
   patchPhase = ''
     runHook prePatch
-    substituteInPlace ./app/node/project/serializer/serializer.h \
-      --replace 'QStringRef' 'QStringView'
-    substituteInPlace ./app/node/project/serializer/serializer.cpp \
-      --replace 'QStringRef' 'QStringView'
     substituteInPlace ./app/node/project/serializer/serializer230220.cpp \
       --replace 'QStringRef' 'QStringView'
     runHook postPatch

--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -20,14 +20,14 @@
 
 stdenv.mkDerivation {
   pname = "olive-editor";
-  version = "unstable-2023-03-20";
+  version = "unstable-2023-06-12";
 
   src = fetchFromGitHub {
     fetchSubmodules = true;
     owner = "olive-editor";
     repo = "olive";
-    rev = "8ca16723613517c41304de318169d27c571b90af";
-    sha256 = "sha256-lL90+8L7J7pjvhbqfeIVF0WKgl6qQzNun8pL9YPL5Is=";
+    rev = "2036fffffd0e24b7458e724b9084ae99c9507c64";
+    sha256 = "sha256-qee9/WTvTy5jWLowvZJOwAjrqznRhJR+u9dYsnCN/Qs=";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
## Description of changes

Updates the olive video editor to the latest master commit, since they aren't making regular releases

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
