### PR TITLE
nixos/modemmanager: support additional FCC unlock scripts

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -935,8 +935,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   using the `pomerium-cli` command, you should now install the `pomerium-cli`
   package.
 
-- The option
-  [services.networking.networkmanager.enableFccUnlock](#opt-networking.networkmanager.enableFccUnlock)
+- The option `services.networking.networkmanager.enableFccUnlock`
   was added to support FCC unlock procedures. Since release 1.18.4, the ModemManager
   daemon no longer automatically performs the FCC unlock procedure by default. See
   [the docs](https://modemmanager.org/docs/modemmanager/fcc-unlock/) for more details.

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -187,6 +187,8 @@
 
 - Emacs macport version 29 was introduced.
 
+- The option `services.networking.networkmanager.enableFccUnlock` was removed in favor of `networking.networkmanager.fccUnlockScripts`, which allows specifying unlock scripts explicitly. The previous option simply did enable all unlock scripts bundled with ModemManager, which is risky, and didn't allow using vendor-provided unlock scripts at all.
+
 - The `html-proofer` package has been updated from major version 3 to major version 5, which includes [breaking changes](https://github.com/gjtorikian/html-proofer/blob/v5.0.8/UPGRADING.md).
 
 - `kratos` has been updated from 0.10.1 to the first stable version 1.0.0, please read the [0.10.1 to 0.11.0](https://github.com/ory/kratos/releases/tag/v0.11.0), [0.11.0 to 0.11.1](https://github.com/ory/kratos/releases/tag/v0.11.1), [0.11.1 to 0.13.0](https://github.com/ory/kratos/releases/tag/v0.13.0) and [0.13.0 to 1.0.0](https://github.com/ory/kratos/releases/tag/v1.0.0) upgrade guides. The most notable breaking change is the introduction of one-time passwords (`code`) and update of the default recovery strategy from `link` to `code`.

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -370,11 +370,12 @@ in
         '';
       };
 
-      enableFccUnlock = mkOption {
+      enableBundledFccUnlockScripts = mkOption {
         type = types.bool;
         default = false;
         description = lib.mdDoc ''
-          Enable FCC unlock procedures. Since release 1.18.4, the ModemManager daemon no longer
+          Enable FCC unlock procedures shipped with ModemManager.
+          Since release 1.18.4, the ModemManager daemon no longer
           automatically performs the FCC unlock procedure by default. See
           [the docs](https://modemmanager.org/docs/modemmanager/fcc-unlock/)
           for more details.
@@ -388,6 +389,7 @@ in
       [ "networking" "networkmanager" "packages" ]
       [ "networking" "networkmanager" "plugins" ])
     (mkRenamedOptionModule [ "networking" "networkmanager" "useDnsmasq" ] [ "networking" "networkmanager" "dns" ])
+    (mkRenamedOptionModule [ "networking" "networkmanager" "enableFccUnlock" ] [ "networking" "networkmanager" "enableBundledFccUnlockScripts" ])
     (mkRemovedOptionModule [ "networking" "networkmanager" "dynamicHosts" ] ''
       This option was removed because allowing (multiple) regular users to
       override host entries affecting the whole system opens up a huge attack
@@ -423,7 +425,7 @@ in
         source = "${pkg}/lib/NetworkManager/${pkg.networkManagerPlugin}";
       })
       cfg.plugins)
-    // optionalAttrs cfg.enableFccUnlock
+    // optionalAttrs cfg.enableBundledFccUnlockScripts
       {
         "ModemManager/fcc-unlock.d".source =
           "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/*";

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -5,7 +5,7 @@ with lib;
 let
   cfg = config.networking.networkmanager;
 
-  delegateWireless = config.networking.wireless.enable == true && cfg.unmanaged != [];
+  delegateWireless = config.networking.wireless.enable == true && cfg.unmanaged != [ ];
 
   enableIwd = cfg.wifi.backend == "iwd";
 
@@ -40,7 +40,7 @@ let
     })
     (mkSection "keyfile" {
       unmanaged-devices =
-        if cfg.unmanaged == [] then null
+        if cfg.unmanaged == [ ] then null
         else lib.concatStringsSep ";" cfg.unmanaged;
     })
     (mkSection "logging" {
@@ -103,7 +103,7 @@ let
   };
 
   macAddressOpt = mkOption {
-    type = types.either types.str (types.enum ["permanent" "preserve" "random" "stable"]);
+    type = types.either types.str (types.enum [ "permanent" "preserve" "random" "stable" ]);
     default = "preserve";
     example = "00:11:22:33:44:55";
     description = lib.mdDoc ''
@@ -126,7 +126,8 @@ let
     pkgs.wpa_supplicant
   ];
 
-in {
+in
+{
 
   meta = {
     maintainers = teams.freedesktop.members;
@@ -156,7 +157,7 @@ in {
           int
           str
         ]));
-        default = {};
+        default = { };
         description = lib.mdDoc ''
           Configuration for the [connection] section of NetworkManager.conf.
           Refer to
@@ -186,7 +187,7 @@ in {
 
       unmanaged = mkOption {
         type = types.listOf types.str;
-        default = [];
+        default = [ ];
         description = lib.mdDoc ''
           List of interfaces that will not be managed by NetworkManager.
           Interface name can be specified here, but if you need more fidelity,
@@ -251,7 +252,7 @@ in {
 
       appendNameservers = mkOption {
         type = types.listOf types.str;
-        default = [];
+        default = [ ];
         description = lib.mdDoc ''
           A list of name servers that should be appended
           to the ones configured in NetworkManager or received by DHCP.
@@ -260,7 +261,7 @@ in {
 
       insertNameservers = mkOption {
         type = types.listOf types.str;
-        default = [];
+        default = [ ];
         description = lib.mdDoc ''
           A list of name servers that should be inserted before
           the ones configured in NetworkManager or received by DHCP.
@@ -336,21 +337,21 @@ in {
             };
           };
         });
-        default = [];
+        default = [ ];
         example = literalExpression ''
-        [ {
-              source = pkgs.writeText "upHook" '''
+          [ {
+                source = pkgs.writeText "upHook" '''
 
-                if [ "$2" != "up" ]; then
-                    logger "exit: event $2 != up"
-                    exit
-                fi
+                  if [ "$2" != "up" ]; then
+                      logger "exit: event $2 != up"
+                      exit
+                  fi
 
-                # coreutils and iproute are in PATH too
-                logger "Device $DEVICE_IFACE coming up"
-            ''';
-            type = "basic";
-        } ]'';
+                  # coreutils and iproute are in PATH too
+                  logger "Device $DEVICE_IFACE coming up"
+              ''';
+              type = "basic";
+          } ]'';
         description = lib.mdDoc ''
           A list of scripts which will be executed in response to  network  events.
         '';
@@ -387,7 +388,7 @@ in {
       [ "networking" "networkmanager" "packages" ]
       [ "networking" "networkmanager" "plugins" ])
     (mkRenamedOptionModule [ "networking" "networkmanager" "useDnsmasq" ] [ "networking" "networkmanager" "dns" ])
-    (mkRemovedOptionModule ["networking" "networkmanager" "dynamicHosts"] ''
+    (mkRemovedOptionModule [ "networking" "networkmanager" "dynamicHosts" ] ''
       This option was removed because allowing (multiple) regular users to
       override host entries affecting the whole system opens up a huge attack
       vector. There seem to be very rare cases where this might be useful.
@@ -403,7 +404,8 @@ in {
   config = mkIf cfg.enable {
 
     assertions = [
-      { assertion = config.networking.wireless.enable == true -> cfg.unmanaged != [];
+      {
+        assertion = config.networking.wireless.enable == true -> cfg.unmanaged != [ ];
         message = ''
           You can not use networking.networkmanager with networking.wireless.
           Except if you mark some interfaces as <literal>unmanaged</literal> by NetworkManager.
@@ -414,25 +416,29 @@ in {
     hardware.wirelessRegulatoryDatabase = true;
 
     environment.etc = {
-        "NetworkManager/NetworkManager.conf".source = configFile;
-      }
-      // builtins.listToAttrs (map (pkg: nameValuePair "NetworkManager/${pkg.networkManagerPlugin}" {
+      "NetworkManager/NetworkManager.conf".source = configFile;
+    }
+    // builtins.listToAttrs (map
+      (pkg: nameValuePair "NetworkManager/${pkg.networkManagerPlugin}" {
         source = "${pkg}/lib/NetworkManager/${pkg.networkManagerPlugin}";
-      }) cfg.plugins)
-      // optionalAttrs cfg.enableFccUnlock
-         {
-           "ModemManager/fcc-unlock.d".source =
-             "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/*";
-         }
-      // optionalAttrs (cfg.appendNameservers != [] || cfg.insertNameservers != [])
-         {
-           "NetworkManager/dispatcher.d/02overridedns".source = overrideNameserversScript;
-         }
-      // listToAttrs (lib.imap1 (i: s:
-         {
-            name = "NetworkManager/dispatcher.d/${dispatcherTypesSubdirMap.${s.type}}03userscript${lib.fixedWidthNumber 4 i}";
-            value = { mode = "0544"; inherit (s) source; };
-         }) cfg.dispatcherScripts);
+      })
+      cfg.plugins)
+    // optionalAttrs cfg.enableFccUnlock
+      {
+        "ModemManager/fcc-unlock.d".source =
+          "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/*";
+      }
+    // optionalAttrs (cfg.appendNameservers != [ ] || cfg.insertNameservers != [ ])
+      {
+        "NetworkManager/dispatcher.d/02overridedns".source = overrideNameserversScript;
+      }
+    // listToAttrs (lib.imap1
+      (i: s:
+        {
+          name = "NetworkManager/dispatcher.d/${dispatcherTypesSubdirMap.${s.type}}03userscript${lib.fixedWidthNumber 4 i}";
+          value = { mode = "0544"; inherit (s) source; };
+        })
+      cfg.dispatcherScripts);
 
     environment.systemPackages = packages;
 

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -370,18 +370,6 @@ in
         '';
       };
 
-      enableBundledFccUnlockScripts = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Enable FCC unlock procedures shipped with ModemManager.
-          Since release 1.18.4, the ModemManager daemon no longer
-          automatically performs the FCC unlock procedure by default. See
-          [the docs](https://modemmanager.org/docs/modemmanager/fcc-unlock/)
-          for more details.
-        '';
-      };
-
       fccUnlockScripts = mkOption {
         type = types.listOf (types.submodule {
           options = {
@@ -410,7 +398,13 @@ in
       [ "networking" "networkmanager" "packages" ]
       [ "networking" "networkmanager" "plugins" ])
     (mkRenamedOptionModule [ "networking" "networkmanager" "useDnsmasq" ] [ "networking" "networkmanager" "dns" ])
-    (mkRenamedOptionModule [ "networking" "networkmanager" "enableFccUnlock" ] [ "networking" "networkmanager" "enableBundledFccUnlockScripts" ])
+    (mkRemovedOptionModule [ "networking" "networkmanager" "enableFccUnlock" ] ''
+      This option was removed, because using bundled FCC unlock scripts is risky,
+      might conflict with vendor-provided unlock scripts, and should
+      be a conscious decision on a per-device basis.
+      Instead it's recommended to use the
+      `networking.networkmanager.fccUnlockScripts` option.
+    '')
     (mkRemovedOptionModule [ "networking" "networkmanager" "dynamicHosts" ] ''
       This option was removed because allowing (multiple) regular users to
       override host entries affecting the whole system opens up a huge attack
@@ -538,16 +532,6 @@ in
           networkmanager-sstp
         ];
       }
-
-      # if cfg.enableBundledFccUnlockScripts is set, populate
-      # networking.networkmanager.fccUnlockScripts with the values from
-      # pkgs.modemmanager.passthru.fccUnlockScripts.
-      (mkIf cfg.enableBundledFccUnlockScripts {
-        networkmanager.fccUnlockScripts = lib.optionals cfg.enableBundledFccUnlockScripts
-          lib.mapAttrsToList
-          (id: path: { inherit id path; })
-          pkgs.modemmanager.passthru.fccUnlockScripts;
-      })
 
       (mkIf cfg.enableStrongSwan {
         networkmanager.plugins = [ pkgs.networkmanager_strongswan ];

--- a/pkgs/tools/networking/modemmanager/default.nix
+++ b/pkgs/tools/networking/modemmanager/default.nix
@@ -12,7 +12,6 @@
 , python3
 , libmbim
 , libqmi
-, modemmanager
 , systemd
 , bash-completion
 , meson
@@ -93,21 +92,6 @@ stdenv.mkDerivation rec {
     patchShebangs tools/tests/test-wrapper.sh
   '';
   installCheckTarget = "check";
-
-  passthru = {
-    # provided FCC unlock scripts. Used by the NixOS module system to symlink
-    # to them from /etc/ModemManager/fcc-unlock.d/….
-    # Most of them actually symlink to a "common" unlock script
-    fccUnlockScripts = {
-      "03f0:4e1d" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1199";
-      "105b:e0ab" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/105b";
-      "1199:9079" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1199";
-      "1eac:1001" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1eac";
-      "2c7c:030a" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/2c7c";
-      "413c:81a3" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1199";
-      "413c:81a8" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1199";
-    };
-  };
 
   meta = with lib; {
     description = "WWAN modem manager, part of NetworkManager";

--- a/pkgs/tools/networking/modemmanager/default.nix
+++ b/pkgs/tools/networking/modemmanager/default.nix
@@ -12,6 +12,7 @@
 , python3
 , libmbim
 , libqmi
+, modemmanager
 , systemd
 , bash-completion
 , meson
@@ -92,6 +93,21 @@ stdenv.mkDerivation rec {
     patchShebangs tools/tests/test-wrapper.sh
   '';
   installCheckTarget = "check";
+
+  passthru = {
+    # provided FCC unlock scripts. Used by the NixOS module system to symlink
+    # to them from /etc/ModemManager/fcc-unlock.d/….
+    # Most of them actually symlink to a "common" unlock script
+    fccUnlockScripts = {
+      "03f0:4e1d" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1199";
+      "105b:e0ab" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/105b";
+      "1199:9079" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1199";
+      "1eac:1001" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1eac";
+      "2c7c:030a" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/2c7c";
+      "413c:81a3" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1199";
+      "413c:81a8" = "${modemmanager}/share/ModemManager/fcc-unlock.available.d/1199";
+    };
+  };
 
   meta = with lib; {
     description = "WWAN modem manager, part of NetworkManager";


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/155414 introduced an option to support enabling the FCC unlock scripts that ModemManager provides, but doesn't execute (since 1.18.4). However, it wasn't possible to add additional, provided-by-the-vendor unlock scripts.

This commit fixes this up, by renaming the option from `networking.networkmanager.enableFccUnlock` to
`networking.networkmanager.enableBundledFccUnlockScripts`, and adding an additional option `networking.networkmanager.fccUnlockScripts`, which allows configuring (other) unlock scripts.

The logic is used in case
`networking.networkmanager.enableBundledFccUnlockScripts` is set to true - it'll then pick up the list of exposed
modemmanager.passthru.fccUnlockScripts and set/extend `networking.networkmanager.fccUnlockScripts` with them.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @jwygoda