### PR TITLE
texlive: split outputs & spring cleaning

### DIFF
--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -373,7 +373,7 @@ rec {
       # (1) binaries requiring --help or -h
       help = [ "arlatex" "bundledoc" "cachepic" "checklistings" "dvipos" "extractres" "fig4latex" "fragmaster"
         "kpsewhere" "latex-git-log" "ltxfileinfo" "mendex" "perltex" "pn2pdf" "psbook" "psnup" "psresize" "purifyeps"
-        "simpdftex" "tex2xindy" "texluac" "texluajitc" "urlbst" "yplan" ];
+        "simpdftex" "tex2xindy" "texluac" "texluajitc" "upmendex" "urlbst" "yplan" ];
       shortHelp = [ "adhocfilelist" "authorindex" "bbl2bib" "bibdoiadd" "bibmradd" "biburl2doi" "bibzbladd" "ctanupload"
         "disdvi" "dvibook" "dviconcat" "getmapdl" "latex2man" "listings-ext.sh" "pygmentex" ];
       # (2) binaries that return non-zero exit code even if correctly asked for help

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -132,7 +132,7 @@ core = stdenv.mkDerivation rec {
 
   inherit (common) binToOutput src prePatch;
 
-  outputs = [ "out" "doc" "dev" ]
+  outputs = [ "out" "dev" "man" "info" ]
     ++ (builtins.map (builtins.replaceStrings [ "-" ] [ "_" ]) corePackages);
 
   nativeBuildInputs = [
@@ -191,10 +191,6 @@ core = stdenv.mkDerivation rec {
        note: for unlinking, the texlinks patch is irrelevant, so we use
        the included texlinks.sh to avoid the dependency on bin.texlinks */ ''
     PATH="$out/bin:$PATH" sh ../texk/texlive/linked_scripts/texlive-extra/texlinks.sh --cnffile "../texk/texlive/tl_support/fmtutil.cnf" --unlink "$out/bin"
-  '' +
-  /* doc location identical with individual TeX pkgs */ ''
-    mkdir -p "$doc/doc"
-    mv "$out"/share/{man,info} "$doc"/doc
   '' + /* remove redundant texmf-dist (content provided by TeX Live packages) */
   ''
     rm -fr "$out"/share/texmf-dist

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -151,7 +151,9 @@ core = stdenv.mkDerivation rec {
 
   preConfigure = ''
     rm -r libs/{cairo,freetype2,gd,gmp,graphite2,harfbuzz,icu,libpaper,libpng} \
-      libs/{lua53,luajit,mpfr,pixman,zlib,zziplib}
+      libs/{lua53,luajit,mpfr,pixman,pplib,teckit,zlib,zziplib} \
+      texk/{bibtex-x,chktex,dvipng,dvisvgm,upmendex,xdvik} \
+      utils/{asymptote,texdoctk,xindy,xpdfopen}
     mkdir WorkDir
     cd WorkDir
   '';
@@ -185,7 +187,6 @@ core = stdenv.mkDerivation rec {
   '' + /* remove redundant texmf-dist (content provided by TeX Live packages) */
   ''
     rm -fr "$out"/share/texmf-dist
-    rm "$out"/bin/texdoctk # installed even with --disable-linked-scripts
   '' + /* install himktables in separate output for use in cross compilation */ ''
      mkdir -p $dev/bin
      cp texk/web2c/.libs/himktables $dev/bin/himktables

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -206,7 +206,7 @@ core = stdenv.mkDerivation rec {
 
 inherit (core-big) metafont mflua metapost luatex luahbtex xetex;
 luajittex = core.big.luajittex or null;
-core-big = stdenv.mkDerivation { #TODO: upmendex
+core-big = stdenv.mkDerivation {
   pname = "texlive-core-big.bin";
   inherit version;
 
@@ -260,7 +260,7 @@ core-big = stdenv.mkDerivation { #TODO: upmendex
       texk/{afm2pl,bibtex-x,chktex,cjkutils,detex,dtl,dvi2tty,dvidvi,dviljk,dviout-util} \
       texk/{dvipdfm-x,dvipng,dvipos,dvipsk,dvisvgm,gregorio,gsftopk,kpathsea} \
       texk/{lcdf-typetools,makeindexk,makejvf,mendexk,musixtnt,ps2pk,psutils,ptexenc} \
-      texk/{seetexk,tex4htk,texlive,ttf2pk2,ttfdump,upmendex,xdvik} \
+      texk/{seetexk,tex4htk,texlive,ttf2pk2,ttfdump,xdvik} \
       utils/{asymptote,autosp,axodraw2,devnag,lacheck,m-tx,pmx,ps2eps,t1utils,texdoctk} \
       utils/{tpic2pdftex,vlna,xindy,xml2pmx,xpdfopen}
     mkdir WorkDir
@@ -274,8 +274,8 @@ core-big = stdenv.mkDerivation { #TODO: upmendex
       ([ "tex" "ptex" "eptex" "uptex" "euptex" "aleph" "hitex" "pdftex"
         "web-progs" "synctex"
       ] ++ lib.optionals (!withLuaJIT) [ "luajittex" "luajithbtex" "mfluajit" ])
-    /* disable all packages, re-enable web2c package */
-    ++ [ "--disable-all-pkgs" "--enable-web2c" ]
+    /* disable all packages, re-enable upmendex, web2c packages */
+    ++ [ "--disable-all-pkgs" "--enable-upmendex" "--enable-web2c" ]
     /* kpathsea requires specifying the kpathsea location manually */
     ++ [ "--with-kpathsea-includes=${core.dev}/include" ];
 

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -191,7 +191,6 @@ core = stdenv.mkDerivation rec {
      cp texk/web2c/.libs/himktables $dev/bin/himktables
   '' + common.moveBins;
 
-  setupHook = ./setup-hook.sh; # TODO: maybe texmf-nix -> texmf (and all references)
   passthru = { inherit version buildInputs; };
 
   meta = with lib; {

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -176,15 +176,11 @@ core = stdenv.mkDerivation rec {
   doCheck = false; # triptest fails, likely due to missing TEXMF tree
   preCheck = "patchShebangs ../texk/web2c";
 
-  installTargets = [ "install" "texlinks" ];
+  installTargets = [ "install" ];
 
   # TODO: perhaps improve texmf.cnf search locations
   postInstall =
-    /* links format -> engine will be regenerated in texlive.combine
-       note: for unlinking, the texlinks patch is irrelevant, so we use
-       the included texlinks.sh to avoid the dependency on bin.texlinks */ ''
-    PATH="$out/bin:$PATH" sh ../texk/texlive/linked_scripts/texlive-extra/texlinks.sh --cnffile "../texk/texlive/tl_support/fmtutil.cnf" --unlink "$out/bin"
-  '' + /* remove redundant texmf-dist (content provided by TeX Live packages) */
+       /* remove redundant texmf-dist (content provided by TeX Live packages) */
   ''
     rm -fr "$out"/share/texmf-dist
   '' + /* install himktables in separate output for use in cross compilation */ ''

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -294,7 +294,7 @@ core-big = stdenv.mkDerivation { #TODO: upmendex
 
   doCheck = false; # fails
 
-  outputs = [ "out" ]
+  outputs = [ "out" "dev" "man" "info" ]
     ++ (builtins.map (builtins.replaceStrings [ "-" ] [ "_" ]) coreBigPackages)
     # some outputs of metapost, omegaware are for ptex/uptex
     ++ [ "ptex" "uptex" ]

--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -120,7 +120,9 @@ let
         inherit meta;
         # shebang interpreters and compiled binaries
         buildInputs = let outName = builtins.replaceStrings [ "-" ] [ "_" ] pname; in
-          [ texliveBinaries.${pname} or texliveBinaries.core.${outName} or null ]
+          [ texliveBinaries.core.${outName} or null
+            texliveBinaries.${pname} or null
+            texliveBinaries.core-big.${outName} or null ]
           ++ (args.extraBuildInputs or [ ]) ++ [ bash perl ]
           ++ (lib.attrVals (args.scriptExts or [ ]) extToInput);
         nativeBuildInputs = extraNativeBuildInputs;

--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -118,8 +118,11 @@ let
       {
         passthru = commonPassthru // { tlType = "bin"; };
         inherit meta;
-        # shebang interpreters
-        buildInputs = (args.extraBuildInputs or [ ]) ++ [ bash perl ] ++ (lib.attrVals (args.scriptExts or [ ]) extToInput);
+        # shebang interpreters and compiled binaries
+        buildInputs = let outName = builtins.replaceStrings [ "-" ] [ "_" ] pname; in
+          [ texliveBinaries.${pname} or texliveBinaries.core.${outName} or null ]
+          ++ (args.extraBuildInputs or [ ]) ++ [ bash perl ]
+          ++ (lib.attrVals (args.scriptExts or [ ]) extToInput);
         nativeBuildInputs = extraNativeBuildInputs;
         # absolute scripts folder
         scriptsFolder = lib.optionalString (run ? outPath) (run.outPath + "/scripts/" + args.scriptsFolder or pname);
@@ -127,8 +130,6 @@ let
         inherit (args) binfiles;
         binlinks = builtins.attrNames (args.binlinks or { });
         bintargets = builtins.attrValues (args.binlinks or { });
-        binfolders = [ (lib.getBin texliveBinaries.core) ] ++
-          lib.optional (texliveBinaries ? ${pname}) (lib.getBin texliveBinaries.${pname});
         # build scripts
         patchScripts = ./patch-scripts.sed;
         makeBinContainers = ./make-bin-containers.sh;

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -19,6 +19,7 @@ let
       withIcu = true; withGraphite2 = true;
     };
     inherit useFixedHashes;
+    tlpdb = overriddenTlpdb;
   };
 
   # function for creating a working environment from a set of TL packages

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -37,7 +37,7 @@ let
   overriddenTlpdb = let
     overrides = import ./tlpdb-overrides.nix {
       inherit
-        lib bin tlpdb tlpdbxz tl
+        stdenv lib bin tlpdb tlpdbxz tl
         installShellFiles
         coreutils findutils gawk getopt ghostscript_headless gnugrep
         gnumake gnupg gnused gzip ncurses perl python3 ruby zip;

--- a/pkgs/tools/typesetting/tex/texlive/make-bin-containers.sh
+++ b/pkgs/tools/typesetting/tex/texlive/make-bin-containers.sh
@@ -20,14 +20,12 @@ for binname in $binfiles ; do
 
   output="$out/bin/$binname"
 
-  # look for existing binary from bin.core or bin.${pname}
-  for folder in $binfolders ; do
-    target="$folder"/bin/"$binname"
-    if [[ -f "$target" && -x "$target" ]] ; then
-      ln -s "$(realpath "$target")" "$output"
-      continue 2
-    fi
-  done
+  # look for existing binary from bin.*
+  target="$(PATH="$HOST_PATH" command -v "$binname" || :)"
+  if [[ -n "$target" && -x "$target" ]] ; then
+    ln -s "$(realpath "$target")" "$output"
+    continue
+  fi
 
   # look for scripts
   # the explicit list of extensions avoid non-scripts such as $binname.cmd, $binname.jar, $binname.pm

--- a/pkgs/tools/typesetting/tex/texlive/setup-hook.sh
+++ b/pkgs/tools/typesetting/tex/texlive/setup-hook.sh
@@ -1,7 +1,0 @@
-addTeXMFPath () {
-    if test -d "$1/share/texmf-nix"; then
-        export TEXINPUTS="${TEXINPUTS}${TEXINPUTS:+:}$1/share/texmf-nix//:"
-    fi
-}
-
-addEnvHooks "$targetOffset" addTeXMFPath

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -1,4 +1,4 @@
-{ lib, tlpdb, bin, tlpdbxz, tl
+{ stdenv, lib, tlpdb, bin, tlpdbxz, tl
 , installShellFiles
 , coreutils, findutils, gawk, getopt, ghostscript_headless, gnugrep
 , gnumake, gnupg, gnused, gzip, ncurses, perl, python3, ruby, zip
@@ -328,6 +328,11 @@ in lib.recursiveUpdate orig rec {
   collection-plaingeneric.deps = orig.collection-plaingeneric.deps ++ [ "xdvi" ];
 
   #### misc
+
+  # RISC-V: https://github.com/LuaJIT/LuaJIT/issues/628
+  luajittex.binfiles = lib.optionals
+    (!(stdenv.hostPlatform.isPower && stdenv.hostPlatform.is64bit) && !stdenv.hostPlatform.isRiscV)
+    orig.luajittex.binfiles;
 
   # tlpdb lists license as "unknown", but the README says lppl13: http://mirrors.ctan.org/language/arabic/arabi-add/README
   arabi-add.license = [  "lppl13c" ];

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -13,7 +13,9 @@ let
     # so we remove them from binfiles, and add back the ones texlinks purposefully ignore (e.g. mptopdf)
     removeFormatLinks = lib.mapAttrs (_: attrs:
       if (attrs ? formats && attrs ? binfiles)
-      then let formatLinks = lib.catAttrs "name" (lib.filter (f: f.name != f.engine) attrs.formats);
+      # TLPDB reports erroneously that various metafont binaries like "mf" are format links to engines
+      # like "mf-nowin"; core-big provides both binaries and links so we simply skip them here
+      then let formatLinks = lib.catAttrs "name" (lib.filter (f: f.name != f.engine && ! lib.hasSuffix "-nowin" f.engine) attrs.formats);
                binNotFormats = lib.subtractLists formatLinks attrs.binfiles;
            in if binNotFormats != [] then attrs // { binfiles = binNotFormats; } else removeAttrs attrs [ "binfiles" ]
       else attrs);
@@ -122,12 +124,6 @@ in lib.recursiveUpdate orig rec {
   epstopdf.binlinks.repstopdf = "epstopdf";
   pdfcrop.binlinks.rpdfcrop = "pdfcrop";
 
-  ptex.binlinks = {
-    pdvitomp = bin.metapost + "/bin/pdvitomp";
-    pmpost = bin.metapost + "/bin/pmpost";
-    r-pmpost = bin.metapost + "/bin/r-pmpost";
-  };
-
   texdef.binlinks = {
     latexdef = "texdef";
   };
@@ -141,13 +137,6 @@ in lib.recursiveUpdate orig rec {
     allec = "allcm";
     kpsepath = "kpsetool";
     kpsexpand = "kpsetool";
-  };
-
-  # metapost binaries are in bin.metapost instead of bin.core
-  uptex.binlinks = {
-    r-upmpost = bin.metapost + "/bin/r-upmpost";
-    updvitomp = bin.metapost + "/bin/updvitomp";
-    upmpost = bin.metapost + "/bin/upmpost";
   };
 
   #### add PATH dependencies without wrappers

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -362,7 +362,7 @@ in lib.recursiveUpdate orig rec {
         mkdir -p support/texdoc
         touch support/texdoc/NEWS
 
-        TEXMFCNF="${bin.core}"/share/texmf-dist/web2c TEXMF="$out" TEXDOCS=. TEXMFVAR=. \
+        TEXMFCNF="${lib.head tl.kpathsea.pkgs}/web2c" TEXMF="$out" TEXDOCS=. TEXMFVAR=. \
           "${bin.luatex}"/bin/texlua "$out"/scripts/texdoc/texdoc.tlu \
           -c texlive_tlpdb=texlive.tlpdb -lM texdoc
 
@@ -372,7 +372,7 @@ in lib.recursiveUpdate orig rec {
 
     # install zsh completion
     postFixup = ''
-      TEXMFCNF="${bin.core}"/share/texmf-dist/web2c TEXMF="$scriptsFolder/../.." \
+      TEXMFCNF="${lib.head tl.kpathsea.pkgs}"/web2c TEXMF="$scriptsFolder/../.." \
         texlua "$out"/bin/texdoc --print-completion zsh > "$TMPDIR"/_texdoc
       substituteInPlace "$TMPDIR"/_texdoc \
         --replace 'compdef __texdoc texdoc' '#compdef texdoc' \

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -106,10 +106,6 @@ in lib.recursiveUpdate orig rec {
 
   # remove man
   texlive-scripts.binfiles = lib.remove "man" orig.texlive-scripts.binfiles;
-
-  # upmendex is "TODO" in bin.nix
-  uptex.binfiles = lib.remove "upmendex" orig.uptex.binfiles;
-
   # xindy is broken on some platforms unfortunately
   xindy.binfiles = if bin ? xindy
     then lib.subtractLists [ "xindy.mem" "xindy.run" ] orig.xindy.binfiles


### PR DESCRIPTION
## Description of changes
Clean up of the `texlive.bin.core{-big}` scripts. Best reviewed by commit, but in synthesis:
- use `binfiles` from `tlpdb.nix` to split `core` and `core-big` by package
- build `core-big` using the standard procedure instead of the ad-hoc configure runs, which caused missing files both in build (e.g. `lua.h`) and in output (`teckit_compile`)
- enable `upmendex`

Can somebody please run `nixpkgs-review` on Linux? A few packages depend on `bin.core` for synctex. If it is just the library we are fine. If they need the absolute path to the `synctex` binary, then they should also depend on `bin.core.synctex` – or we leave `synctex` in `bin.core.out`.

PS: with this automatic splitting of `bin.core` do we need a separate `core-big`?

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).