### PR TITLE
libredwg: 0.12.5 -> 0.12.5.6248

### DIFF
--- a/pkgs/development/libraries/libredwg/default.nix
+++ b/pkgs/development/libraries/libredwg/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , writeShellScript
 , pkg-config
@@ -17,19 +18,28 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libredwg";
-  version = "0.12.5";
+  version = "0.12.5.6248";
 
   src = fetchFromGitHub {
     owner = "LibreDWG";
     repo = pname;
     rev = version;
-    sha256 = "sha256-s9aiOKSM7+3LJNE+jRrEMcL1QKRWrlTKbwO7oL9VhuE=";
+    hash = "sha256-EHfqj+FeZZpQzF9/LFWg+onTMz2/9tvXNcdpZrdjry0=";
     fetchSubmodules = true;
   };
 
+  patches = [
+    (fetchpatch {
+      name = "dwg2svg-strcasestr-musl-fix.patch";
+      # https://github.com/LibreDWG/libredwg/pull/822
+      url = "https://github.com/LibreDWG/libredwg/commit/eec0b7aac6d2f695b7b258f47c3bde3f71f963ee.patch";
+      hash = "sha256-TjpJuhRl9t0b9NOJ1FEOO0/y586WwaJcNzTM0cTwmYI=";
+    })
+  ];
+
   postPatch = let
     printVersion = writeShellScript "print-version" ''
-      echo ${lib.escapeShellArg version}
+      echo -n ${lib.escapeShellArg version}
     '';
   in ''
     # avoid git dependency


### PR DESCRIPTION
## Description of changes

There have been so many CVEs since 0.12.5, I'm not sure I should/can list them all (especially as it's not made clear whether they're all addressed). At this point we're going to have to jump to these "nightly" pseudo-releases.

CVE-2023-36271
CVE-2023-36272
CVE-2023-36273
CVE-2023-36274
CVE-2023-25222

Also tested `pkgsStatic`, `pkgsMusl`, `pkgsCross.aarch64-multiplatform` and `pkgsi686Linux` variants.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
