### PR TITLE
diffoscope: Fix test failure

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -92,6 +92,7 @@ python3.pkgs.buildPythonApplication rec {
 
   patches = [
     ./ignore_links.patch
+    ./fix-test_fit.patch
   ];
 
   postPatch = ''

--- a/pkgs/tools/misc/diffoscope/fix-test_fit.patch
+++ b/pkgs/tools/misc/diffoscope/fix-test_fit.patch
@@ -1,0 +1,58 @@
+From f1e9fa32c925fe7fb3cd825a02dcff52d305d845 Mon Sep 17 00:00:00 2001
+From: Andrew Marshall <andrew@johnandrewmarshall.com>
+Date: Mon, 28 Aug 2023 19:03:38 -0400
+Subject: [PATCH] Fix test_fit with file 5.45
+
+See also 435a8fe9a201a7e74e705e06cc56b66fa6cb4af9.
+---
+ tests/comparators/test_fit.py | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+diff --git a/tests/comparators/test_fit.py b/tests/comparators/test_fit.py
+index d8478c00..47258a3e 100644
+--- a/tests/comparators/test_fit.py
++++ b/tests/comparators/test_fit.py
+@@ -27,7 +27,11 @@
+ from diffoscope.comparators.utils.specialize import specialize
+ 
+ from ..utils.data import data, assert_diff, load_fixture
+-from ..utils.tools import skip_unless_tools_exist, skip_unless_tool_is_at_least
++from ..utils.tools import (
++    skip_unless_file_version_is_at_least,
++    skip_unless_tool_is_at_least,
++    skip_unless_tools_exist,
++)
+ from ..utils.nonexisting import assert_non_existing
+ 
+ cpio1 = load_fixture("test1.cpio")
+@@ -124,19 +128,21 @@ def test_nested_listing(nested_differences):
+ @skip_unless_tools_exist("cpio")
+ @skip_unless_tool_is_at_least("dumpimage", dumpimage_version, "2021.01")
+ @skip_unless_tools_exist("fdtdump")
++@skip_unless_file_version_is_at_least("5.45")
+ def test_nested_symlink(nested_differences):
+-    assert nested_differences[1].source1 == "dir/link"
+-    assert nested_differences[1].comment == "symlink"
+-    assert_diff(nested_differences[1], "symlink_expected_diff")
++    assert nested_differences[2].source1 == "dir/link"
++    assert nested_differences[2].comment == "symlink"
++    assert_diff(nested_differences[2], "symlink_expected_diff")
+ 
+ 
+ @skip_unless_tools_exist("cpio")
+ @skip_unless_tool_is_at_least("dumpimage", dumpimage_version, "2021.01")
+ @skip_unless_tools_exist("fdtdump")
++@skip_unless_file_version_is_at_least("5.45")
+ def test_nested_compressed_files(nested_differences):
+-    assert nested_differences[2].source1 == "dir/text"
+-    assert nested_differences[2].source2 == "dir/text"
+-    assert_diff(nested_differences[2], "text_ascii_expected_diff")
++    assert nested_differences[3].source1 == "dir/text"
++    assert nested_differences[3].source2 == "dir/text"
++    assert_diff(nested_differences[3], "text_ascii_expected_diff")
+ 
+ 
+ @skip_unless_tools_exist("cpio")
+-- 
+2.41.0
+


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/252045

Patch not yet upstreamed as a I do not have salsa.debian.org access.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
