### PR TITLE
libmbim: backport Intel mutual authentication and intel tools patches

### DIFF
--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -30,6 +31,24 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-aaYjvJ2OMTzkUyqWCyHdmsKJ3VGqBmKQzb1DWK/1cPU=";
   };
+
+  patches = [
+    # Intel Mutual Authentication - FCC lock. Part of 1.30, backported to
+    # openSUSE and Fedora and ChromeOS.
+    # https://src.fedoraproject.org/rpms/libmbim/blob/rawhide/f/libmbim.spec
+    (fetchpatch {
+      url = "https://cgit.freedesktop.org/libmbim/libmbim/patch/?id=910db9cb2b6fde303d3b4720890cf6dc6fc00880";
+      hash = "sha256-412sXdWb8WsSexe1scI/C57dwENgNWoREGO1GxSF4hs=";
+    })
+
+    # Intel Tools. Allows tracing various commands. Part of 1.30, backported to
+    # openSUSE, Fedora and ChromeOS.
+    # https://src.fedoraproject.org/rpms/libmbim/blob/rawhide/f/libmbim.spec
+    (fetchpatch {
+      url = "https://cgit.freedesktop.org/libmbim/libmbim/patch/?id=8a6dec6ed11931601e605c9537da9904b3be5bc0";
+      hash = "sha256-tU4zkUl5aZJE+g/qbnWprUHe/PmZvqVKB9qecSaUBhk=";
+    })
+  ];
 
   mesonFlags = [
     "-Dudevdir=${placeholder "out"}/lib/udev"


### PR DESCRIPTION
These patches are merged into 1.30, and were backported to at least openSUSE, Fedora and ChromeOS.

They're used to FCC unlock various wwan modems.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
