### PR TITLE
python3Packages.pytimeparse2: init at 1.7.1 python3Packages.mysql-connector: 8.0.29 -> 8.0.33 sqlite3-to-mysql: 1.4.19 -> 2.0.3 

### DIFF
--- a/pkgs/development/python-modules/mysql-connector/0001-Revert-Fix-MacOS-wheels-platform-tag.patch
+++ b/pkgs/development/python-modules/mysql-connector/0001-Revert-Fix-MacOS-wheels-platform-tag.patch
@@ -1,36 +1,22 @@
-From c5d32ef5d656b0aa4b2c1fc61c901d40bf2fb96a Mon Sep 17 00:00:00 2001
-From: Alexander Ben Nasrallah <me@abn.sh>
-Date: Mon, 19 Jul 2021 17:24:41 +0200
-Subject: [PATCH] Revert "Fix MacOS wheels platform tag"
-
-This reverts commit d1e89fd3d7391084cdf35b0806cb5d2a4b413654.
----
- cpydist/__init__.py | 5 +----
- 1 file changed, 1 insertion(+), 4 deletions(-)
-
 diff --git a/cpydist/__init__.py b/cpydist/__init__.py
-index 0e7f341..2619d7a 100644
+index 7fdbaf2..3c427da 100644
 --- a/cpydist/__init__.py
 +++ b/cpydist/__init__.py
-@@ -41,7 +41,7 @@ from distutils.command.install import install
- from distutils.command.install_lib import install_lib
- from distutils.core import Command
- from distutils.dir_util import mkpath, remove_tree
--from distutils.sysconfig import get_config_vars, get_python_version
-+from distutils.sysconfig import get_python_version
- from distutils.version import LooseVersion
- from subprocess import check_call, Popen, PIPE
- 
-@@ -57,9 +57,6 @@ version_py = os.path.join("lib", "mysql", "connector", "version.py")
+@@ -38,7 +38,7 @@ import tempfile
+ from glob import glob
+ from pathlib import Path
+ from subprocess import PIPE, Popen, check_call
+-from sysconfig import get_config_vars, get_python_version
++from sysconfig import get_python_version
+
+ from setuptools import Command
+ from setuptools.command.build_ext import build_ext
+@@ -68,8 +68,6 @@ version_py = os.path.join("lib", "mysql", "connector", "version.py")
  with open(version_py, "rb") as fp:
      exec(compile(fp.read(), version_py, "exec"))
- 
+
 -if "MACOSX_DEPLOYMENT_TARGET" in get_config_vars():
 -    get_config_vars()["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
--
- COMMON_USER_OPTIONS = [
-     ("byte-code-only", None,
-      "remove Python .py files; leave byte code .pyc only"),
--- 
-2.31.1
 
+ COMMON_USER_OPTIONS = [
+     (

--- a/pkgs/development/python-modules/mysql-connector/default.nix
+++ b/pkgs/development/python-modules/mysql-connector/default.nix
@@ -6,21 +6,30 @@
 , fetchFromGitHub
 , protobuf
 , pythonOlder
-, fetchpatch
+, mysql80
+, openssl
+, pkgs
 }:
 
 buildPythonPackage rec {
   pname = "mysql-connector";
-  version = "8.0.29";
+  version = "8.0.33";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
+
+  setupPyBuildFlags = [
+    "--with-mysql-capi=\"${mysql80}\""
+    "--with-openssl-include-dir=\"${openssl.dev}/include\""
+    "--with-openssl-lib-dir=\"${lib.getLib openssl}/lib\""
+    "-L \"${lib.getLib pkgs.zstd}/lib:${lib.getLib mysql80}/lib\""
+  ];
 
   src = fetchFromGitHub {
     owner = "mysql";
     repo = "mysql-connector-python";
     rev = version;
-    hash = "sha256-X0qiXNYkNoR00ESUdByPj4dPnEnjLyopm25lm1JvkAk=";
+    hash = "sha256-GtMq7E2qBqFu54hjUotzPyxScTKXNdEQcmgHnS7lBhc=";
   };
 
   patches = [
@@ -30,17 +39,19 @@ buildPythonPackage rec {
     # 10.12. The patch reverts
     # https://github.com/mysql/mysql-connector-python/commit/d1e89fd3d7391084cdf35b0806cb5d2a4b413654
     ./0001-Revert-Fix-MacOS-wheels-platform-tag.patch
-
-    # Allow for clang to be used to build native extensions
-    (fetchpatch {
-      url = "https://github.com/mysql/mysql-connector-python/commit/fd24ce9dc8c60cc446a8e69458f7851d047c7831.patch";
-      hash = "sha256-WvU1iB53MavCsksKCjGvUl7R3Ww/38alxxMVzjpr5Xg=";
-    })
   ];
+
+  nativeBuildInputs = [
+    mysql80
+  ];
+
 
   propagatedBuildInputs = [
     dnspython
     protobuf
+    mysql80
+    openssl
+    pkgs.zstd
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pytimeparse2/default.nix
+++ b/pkgs/development/python-modules/pytimeparse2/default.nix
@@ -1,0 +1,32 @@
+{ lib, fetchFromGitHub, buildPythonPackage, dateutils }:
+
+buildPythonPackage rec {
+  pname = "pytimeparse2";
+  version = "1.7.1";
+
+  src = fetchFromGitHub {
+    owner = "onegreyonewhite";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-zWRbSohTvbVd3GcRRoxH/UReVGYHC0YmbNgbt8N0X48=";
+  };
+
+  propagatedBuildInputs = [ dateutils ];
+
+  # custom checks, see
+  # https://github.com/onegreyonewhite/pytimeparse2/blob/e00df7506b6925f2c6a5783e89e9f239d128271a/tox.ini#L36C20-L36C78
+  checkPhase = ''
+    runHook preCheck
+    python tests.py -vv --failfast
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "pytimeparse2" ];
+
+  meta = with lib; {
+    description = "A pytimeparse based project with the aim of optimizing functionality and providing stable support";
+    homepage = "https://github.com/onegreyonewhite/pytimeparse2";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/tools/misc/sqlite3-to-mysql/default.nix
+++ b/pkgs/tools/misc/sqlite3-to-mysql/default.nix
@@ -1,57 +1,37 @@
 { lib
 , fetchFromGitHub
-, python3
+, python3Packages
 , nixosTests
 , testers
 , sqlite3-to-mysql
 , fetchPypi
+, mysql80
 }:
 
-let
-  py = python3.override {
-    packageOverrides = self: super: {
-      # sqlite3-to-mysql is incompatible with versions > 1.4.44 of sqlalchemy
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs rec {
-        version = "1.4.44";
-        format = "setuptools";
-        src = fetchPypi {
-          pname = "SQLAlchemy";
-          inherit version;
-          hash = "sha256-LdpflnGa6Js+wPG3lpjYbrmuyx1U6ZCrs/3ZLAS0apA=";
-        };
-        disabledTestPaths = [
-           "test/aaa_profiling"
-           "test/ext/mypy"
-        ];
-      };
-    };
-    self = py;
-  };
-
-in
-with py.pkgs; buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "sqlite3-to-mysql";
-  version = "1.4.19";
+  version = "2.0.3";
   format = "pyproject";
+
+  disabled = python3Packages.pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "techouse";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-gtXwDLHl5f1sXLm+b8l08bY/XJkN+zVtd7m45K0CAYY=";
+    hash = "sha256-rlKJKthop9BQnqjTUq1hZM/NP69gPdEFTq1rU+CbpWA=";
   };
 
-  nativeBuildInputs = [
-    setuptools
+  nativeBuildInputs = with python3Packages; [
+    hatchling
   ];
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3Packages; [
     click
     mysql-connector
-    pytimeparse
+    pytimeparse2
     pymysql
     pymysqlsa
-    six
     simplejson
     sqlalchemy
     sqlalchemy-utils
@@ -59,6 +39,7 @@ with py.pkgs; buildPythonApplication rec {
     tabulate
     unidecode
     packaging
+    mysql80
   ];
 
   # tests require a mysql server instance

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10603,6 +10603,8 @@ self: super: with self; {
 
   pytimeparse = callPackage ../development/python-modules/pytimeparse { };
 
+  pytimeparse2 = callPackage ../development/python-modules/pytimeparse2 { };
+
   pytm = callPackage ../development/python-modules/pytm { };
 
   pytmx = callPackage ../development/python-modules/pytmx { };


### PR DESCRIPTION
## Description of changes

For the update of `sqlite3-to-mysql` I had to update `mysql-connector` and init `pytimeparse2`:

- Changelog for `mysql-connector`: https://github.com/mysql/mysql-connector-python/blob/8.0.33/CHANGES.txt
  - For the "C" extension to work I had to add the corresponding libraries to `setup.py`. 
  - I removed "Allow for clang to be used to build native extensions" patch, since upstream incoprorated the change [here](https://github.com/mysql/mysql-connector-python/commit/6eb19b9efdca13df9b67417578b8390a2786928a)
- `pytimeparse2` : https://github.com/onegreyonewhite/pytimeparse2
- `sqlite3-to-mysql` Changelog: https://github.com/techouse/sqlite3-to-mysql/blob/master/CHANGELOG.md

Info at maintainers: @neosimsim @turion 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
