### PR TITLE
wireguard-tools: bake wireguard-go in PATH on Darwin

### DIFF
--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -8,6 +8,7 @@
 , openresolv
 , procps
 , bash
+, wireguard-go
 }:
 
 stdenv.mkDerivation rec {
@@ -45,6 +46,11 @@ stdenv.mkDerivation rec {
       wrapProgram $f \
         --prefix PATH : ${lib.makeBinPath [ procps iproute2 ]} \
         --suffix PATH : ${lib.makeBinPath [ iptables openresolv ]}
+    done
+  '' + lib.optionalString stdenv.isDarwin ''
+    for f in $out/bin/*; do
+      wrapProgram $f \
+        --prefix PATH : ${lib.makeBinPath [ wireguard-go ]}
     done
   '';
 


### PR DESCRIPTION
## Description of changes

It’s a dependency. Without this, wg-quick doesn’t work if it’s installed on a system without wireguard-go available in the PATH of the user.

This reverts #160951. In the discussion on that PR there seemed to be some uncertainty around whether or not this code was even necessary on Darwin, although I think in the end they were clear that:

- wireguard-go is necessary for wireguard-tools to work on Darwin
- this should be removed from PATH anyway, and the user should just know to have wireguard-go on their PATH if they want wireguard-tools to work on Darwin

The reason that I need `wireguard-go` baked in to the `wireguard-tools` PATH on my machine, and not just on my shell PATH, is that I call `wg-quick` (from wireguard-tools) in a headless environment that doesn't load any shell init code, and therefore doesn't know about the Nix path.

I could of course just create my own wrapper for this on my end--I'm just surprised that this is necessary, it doesn't feel very Nix-y to have to manage dependencies this way. I'm not sure what the advantage is of not having this baked in, in the first place, given that it's necessary for this tool to work on Darwin.

What are your thoughts?
## Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
