### PR TITLE
python310Packages.quandl: fix tests for pandas 2

### DIFF
--- a/pkgs/development/python-modules/quandl/default.nix
+++ b/pkgs/development/python-modules/quandl/default.nix
@@ -29,8 +29,12 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit version;
     pname = "Quandl";
-    sha256 = "6e0b82fbc7861610b3577c5397277c4220e065eee0fed4e46cd6b6021655b64c";
+    hash = "sha256-bguC+8eGFhCzV3xTlyd8QiDgZe7g/tTkbNa2AhZVtkw=";
   };
+
+  patches = [
+    ./pandas2-datetime-removal.patch
+  ];
 
   propagatedBuildInputs = [
     pandas

--- a/pkgs/development/python-modules/quandl/pandas2-datetime-removal.patch
+++ b/pkgs/development/python-modules/quandl/pandas2-datetime-removal.patch
@@ -1,0 +1,33 @@
+diff --git a/test/test_datatable_data.py b/test/test_datatable_data.py
+index ee9ac61..0266a19 100644
+--- a/test/test_datatable_data.py
++++ b/test/test_datatable_data.py
+@@ -1,3 +1,4 @@
++import datetime
+ import re
+ import unittest
+ import httpretty
+@@ -135,7 +136,7 @@ class ListDatatableDataTest(unittest.TestCase):
+         df = results.to_pandas()
+         self.assertEqual(df.index.name, 'None')
+ 
+-    # if datatable has Date field then it should be convert to pandas datetime
++    # if datatable has Date field then it should be convert to datetime
+     @parameterized.expand(['GET', 'POST'])
+     def test_pandas_dataframe_date_field_is_datetime(self, request_method):
+         if request_method == 'POST':
+@@ -143,10 +144,10 @@ class ListDatatableDataTest(unittest.TestCase):
+         datatable = Datatable('ZACKS/FC')
+         results = Data.page(datatable, params={})
+         df = results.to_pandas()
+-        self.assertIsInstance(df['per_end_date'][0], pandas.datetime)
+-        self.assertIsInstance(df['per_end_date'][1], pandas.datetime)
+-        self.assertIsInstance(df['per_end_date'][2], pandas.datetime)
+-        self.assertIsInstance(df['per_end_date'][3], pandas.datetime)
++        self.assertIsInstance(df['per_end_date'][0], datetime.datetime)
++        self.assertIsInstance(df['per_end_date'][1], datetime.datetime)
++        self.assertIsInstance(df['per_end_date'][2], datetime.datetime)
++        self.assertIsInstance(df['per_end_date'][3], datetime.datetime)
+ 
+     @parameterized.expand(['GET', 'POST'])
+     def test_to_numpy_returns_numpy_object(self, request_method):


### PR DESCRIPTION
## Description of changes

The upstream has archived their repository, but this was simple enough to fix so I added a patch to deal with https://github.com/pandas-dev/pandas/pull/30489. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
