### PR TITLE
dosfstools: backport reproducible builds patch

### DIFF
--- a/pkgs/tools/filesystems/dosfstools/default.nix
+++ b/pkgs/tools/filesystems/dosfstools/default.nix
@@ -22,6 +22,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/dosfstools/dosfstools/commit/2d3125c4a74895eae1f66b93287031d340324524.patch";
       sha256 = "nlIuRDsNjk23MKZL9cZ05odOfTXvsyQaKcv/xEr4c+U=";
     })
+    # reproducible builds fix backported from master
+    # (respect SOURCE_DATE_EPOCH)
+    # TODO: remove on the next release
+    (fetchpatch {
+      url = "https://github.com/dosfstools/dosfstools/commit/8da7bc93315cb0c32ad868f17808468b81fa76ec.patch";
+      sha256 = "sha256-Quegj5uYZgACgjSZef6cjrWQ64SToGQxbxyqCdl8C7o=";
+    })
   ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ]


### PR DESCRIPTION
## Description of changes

Upstream, dosfstools respects `SOURCE_DATE_EPOCH` since this commit: https://github.com/dosfstools/dosfstools/commit/8da7bc93315cb0c32ad868f17808468b81fa76ec This means tools like mkfs.vfat will create deterministic outputs when `SOURCE_DATE_EPOCH` is set. A backport in nixpkgs is warranted since this was already merged in 2021 and no new version of dosfstools has been released since then.
Many parts of nixpkgs would benefit from this backport including multiple places[^1][^2][^3] where EFI or other FAT partitions are created for bootable images.

Basic reproducibility test that works with this patch:

```
SOURCE_DATE_EPOCH=0 /nix/store/fkiiz242j455mw4bl9a0z402nslzq8kv-dosfstools-4.2/bin/mkfs.vfat -nEFI -F32 -i  1234 -C  reproducible1.img 4096
SOURCE_DATE_EPOCH=0 /nix/store/fkiiz242j455mw4bl9a0z402nslzq8kv-dosfstools-4.2/bin/mkfs.vfat -nEFI -F32 -i  1234 -C  reproducible2.img 4096
sha256sum reproducible*.img
# output will match d93faa0594292829c04a4a3d6659cb0b873a79cd9786fe3cca64e529251d883d
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

[^1]: https://github.com/NixOS/nixpkgs/blob/72c6fa4b684298a9b92283279c260692cc22e810/nixos/modules/installer/sd-card/sd-image.nix#L228
[^2]: https://github.com/NixOS/nixpkgs/blob/72c6fa4b684298a9b92283279c260692cc22e810/nixos/modules/installer/cd-dvd/iso-image.nix#L430
[^3]: https://github.com/NixOS/nixpkgs/blob/72c6fa4b684298a9b92283279c260692cc22e810/nixos/lib/make-disk-image.nix#L560