### PR TITLE
Automatically updated nixos channel pins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,7 @@
 # GitHub actions
 /.github/workflows @NixOS/Security @Mic92 @zowoq
 /.github/workflows/merge-staging @FRidh
+/.github/workflows/channel-pin.yml @infinisil
 
 # EditorConfig
 /.editorconfig @Mic92 @zowoq
@@ -29,6 +30,7 @@
 /lib/debug.nix              @edolstra @Profpatsch
 /lib/asserts.nix            @edolstra @Profpatsch
 /lib/path.*                 @infinisil @fricklerhandwerk
+/lib/channel.*              @infinisil
 
 # Nixpkgs Internals
 /default.nix                                     @Ericson2314

--- a/.github/workflows/channel-pin.yml
+++ b/.github/workflows/channel-pin.yml
@@ -1,0 +1,118 @@
+name: Update channel pins
+
+on:
+  push:
+    branches:
+      - nixos-unstable
+      # Any release branches like nixos-23.05
+      - 'nixos-[0-9][0-9].[0-9][0-9]'
+
+# cancel any other workflows in progress
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+# Needed to create PRs
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_pin:
+    name: Update channel pin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cachix/install-nix-action@v22
+      - name: Compute development branch
+        id: dev-branch
+        run: |
+          if [[ "$GITHUB_REF_NAME" == nixos-unstable ]]; then
+            branch=master
+          else
+            # Removes the "nixos" prefix and replaces it with "release"
+            branch=release${GITHUB_REF_NAME#nixos}
+          fi
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+      - name: Check out development branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.dev-branch.outputs.branch }}
+      - name: Update pin
+        id: update
+        run: |
+          newRev=$GITHUB_SHA
+          pinFile=lib/channel/pin.json
+
+          echo "Fetching new revision $newRev"
+          stdout=$(nix-prefetch-url \
+              "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tarball/$newRev" \
+              --type sha256 --unpack --print-path --name nixpkgs)
+          mapfile -t newInfo <<<"$stdout"
+          newHash=${newInfo[0]}
+          newPath=${newInfo[1]}
+          newPinFileContents=$(jq -n \
+              --arg rev "$newRev" \
+              --arg sha256 "$newHash" \
+              '$ARGS.named')
+
+          echo -e "File $pinFile would be updated to:\n$newPinFileContents"
+
+          echo "Comparing this with the revision of the existing file"
+          if ! oldRev=$(jq -r '.rev' "$pinFile"); then
+            echo "There is no existing file, make sure to initialize it properly, possibly using the above value"
+            exit 1
+          else
+            echo "The existing file has revision $oldRev, now fetching that too"
+            stdout=$(nix-prefetch-url \
+                "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tarball/$oldRev" \
+                --type sha256 --unpack --print-path --name nixpkgs)
+            mapfile -t newInfo <<<"$stdout"
+            oldHash=${oldInfo[0]}
+            oldPath=${oldInfo[1]}
+
+            change_url="$GITHUB_SERVER_URL"/"$GITHUB_REPOSITORY"/compare/"$oldRev".."$newRev"
+
+            echo "Checking if anything other than $pinFile changed between $oldRev and $newRev"
+            # Only don't make a PR if only the pin file changed, not if it was added/removed
+            if [[ -f "$oldPath"/"$pinFile" ]] \
+              && [[ -f "$newPath"/"$pinFile" ]] \
+              && diff --recursive --exclude "$pinFile" "$oldPath" "$newPath"; then
+              echo "Nothing changed, no PR to update the pin necessary"
+              create_pr=
+            else
+              echo "The channel changed, PR to update the pin is necessary"
+              create_pr=1
+            fi
+          fi
+          echo "create_pr=$create_pr" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$create_pr" ]]; then
+            echo "Updating $pinFile"
+            printf "%s\n" "$newPinFileContents" > "$pinFile"
+
+            echo "Assembling PR title and body"
+            if [[ "$GITHUB_REF_NAME" != nixos-unstable ]]; then
+              pr_title="[${GITHUB_REF_NAME#nixos-}] "
+            fi
+            pr_title="${pr_title}Update pinned channel commit"
+
+            pr_body_path=$(mktemp)
+            {
+              echo "Automated PR to update the pin of the $GITHUB_REF_NAME channel in the ${{ steps.dev_branch.outputs.branch }} branch to the latest commit $GITHUB_SHA."
+              echo ""
+              echo "[Channel changes]($change_url)"
+            } > "$pr_body_path"
+
+            echo "pr_title=$pr_title" >> "$GITHUB_OUTPUT"
+            echo "pr_body_path=$pr_body_path" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        if: ${{ steps.update.outputs.create_pr != '' }}
+        with:
+          branch: "update-channel-pin/${{ steps.dev-branch.outputs.branch }}"
+          commit-message: "Update pinned channel commit"
+          title: "${{ steps.update.outputs.pr_title }}"
+          author: "GitHub <noreply@github.com>"
+          body-path: "${{ steps.update.outputs.pr_body_path }}"
+

--- a/lib/channel/default.nix
+++ b/lib/channel/default.nix
@@ -1,0 +1,4 @@
+{ lib }:
+{
+  latestKnownNixOSChannelInfo = lib.importJSON ./pin.json;
+}

--- a/lib/channel/pin.json
+++ b/lib/channel/pin.json
@@ -1,0 +1,4 @@
+{
+  "rev": "a999c1cc0c9eb2095729d5aa03e0d8f7ed256780",
+  "sha256": "178smvv8f8pashdjcr9bhmp0baji0lhfcxqy3cn7m19g8rgd6539"
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -63,6 +63,8 @@ let
     # linux kernel configuration
     kernel = callLibs ./kernel.nix;
 
+    channel = callLibs ./channel;
+
     inherit (builtins) add addErrorContext attrNames concatLists
       deepSeq elem elemAt filter genericClosure genList getAttr
       hasAttr head isAttrs isBool isInt isList isPath isString length


### PR DESCRIPTION
## Description of changes

> **Warning**
> A bit drafty, please only review the overall idea for now

This makes two changes:
- `lib.channel.latestKnownNixOSChannelInfo`: An attribute set containing information on the latest known successful NixOS channel (either `nixos-unstable` on `master` or `nixos-XX.YY` on `release-XX.YY`): 
  ```nix
  {
    rev = "a999c1cc0c9eb2095729d5aa03e0d8f7ed256780";
    sha256 = "178smvv8f8pashdjcr9bhmp0baji0lhfcxqy3cn7m19g8rgd6539";
  }
  ```
- A GitHub Actions workflow to keep this updated whenever the channel gets updated:
  - Pushes to the `nixos-unstable` branch (only done when the channel updates) will cause it to create a PR to update the pin on the `master` branch.
  - Simliarly, pushes to the `nixos-XX.YY` branches will cause it to create PR's to the `release-XX.YY` branches.
  
  These PR's will have to be reviewed and merged manually.

[Here's](https://github.com/tweag/nixpkgs/actions/runs/6006307372/job/16290613182) a successful run of the workflow in a fork which I simulated by pushing to the `nixos-unstable` branch, and it created [this PR](https://github.com/tweag/nixpkgs/pull/67).

## Motivation
For [RFC 140](https://github.com/NixOS/rfcs/pull/140) I would like to have the checking tool introduced in https://github.com/NixOS/nixpkgs/pull/250885 be run for every PR, to ensure the structure of `pkgs/by-name` stays correct. In order to make that possible, the tool will be always be pre-built on the `nixos-*` channels, allowing CI to run it without building anything. See [here](https://github.com/tweag/nixpkgs/tree/spp-1a/pkgs/test/nixpkgs-check-by-name#hydra-builds) for more context.

While CI _could_ just fetch from the unstable channel directly, this would make CI impure, giving potentially different results at different times for the same revision since the channel could be updated at any time.

By pinning the channel inside Nixpkgs itself, this isn't a problem anymore, because CI can use the Nixpkgs from the pinned version.

## Things done
- [x] Verified that the workflow runs successfully in a fork, including for release branches.
- [ ] Documentation