### PR TITLE
libicns: 0.8.1 -> unstable-2022-04-10

### DIFF
--- a/pkgs/development/libraries/libicns/default.nix
+++ b/pkgs/development/libraries/libicns/default.nix
@@ -1,24 +1,18 @@
-{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, libpng, openjpeg }:
+{ lib, stdenv, fetchgit, autoreconfHook, pkg-config, libpng, openjpeg, zlib }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "libicns";
-  version = "0.8.1";
+  version = "unstable-2022-04-10";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/icns/${pname}-${version}.tar.gz";
-    sha256 = "1hjm8lwap7bjyyxsyi94fh5817xzqhk4kb5y0b7mb6675xw10prk";
+  src = fetchgit {
+    name = "libicns";
+    url = "https://git.code.sf.net/p/icns/code";
+    rev = "921f972c461c505e5ac981aaddbdfdde97e8bb2b";
+    hash = "sha256-YeO0rlTujDNmrdJ3DRyl3TORswF2KFKA+wVUxJo8Dno";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/libi/libicns/0.8.1-3.1/debian/patches/support-libopenjp2.patch";
-      sha256 = "0ss298lyzvydxvaxsadi6kbbjpwykd86jw3za76brcsg2dpssgas";
-    })
-  ];
-
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ libpng openjpeg ];
-  env.NIX_CFLAGS_COMPILE = toString [ "-I${openjpeg.dev}/include/${openjpeg.incDir}" ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ libpng openjpeg zlib ];
 
   meta = with lib; {
     description = "Library for manipulation of the Mac OS icns resource format";


### PR DESCRIPTION
## Description of changes

libicns hasn’t had a release in over a decade, but development has continued upstream. Updating removes the need for the openjp2 patch and includes fixes needed to build with newer versions of clang.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
