### PR TITLE
ansible-lint: Unset PYTHONPATH in wrapper 

### DIFF
--- a/pkgs/tools/admin/ansible/lint.nix
+++ b/pkgs/tools/admin/ansible/lint.nix
@@ -6,12 +6,12 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "ansible-lint";
-  version = "6.17.1";
+  version = "6.18.0";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-804zPzVVyZ/zTHePYdRw0eOh623HYJDQ3XuVsslHRcI=";
+    hash = "sha256-VHRO5/j9DsOAUfC23yFTUjk5o5HuS7SPCIW1/N2C+bk=";
   };
 
   postPatch = ''

--- a/pkgs/tools/admin/ansible/lint.nix
+++ b/pkgs/tools/admin/ansible/lint.nix
@@ -79,7 +79,10 @@ python3.pkgs.buildPythonApplication rec {
     "test_discover_lintables_umlaut"
   ];
 
-  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ ansible ]}" ];
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ ansible ]}"
+    "--unset PYTHONPATH"
+  ];
 
   meta = with lib; {
     description = "Best practices checker for Ansible";


### PR DESCRIPTION
## Description of changes

Since the update of `ruamel.yaml` to 0.17.32 (5330b05d9952aad7606d5c0658d65faf1955c659), `ansible-lint` is broken with the following error, when ran from a `nix-shell`:
```
Traceback (most recent call last):
  File "/nix/store/20wbbb8w5d95k23hyf417aqh85qjmzp9-ansible-lint-6.17.1/bin/.ansible-lint-wrapped", line 6, in <module>
    from ansiblelint.__main__ import _run_cli_entrypoint
  File "/nix/store/20wbbb8w5d95k23hyf417aqh85qjmzp9-ansible-lint-6.17.1/lib/python3.10/site-packages/ansiblelint/__main__.py", line 39, in <module>
    from ansiblelint import cli
  File "/nix/store/20wbbb8w5d95k23hyf417aqh85qjmzp9-ansible-lint-6.17.1/lib/python3.10/site-packages/ansiblelint/cli.py", line 29, in <module>
    from ansiblelint.yaml_utils import clean_json
  File "/nix/store/20wbbb8w5d95k23hyf417aqh85qjmzp9-ansible-lint-6.17.1/lib/python3.10/site-packages/ansiblelint/yaml_utils.py", line 15, in <module>
    import ruamel.yaml.events
ModuleNotFoundError: No module named 'ruamel.yaml'
```

I did some investigation, and it appears to have something to do with different versions of Python namespaces. I'm not very familiar with the Python packaging and module loading process, so that was as far as I got. @tjni has been working on this (see [here](https://sourceforge.net/p/ruamel-base/tickets/2/)), so I hope that he understands the problem better than I do. In any case, I found that unsetting the `PYTHONPATH` environment variable fixes the problem for `ansible-lint` so this PR does exactly that.

I think a better fix needs to be found in the future, but for now, this fix at least mitigates the issue.

In addition, since an update for `ansible-lint` was released in the meantime, this PR includes a version bump.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] ~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] ~(Package updates) Added a release notes entry if the change is major or breaking~
  - [ ] ~(Module updates) Added a release notes entry if the change is significant~
  - [ ] ~(Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
