### PR TITLE
nixos/device-tree: Add more options to the module

### DIFF
--- a/pkgs/os-specific/linux/device-tree/default.nix
+++ b/pkgs/os-specific/linux/device-tree/default.nix
@@ -1,6 +1,29 @@
-{ lib, stdenvNoCC, dtc }:
+{ lib, stdenv, stdenvNoCC, dtc }:
 
 with lib; {
+  # Compile single Device Tree overlay source
+  # file (.dts) into its compiled variant (.dtb)
+  compileDTS = ({
+    name,
+    dtsFile,
+    includePaths ? [],
+    extraPreprocessorFlags ? []
+  }: stdenv.mkDerivation {
+    inherit name;
+
+    nativeBuildInputs = [ dtc ];
+
+    buildCommand =
+      let
+        includeFlagsStr = lib.concatMapStringsSep " " (includePath: "-I${includePath}") includePaths;
+        extraPreprocessorFlagsStr = lib.concatStringsSep " " extraPreprocessorFlags;
+      in
+      ''
+        $CC -E -nostdinc ${includeFlagsStr} -undef -D__DTS__ -x assembler-with-cpp ${extraPreprocessorFlagsStr} ${dtsFile} | \
+        dtc -I dts -O dtb -@ -o $out
+      '';
+  });
+
   applyOverlays = (base: overlays': stdenvNoCC.mkDerivation {
     name = "device-tree-overlays";
     nativeBuildInputs = [ dtc ];


### PR DESCRIPTION
## Things done

Improve devicetree module by:
- Exposing compileDTS to make it easier for user to compile their own custom dts
- Expose more customization options for compiling dtbo in hardware.devicetree
- Allow custom dtb source in hardware.devicetree so that users don't have to use dtb from kernel but still get other benefits of the module like overlay support


- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested by building with the various new options on the closure `nixos/modules/installer/sd-card/sd-image-aarch64.nix` closure. The dtb changes are observed to take effects
