### PR TITLE
python310Packages.scikit-fuzzy: fix tests for numpy 1.25

### DIFF
--- a/pkgs/development/python-modules/scikit-fuzzy/default.nix
+++ b/pkgs/development/python-modules/scikit-fuzzy/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
+, fetchpatch
 , matplotlib
 , networkx
 , nose
@@ -24,11 +25,27 @@ buildPythonPackage rec {
     hash = "sha256-kS48aHC719wUdc2WcJa9geoMUcLHSj7ZsoRZYAhF2a0=";
   };
 
+  patches = [
+    # https://github.com/scikit-fuzzy/scikit-fuzzy/pull/299
+    (fetchpatch {
+      name = "numpy-1.25-test-compatibility-1.patch";
+      url = "https://github.com/scikit-fuzzy/scikit-fuzzy/commit/d7d114cff002e2edf9361a55cb985615e91797b5.patch";
+      hash = "sha256-udF/z94tVGRHq7gcOko4BSkvVnqe/A/bAARfCPrc06M=";
+    })
+    (fetchpatch {
+      name = "numpy-1.25-test-compatibility-2.patch";
+      url = "https://github.com/scikit-fuzzy/scikit-fuzzy/commit/f1612f6aeff34dc9329dbded7cee098fcd22ffd9.patch";
+      hash = "sha256-Le1ECR4+RjWCkfqjVrd471GD7tuVaQlZ7RZd3zvFdHU=";
+    })
+    (fetchpatch {
+      name = "numpy-1.25-test-compatibility-3.patch";
+      url = "https://github.com/scikit-fuzzy/scikit-fuzzy/commit/459b9602cf182b7b42f93aad8bcf3bda6f20bfb5.patch";
+      hash = "sha256-gKrhNpGt6XoAlMwQW70OPFZj/ZC8NhQq6dEaBpGE8yY=";
+    })
+  ];
+
   propagatedBuildInputs = [ networkx numpy scipy ];
   nativeCheckInputs = [ matplotlib nose pytestCheckHook ];
-
-  # numpy API breakage: "AttributeError: module 'numpy' has no attribute 'float'"
-  disabledTests = [ "test_fuzzy_compare" ];
 
   pythonImportsCheck = [ "skfuzzy" ];
 


### PR DESCRIPTION
## Description of changes

Fetch https://github.com/scikit-fuzzy/scikit-fuzzy/pull/299 to fix the tests when run against numpy 1.25.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
