### PR TITLE
python310Packages.pyopengl-accelerate: unbreak on Python >= 3.10

### DIFF
--- a/pkgs/development/python-modules/pyopengl-accelerate/default.nix
+++ b/pkgs/development/python-modules/pyopengl-accelerate/default.nix
@@ -2,18 +2,29 @@
 , buildPythonPackage
 , pythonAtLeast
 , fetchPypi
+, cython_3
+, numpy
+, setuptools
+, wheel
 }:
 
 buildPythonPackage rec {
   pname = "pyopengl-accelerate";
   version = "3.1.7";
-  disabled = pythonAtLeast "3.10"; # fails to compile
+  format = "pyproject";
 
   src = fetchPypi {
     pname = "PyOpenGL-accelerate";
     inherit version;
     hash = "sha256-KxI2ISc6k59/0uwidUHjmfm11OgV1prgvbG2xwopNoA=";
   };
+
+  nativeBuildInputs = [
+    cython_3
+    numpy
+    setuptools
+    wheel
+  ];
 
   meta = {
     description = "This set of C (Cython) extensions provides acceleration of common operations for slow points in PyOpenGL 3.x";


### PR DESCRIPTION
## Description of changes

While debugging a failure in `friture`, I wondered why it was pinned to Python 3.9. Turns out pyopengl-accelerate at the time did not compile on Python >= 3.10. However, after https://github.com/mcfletch/pyopengl/commit/cee65343744e9f369fcef3d51e19697a92b4d1c6 and https://github.com/mcfletch/pyopengl/commit/bb61b56f2fc717a332b91dafb3c0c446c22b9eba, it seems that it now does. This was already released in the current version we package: 3.1.7.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
