### PR TITLE
flare-floss: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/tools/security/flare-floss/default.nix
+++ b/pkgs/tools/security/flare-floss/default.nix
@@ -2,32 +2,10 @@
 , python3
 , fetchFromGitHub
 }:
-let
-  py = python3.override {
-    packageOverrides = final: prev: {
-      # required for networkx 2.5.1
-      decorator = prev.decorator.overridePythonAttrs (o: o // rec {
-        version = "4.4.2";
-        src = o.src.override {
-          inherit version;
-          hash = "sha256-46YvBSAXJEDKDcyCN0kxk4Ljd/N/FAoLme9F/suEv+c=";
-        };
-      });
 
-      # flare-floss requires this exact version (newer versions are incompatible)
-      networkx = prev.networkx.overridePythonAttrs (o: o // rec {
-        version = "2.5.1";
-        src = o.src.override {
-          inherit version;
-          hash = "sha256-EJzVhcrEEpf3EQPDxCrG73N58peI61TLdRvlpmO7I1o=";
-        };
-      });
-    };
-  };
-in
-py.pkgs.buildPythonPackage rec {
+python3.pkgs.buildPythonPackage rec {
   pname = "flare-floss";
-  version = "2.2.0";
+  version = "2.3.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
@@ -35,7 +13,7 @@ py.pkgs.buildPythonPackage rec {
     repo = "flare-floss";
     rev = "refs/tags/v${version}";
     fetchSubmodules = true; # for tests
-    hash = "sha256-Oa0DMl7RKNfA00shcc4y1sNd2OiKCf0sA0EUC5gByBI=";
+    hash = "sha256-tOLnve5XBc3TtSgucPIddBHD0YJhsRpRduXsKrtJ/eQ=";
   };
 
   postPatch = ''
@@ -46,17 +24,19 @@ py.pkgs.buildPythonPackage rec {
       --replace 'sigs_path = os.path.join(get_default_root(), "sigs")' 'sigs_path = "'"$out"'/share/flare-floss/sigs"'
   '';
 
-  propagatedBuildInputs = with py.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     halo
     networkx
+    pefile
     pydantic
+    rich
     tabulate
     tqdm
     viv-utils
     vivisect
   ] ++ viv-utils.optional-dependencies.flirt;
 
-  nativeCheckInputs = with py.pkgs; [
+  nativeCheckInputs = with python3.pkgs; [
     pytest-sugar
     pytestCheckHook
     pyyaml


### PR DESCRIPTION
## Description of changes

https://github.com/mandiant/flare-floss/releases/tag/v2.3.0

This update is needed for the package to work on Python 3.11. The old pinned version of networkx doesn't work anymore, but the original error for which pinning was needed was fixed by https://github.com/mandiant/flare-floss/pull/627. Since then, the version of networkx was only pinned for Python 3.7 support (in fact, upstream recently unpinned it since they dropped support; they just haven't released that yet).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
