### PR TITLE
wineserverHook: init

### DIFF
--- a/pkgs/build-support/setup-hooks/wineserver-hook/default.nix
+++ b/pkgs/build-support/setup-hooks/wineserver-hook/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, makeSetupHook
+, writeScript
+, wine
+}:
+let
+  wineExecutable = lib.getExe wine;
+in
+makeSetupHook {
+  name = "wineserver-hook";
+
+  propagatedBuildInputs = [
+    wine
+  ];
+
+  passthru = {
+    inherit wine wineExecutable;
+  };
+
+} (writeScript "wineserver-hook" ''
+  export WINEDEBUG=fixme-all,err-systray
+  export WINEPREFIX=/tmp/wine
+  export WINEDLLOVERRIDES="winemenubuilder.exe=d"
+
+  mkdir -p "$WINEPREFIX"
+  ${wine}/bin/wineserver -p >/dev/null
+  ${wine}/bin/wineboot -i >/dev/null
+
+  ${wineExecutable} reg add 'HKCU\Software\Wine\Drivers' /f /v Graphics /d "null" >/dev/null
+  ${wineExecutable} reg add 'HKCU\Software\Wine\Drivers' /f /v Audio /d "" >/dev/null
+  ${wineExecutable} reg add 'HKCU\Software\Wine\WineDbg' /f /v ShowCrashDialog /t REG_DWORD /d 0 >/dev/null
+'')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41512,6 +41512,10 @@ with pkgs;
     wineRelease = "wayland";
   });
 
+  wineserverHook = callPackage ../build-support/setup-hooks/wineserver-hook {
+    wine = wineWowPackages.minimal;
+  };
+
   wineasio = callPackage ../applications/emulators/wineasio { };
 
   wishbone-tool = callPackage ../development/tools/misc/wishbone-tool { };


### PR DESCRIPTION
## Description of changes

Add `wineserverHook`, a setup hook that spawns a wineserver instance for the lifetime of the build.
Allows using wine during the build process without having to wait eons.

This disgusting thing has been used to create a cross-compiling stdenv using a proprietary Clang-based Windows toolchain.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
