### PR TITLE
fetchers: Add `fetchDebianPatch`

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -123,8 +123,8 @@ Patches are fetched from `sources.debian.org`, and so must come from a
 package version that was uploaded to the Debian archive.  Packages may
 be removed from there once that specific version isn't in any suite
 anymore (stable, testing, unstable, etc.), so maintainers should use
-`copy-tarballs.pl` to archive the patch if it needs to be available in
-the very long-term.
+`copy-tarballs.pl` to archive the patch if it needs to be available
+longer-term.
 
 [Debian revision number]: https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
 

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -82,6 +82,53 @@ Note that because the checksum is computed after applying these effects, using o
 
 Most other fetchers return a directory rather than a single file.
 
+
+## `fetchDebianPatch` {#fetchdebianpatch}
+
+A wrapper around `fetchpatch`, which takes:
+- `name` and `hash`: the patch's filename without the `.patch` suffix,
+  and its hash after normalization by `fetchpatch` ;
+- `pname`: the Debian source package's name ;
+- `version`: the upstream version number ;
+- `debianRevision`: the [Debian revision number] if applicable ;
+- the `area` of the Debian archive: `main` (default), `contrib`, or `non-free`.
+
+Here is an example of `fetchDebianPatch` in action:
+
+```nix
+{ lib
+, fetchDebianPatch
+, buildPythonPackage
+}:
+
+buildPythonPackage rec {
+  pname = "pysimplesoap";
+  version = "1.16.2";
+  src = ...;
+
+  patches = [
+    (fetchDebianPatch {
+      inherit pname version;
+      debianRevision = "5";
+      name = "Add-quotes-to-SOAPAction-header-in-SoapClient";
+      hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0=";
+    })
+  ];
+
+  ...
+}
+```
+
+Patches are fetched from `sources.debian.org`, and so must come from a
+package version that was uploaded to the Debian archive.  Packages may
+be removed from there once that specific version isn't in any suite
+anymore (stable, testing, unstable, etc.), so maintainers should use
+`copy-tarballs.pl` to archive the patch if it needs to be available in
+the very long-term.
+
+[Debian revision number]: https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+
+
 ## `fetchsvn` {#fetchsvn}
 
 Used with Subversion. Expects `url` to a Subversion directory, `rev`, and `hash`.

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -86,7 +86,7 @@ Most other fetchers return a directory rather than a single file.
 ## `fetchDebianPatch` {#fetchdebianpatch}
 
 A wrapper around `fetchpatch`, which takes:
-- `name` and `hash`: the patch's filename without the `.patch` suffix,
+- `patch` and `hash`: the patch's filename without the `.patch` suffix,
   and its hash after normalization by `fetchpatch` ;
 - `pname`: the Debian source package's name ;
 - `version`: the upstream version number ;

--- a/pkgs/build-support/fetchdebianpatch/default.nix
+++ b/pkgs/build-support/fetchdebianpatch/default.nix
@@ -1,0 +1,13 @@
+{ lib, fetchpatch }:
+
+lib.makeOverridable (
+  { pname, version, debianRevision ? null, name, hash, area ? "main" }:
+  let versionString =
+    if debianRevision == null then version else "${version}-${debianRevision}";
+  in fetchpatch {
+    url =
+      "https://sources.debian.org/data/${area}/${builtins.substring 0 1 pname}/"
+      + "${pname}/${versionString}/debian/patches/${name}.patch";
+    inherit hash;
+  }
+)

--- a/pkgs/build-support/fetchdebianpatch/default.nix
+++ b/pkgs/build-support/fetchdebianpatch/default.nix
@@ -3,12 +3,17 @@
 lib.makeOverridable (
   { pname, version, debianRevision ? null, patch, hash,
     area ? "main", name ? "${patch}.patch" }:
-  let versionString =
-    if debianRevision == null then version else "${version}-${debianRevision}";
+  let
+    inherit (lib.strings) hasPrefix substring;
+    prefix =
+      substring 0 (if hasPrefix "lib" pname then 4 else 1) pname;
+    versionString =
+      if debianRevision == null then version
+      else "${version}-${debianRevision}";
   in fetchpatch {
     inherit name hash;
     url =
-      "https://sources.debian.org/data/${area}/${builtins.substring 0 1 pname}/"
+      "https://sources.debian.org/data/${area}/${prefix}/"
       + "${pname}/${versionString}/debian/patches/${patch}.patch";
   }
 )

--- a/pkgs/build-support/fetchdebianpatch/default.nix
+++ b/pkgs/build-support/fetchdebianpatch/default.nix
@@ -1,13 +1,14 @@
 { lib, fetchpatch }:
 
 lib.makeOverridable (
-  { pname, version, debianRevision ? null, name, hash, area ? "main" }:
+  { pname, version, debianRevision ? null, patch, hash,
+    area ? "main", name ? "${patch}.patch" }:
   let versionString =
     if debianRevision == null then version else "${version}-${debianRevision}";
   in fetchpatch {
+    inherit name hash;
     url =
       "https://sources.debian.org/data/${area}/${builtins.substring 0 1 pname}/"
-      + "${pname}/${versionString}/debian/patches/${name}.patch";
-    inherit hash;
+      + "${pname}/${versionString}/debian/patches/${patch}.patch";
   }
 )

--- a/pkgs/build-support/fetchdebianpatch/tests.nix
+++ b/pkgs/build-support/fetchdebianpatch/tests.nix
@@ -8,4 +8,12 @@
     patch = "Add-quotes-to-SOAPAction-header-in-SoapClient";
     hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0=";
   };
+
+  libPackage = testers.invalidateFetcherByDrvHash fetchDebianPatch {
+    pname = "libfile-pid-perl";
+    version = "1.01";
+    debianRevision = "2";
+    patch = "missing-pidfile";
+    hash = "sha256-VBsIYyCnjcZLYQ2Uq2MKPK3kF2wiMKvnq0m727DoavM=";
+  };
 }

--- a/pkgs/build-support/fetchdebianpatch/tests.nix
+++ b/pkgs/build-support/fetchdebianpatch/tests.nix
@@ -1,0 +1,11 @@
+{ testers, fetchDebianPatch, ... }:
+
+{
+  simple = testers.invalidateFetcherByDrvHash fetchDebianPatch {
+    pname = "pysimplesoap";
+    version = "1.16.2";
+    debianRevision = "5";
+    patch = "Add-quotes-to-SOAPAction-header-in-SoapClient";
+    hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0=";
+  };
+}

--- a/pkgs/development/python-modules/pysimplesoap/default.nix
+++ b/pkgs/development/python-modules/pysimplesoap/default.nix
@@ -25,17 +25,17 @@ buildPythonPackage rec {
     debianRevision = "5";
   } // args)) [
     # Merged upstream: f5f96210e1483f81cb5c582a6619e3ec4b473027
-    { name = "Add-quotes-to-SOAPAction-header-in-SoapClient";
+    { patch = "Add-quotes-to-SOAPAction-header-in-SoapClient";
       hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0="; }
     # Merged upstream: ad03a21cafab982eed321553c4bfcda1755182eb
-    { name = "fix-httplib2-version-check";
+    { patch = "fix-httplib2-version-check";
       hash = "sha256-zUeF3v0N/eMyRVRH3tQLfuUfMKOD/B/aqEwFh/7HxH4="; }
-    { name = "reorder-type-check-to-avoid-a-TypeError";
+    { patch = "reorder-type-check-to-avoid-a-TypeError";
       hash = "sha256-2p5Cqvh0SPfJ8B38wb/xq7jWGYgpI9pavA6qkMUb6hA="; }
     # Merged upstream: 033e5899e131a2c1bdf7db5852f816f42aac9227
-    { name = "Support-integer-values-in-maxOccurs-attribute";
+    { patch = "Support-integer-values-in-maxOccurs-attribute";
       hash = "sha256-IZ0DP7io+ihcnB5547cR53FAdnpRLR6z4J5KsNrkfaI="; }
-    { name = "PR204";
+    { patch = "PR204";
       hash = "sha256-JlxeTnKDFxvEMFBthZsaYRbNOoBvLJhBnXCRoiL/nVw="; }
   ] ++ [ ./stringIO.patch ];
 

--- a/pkgs/development/python-modules/pysimplesoap/default.nix
+++ b/pkgs/development/python-modules/pysimplesoap/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchpatch
+, fetchDebianPatch
 , fetchPypi
 , buildPythonPackage
 , m2crypto
@@ -20,28 +20,24 @@ buildPythonPackage rec {
     m2crypto
   ];
 
-  patches =
-    let
-      debianRevision = "5";  # The Debian package revision we get patches from
-      fetchDebianPatch = { name, hash }: fetchpatch {
-        url = "https://salsa.debian.org/python-team/packages/pysimplesoap/-/raw/debian/${version}-${debianRevision}/debian/patches/${name}.patch";
-        inherit hash;
-      };
-    in map fetchDebianPatch [
-      # Merged upstream: f5f96210e1483f81cb5c582a6619e3ec4b473027
-      { name = "Add-quotes-to-SOAPAction-header-in-SoapClient";
-        hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0="; }
-      # Merged upstream: ad03a21cafab982eed321553c4bfcda1755182eb
-      { name = "fix-httplib2-version-check";
-        hash = "sha256-zUeF3v0N/eMyRVRH3tQLfuUfMKOD/B/aqEwFh/7HxH4="; }
-      { name = "reorder-type-check-to-avoid-a-TypeError";
-        hash = "sha256-2p5Cqvh0SPfJ8B38wb/xq7jWGYgpI9pavA6qkMUb6hA="; }
-      # Merged upstream: 033e5899e131a2c1bdf7db5852f816f42aac9227
-      { name = "Support-integer-values-in-maxOccurs-attribute";
-        hash = "sha256-IZ0DP7io+ihcnB5547cR53FAdnpRLR6z4J5KsNrkfaI="; }
-      { name = "PR204";
-        hash = "sha256-JlxeTnKDFxvEMFBthZsaYRbNOoBvLJhBnXCRoiL/nVw="; }
-    ] ++ [ ./stringIO.patch ];
+  patches = map (args: fetchDebianPatch ({
+    inherit pname version;
+    debianRevision = "5";
+  } // args)) [
+    # Merged upstream: f5f96210e1483f81cb5c582a6619e3ec4b473027
+    { name = "Add-quotes-to-SOAPAction-header-in-SoapClient";
+      hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0="; }
+    # Merged upstream: ad03a21cafab982eed321553c4bfcda1755182eb
+    { name = "fix-httplib2-version-check";
+      hash = "sha256-zUeF3v0N/eMyRVRH3tQLfuUfMKOD/B/aqEwFh/7HxH4="; }
+    { name = "reorder-type-check-to-avoid-a-TypeError";
+      hash = "sha256-2p5Cqvh0SPfJ8B38wb/xq7jWGYgpI9pavA6qkMUb6hA="; }
+    # Merged upstream: 033e5899e131a2c1bdf7db5852f816f42aac9227
+    { name = "Support-integer-values-in-maxOccurs-attribute";
+      hash = "sha256-IZ0DP7io+ihcnB5547cR53FAdnpRLR6z4J5KsNrkfaI="; }
+    { name = "PR204";
+      hash = "sha256-JlxeTnKDFxvEMFBthZsaYRbNOoBvLJhBnXCRoiL/nVw="; }
+  ] ++ [ ./stringIO.patch ];
 
   meta = with lib; {
     description = "Python simple and lightweight SOAP Library";

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -35,6 +35,7 @@ with pkgs;
   fetchurl = callPackages ../build-support/fetchurl/tests.nix { };
   fetchpatch = callPackages ../build-support/fetchpatch/tests.nix { };
   fetchpatch2 = callPackages ../build-support/fetchpatch/tests.nix { fetchpatch = fetchpatch2; };
+  fetchDebianPatch = callPackages ../build-support/fetchdebianpatch/tests.nix { };
   fetchzip = callPackages ../build-support/fetchzip/tests.nix { };
   fetchgit = callPackages ../build-support/fetchgit/tests.nix { };
   fetchFirefoxAddon = callPackages ../build-support/fetchfirefoxaddon/tests.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1173,6 +1173,8 @@ with pkgs;
       tests = pkgs.tests.fetchzip;
     };
 
+  fetchDebianPatch = callPackage ../build-support/fetchdebianpatch { };
+
   fetchCrate = callPackage ../build-support/rust/fetchcrate.nix { };
 
   fetchFromGitea = callPackage ../build-support/fetchgitea { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1173,7 +1173,10 @@ with pkgs;
       tests = pkgs.tests.fetchzip;
     };
 
-  fetchDebianPatch = callPackage ../build-support/fetchdebianpatch { };
+  fetchDebianPatch = callPackage ../build-support/fetchdebianpatch { }
+    // {
+      tests = pkgs.tests.fetchDebianPatch;
+    };
 
   fetchCrate = callPackage ../build-support/rust/fetchcrate.nix { };
 


### PR DESCRIPTION
## Description of changes

- Add a `fetchDebianPatch` helper, to acquire patches from `sources.debian.org`.
- Document it, in the [fetchers] chapters of the nixpkgs manual.
- Convert `pythonPackages.pysimplesoap` to its use, as a demonstration.

[fetchers]: https://nixos.org/manual/nixpkgs/unstable/#chap-pkgs-fetchers



## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Rationale

While packaging `pythonPackages.debianbts` (#252173), @mkg20001 pointed out that the 
quick helper I wrote could be more widely-useful.  A cursory search confirmed as much: 
<details>
<summary>`rg -c 'debian\.org.*\.patch'` found 154 matches across 74 files</summary>
pkgs/top-level/perl-packages.nix:6

pkgs/desktops/mate/mate-utils/default.nix:1

pkgs/games/rrootage/default.nix:1

pkgs/games/btanks/default.nix:4

pkgs/games/t4kcommon/default.nix:1

pkgs/games/megaglest/default.nix:1

pkgs/games/torcs/default.nix:4

pkgs/games/globulation/default.nix:4

pkgs/games/tumiki-fighters/default.nix:1

pkgs/games/lgames/lbreakout2/default.nix:1

pkgs/games/scorched3d/default.nix:1

pkgs/games/torus-trooper/default.nix:1

pkgs/applications/misc/xneur/default.nix:2

pkgs/applications/misc/slic3r/default.nix:3

pkgs/applications/radio/tlf/default.nix:1

pkgs/applications/audio/sooperlooper/default.nix:1

pkgs/applications/audio/eq10q/default.nix:1

pkgs/applications/audio/mpg321/default.nix:1

pkgs/applications/networking/freefilesync/default.nix:2

pkgs/applications/networking/modem-manager-gui/default.nix:3

pkgs/applications/networking/mailreaders/mutt/default.nix:1

pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix:1

pkgs/applications/window-managers/afterstep/default.nix:1

pkgs/applications/science/math/giac/default.nix:1

pkgs/applications/science/logic/hol_light/default.nix:1

pkgs/applications/emulators/pcsxr/default.nix:8

pkgs/os-specific/linux/tiptop/default.nix:1

pkgs/os-specific/linux/i7z/default.nix:3

pkgs/os-specific/linux/macchanger/default.nix:5

pkgs/misc/drivers/hplip/default.nix:1

pkgs/misc/drivers/foomatic-filters/default.nix:1

pkgs/tools/archivers/arj/default.nix:23

pkgs/tools/archivers/unzip/default.nix:3

pkgs/tools/archivers/sharutils/default.nix:2

pkgs/tools/security/super/default.nix:1

pkgs/tools/typesetting/tex/texlive/bin.nix:1

pkgs/tools/security/pinentry/default.nix:1

pkgs/tools/security/tpm-tools/default.nix:1

pkgs/tools/audio/pasystray/default.nix:2

pkgs/tools/system/fakeroot/default.nix:1

pkgs/tools/package-management/checkinstall/default.nix:1

pkgs/tools/compression/bsdiff/default.nix:4

pkgs/tools/backup/partimage/default.nix:1

pkgs/tools/networking/uwimap/default.nix:1

pkgs/tools/networking/nfstrace/default.nix:1

pkgs/tools/networking/wifite2/default.nix:3

pkgs/tools/text/catdoc/default.nix:1

pkgs/tools/networking/openssh/default.nix:1

pkgs/tools/networking/p2p/amule/default.nix:1

pkgs/tools/inputmethods/m17n-lib/otf.nix:3

pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix:1

pkgs/tools/filesystems/jfsutils/default.nix:1

pkgs/misc/cups/drivers/cups-drv-rastertosag-gdi/default.nix:1

pkgs/servers/mail/dovecot/default.nix:1

pkgs/development/libraries/qt-5/5.15/default.nix:5

pkgs/development/libraries/flann/default.nix:3

pkgs/development/libraries/nss/generic.nix:1

pkgs/development/libraries/intel-media-driver/default.nix:1

pkgs/development/libraries/jxrlib/default.nix:3

pkgs/development/libraries/SDL_Pango/default.nix:1

pkgs/development/libraries/libmatheval/default.nix:3

pkgs/development/libraries/libicns/default.nix:1

pkgs/development/libraries/libconfuse/default.nix:2

pkgs/development/libraries/libqtdbustest/default.nix:2

pkgs/development/libraries/bulletml/default.nix:1

pkgs/development/libraries/plib/default.nix:1

pkgs/servers/prayer/default.nix:2

pkgs/development/tools/vagrant/0004-Support-system-installed-plugins.patch:1

pkgs/development/tools/misc/intltool/default.nix:1

pkgs/development/python-modules/boto/default.nix:2

pkgs/development/python-modules/brian2/default.nix:1

pkgs/development/interpreters/spidermonkey/common.nix:1

pkgs/development/ruby-modules/gem-config/default.nix:1

pkgs/data/fonts/openmoji/default.nix:1
<details>
