### PR TITLE
obs-studio-plugins.obs-replay-source: init at 1.6.12

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -42,6 +42,8 @@
 
   obs-pipewire-audio-capture = callPackage ./obs-pipewire-audio-capture.nix { };
 
+  obs-replay-source = qt6Packages.callPackage ./obs-replay-source.nix { };
+
   obs-rgb-levels-filter = callPackage ./obs-rgb-levels-filter.nix { };
 
   obs-scale-to-sound = callPackage ./obs-scale-to-sound.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-replay-source.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-replay-source.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, libcaption
+, obs-studio
+, qtbase
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "obs-replay-source";
+  version = "1.6.12";
+
+  src = fetchFromGitHub {
+    owner = "exeldro";
+    repo = "obs-replay-source";
+    rev = finalAttrs.version;
+    sha256 = "sha256-MzugH6r/jY5Kg7GIR8/o1BN36FenBzMnqrPUceJmbPs=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libcaption obs-studio qtbase ];
+
+  postInstall = ''
+    mkdir -p "$out/lib" "$out/share"
+    mv "$out/obs-plugins/64bit" "$out/lib/obs-plugins"
+    rm -rf "$out/obs-plugins"
+    mv "$out/data" "$out/share/obs"
+  '';
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Replay source for OBS studio";
+    homepage = "https://github.com/exeldro/obs-replay-source";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pschmitt ];
+  };
+})

--- a/pkgs/development/libraries/libcaption/default.nix
+++ b/pkgs/development/libraries/libcaption/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, re2c
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libcaption";
+  version = "0.7";
+
+  src = fetchFromGitHub {
+    owner = "szatmary";
+    repo = "libcaption";
+    rev = finalAttrs.version;
+    sha256 = "sha256-OBtxoFJF0cxC+kfSK8TIKIdLkmCh5WOJlI0fejnisJo=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ re2c ];
+
+  meta = with lib; {
+    description = "Free open-source CEA608 / CEA708 closed-caption encoder/decoder";
+    homepage = "https://github.com/szatmary/libcaption";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pschmitt ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22590,6 +22590,8 @@ with pkgs;
     then pkgs.libcanberra
     else pkgs.libcanberra-gtk2;
 
+  libcaption = callPackage ../development/libraries/libcaption { };
+
   libcbor = callPackage ../development/libraries/libcbor { };
 
   libccd = callPackage ../development/libraries/libccd { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This add [obs-replay-source](https://github.com/exeldro/obs-replay-source), which depends on [libcaption](https://github.com/szatmary/libcaption).

I didn't really know *where* to put the libcaption package, and settled on `pkgs/development/libraries/`. Do let me know if this is inappropriate.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
