### PR TITLE
misc-gitology: init at unstable-2023-06-22

### DIFF
--- a/pkgs/by-name/mi/misc-gitology/package.nix
+++ b/pkgs/by-name/mi/misc-gitology/package.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  perl,
+  python3,
+}:
+stdenv.mkDerivation {
+  pname = "misc-gitology";
+  version = "unstable-2024-08-26";
+
+  src = fetchFromGitHub {
+    owner = "da-x";
+    repo = "misc-gitology";
+    rev = "8f6b200ed5f4d39f86026cf050f325d5f5713950";
+    hash = "sha256-6LoMJUOyBpP1HvVXNahEQlN1JKC9KflcOH9QWIi4M6s=";
+  };
+
+  dontBuild = true;
+
+  buildInputs = [
+    python3
+    # For `git-find-blob`:
+    perl
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    find . \
+      -type f \
+      -executable \
+      -maxdepth 1 \
+      -exec install --target-directory=$out/bin/ {} +
+  '';
+
+  meta = with lib; {
+    description = "Assortment of scripts around Git";
+    homepage = "https://github.com/da-x/misc-gitology";
+    license = [ licenses.bsd2 ];
+    maintainers = [ maintainers._9999years ];
+  };
+
+  passthru.updateScript = nix-update-script { };
+}

--- a/pkgs/by-name/mi/misc-gitology/package.nix
+++ b/pkgs/by-name/mi/misc-gitology/package.nix
@@ -26,12 +26,14 @@ stdenv.mkDerivation {
   ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     find . \
       -type f \
       -executable \
       -maxdepth 1 \
       -exec install --target-directory=$out/bin/ {} +
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/mi/misc-gitology/package.nix
+++ b/pkgs/by-name/mi/misc-gitology/package.nix
@@ -8,7 +8,7 @@
 }:
 stdenv.mkDerivation {
   pname = "misc-gitology";
-  version = "unstable-2024-08-26";
+  version = "0-unstable-2024-08-26";
 
   src = fetchFromGitHub {
     owner = "da-x";


### PR DESCRIPTION
## Description of changes

A collection of useful Git scripts, notably including `git-flip-history` (which lets you split a commit by writing a series of commits _undoing_ the changes one by one).

See: https://blog.aloni.org/posts/gitology-1-git-flip-history/

Upstream repo: https://github.com/da-x/misc-gitology


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).