### PR TITLE
timedoctor-desktop: init at 3.12.16

### DIFF
--- a/pkgs/applications/office/timedoctor-desktop/default.nix
+++ b/pkgs/applications/office/timedoctor-desktop/default.nix
@@ -1,0 +1,42 @@
+{ appimageTools
+, fetchurl
+, lib
+, makeWrapper
+}:
+
+let
+  pname = "timedoctor-desktop";
+  version = "3.12.16";
+
+  src = fetchurl {
+    url = "https://repo2.timedoctor.com/td-desktop-hybrid/prod/v${version}/timedoctor-desktop_${version}_linux-x86_64.AppImage";
+    hash = "sha256-EodbUs88REwa3JMy2/reHcxLwvNaPtVKZDIkLPd11BU=";
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 rec {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    mv $out/bin/{${pname}-${version},${pname}}
+    install -Dm444 ${appimageContents}/timedoctor-desktop.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/timedoctor-desktop.png -t $out/share/pixmaps
+    substituteInPlace $out/share/applications/timedoctor-desktop.desktop \
+      --replace 'Exec=AppRun' 'Exec=timedoctor-desktop'
+    source "${makeWrapper}/nix-support/setup-hook"
+    wrapProgram "$out/bin/timedoctor-desktop" \
+      --add-flags "--disable-gpu-sandbox"
+  '';
+
+  extraPkgs = _: with _; [
+    (libjpeg.override { enableJpeg8 = true; })
+  ];
+
+  meta = with lib; {
+    description = "Employee time tracking software (Time Doctor Classic)";
+    homepage = "https://www.timedoctor.com";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ surfaceflinger ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1728,7 +1728,7 @@ mapAliases ({
   thunderbird-bin-68 = thunderbird-68;
   thunderbird-wayland = thunderbird; # Added 2022-11-15
   timescale-prometheus = promscale; # Added 2020-09-29
-  timedoctor = throw "'timedoctor' has been removed from nixpkgs"; # Added 2022-10-09
+  timedoctor = timedoctor-desktop; # Added 2023-08-29
   timetable = throw "timetable has been removed, as the upstream project has been abandoned"; # Added 2021-09-05
   tinygltf = throw "TinyglTF has been embedded in draco due to lack of other users and compatibility breaks."; # Added 2023-06-25
   tixati = throw "'tixati' has been removed from nixpkgs as it is unfree and unmaintained"; # Added 2023-03-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3078,6 +3078,8 @@ with pkgs;
 
   termsyn = callPackage ../data/fonts/termsyn { };
 
+  timedoctor-desktop = callPackage ../applications/office/timedoctor-desktop { };
+
   tvnamer = callPackage ../tools/misc/tvnamer { };
 
   twine = with python3Packages; toPythonApplication twine;


### PR DESCRIPTION
## Description of changes

Readded a package for Time Doctor Classic. I need this thing for my job and it's been working so far so I might as well upstream it :)

Besides Time Doctor Classic there's also Time Doctor 2. The difference in packaging is that TD2 uses this weird makeself script to install and then patchelf(!!) itself. I couldn't figure out how to get this working so if someone could take a look at it, it would be great. I even emailed its developers to consider making an AppImage release and apparently it was noted.

While this software might be considered spyware, it's sadly actually quite popular even while "free"lancing so it would definitely be useful for some folks if both versions were available in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
