### PR TITLE
ccl: 1.12 -> 1.12.2

### DIFF
--- a/pkgs/development/compilers/ccl/default.nix
+++ b/pkgs/development/compilers/ccl/default.nix
@@ -87,6 +87,8 @@ in stdenv.mkDerivation rec {
     homepage    = "https://ccl.clozure.com/";
     maintainers = lib.teams.lisp.members;
     platforms   = attrNames options;
+    # assembler failures during build, x86_64-darwin broken since 2020-10-14
+    broken      = (stdenv.isDarwin && stdenv.isx86_64);
     license     = licenses.asl20;
   };
 }

--- a/pkgs/development/compilers/ccl/default.nix
+++ b/pkgs/development/compilers/ccl/default.nix
@@ -2,10 +2,10 @@
 
 let
   options = rec {
-    /* TODO: there are also FreeBSD and Windows versions */
+    # TODO: there are also FreeBSD and Windows versions
     x86_64-linux = {
       arch = "linuxx86";
-      sha256 = "0d5bsizgpw9hv0jfsf4bp5sf6kxh8f9hgzz9hsjzpfhs3npmmac4";
+      sha256 = "0mhmm8zbk42p2b9amy702365m687k5p0xnz010yqrki6mwyxlkx9";
       runtime = "lx86cl64";
       kernel = "linuxx8664";
     };
@@ -17,13 +17,13 @@ let
     };
     armv7l-linux = {
       arch = "linuxarm";
-      sha256 = throw "ccl all-in-one linuxarm archive missing upstream";
+      sha256 = "1a4y07cmmn1r88b4hl4msb0bvr2fxd2vw9lf7h4j9f7a5rpq7124";
       runtime = "armcl";
       kernel = "linuxarm";
     };
     x86_64-darwin = {
       arch = "darwinx86";
-      sha256 = "1l060719k8mjd70lfdnr0hkybk7v88zxvfrsp7ww50q808cjffqk";
+      sha256 = "1xclnik6pqhkmr15cbqa2n1ddzdf0rs452lyiln3c42nmkf9jjb6";
       runtime = "dx86cl64";
       kernel = "darwinx8664";
     };
@@ -31,48 +31,14 @@ let
   };
   cfg = options.${stdenv.hostPlatform.system} or (throw "missing source url for platform ${stdenv.hostPlatform.system}");
 
-  # The 1.12 github release of CCL seems to be missing the usual
-  # ccl-1.12-linuxarm.tar.gz tarball, so we build it ourselves here
-  linuxarm-src = runCommand "ccl-1.12-linuxarm.tar.gz" {
-    outer = fetchurl {
-      url = "https://github.com/Clozure/ccl/archive/v1.12.tar.gz";
-      sha256 = "0lmxhll6zgni0l41h4kcf3khbih9r0f8xni6zcfvbi3dzfs0cjkp";
-    };
-    inner = fetchurl {
-      url = "https://github.com/Clozure/ccl/releases/download/v1.12/linuxarm.tar.gz";
-      sha256 = "0x4bjx6cxsjvxyagijhlvmc7jkyxifdvz5q5zvz37028va65243c";
-    };
-  } ''
-    tar xf $outer
-    tar xf $inner -C ccl
-    tar czf $out ccl
-  '';
-
-in
-
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname = "ccl";
-  version  = "1.12";
+  version = "1.12.2";
 
-  src = if cfg.arch == "linuxarm" then linuxarm-src else fetchurl {
+  src = fetchurl {
     url = "https://github.com/Clozure/ccl/releases/download/v${version}/ccl-${version}-${cfg.arch}.tar.gz";
     sha256 = cfg.sha256;
   };
-
-  patches = [
-    # Pull upstream fiux for -fno-common toolchains:
-    #  https://github.com/Clozure/ccl/pull/316
-    (fetchpatch {
-      name = "fno-common-p1.patch";
-      url = "https://github.com/Clozure/ccl/commit/185dc1a00e7492f8be98e5f93b561758423595f1.patch";
-      sha256 = "0wqfds7346qdwdsxz3bl2p601ib94rdp9nknj7igj01q8lqfpajw";
-    })
-    (fetchpatch {
-      name = "fno-common-p2.patch";
-      url = "https://github.com/Clozure/ccl/commit/997de91062d1f152d0c3b322a1e3694243e4a403.patch";
-      sha256 = "10w6zw8wgalkdyya4m48lgca4p9wgcp1h44hy9wqr94dzlllq0f6";
-    })
-  ];
 
   buildInputs = if stdenv.isDarwin then [ bootstrap_cmds m4 ] else [ glibc m4 ];
 
@@ -121,8 +87,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://ccl.clozure.com/";
     maintainers = lib.teams.lisp.members;
     platforms   = attrNames options;
-    # assembler failures during build, x86_64-darwin broken since 2020-10-14
-    broken      = (stdenv.isDarwin && stdenv.isx86_64);
     license     = licenses.asl20;
   };
 }


### PR DESCRIPTION
## Description of changes

This updates CCL. I also removed:
* the workaround for `linuxarm` as it no longer applies
* the patches as they are included in releases since 1.12.1
* ~~no longer marking the package as broken for Darwin. Upstream notes suggest
  Darwin works fine in releases after 1.12. But I can't confirm this as I don't
  have a Mac around.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] armv7l-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

