### PR TITLE
Revert "nimdow: 0.7.36->0.7.37"

### DIFF
--- a/pkgs/applications/window-managers/nimdow/default.nix
+++ b/pkgs/applications/window-managers/nimdow/default.nix
@@ -1,14 +1,14 @@
 { lib, fetchFromGitHub, nimPackages, libX11, libXft, libXinerama }:
 nimPackages.buildNimPackage rec {
   pname = "nimdow";
+  version = "0.7.36";
 
-  version = "0.7.37";
 
   src = fetchFromGitHub {
     owner = "avahe-kellenberger";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-930wDS0UW65QzpUHHOuM25oi/OhFmG0Q7N05ftu7XlI=";
+    hash = "sha256-+36wxKgboOd3HvGnD555WySzJWGL39DaFXmIaFYtSN8=";
   };
 
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#252190

I accidentially merged the above PR because I miss-saw the nixpkgs-review output.

Thanks to @vcunat telling me, please ACK this!