### PR TITLE
lunarml: unstable-2023-07-25 -> unstable-2023-08-25

### DIFF
--- a/pkgs/development/compilers/lunarml/default.nix
+++ b/pkgs/development/compilers/lunarml/default.nix
@@ -5,19 +5,16 @@
 , lua5_3
 }:
 
-let
-  pname = "lunarml";
-in
 stdenvNoCC.mkDerivation {
-  inherit pname;
+  pname = "lunarml";
 
-  version = "unstable-2023-07-25";
+  version = "unstable-2023-08-25";
 
   src = fetchFromGitHub {
     owner = "minoki";
     repo = "LunarML";
-    rev = "4a5f9c7d42c6b1fcd3d73ab878321f887a153aa7";
-    sha256 = "dpYUXMbYPRvk+t6Cnc4uh8w5MwuPXuKPgZQl2P0EBZU=";
+    rev = "69d09b47601f4041ca7e8a513c75f3e4835af9dd";
+    sha256 = "sha256-GXUcWI4/akOKIvCHrsOfceZEdyNZdIdalTc6wX+svS4=";
   };
 
   outputs = [ "out" "doc" ];
@@ -37,18 +34,21 @@ stdenvNoCC.mkDerivation {
   doCheck = true;
 
   installPhase = ''
-    mkdir -p $doc/${pname} $out/{bin,lib}
+    runHook preInstall
+
+    mkdir -p $doc/lunarml $out/{bin,lib}
     cp -r bin $out
     cp -r lib $out
-    cp -r doc/* README.* LICENSE* $doc/${pname}
-    cp -r example $doc/${pname}
+    cp -r example $doc/lunarml
+
+    runHook postInstall
   '';
 
   meta = {
     description = "Standard ML compiler that produces Lua/JavaScript";
     homepage = "https://github.com/minoki/LunarML";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ toastal ];
+    maintainers = with lib.maintainers; [ toastal ratsclub ];
     platforms = mlton.meta.platforms;
   };
 }


### PR DESCRIPTION
## Description of changes

Bumps LunarML. I tested this against my SML projects and it didn't introduce a regression.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
