### PR TITLE
catppuccin-catwalk: adopt rust rewrite

### DIFF
--- a/pkgs/development/tools/misc/catppuccin-catwalk/default.nix
+++ b/pkgs/development/tools/misc/catppuccin-catwalk/default.nix
@@ -1,41 +1,37 @@
 { lib
-, fetchPypi
-, python3
-,
+, fetchFromGitHub
+, rustPlatform
+, installShellFiles
 }:
 
-python3.pkgs.buildPythonApplication rec {
+rustPlatform.buildRustPackage {
   pname = "catppuccin-catwalk";
-  version = "0.4.0";
-  format = "pyproject";
+  version = "0.1.0";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "catppuccin_catwalk";
-    hash = "sha256-5TAw5H3soxe9vLhfj1qs8uMr4ybrHlCj4zdsMzvPo6s=";
+  src = fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "toolbox";
+    rev = "b38153e94622bab574224bb24a6ae953b3a849da";
+    hash = "sha256-zZRl6Xem41pBQmEoK24YR4TKiQ84nU5phBih2TF8G8g=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'Pillow = "^' 'Pillow = ">='
+  buildAndTestSubdir = "catwalk";
+  cargoHash = "sha256-KoxivYLzJEjWbxIkizrMpmVwUF7bfVxl13H774lzQRg=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd catwalk \
+      --bash <("$out/bin/catwalk" completion bash) \
+      --zsh <("$out/bin/catwalk" completion zsh) \
+      --fish <("$out/bin/catwalk" completion fish)
   '';
 
-  nativeBuildInputs = with python3.pkgs; [
-    poetry-core
-  ];
-
-  propagatedBuildInputs = with python3.pkgs; [
-    pillow
-  ];
-
-  pythonImports = [
-    "catwalk"
-  ];
-
   meta = with lib; {
-    homepage = "https://github.com/catppuccin/toolbox";
+    homepage = "https://github.com/catppuccin/toolbox/tree/main/catwalk";
     description = "A CLI for Catppuccin that takes in four showcase images and displays them all at once";
     license = licenses.mit;
     maintainers = with maintainers; [ ryanccn ];
+    mainProgram = "catwalk";
   };
 }


### PR DESCRIPTION
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
