### PR TITLE
pyroscope: init at 1.1.0

### DIFF
--- a/pkgs/servers/monitoring/pyroscope/default.nix
+++ b/pkgs/servers/monitoring/pyroscope/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "pyroscope";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "pyroscope";
+    hash = "sha256-XLqrQ5E4SWouqsqaHM3TXXODVK3Mhgbl3yeCq4oI8us=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-b/AeiSD88UL/5ax+Gvu6CSjUbXd62oneyi6PActI9YI=";
+
+  ldflags = let
+    prefix = "github.com/grafana/pyroscope/pkg/util/build";
+  in [
+    "-s" "-w"
+    # https://github.com/grafana/pyroscope/blob/v1.1.0/Makefile#L30
+    "-X ${prefix}.Version=${version}"
+    "-X ${prefix}.Branch=v${version}"
+    "-X ${prefix}.Revision=v${version}"
+    "-X ${prefix}.BuildUser=nix"
+    "-X ${prefix}.BuildDate=1980-01-01T00:00:00Z"
+  ];
+
+  subPackages = [
+    "cmd/pyroscope"
+    "cmd/profilecli"
+  ];
+
+  meta = with lib; {
+    description = "Grafana Pyroscope is an open source database that provides fast, scalable, highly available, and efficient storage and querying of profiling data.";
+    license = licenses.agpl3;
+    homepage = "https://grafana.com/oss/pyroscope";
+    changelog = "https://github.com/grafana/pyroscope/releases/tag/v${version}";
+    maintainers = with maintainers; [ cathalmullan ];
+    mainProgram = "pyroscope";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26596,6 +26596,8 @@ with pkgs;
 
   phlare = callPackage ../servers/monitoring/phlare { };
 
+  pyroscope = callPackage ../servers/monitoring/pyroscope { };
+
   grafana_reporter = callPackage ../servers/monitoring/grafana-reporter { };
 
   grafana-image-renderer = callPackage ../servers/monitoring/grafana-image-renderer { };


### PR DESCRIPTION
## Description of changes

Grafana Pyroscope is an open source continous profiling database that provides fast, scalable, highly available, and efficient storage and querying.

https://grafana.com/oss/pyroscope

Resolves #252199

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
