### PR TITLE
cpplint: patch so that tests pass on python 3.11

### DIFF
--- a/pkgs/development/tools/analysis/cpplint/default.nix
+++ b/pkgs/development/tools/analysis/cpplint/default.nix
@@ -1,18 +1,34 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib, python3Packages, fetchFromGitHub, fetchpatch }:
 
 python3Packages.buildPythonApplication rec {
   pname = "cpplint";
   version = "1.5.5";
+  format = "setuptools";
 
   # Fetch from github instead of pypi, since the test cases are not in the pypi archive
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-JXz2Ufo7JSceZVqYwCRkuAsOR08znZlIUk8GCLAyiI4=";
+    hash = "sha256-JXz2Ufo7JSceZVqYwCRkuAsOR08znZlIUk8GCLAyiI4=";
   };
 
-  patches = [ ./0001-Remove-pytest-runner-version-pin.patch ];
+  patches = [
+    ./0001-Remove-pytest-runner-version-pin.patch
+
+    # The patch below stops using the sre_compile module, which was deprecated
+    # in Python 3.11 and replaces it with re.compile. Upstream is unsure if it
+    # should use re.compile or re._compiler.compile, so we should monitor the
+    # thread for updates.
+    #
+    #   https://github.com/cpplint/cpplint/pull/214
+    #
+    (fetchpatch {
+      name = "python-3.11-compatibility.patch";
+      url = "https://github.com/cpplint/cpplint/commit/e84e84f53915ae2a9214e756cf89c573a73bbcd3.patch";
+      hash = "sha256-u57AFWaVmGFSsvSGq1x9gZmTsuZPqXvTC7mTfyb2164=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs cpplint_unittest.py


### PR DESCRIPTION
## Description of changes

Pull in the first commit from https://github.com/cpplint/cpplint/pull/214 upstream to keep this package's tests passing on Python 3.11, and to future proof ourselves in future Python versions. You'll see from that PR that upstream is undecided between whether it should use `re.compile` (in the current commit) or `re._compiler.compile`, but I think using `re.compile` is fine unless we hear a report about a regression.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
