### PR TITLE
pythonPackages.debianbts: init at 4.0.1

### DIFF
--- a/pkgs/development/python-modules/debianbts/default.nix
+++ b/pkgs/development/python-modules/debianbts/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pysimplesoap
+, pytest , pytest-xdist
+, pythonOlder
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "python-debianbts";
+  version = "4.0.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b0817d593ccdfb58a5f37b8cb3873bd0b2268b434f2798dc75b206d7550fdf04";
+  };
+
+  buildInputs = [ setuptools ];
+  propagatedBuildInputs = [ pysimplesoap ];
+  checkInputs = [
+    pytest
+    pytest-xdist
+  ];
+
+  meta = with lib; {
+    description = "Python interface to Debian's Bug Tracking System";
+    homepage = "https://github.com/venthur/python-debianbts";
+    downloadPage = "https://pypi.org/project/python-debianbts/";
+    changelog = "https://github.com/venthur/python-debianbts/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = [ maintainers.nicoo ];
+  };
+}

--- a/pkgs/development/python-modules/pysimplesoap/default.nix
+++ b/pkgs/development/python-modules/pysimplesoap/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, fetchpatch
+, fetchPypi
+, buildPythonPackage
+, m2crypto
+}:
+
+buildPythonPackage rec {
+  pname = "pysimplesoap";
+  # Unfortunately, the latest stable release is broken on Python 3.
+  version = "1.16.2";
+
+  src = fetchPypi {
+    pname = "PySimpleSOAP";
+    inherit version;
+    hash = "sha256-sbv00NCt/5tlIZfWGqG3ZzGtYYhJ4n0o/lyyUJFtZ+E=";
+  };
+
+  propagatedBuildInputs = [
+    m2crypto
+  ];
+
+  patches =
+    let
+      debianRevision = "5";  # The Debian package revision we get patches from
+      fetchDebianPatch = { name, hash }: fetchpatch {
+        url = "https://salsa.debian.org/python-team/packages/pysimplesoap/-/raw/debian/${version}-${debianRevision}/debian/patches/${name}.patch";
+        inherit hash;
+      };
+    in map fetchDebianPatch [
+      # Merged upstream: f5f96210e1483f81cb5c582a6619e3ec4b473027
+      { name = "Add-quotes-to-SOAPAction-header-in-SoapClient";
+        hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0="; }
+      # Merged upstream: ad03a21cafab982eed321553c4bfcda1755182eb
+      { name = "fix-httplib2-version-check";
+        hash = "sha256-zUeF3v0N/eMyRVRH3tQLfuUfMKOD/B/aqEwFh/7HxH4="; }
+      { name = "reorder-type-check-to-avoid-a-TypeError";
+        hash = "sha256-2p5Cqvh0SPfJ8B38wb/xq7jWGYgpI9pavA6qkMUb6hA="; }
+      # Merged upstream: 033e5899e131a2c1bdf7db5852f816f42aac9227
+      { name = "Support-integer-values-in-maxOccurs-attribute";
+        hash = "sha256-IZ0DP7io+ihcnB5547cR53FAdnpRLR6z4J5KsNrkfaI="; }
+      { name = "PR204";
+        hash = "sha256-JlxeTnKDFxvEMFBthZsaYRbNOoBvLJhBnXCRoiL/nVw="; }
+    ] ++ [ ./stringIO.patch ];
+
+  meta = with lib; {
+    description = "Python simple and lightweight SOAP Library";
+    homepage = "https://github.com/pysimplesoap/pysimplesoap";
+    license = licenses.lgpl3Plus;
+
+    # I don't directly use this, only needed it as a dependency of debianbts
+    #  so co-maintainers would be welcome.
+    maintainers = [ maintainers.nicoo ];
+  };
+}

--- a/pkgs/development/python-modules/pysimplesoap/stringIO.patch
+++ b/pkgs/development/python-modules/pysimplesoap/stringIO.patch
@@ -1,0 +1,31 @@
+diff --git i/pysimplesoap/c14n.py w/pysimplesoap/c14n.py
+index 5749e49..297592e 100644
+--- i/pysimplesoap/c14n.py
++++ w/pysimplesoap/c14n.py
+@@ -55,11 +55,8 @@ except:
+     class XMLNS:
+         BASE = "http://www.w3.org/2000/xmlns/"
+         XML = "http://www.w3.org/XML/1998/namespace"
+-try:
+-    import cStringIO
+-    StringIO = cStringIO
+-except ImportError:
+-    import StringIO
++
++from io import StringIO
+ 
+ _attrs = lambda E: (E.attributes and E.attributes.values()) or []
+ _children = lambda E: E.childNodes or []
+diff --git i/pysimplesoap/xmlsec.py w/pysimplesoap/xmlsec.py
+index 2f96df7..053149f 100644
+--- i/pysimplesoap/xmlsec.py
++++ w/pysimplesoap/xmlsec.py
+@@ -15,7 +15,7 @@ from __future__ import print_function
+ import base64
+ import hashlib
+ import os
+-from cStringIO import StringIO
++from io import StringIO
+ from M2Crypto import BIO, EVP, RSA, X509, m2
+ 
+ # if lxml is not installed, use c14n.py native implementation

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2557,6 +2557,8 @@ self: super: with self; {
 
   debian = callPackage ../development/python-modules/debian { };
 
+  debianbts = callPackage ../development/python-modules/debianbts { };
+
   debian-inspector = callPackage ../development/python-modules/debian-inspector { };
 
   debtcollector = callPackage ../development/python-modules/debtcollector { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8232,6 +8232,8 @@ self: super: with self; {
 
   pysiaalarm = callPackage ../development/python-modules/pysiaalarm { };
 
+  pysimplesoap = callPackage ../development/python-modules/pysimplesoap { };
+
   pyskyqhub = callPackage ../development/python-modules/pyskyqhub { };
 
   pyskyqremote = callPackage ../development/python-modules/pyskyqremote { };


### PR DESCRIPTION
## Description of changes

- packaged `debianbts` v4.0.1
- packaged `pysimplesoap` v1.16.2
  dependency of `debianbts`
  had to pull in Debian's patches: upstream is broken for Py3, and unresponsive
  also had to write an additional, near-trivial patch

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
