### PR TITLE
fw-ectool: init at unstable-2022-12-03

### DIFF
--- a/pkgs/os-specific/linux/fw-ectool/default.nix
+++ b/pkgs/os-specific/linux/fw-ectool/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, hostname
+}:
+
+stdenv.mkDerivation {
+  pname = "fw-ectool";
+  version = "unstable-2022-12-03";
+
+  src = fetchFromGitHub {
+    owner = "DHowett";
+    repo = "fw-ectool";
+    rev = "54c140399bbc3e6a3dce6c9f842727c4128367be";
+    hash = "sha256-2teJFz4zcA+USpbVPXMEIHLdmMLem8ik7YrmrSxr/n0=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    hostname
+  ];
+
+  buildPhase = ''
+    patchShebangs util
+    make out=out utils
+  '';
+
+  installPhase = ''
+    install -D out/util/ectool $out/bin/ectool
+  '';
+
+  meta = with lib; {
+    description = "EC-Tool adjusted for usage with framework embedded controller";
+    homepage = "https://github.com/DHowett/framework-ec";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.mkg20001 ];
+    platforms = platforms.linux;
+    mainProgram = "ectool";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4691,6 +4691,8 @@ with pkgs;
 
   cowsay = callPackage ../tools/misc/cowsay { };
 
+  fw-ectool = callPackage ../os-specific/linux/fw-ectool { };
+
   czkawka = callPackage ../tools/misc/czkawka {
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

new package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
