### PR TITLE
ocamlPackages.earlybird: 1.1.0 → 1.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/earlybird/default.nix
+++ b/pkgs/development/ocaml-modules/earlybird/default.nix
@@ -1,30 +1,38 @@
 { lib, fetchFromGitHub, ocaml, buildDunePackage
 , cmdliner, dap, fmt, iter, logs, lru, lwt_ppx, lwt_react, menhir, menhirLib, path_glob, ppx_deriving_yojson
+, ppx_optcomp
 , gitUpdater
 }:
 
-if lib.versionAtLeast ocaml.version "4.13"
-then throw "earlybird is not available for OCaml ${ocaml.version}"
-else
-
 buildDunePackage rec {
   pname = "earlybird";
-  version = "1.1.0";
+  version = "1.2.1";
 
-  duneVersion = "3";
-
-  minimalOCamlVersion = "4.11";
+  minimalOCamlVersion = "4.12";
 
   src = fetchFromGitHub {
     owner = "hackwaly";
     repo = "ocamlearlybird";
     rev = version;
-    hash = "sha256-8JHZWsgpz2pzpDxST3bkMSmPHtj7MDzD5G3ujqMW+MU=";
+    hash = "sha256-p29uTdx8+mZKXUL+ng/FzpKuhnykEe8Sy968Wa/KUn4=";
   };
 
   nativeBuildInputs = [ menhir ];
 
-  buildInputs = [ cmdliner dap fmt iter logs lru lwt_ppx lwt_react menhirLib path_glob ppx_deriving_yojson ];
+  buildInputs = [
+    cmdliner
+    dap
+    fmt
+    iter
+    logs
+    lru
+    lwt_ppx
+    lwt_react
+    menhirLib
+    path_glob
+    ppx_deriving_yojson
+    ppx_optcomp
+  ];
 
   passthru.updateScript = gitUpdater { };
 


### PR DESCRIPTION
## Description of changes

https://github.com/hackwaly/ocamlearlybird/blob/1.2.1/CHANGELOG.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
