### PR TITLE
dioxus-cli: 0.3.2 -> 0.4.0

### DIFF
--- a/pkgs/development/tools/rust/dioxus-cli/default.nix
+++ b/pkgs/development/tools/rust/dioxus-cli/default.nix
@@ -1,29 +1,47 @@
-{ lib, fetchCrate, rustPlatform, openssl, pkg-config, cacert, stdenv, CoreServices }:
+{ lib
+, stdenv
+, fetchCrate
+, rustPlatform
+, pkg-config
+, cacert
+, openssl
+, darwin
+}:
+
 rustPlatform.buildRustPackage rec {
   pname = "dioxus-cli";
-  version = "0.3.2";
+  version = "0.4.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-8S8zUOb2oiXbJQRgY/g9H2+EW+wWOQugr8+ou34CYPg=";
+    hash = "sha256-4BIuD/rrA398hPEoNt5PwWylPAR0fA1UKc90xyH5Fd0=";
   };
 
+  cargoHash = "sha256-ok+fjvwz4k0/M5j7wut2A2AK6tuO3UfZtgoCXaCaHXY=";
+
   nativeBuildInputs = [ pkg-config cacert ];
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ CoreServices ];
-
-  cargoSha256 = "sha256-sCP8njwYA29XmYu2vfuog0NCL1tZlsZiupkDVImrYCE=";
-
-  checkFlags = [
-    # these tests require dioxous binary in PATH,
-    # can be removed after: https://github.com/DioxusLabs/dioxus/pull/1138
-    "--skip=cli::autoformat::spawn_properly"
-    "--skip=cli::translate::generates_svgs"
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.CoreServices
   ];
 
+  OPENSSL_NO_VENDOR = 1;
+
+  checkFlags = [
+    # requires network access
+    "--skip=server::web::proxy::test::add_proxy"
+    "--skip=server::web::proxy::test::add_proxy_trailing_slash"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/dx --version | grep "dioxus ${version}"
+  '';
+
   meta = with lib; {
-    description = "CLI tool for developing, testing, and publishing Dioxus apps";
     homepage = "https://dioxuslabs.com";
+    description = "CLI tool for developing, testing, and publishing Dioxus apps";
     license = with licenses; [ mit asl20 ];
-    maintainers = with maintainers; [ xanderio ];
+    maintainers = with maintainers; [ xanderio cathalmullan ];
+    mainProgram = "dx";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19177,9 +19177,7 @@ with pkgs;
 
   dive = callPackage ../development/tools/dive { };
 
-  dioxus-cli = callPackage ../development/tools/rust/dioxus-cli {
-    inherit (darwin.apple_sdk.frameworks) CoreServices;
-  };
+  dioxus-cli = callPackage ../development/tools/rust/dioxus-cli { };
 
   doclifter = callPackage ../development/tools/misc/doclifter { };
 


### PR DESCRIPTION
## Description of changes

* updated package
* added myself as maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
