### PR TITLE
python3Packages.openusd: init at 23.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16391,6 +16391,12 @@
     githubId = 543055;
     name = "Shadaj Laddad";
   };
+  shaddydc = {
+    email = "nixpkgs@shaddy.dev";
+    github = "ShaddyDC";
+    githubId = 18403034;
+    name = "Shaddy";
+  };
   shadowrz = {
     email = "shadowrz+nixpkgs@disroot.org";
     matrix = "@ShadowRZ:matrixim.cc";

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -1,0 +1,131 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, writeShellScriptBin
+, cmake
+, doxygen
+, draco
+, graphviz-nox
+, ninja
+, setuptools
+, pyqt6
+, pyopengl
+, jinja2
+, pyside6
+, boost
+, numpy
+, git
+, tbb
+, opensubdiv
+, openimageio
+, opencolorio
+, osl
+, ptex
+, embree
+, alembic
+, openexr
+, flex
+, bison
+, qt6
+, python
+}:
+let
+  # Matches the pyside6-uic implementation
+  # https://code.qt.io/cgit/pyside/pyside-setup.git/tree/sources/pyside-tools/pyside_tool.py?id=e501cad66146a49c7a259579c7bb94bc93a67a08#n82
+  pyside-tools-uic = writeShellScriptBin "pyside6-uic" ''
+    exec ${qt6.qtbase}/libexec/uic -g python "$@"
+  '';
+in
+buildPythonPackage rec {
+  pname = "OpenUSD";
+  version = "23.11";
+  src = fetchFromGitHub {
+    owner = "PixarAnimationStudios";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-5zQrfB14kXs75WbL3s4eyhxELglhLNxU2L2aVXiyVjg=";
+  };
+
+  outputs = ["out" "doc"];
+
+  format = "other";
+
+  propagatedBuildInputs = [
+    setuptools
+    pyqt6
+    pyopengl
+    jinja2
+    pyside6
+    pyside-tools-uic
+    boost
+    numpy
+  ];
+
+  cmakeFlags = [
+    "-DPXR_BUILD_EXAMPLES=OFF"
+    "-DPXR_BUILD_TUTORIALS=OFF"
+    "-DPXR_BUILD_USD_TOOLS=ON"
+    "-DPXR_BUILD_IMAGING=ON"
+    "-DPXR_BUILD_USD_IMAGING=ON"
+    "-DPXR_BUILD_USDVIEW=ON"
+    "-DPXR_BUILD_DOCUMENTATION=ON"
+    "-DPXR_BUILD_PYTHON_DOCUMENTATION=ON"
+    "-DPXR_BUILD_EMBREE_PLUGIN=ON"
+    "-DPXR_BUILD_ALEMBIC_PLUGIN=ON"
+    "-DPXR_ENABLE_OSL_SUPPORT=ON"
+    "-DPXR_BUILD_DRACO_PLUGIN=ON"
+    "-DPXR_BUILD_MONOLITHIC=ON" # Seems to be commonly linked to monolithically
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    git
+    qt6.wrapQtAppsHook
+    doxygen
+    graphviz-nox
+  ];
+  buildInputs = [
+    tbb
+    opensubdiv
+    openimageio
+    opencolorio
+    osl
+    ptex
+    embree
+    alembic.dev
+    openexr
+    flex
+    bison
+    boost
+    draco
+    qt6.qtbase
+    qt6.qtwayland
+  ];
+
+  pythonImportsCheck = [ "pxr" "pxr.Usd" ];
+
+  postInstall = ''
+    # Make python lib properly accessible
+    target_dir=$out/${python.sitePackages}
+    mkdir -p $(dirname $target_dir)
+    mv $out/lib/python $target_dir
+
+    mv $out/docs $doc
+
+    rm $out/share -r # only examples
+    rm $out/tests -r
+  '';
+
+  meta = {
+    description = "Universal Scene Description";
+    longDescription = ''
+      Universal Scene Description (USD) is an efficient, scalable system
+      for authoring, reading, and streaming time-sampled scene description
+      for interchange between graphics applications.
+    '';
+    homepage = "https://openusd.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ shaddydc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9019,6 +9019,10 @@ self: super: with self; {
 
   openapi-core = callPackage ../development/python-modules/openapi-core { };
 
+  openusd = callPackage ../development/python-modules/openusd {
+    alembic = pkgs.alembic;
+  };
+
   overly = callPackage ../development/python-modules/overly { };
 
   overpy = callPackage ../development/python-modules/overpy { };


### PR DESCRIPTION
## Description of changes

Closes #250542 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [OpenUSD](https://github.com/PixarAnimationStudios/OpenUSD).

---

Technically, this library depends on pyside6-tools, which shares a repository with [pyside6](https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/development/python-modules/pyside6/default.nix#L73) and [shiboken6](https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/development/python-modules/shiboken6/default.nix#L60). However, whether I built it the same way as those 2 or was following the [arch PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/pyside6/-/blob/main/PKGBUILD?ref_type=heads) directly, I didn't get the correct `pyside6-uic` binary out, and for all that it's used here, investigating further didn't seem worth the effort.
Ideally, that would be packaged properly in the future and used here for the build.

I have not checked all the resulting binaries, but I have checked a couple including `usdview` and `usdcat`, I have tried using it as a library from C++, and I have tried using the python bindings.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
