### PR TITLE
dig: fix nix run usage

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26381,7 +26381,11 @@ with pkgs;
 
   bind = callPackage ../servers/dns/bind { };
   dnsutils = bind.dnsutils;
-  dig = bind.dnsutils;
+  dig = bind.dnsutils // {
+    meta = bind.dnsutils.meta // {
+      mainProgram = "dig";
+    };
+  };
 
   bird = callPackage ../servers/bird { };
 


### PR DESCRIPTION
nix run .#dig -- nixos.org
I think it's nice, given that we have the `dig` attribute already.

_The normal PR checklist doesn't really apply here._