### PR TITLE
grin: use nose3 for python 3.11 compatibility

### DIFF
--- a/pkgs/tools/text/grin/default.nix
+++ b/pkgs/tools/text/grin/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, python3Packages }:
+{ lib, fetchFromGitHub, fetchpatch, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
   pname = "grin";
@@ -9,10 +9,21 @@ python3Packages.buildPythonApplication rec {
     owner = "matthew-brett";
     repo = pname;
     rev = "1.3.0";
-    sha256 = "057d05vzx4sf415vnh3qj2g351xhb3illjxjs9mdl3nsnb5r84kv";
+    hash = "sha256-exKUy7LaDtpq0rJLSuNYsIcynpB4QLtLIE6T/ncB7RQ=";
   };
 
-  buildInputs = with python3Packages; [ nose ];
+  patches = [
+    # https://github.com/matthew-brett/grin/pull/4
+    (fetchpatch {
+      name = "replace-nose-with-nose3.patch";
+      url = "https://github.com/matthew-brett/grin/commit/ba473fa4f5da1b337ee80d7d31772a4e41ffa62d.patch";
+      hash = "sha256-CnWHynKSsXYjSsTLdPuwpcIndrCdq3cQYS8teg5EM0A=";
+    })
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    nose3
+  ];
 
   meta = {
     homepage = "https://github.com/matthew-brett/grin";


### PR DESCRIPTION
## Description of changes

Otherwise, we encounter the following error:

```
======================================================================
ERROR: <nose.suite.ContextSuite context=test_file_recognizer>
test suite for <module 'test_file_recognizer' from '/build/source/tests/test_file_recognizer.py'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/nix/store/2cvn5s3phk0d4la2sl8lw25z7rlisa42-python3.11-nose-1.3.7/lib/python3.11/site-packages/nose/suite.py", line 209, in run
    self.setUp()
  File "/nix/store/2cvn5s3phk0d4la2sl8lw25z7rlisa42-python3.11-nose-1.3.7/lib/python3.11/site-packages/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/nix/store/2cvn5s3phk0d4la2sl8lw25z7rlisa42-python3.11-nose-1.3.7/lib/python3.11/site-packages/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/nix/store/2cvn5s3phk0d4la2sl8lw25z7rlisa42-python3.11-nose-1.3.7/lib/python3.11/site-packages/nose/util.py", line 453, in try_run
    inspect.getargspec(func)
    ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'

----------------------------------------------------------------------
Ran 0 tests in 0.015s
```

Pulls in https://github.com/matthew-brett/grin/pull/4 so that setuptools does not complain about a missing dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
