### PR TITLE
ocamlPackages.arp: 3.0.0 → 3.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/arp/default.nix
+++ b/pkgs/development/ocaml-modules/arp/default.nix
@@ -9,7 +9,6 @@
 , logs
 , lwt
 , macaddr
-, mirage-profile
 , mirage-time
 , alcotest
 , mirage-clock-unix
@@ -23,15 +22,14 @@
 
 buildDunePackage rec {
   pname = "arp";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchurl {
-    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "1x3l8v96ywc3wrcwbf0j04b8agap4fif0fz6ki2ndzx57yqcjszn";
+    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    hash = "sha256-g/aEhpufQcyS/vCtKk0Z1sYaYNRmQFaZ9rTp9F4nq54=";
   };
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   nativeBuildInputs = [
     bisect_ppx
@@ -45,7 +43,6 @@ buildDunePackage rec {
     logs
     lwt
     macaddr
-    mirage-profile
     mirage-time
   ];
 


### PR DESCRIPTION
## Description of changes

https://github.com/mirage/arp/blob/v3.1.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
