### PR TITLE
aws-workspaces: 4.6.0.4187 -> 2023.0.4395

### DIFF
--- a/pkgs/applications/networking/remote/aws-workspaces/default.nix
+++ b/pkgs/applications/networking/remote/aws-workspaces/default.nix
@@ -1,19 +1,19 @@
 { stdenv, lib
 , makeWrapper, dpkg, fetchurl, autoPatchelfHook
-, curl, libkrb5, lttng-ust, libpulseaudio, gtk3, openssl_1_1, icu70, webkitgtk, librsvg, gdk-pixbuf, libsoup, glib-networking, graphicsmagick_q16, libva, libusb1, hiredis
+, curl, libkrb5, lttng-ust, libpulseaudio, gtk3, openssl, icu70, webkitgtk, librsvg, gdk-pixbuf, libsoup, glib-networking, graphicsmagick_q16, libva, libusb1, hiredis, pcsclite, jbigkit, libvdpau
 }:
 
 stdenv.mkDerivation rec {
   pname = "aws-workspaces";
-  version = "4.6.0.4187";
+  version = "2023.0.4395";
 
   src = fetchurl {
-    # ref https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/focal/main/binary-amd64/Packages
     urls = [
-      "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/focal/main/binary-amd64/workspacesclient_${version}_amd64.deb"
-      "https://archive.org/download/workspacesclient_${version}_amd64/workspacesclient_${version}_amd64.deb"
+      # Original source is https://d3nt0h4h6pmmc4.cloudfront.net/new_workspacesclient_jammy_amd64.deb.
+      # It doesn't seem like Amazon provides a repository for Ubuntu 22.04 (jammy) - at least not yet, so I am using archive.org to pin the version.
+      "https://archive.org/download/new_workspacesclient_jammy_2023.0.4395_amd64/new_workspacesclient_jammy_2023.0.4395_amd64.deb"
     ];
-    sha256 = "sha256-A+b79ewh4hBIf8jgK0INILFktTqRRpOgXRH0FGziV6c=";
+    sha256 = "sha256-w6056o4mAI39SEq94s5UabdPllCrSaK11LMi97XeDYA=";
   };
 
   nativeBuildInputs = [
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     lttng-ust
     libpulseaudio
     gtk3
-    openssl_1_1.out
+    openssl
     icu70
     webkitgtk
     librsvg
@@ -43,6 +43,9 @@ stdenv.mkDerivation rec {
     hiredis
     libusb1
     libva
+    pcsclite
+    jbigkit
+    libvdpau
   ];
 
   unpackPhase = ''
@@ -50,17 +53,15 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    patchelf --replace-needed liblttng-ust.so.0 liblttng-ust.so $out/lib/libcoreclrtraceptprovider.so
-    patchelf --replace-needed libGraphicsMagick++-Q16.so.12 libGraphicsMagick++.so.12 $out/usr/lib/x86_64-linux-gnu/pcoip-client/vchan_plugins/libvchan-plugin-clipboard.so
-    patchelf --replace-needed libhiredis.so.0.14 libhiredis.so $out/lib/libpcoip_core.so
+    patchelf --replace-needed libjbig.so.0 libjbig.so $out/bin/workspacesclient/dcv/libtiff.so.6
   '';
 
   installPhase = ''
     mkdir -p $out/bin $out/lib
-    mv $out/opt/workspacesclient/* $out/lib
+    mv $out/usr/lib/x86_64-linux-gnu/* $out/lib
     rm -rf $out/opt
 
-    wrapProgram $out/lib/workspacesclient \
+    wrapProgram $out/usr/bin/workspacesclient \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
       --set GDK_PIXBUF_MODULE_FILE "${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
       --set GIO_EXTRA_MODULES "${glib-networking.out}/lib/gio/modules"

--- a/pkgs/applications/networking/remote/aws-workspaces/default.nix
+++ b/pkgs/applications/networking/remote/aws-workspaces/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib
 , makeWrapper, dpkg, fetchurl, autoPatchelfHook
-, curl, libkrb5, lttng-ust, libpulseaudio, gtk3, openssl, icu70, webkitgtk, librsvg, gdk-pixbuf, libsoup, glib-networking, graphicsmagick_q16, libva, libusb1, hiredis, pcsclite, jbigkit, libvdpau
+, curl, libkrb5, lttng-ust, libpulseaudio, gtk3, openssl, icu70, webkitgtk, librsvg, gdk-pixbuf, libsoup, glib-networking, graphicsmagick_q16, libva, libusb1, hiredis, pcsclite, jbigkit, libtiff, libvdpau
+, ffmpeg_6, lmdb, protobufc, zlib
 }:
 
 stdenv.mkDerivation rec {
@@ -46,19 +47,22 @@ stdenv.mkDerivation rec {
     pcsclite
     jbigkit
     libvdpau
+    libtiff
+    ffmpeg_6.lib
+    lmdb
+    protobufc
+    zlib
   ];
 
   unpackPhase = ''
     ${dpkg}/bin/dpkg -x $src $out
-  '';
-
-  preFixup = ''
-    patchelf --replace-needed libjbig.so.0 libjbig.so $out/bin/workspacesclient/dcv/libtiff.so.6
+    rm -rf $out/usr/lib/x86_64-linux-gnu/workspacesclient/dcv/g*
+    rm -rf $out/usr/lib/x86_64-linux-gnu/workspacesclient/dcv/lib[acefghjlnoptz]*
+    ls -alR $out
   '';
 
   installPhase = ''
     mkdir -p $out/bin $out/lib
-    mv $out/usr/lib/x86_64-linux-gnu/* $out/lib
     rm -rf $out/opt
 
     wrapProgram $out/usr/bin/workspacesclient \
@@ -66,7 +70,7 @@ stdenv.mkDerivation rec {
       --set GDK_PIXBUF_MODULE_FILE "${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
       --set GIO_EXTRA_MODULES "${glib-networking.out}/lib/gio/modules"
 
-    mv $out/lib/workspacesclient $out/bin
+    mv $out/usr/bin/workspacesclient $out/bin/workspacesclient
   '';
 
   meta = with lib; {
@@ -76,5 +80,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ]; # TODO Mac support
     maintainers = with maintainers; [ mausch dylanmtaylor ];
+    mainProgram = "workspacesclient";
   };
 }


### PR DESCRIPTION
## Description of changes

*THIS IS A MAJOR, BREAKING CHANGE TO THIS PACKAGE.*

This is a work in progress and it is not ready to be reviewed or merge yet. Now that Amazon is building against Ubuntu 22.04 which has modern OpenSSL support (see #210452), it makes sense to rebase against this Ubuntu version. Unfortunately, in the newer client, only WSP workspaces are supported, which is a major breaking change. It seems like all of the new workspaces use the WSP protocol though, so this will be beneficial to the largest number of users. There is no repo for the jammy packages (yet, anyways), so I renamed the file and uploaded it to archive.org so we could version it. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
