### PR TITLE
balena-cli: 16.7.6 -> 17.0.0; Build from source

### DIFF
--- a/pkgs/tools/admin/balena-cli/default.nix
+++ b/pkgs/tools/admin/balena-cli/default.nix
@@ -7,6 +7,7 @@
 , nodePackages
 , python3
 , udev
+, darwin
 }:
 
 buildNpmPackage rec {
@@ -30,10 +31,15 @@ buildNpmPackage rec {
   nativeBuildInputs = [
     nodePackages.node-gyp
     python3
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.cctools
   ];
 
-  buildInputs = lib.optionals (!stdenv.isDarwin) [
+  buildInputs = lib.optionals stdenv.isLinux [
     udev
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Foundation
+    darwin.apple_sdk.frameworks.Cocoa
   ];
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/tools/admin/balena-cli/default.nix
+++ b/pkgs/tools/admin/balena-cli/default.nix
@@ -1,93 +1,49 @@
 { lib
 , stdenv
-, fetchzip
+, buildNpmPackage
+, fetchFromGitHub
 , testers
+, balena-cli
+, nodePackages
+, python3
+, udev
 }:
-let
-  inherit (stdenv.hostPlatform) system;
-  throwSystem = throw "Unsupported system: ${system}";
 
-  plat = {
-    x86_64-linux = "linux-x64";
-    x86_64-darwin = "macOS-x64";
-    # Balena only packages for x86 so we rely on Rosetta for Apple Silicon
-    aarch64-darwin = "macOS-x64";
-  }.${system} or throwSystem;
-
-  sha256 = {
-    x86_64-linux = "sha256-USljQ/cnbSabzsZWXlZ0eeZSqkTr3wVP0ktXqZ7Fw4U=";
-    x86_64-darwin = "sha256-NWzJPB+HzlsB6yTcEMwTg8pioonGWPOU96jyIpiZiTY=";
-    aarch64-darwin = "sha256-NWzJPB+HzlsB6yTcEMwTg8pioonGWPOU96jyIpiZiTY=";
-  }.${system} or throwSystem;
-
-  version = "16.7.6";
-  src = fetchzip {
-    url = "https://github.com/balena-io/balena-cli/releases/download/v${version}/balena-cli-v${version}-${plat}-standalone.zip";
-    inherit sha256;
-  };
-in
-stdenv.mkDerivation (finalAttrs: {
+buildNpmPackage rec {
   pname = "balena-cli";
-  inherit version src;
+  version = "17.0.0";
 
-  installPhase = ''
-    runHook preInstall
+  src = fetchFromGitHub {
+    owner = "balena-io";
+    repo = "balena-cli";
+    rev = "v${version}";
+    hash = "sha256-sNpxjSumiP+4fX6b3j+HEl/lr4pvudrhfTzr2TYastE=";
+  };
 
-    mkdir -p $out/bin
-    cp -r ./* $out/
-    ln -s $out/balena $out/bin/balena
+  npmDepsHash = "sha256-q2Yc6e5dEiP2Q4tFIeqj4mswM1/pX1pdGeoagyiupvs=";
 
-    runHook postInstall
+  postPatch = ''
+    ln -s npm-shrinkwrap.json package-lock.json
   '';
+  makeCacheWritable = true;
+
+  nativeBuildInputs = [
+    nodePackages.node-gyp
+    python3
+  ];
+
+  buildInputs = lib.optionals (!stdenv.isDarwin) [
+    udev
+  ];
 
   passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
+    package = balena-cli;
     command = ''
       # Override default cache directory so Balena CLI's unavoidable update check does not fail due to write permissions
       BALENARC_DATA_DIRECTORY=./ balena --version
     '';
     inherit version;
   };
-
-  # https://github.com/NixOS/nixpkgs/pull/48193/files#diff-b65952dbe5271c002fbc941b01c3586bf5050ad0e6aa6b2fcc74357680e103ea
-  preFixup =
-    if stdenv.isLinux then
-      let
-        libPath = lib.makeLibraryPath [ stdenv.cc.cc ];
-      in
-      ''
-        orig_size=$(stat --printf=%s $out/balena)
-        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/balena
-        patchelf --set-rpath ${libPath} $out/balena
-        chmod +x $out/balena
-        new_size=$(stat --printf=%s $out/balena)
-        ###### zeit-pkg fixing starts here.
-        # we're replacing plaintext js code that looks like
-        # PAYLOAD_POSITION = '1234                  ' | 0
-        # [...]
-        # PRELUDE_POSITION = '1234                  ' | 0
-        # ^-----20-chars-----^^------22-chars------^
-        # ^-- grep points here
-        #
-        # var_* are as described above
-        # shift_by seems to be safe so long as all patchelf adjustments occur
-        # before any locations pointed to by hardcoded offsets
-        var_skip=20
-        var_select=22
-        shift_by=$(expr $new_size - $orig_size)
-        function fix_offset {
-          # $1 = name of variable to adjust
-          location=$(grep -obUam1 "$1" $out/bin/balena | cut -d: -f1)
-          location=$(expr $location + $var_skip)
-          value=$(dd if=$out/balena iflag=count_bytes,skip_bytes skip=$location \
-                     bs=1 count=$var_select status=none)
-          value=$(expr $shift_by + $value)
-          echo -n $value | dd of=$out/balena bs=1 seek=$location conv=notrunc
-        }
-        fix_offset PAYLOAD_POSITION
-        fix_offset PRELUDE_POSITION
-      '' else '''';
-  dontStrip = true;
 
   meta = with lib; {
     description = "A command line interface for balenaCloud or openBalena";
@@ -100,9 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/balena-io/balena-cli";
     changelog = "https://github.com/balena-io/balena-cli/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = [ maintainers.kalebpace ];
-    platforms = platforms.linux ++ platforms.darwin;
-    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    maintainers = [ maintainers.kalebpace maintainers.doronbehar ];
     mainProgram = "balena";
   };
-})
+}


### PR DESCRIPTION
###### Motivation for this change

Tested `balena login`, and `balena scan`, though without devices attached. All seems to be functional.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
