### PR TITLE
emacs-macport: build on LLVM 14

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -8,9 +8,9 @@ lib.makeScope pkgs.newScope (self:
       inherit gconf;
 
       inherit (pkgs.darwin) sigtool;
-      inherit (pkgs.darwin.apple_sdk.frameworks)
-        AppKit Carbon Cocoa GSS ImageCaptureCore ImageIO IOKit OSAKit Quartz
-        QuartzCore WebKit;
+      inherit (pkgs.darwin.apple_sdk_11_0.frameworks)
+        Accelerate AppKit Carbon Cocoa GSS ImageCaptureCore ImageIO IOKit OSAKit
+        Quartz QuartzCore UniformTypeIdentifiers WebKit;
     };
   in {
     sources = import ./sources.nix {

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -42,7 +42,7 @@
 , libtiff
 , libwebp
 , libxml2
-, llvmPackages_6
+, llvmPackages_14
 , m17n_lib
 , makeWrapper
 , motif
@@ -99,6 +99,7 @@
   else "lucid")
 
 # macOS dependencies for NS and macPort
+, Accelerate
 , AppKit
 , Carbon
 , Cocoa
@@ -109,6 +110,7 @@
 , OSAKit
 , Quartz
 , QuartzCore
+, UniformTypeIdentifiers
 , WebKit
 }:
 
@@ -135,7 +137,7 @@ let
   ];
 
   inherit (if variant == "macport"
-           then llvmPackages_6.stdenv
+           then llvmPackages_14.stdenv
            else stdenv) mkDerivation;
 in
 mkDerivation (finalAttrs: (lib.optionalAttrs withNativeCompilation {
@@ -287,6 +289,7 @@ mkDerivation (finalAttrs: (lib.optionalAttrs withNativeCompilation {
     GSS
     ImageIO
   ] ++ lib.optionals (variant == "macport") [
+    Accelerate
     AppKit
     Carbon
     Cocoa
@@ -294,6 +297,7 @@ mkDerivation (finalAttrs: (lib.optionalAttrs withNativeCompilation {
     OSAKit
     Quartz
     QuartzCore
+    UniformTypeIdentifiers
     WebKit
     # TODO are these optional?
     GSS
@@ -336,6 +340,11 @@ mkDerivation (finalAttrs: (lib.optionalAttrs withNativeCompilation {
   ++ lib.optional withXinput2 "--with-xinput2"
   ++ lib.optional withXwidgets "--with-xwidgets"
   ;
+
+  # Fixes intermittent segfaults when compiled with LLVM >= 7.0.
+  # See https://github.com/NixOS/nixpkgs/issues/127902
+  env.NIX_CFLAGS_COMPILE = lib.optionalString (variant == "macport")
+    "-include ${./macport_noescape_noop.h}";
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/editors/emacs/macport_noescape_noop.h
+++ b/pkgs/applications/editors/emacs/macport_noescape_noop.h
@@ -1,0 +1,31 @@
+#ifndef NOESCAPE_NOOP_H_
+#define NOESCAPE_NOOP_H_
+
+// First, do some work to get definitions for *_WIDTH. Normally, Emacs would
+// have these defined by headers in-tree, but clang's headers clash with those.
+// Due to how include paths work, we have to include clang headers if we want to
+// mess with CoreFoundation definitions.
+#pragma push_macro("__STDC_VERSION__")
+// Make the preprocessor think that we're on C2x. The macros we want are gated
+// on it.
+#undef __STDC_VERSION__
+#define __STDC_VERSION__ 202000L
+// Include limits.h first, as stdint.h includes it.
+#include <limits.h>
+
+// XX: clang's stdint.h is shy and won't give us its defs unless it thinks it's
+// in freestanding mode.
+#undef __STDC_HOSTED__
+#include <stdint.h>
+#define __STDC_HOSTED__ 1
+
+#pragma pop_macro("__STDC_VERSION__")
+
+// Now, pull in the header that defines CF_NOESCAPE.
+#include <CoreFoundation/CFBase.h>
+
+// Redefine CF_NOESCAPE as empty.
+#undef CF_NOESCAPE
+#define CF_NOESCAPE
+
+#endif // NOESCAPE_NOOP_H_

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31477,7 +31477,7 @@ with pkgs;
 
   em = callPackage ../applications/editors/em { };
 
-  inherit (recurseIntoAttrs (callPackage ../applications/editors/emacs { }))
+  inherit (recurseIntoAttrs (darwin.apple_sdk_11_0.callPackage ../applications/editors/emacs { }))
     emacs28
     emacs28-gtk2
     emacs28-gtk3


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Compile emacs-macport with `llvmPackages_14`:
- Add `Accelerate` and `UniformTypeIdentifiers` headers
- Work around `__attribute__((noescape))` codegen issue with header

This should fix the derivation on `aarch64-darwin`.

Resolves #127902.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
