### PR TITLE
pythonPackages.pydiscourse: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/pydiscourse/default.nix
+++ b/pkgs/development/python-modules/pydiscourse/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, requests
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pydiscourse";
+  version = "1.4.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  src = fetchFromGitHub {
+    owner = "pydiscourse";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-peDkXRcD/ieWYWXqv8hPxTSNRXBHcb/3sj/JJSF2RYg=";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  pythonImportsCheck = [ "pydiscourse" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/pydiscourse/pydiscourse";
+    changelog = "https://github.com/pydiscourse/pydiscourse/releases/tag/v${version}";
+    description = "A Python library for working with Discourse";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Dettorer ];
+  };
+}

--- a/pkgs/development/python-modules/pydiscourse/default.nix
+++ b/pkgs/development/python-modules/pydiscourse/default.nix
@@ -13,10 +13,6 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
-  nativeCheckInputs = [
-    unittestCheckHook
-  ];
-
   src = fetchFromGitHub {
     owner = "pydiscourse";
     repo = pname;
@@ -24,14 +20,22 @@ buildPythonPackage rec {
     hash = "sha256-peDkXRcD/ieWYWXqv8hPxTSNRXBHcb/3sj/JJSF2RYg=";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [
+    requests
+  ];
 
-  pythonImportsCheck = [ "pydiscourse" ];
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pydiscourse"
+  ];
 
   meta = with lib; {
+    description = "A Python library for working with Discourse";
     homepage = "https://github.com/pydiscourse/pydiscourse";
     changelog = "https://github.com/pydiscourse/pydiscourse/releases/tag/v${version}";
-    description = "A Python library for working with Discourse";
     license = licenses.mit;
     maintainers = with maintainers; [ Dettorer ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8964,6 +8964,8 @@ self: super: with self; {
 
   pydigiham = callPackage ../development/python-modules/pydigiham { };
 
+  pydiscourse = callPackage ../development/python-modules/pydiscourse { };
+
   pydispatcher = callPackage ../development/python-modules/pydispatcher { };
 
   pydmd = callPackage ../development/python-modules/pydmd { };


### PR DESCRIPTION
## Description of changes

Add the  [`pydiscourse`](https://github.com/pydiscourse/pydiscourse/tree/master) Python module for Python 3.8, 3.9 and 3.10

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
