### PR TITLE
Add `meta.mainProgram`

### DIFF
--- a/pkgs/applications/virtualization/tart/default.nix
+++ b/pkgs/applications/virtualization/tart/default.nix
@@ -40,6 +40,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://tart.run";
     license = licenses.fairsource09;
     maintainers = with maintainers; [ emilytrau Enzime ];
+    mainProgram = finalAttrs.pname;
     platforms = [ "aarch64-darwin" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/development/python-modules/vncdo/default.nix
+++ b/pkgs/development/python-modules/vncdo/default.nix
@@ -6,6 +6,7 @@
 , nose
 , ptyprocess
 }:
+
 buildPythonPackage rec {
   pname = "vncdo";
   version = "0.12.0";
@@ -32,7 +33,7 @@ buildPythonPackage rec {
     description = "A command line VNC client and python library";
     license = licenses.mit;
     maintainers = with maintainers; [ elitak ];
+    mainProgram = pname;
     platforms = with platforms; linux ++ darwin;
   };
-
 }

--- a/pkgs/tools/networking/passh/default.nix
+++ b/pkgs/tools/networking/passh/default.nix
@@ -1,18 +1,19 @@
 { lib, fetchFromGitHub, stdenv }:
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "passh";
   version = "2020-03-18";
 
   src = fetchFromGitHub {
     owner = "clarkwang";
-    repo = pname;
+    repo = finalAttrs.pname;
     rev = "7112e667fc9e65f41c384f89ff6938d23e86826c";
     sha256 = "1g0rx94vqg36kp46f8v4x6jcmvdk85ds6bkrpayq772hbdm1b5z5";
   };
 
   installPhase = ''
     mkdir -p $out/bin
-    cp passh $out/bin
+    cp ${finalAttrs.pname} $out/bin
   '';
 
   meta = with lib; {
@@ -20,6 +21,7 @@ stdenv.mkDerivation rec {
     description = "An sshpass alternative for non-interactive ssh auth";
     license = licenses.gpl3;
     maintainers = [ maintainers.lovesegfault ];
+    mainProgram = finalAttrs.pname;
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).