### PR TITLE
colord-kde: fix missing buildInput

### DIFF
--- a/pkgs/applications/kde/colord-kde.nix
+++ b/pkgs/applications/kde/colord-kde.nix
@@ -1,8 +1,8 @@
 { mkDerivation, lib
 , extra-cmake-modules, ki18n
-, kconfig, kconfigwidgets, kcoreaddons, kdbusaddons, kiconthemes, kcmutils
-, kio, knotifications, plasma-framework, kwidgetsaddons, kwindowsystem
-, kitemmodels, kitemviews, lcms2, libXrandr, qtx11extras
+, kconfig, kconfigwidgets, kcoreaddons, kdbusaddons, kiconthemes, kirigami-addons
+, kcmutils, kio, knotifications, plasma-framework, kwidgetsaddons
+, kwindowsystem, kitemmodels, kitemviews, lcms2, libXrandr, qtx11extras
 }:
 
 mkDerivation {
@@ -11,7 +11,7 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules ];
 
   buildInputs = [
-    kconfig kconfigwidgets kcoreaddons kdbusaddons kiconthemes
+    kconfig kconfigwidgets kcoreaddons kdbusaddons kiconthemes kirigami-addons
     kcmutils ki18n kio knotifications plasma-framework kwidgetsaddons
     kwindowsystem kitemmodels kitemviews lcms2 libXrandr qtx11extras
   ];


### PR DESCRIPTION
Added a buildInput that is not strictly required for the package to compile, but without which the package will not actually work at all.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
