### PR TITLE
Fix uboot build on some Allwinner sunxi platforms

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -333,6 +333,7 @@ in {
     defconfig = "a64-olinuxino-emmc_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    SCP = "/dev/null";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
@@ -346,6 +347,7 @@ in {
     defconfig = "orangepi_zero_plus2_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    SCP = "/dev/null";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
@@ -366,6 +368,7 @@ in {
     defconfig = "orangepi_3_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinnerH6}/bl31.bin";
+    SCP = "/dev/null";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
@@ -379,6 +382,7 @@ in {
     defconfig = "pine64_plus_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    SCP = "/dev/null";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
@@ -386,6 +390,7 @@ in {
     defconfig = "pine64-lts_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    SCP = "/dev/null";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
@@ -393,6 +398,7 @@ in {
     defconfig = "pinebook_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    SCP = "/dev/null";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
@@ -534,6 +540,7 @@ in {
     defconfig = "sopine_baseboard_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    SCP = "/dev/null";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 


### PR DESCRIPTION
## Description of changes

U-boot currently fails to build on Allwinner sunxi platforms with support for SCP firmware. Providing a SCP firmware is optional, however u-boot emits an error if not explicitly disabled.  It is recommended to pass "/dev/null" via the SCP environment variable to explicitly disable the error[0].

```
binman: Filename 'scp.bin' not found in input path (.,.,./board/sunxi,arch/arm/dts) (cwd='/build/u-boot-2023.07.02')
make: *** [Makefile:1111: .binman_stamp] Error 1
```

The expected firmware for SCP is Crust[1].  It exists to implement forms of deep sleep.  It is especially useful on devices with batteries, such as the PinePhone, and handles shutdown/reboot on devices without a PMIC.

Crust is supported upstream in u-boot since 2021.01-rc1 and ARM Trusted Firmware-A since v2.3.  The patches required for Crust to co-exist with the Linux kernel however are not upstream.

As the SCP firmware is optional, and any previously building forms of uboot for these boards would have been built without Crust, excluding it restores functionality without unexpectedly removing a feature. Further including it would potentially break booting with unpatched kernels, I have not attempted to test this.

I do not have access to any of these devices.  This was found as I'm starting to attempt to bootstrap the OrangePi Prime which contains an Allwinner H5.

[0]: https://elixir.bootlin.com/u-boot/v2023.07.02/source/board/sunxi/README.sunxi64#L85
[1]: https://github.com/crust-firmware/crust

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
