### PR TITLE
monado: unstable-2023-01-14 -> unstable-2023-08-22

### DIFF
--- a/pkgs/applications/graphics/monado/force-enable-steamvr_lh.patch
+++ b/pkgs/applications/graphics/monado/force-enable-steamvr_lh.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4308d73d..0081d536 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,6 +219,7 @@ option(BUILD_TESTING "Enable building of the test suite?" ON)
+ if(EXISTS "$ENV{HOME}/.steam/root")
+ 	set(XRT_HAVE_STEAM YES)
+ endif()
++set(XRT_HAVE_STEAM YES)
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+ 	set(XRT_HAVE_INTERNAL_HID ON)

--- a/pkgs/applications/graphics/monado/steamvr_lh-use-old-interface.patch
+++ b/pkgs/applications/graphics/monado/steamvr_lh-use-old-interface.patch
@@ -1,0 +1,13 @@
+diff --git a/src/xrt/drivers/steamvr_lh/steamvr_lh.cpp b/src/xrt/drivers/steamvr_lh/steamvr_lh.cpp
+index 24b69fd..5b3a5ca 100644
+--- a/src/xrt/drivers/steamvr_lh/steamvr_lh.cpp
++++ b/src/xrt/drivers/steamvr_lh/steamvr_lh.cpp
+@@ -138,7 +138,7 @@ Context::setup_hmd(const char *serial, vr::ITrackedDeviceServerDriver *driver)
+ 	vr::EVRInitError err = driver->Activate(0);
+ 	VERIFY(err == vr::VRInitError_None, std::to_string(err).c_str());
+ 
+-	auto *display = static_cast<vr::IVRDisplayComponent *>(driver->GetComponent(vr::IVRDisplayComponent_Version));
++	auto *display = static_cast<vr::IVRDisplayComponent *>(driver->GetComponent("IVRDisplayComponent_003"));
+ 	VERIFY(display, "IVRDisplayComponent is null");
+ #undef VERIFY
+ 


### PR DESCRIPTION
## Description of changes

Some exciting stuff since the last time we updated Monado.
Most interesting for most would be the new `steamvr_lh` driver, that can be used by setting `LH_DRIVER=steamvr` for monado-service.

The patches in the derivation are mostly to make `steamvr_lh` work properly.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
