### PR TITLE
bcachefs: 2023-06-28 -> 2023-09-12

### DIFF
--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -62,8 +62,14 @@ in
     }
 
     (mkIf ((elem "bcachefs" config.boot.initrd.supportedFilesystems) || (bootFs != {})) {
-      # chacha20 and poly1305 are required only for decryption attempts
-      boot.initrd.availableKernelModules = [ "bcachefs" "sha256" "chacha20" "poly1305" ];
+      boot.initrd.availableKernelModules = [
+        "bcachefs"
+        "sha256" "chacha20" "poly1305" # encrypted devices
+        "crc32c" "crc64" "xxhash" # checksums
+        "lz4" "lz4hc" "zstd" # compression
+        "raid6_pq" "xor" # erasure coding
+        "mean_and_variance"
+      ];
 
       boot.initrd.systemd.extraBin = {
         "bcachefs" = "${pkgs.bcachefs-tools}/bin/bcachefs";

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -2,12 +2,12 @@
 , stdenv
 , fetchpatch
 , kernel
-, commitDate ? "2023-06-28"
+, commitDate ? "2023-09-13"
 # bcachefs-tools stores the expected-revision in:
 #   https://evilpiepirate.org/git/bcachefs-tools.git/tree/.bcachefs_revision
 # but this does not means that it'll be the latest-compatible revision
-, currentCommit ? "84f132d5696138bb038d2dc8f1162d2fab5ac832"
-, diffHash ? "sha256-RaBWBU7rXjJFb1euFAFBHWCBQAG7npaCodjp/vMYpyw="
+, currentCommit ? "15565e8cd725d6c5817ffb4bc67b6a890266b1f8"
+, diffHash ? "sha256-fvAbH+c4M7yQ0q7fjQaYvj8GYbV2ap89iXTrtSPVi2g="
 , kernelPatches # must always be defined in bcachefs' all-packages.nix entry because it's also a top-level attribute supplied by callPackage
 , argsOverride ? {}
 , ...

--- a/pkgs/tools/filesystems/bcachefs-tools/default.nix
+++ b/pkgs/tools/filesystems/bcachefs-tools/default.nix
@@ -23,16 +23,16 @@
 , fuseSupport ? false
 }:
 let
-  rev = "cfa816bf3f823a3bedfedd8e214ea929c5c755fe";
+  rev = "9fe08ba354453dddc527313f6787ddaaf5361a5e";
 in stdenv.mkDerivation {
   pname = "bcachefs-tools";
-  version = "unstable-2023-06-28";
+  version = "unstable-2023-09-08";
 
   src = fetchFromGitHub {
     owner = "koverstreet";
     repo = "bcachefs-tools";
     inherit rev;
-    hash = "sha256-XgXUwyZV5N8buYTuiu1Y1ZU3uHXjZ/OZ1kbZ9d6Rt5I=";
+    hash = "sha256-BE0PKSsexb5LaZySOjAgjgefuMz0ck3PDu+gH/UGqcM=";
   };
 
   # errors on fsck_err function. Maybe miss-detection?

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -203,8 +203,8 @@ in {
 
     linux_testing_bcachefs = callPackage ../os-specific/linux/kernel/linux-testing-bcachefs.nix {
       # Pinned on the last version which Kent's commits can be cleany rebased up.
-      kernel = linux_6_4;
-      kernelPatches = linux_6_4.kernelPatches;
+      kernel = linux_6_5;
+      kernelPatches = linux_6_5.kernelPatches;
    };
 
     linux_hardkernel_4_14 = callPackage ../os-specific/linux/kernel/linux-hardkernel-4.14.nix {


### PR DESCRIPTION
## Description of changes
Updating bcachefs.
All tests except for `bcachefsEncrypted` succeed.
Given that encryption still works on my machine, without segfaulting, the test itself or the VM environment seems to be the problem.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
