### PR TITLE
nixpkgs-check-by-name: Remove case-sensitive duplicate path from tree

### DIFF
--- a/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/default.nix
@@ -1,1 +1,0 @@
-import ../mock-nixpkgs.nix { root = ./.; }

--- a/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/expected
+++ b/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/expected
@@ -1,1 +1,0 @@
-pkgs/by-name/fo: Duplicate case-sensitive package directories "foO" and "foo".

--- a/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/pkgs/by-name/fo/foO/package.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/pkgs/by-name/fo/foO/package.nix
@@ -1,1 +1,0 @@
-{ someDrv }: someDrv

--- a/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/pkgs/by-name/fo/foo/package.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/pkgs/by-name/fo/foo/package.nix
@@ -1,1 +1,0 @@
-{ someDrv }: someDrv


### PR DESCRIPTION
## Description of changes

The channel updates are [blocked](https://hydra.nixos.org/build/233371356/nixlog/1) because https://github.com/NixOS/nixpkgs/pull/250885 added a case-sensitive duplicate path to the tree:

```
Files in nixpkgs must not vary only by case
The offending paths:
[...]/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/pkgs/by-name/fo/foO
[...]/pkgs/test/nixpkgs-check-by-name/tests/case-sensitive-duplicate-package/pkgs/by-name/fo/foo
```

This removes the duplicate and generates the file dynamically for the tests instead.

## Things done
- [x] `nix-build -A tests.nixpkgs-check-by-name` on `x86_64-linux`
- [x] `nix-build pkgs/top-level/release.nix -A tarball` (up the point where it failed before, doesn't fail anymore there)