### PR TITLE
nixos/doc: add ctags support for NixOS options

### DIFF
--- a/nixos/lib/ctags.nix
+++ b/nixos/lib/ctags.nix
@@ -1,0 +1,28 @@
+# Implementation of ctags(1) compatible tags file for NixOS options
+{ lib, options }:
+with lib;
+let
+  locationToTagLine = name: loc:
+    let line = if loc ? line && loc.line != null then loc.line else 1;
+    in
+    if loc != null then
+      "${name}\t${loc.file}\t${toString line}"
+    else "";
+
+  toTags = acc0: struct: (foldl'
+    (acc: name:
+      let item = struct.${name}; in
+      if item ? _type && item._type == "option" then
+        acc ++ map (locationToTagLine (toString item)) item.declarationPositions
+      else toTags acc item
+    )
+    acc0
+    (attrNames struct));
+
+  # see vim help tags-file-format for details
+  header = ''
+    !_TAG_FILE_SORTED''\t1''\t1
+    !_TAG_FILE_ENCODING''\tutf-8''\t1
+  '';
+in
+header + concatStringsSep "\n" (sort lessThan (toTags [ ] options)) + "\n"

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -151,6 +151,10 @@ let
       ];
     };
 
+    options-ctags = import ../../lib/ctags.nix {
+      inherit lib options;
+    };
+
 in
 
 {
@@ -348,6 +352,7 @@ in
 
     (mkIf cfg.nixos.enable {
       system.build.manual = manual;
+      system.build.optionsCtags.vim = pkgs.writeTextFile { name = "options-tags"; text = options-ctags; };
 
       environment.systemPackages = []
         ++ optional cfg.man.enable manual.nixos-configuration-reference-manpage

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -148,6 +148,7 @@ in rec {
   manualEpub = (buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manualEpub));
   nixos-configuration-reference-manpage = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.nixos-configuration-reference-manpage);
   options = (buildFromConfig ({ ... }: { }) (config: config.system.build.manual.optionsJSON)).x86_64-linux;
+  optionsCtagsVim = (buildFromConfig ({ ... }: { }) (config: config.system.build.optionsCtags.vim)).x86_64-linux;
 
 
   # Build the initial ramdisk so Hydra can keep track of its size over time.


### PR DESCRIPTION
## Description of changes

This is rather a strawman of a PR to try to figure out the best spot to
put this code and the documentation of how to use it. I don't really
know.

I will write a test when I have an idea of what to put in the test and where to put the test.

Sample content:
```
!_TAG_FILE_SORTED	1	1
!_TAG_FILE_ENCODING	utf-8	1
_module.args	/home/jade/dev/nixpkgs/lib/modules.nix	122
_module.check	/home/jade/dev/nixpkgs/lib/modules.nix	186
_module.freeformType	/home/jade/dev/nixpkgs/lib/modules.nix	193
_module.specialArgs	/home/jade/dev/nixpkgs/lib/modules.nix	209
appstream.enable	/home/jade/dev/nixpkgs/nixos/modules/config/appstream.nix	6
assertions	/home/jade/dev/nixpkgs/nixos/modules/misc/assertions.nix	9
boot.binfmt.emulatedSystems	/home/jade/dev/nixpkgs/nixos/modules/system/boot/binfmt.nix	272
```

Sample usage (can be used in parallel with `nix-doc tags`):
```
nix build -f nixos/release.nix optionsCtags -o opts-tags
(in vim): :set tags+=opts-tags
          :tj boot.binfmt.emulatedSystems
```

This PR depends on and contains https://github.com/NixOS/nixpkgs/pull/249243. Marked as draft till that's
worked out. This PR pair replaces https://github.com/NixOS/nixpkgs/pull/208173.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
