### PR TITLE
Add mainProgram to `xorg.xrandr`

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -979,6 +979,9 @@ self: super:
     postInstall = ''
       rm $out/bin/xkeystone
     '';
+    meta = attrs.meta // {
+      mainProgram = "xrandr";
+    };
   });
 
   xset = super.xset.overrideAttrs (attrs: {


### PR DESCRIPTION
## Description of changes

Fix warning described in https://github.com/NixOS/nixpkgs/issues/249169#issuecomment-1694749318

```
trace: warning: getExe: Package "xrandr-1.5.2" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
```

## Things done

Added `"xrandr"` as the main program name for `xorg.xrandr`.

As mentioned on https://github.com/NixOS/nixpkgs/issues/219567#issuecomment-1696595117 I think this serves as a workaround to remove the warning that is suddenly appearing for (to my understanding) any user using an xorg-based desktop environment that updated after https://github.com/NixOS/nixpkgs/pull/246386. But IMHO, the name of the executable should be included in [this](https://github.com/NixOS/nixpkgs/blob/ea5234e7073d5f44728c499192544a84244bf35a/pkgs/servers/x11/xorg/default.nix) generated file