### PR TITLE
yosys-symbiflow:  1.20230425 -> 1.20230808 (and libraries uhdm 1.57 -> 1.73, surelog 1.57->1.73) 

### DIFF
--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -10,19 +10,19 @@
 , gtest
 , uhdm
 , antlr4
-, flatbuffers
 , capnproto
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "surelog";
-  version = "1.57";
+  version = "1.73";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-Gty0OSNG5Nonyw7v2KiKP51LhiugMY7uqI6aJ6as0SQ=";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-z47Eqs3fP53pbEb3s66CqMiO4UpEwox+fKakxtRBakQ=";
+    fetchSubmodules = false;  # we use all dependencies from nix
   };
 
   nativeBuildInputs = [
@@ -40,14 +40,13 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libuuid
     gperftools
-    flatbuffers
     uhdm
     capnproto
     antlr4.runtime.cpp
   ];
 
   cmakeFlags = [
-    "-DSURELOG_USE_HOST_FLATBUFFERS=On"
+    "-DSURELOG_USE_HOST_CAPNP=On"
     "-DSURELOG_USE_HOST_UHDM=On"
     "-DSURELOG_USE_HOST_GTEST=On"
     "-DSURELOG_USE_HOST_ANTLR=On"
@@ -66,7 +65,8 @@ stdenv.mkDerivation rec {
     description = "SystemVerilog 2017 Pre-processor, Parser, Elaborator, UHDM Compiler";
     homepage = "https://github.com/chipsalliance/Surelog";
     license = lib.licenses.asl20;
+    mainProgram = "surelog";
     maintainers = with lib.maintainers; [ matthuszagh ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/applications/science/logic/uhdm/default.nix
+++ b/pkgs/applications/science/logic/uhdm/default.nix
@@ -7,15 +7,16 @@
 , gtest
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "UHDM";
-  version = "1.57";
+  version = "1.73";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-z3vURlKXCW5W2naVwJjBXcn94u80JsBxlUOIy9ylsJw=";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-VmRn51UrJTGEG4n2fi5kRv8khXakfGbqMtYPejsZCBI=";
+    fetchSubmodules = false;  # we use all dependencies from nix
   };
 
   nativeBuildInputs = [
@@ -43,4 +44,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ matthuszagh ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/compilers/yosys/plugins/symbiflow.nix
+++ b/pkgs/development/compilers/yosys/plugins/symbiflow.nix
@@ -11,17 +11,16 @@
 , capnproto
 , surelog
 , antlr4
-, flatbuffers
 , pkg-config
 }: let
 
-  version = "1.20230425";
+  version = "1.20230808";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo  = "yosys-f4pga-plugins";
     rev   = "v${version}";
-    hash  = "sha256-KNkmhvpKTby85P88+DqCOOGxIKpzbw5KF9ymqy40pfw=";
+    hash  = "sha256-wksAHLgLjVZE4Vk2QVcJN1mnQ9mxWCZHk55oO99cVJ0=";
   };
 
   # Supported symbiflow plugins.


### PR DESCRIPTION
## Description of changes

uhdm: 1.57 -> 1.73
surelog: 1.57 -> 1.73
yosys-symbiflow:  1.20230425 -> 1.20230808

These build on top of each other and are in active development, so update them all at in this PR (each of the updates is their separate commit of course).

While at it, use the `finalAttrs` pattern for Surelog and UHDM to make overrides simpler.
Also explicitly mention that we do _not_ fetch submodules to emphasize that all vendored dependencies are not from there but all come from nix.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
