### PR TITLE
globaleaks: init at 4.13.0

### DIFF
--- a/pkgs/servers/web-apps/globaleaks/default.nix
+++ b/pkgs/servers/web-apps/globaleaks/default.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchPypi,
+  python3,
+  buildNpmPackage,
+  nodePackages,
+  pkg-config,
+  pixman,
+  cairo,
+  pango,
+}: let
+  python = python3.override {
+    packageOverrides = self: super: {
+      sqlalchemy = super.sqlalchemy.overridePythonAttrs rec {
+        version = "1.4.46";
+        src = fetchPypi {
+          pname = "SQLAlchemy";
+          inherit version;
+          hash = "sha256-aRO4JH2KKS74MVFipRkx4rQM6RaB8bbxj2lwRSAMSjA=";
+        };
+        disabledTestPaths = [];
+      };
+    };
+  };
+
+  pname = "globaleaks";
+  version = "4.13.0";
+
+  src = fetchFromGitHub {
+    owner = "globaleaks";
+    repo = "GlobaLeaks";
+    rev = "v${version}";
+    hash = "sha256-+eYD+nPqmAxGCaQUNewMzmSX0lw4OivIv1PSnHvZUxQ=";
+  };
+
+  meta = with lib; {
+    description = "GlobaLeaks is free, open source software enabling anyone to easily set up and maintain a secure whistleblowing platform. ";
+    license = licenses.agpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [andresnav];
+  };
+
+  clientPackage = buildNpmPackage {
+    pname = "${pname}-client";
+    inherit version src meta;
+
+    sourceRoot = "${src.name}/client";
+
+    # Errro with conflicting versions of stylelint, using `15.10.2`.
+    postPatch = ''
+      substituteInPlace npm-shrinkwrap.json \
+      --replace '"stylelint": "15.10.3",' '"stylelint": "15.10.2",'
+
+      substituteInPlace package.json \
+      --replace '"stylelint": "15.10.3",' '"stylelint": "15.10.2",'
+
+      ln -s npm-shrinkwrap.json package-lock.json
+    '';
+
+    nativeBuildInputs = [
+      nodePackages.node-gyp
+      python
+      pkg-config
+    ];
+
+    buildInputs = [
+      pixman
+      cairo
+      pango
+    ];
+
+    env = {
+      CYPRESS_INSTALL_BINARY = 0; # cypress tries to download binaries otherwise
+    };
+
+    npmDepsHash = "sha256-GgPa9zIVqI/YQmO5xpi6qmabWpQOlpV2Du2TuKJPBVQ=";
+
+    buildPhase = ''
+      runHook preBuild
+
+      node_modules/grunt/bin/grunt build
+
+      runHook postBuild
+    '';
+  };
+in
+  python.pkgs.buildPythonApplication rec {
+    inherit pname version src meta;
+
+    sourceRoot = "${src.name}/backend";
+
+    propagatedBuildInputs = with python.pkgs; [
+      twisted
+      h2
+      priority
+      sqlalchemy
+      pyotp
+      cryptography
+      pynacl
+      acme
+      python-gnupg
+      service-identity
+      debian
+      txtorcon
+      clientPackage
+    ];
+
+    # Done so globaleaks can recognize where the client is built
+    postPatch = ''
+      substituteInPlace globaleaks/settings.py \
+      --replace '/usr/share/globaleaks/client/' '${clientPackage}/lib/node_modules/GlobaLeaks/build'
+    '';
+
+    postInstall = ''
+      find $out -name "__pycache__" -type d | xargs rm -rv
+    '';
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31782,6 +31782,8 @@ with pkgs;
 
   glicol-cli = callPackage ../applications/audio/glicol-cli { };
 
+  globaleaks = callPackage ../servers/web-apps/globaleaks {};
+
   globe-cli = callPackage ../applications/misc/globe-cli { };
 
   gnmic = callPackage ../applications/networking/gnmic { };


### PR DESCRIPTION
## Description of changes

[Globaleaks website](https://www.globaleaks.org/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I have tested all the functionality, the package works the same way as the one provided for debian by the developer.
