### PR TITLE
yx: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17613,6 +17613,15 @@
     github = "twitchyliquid64";
     githubId = 6328589;
   };
+  twz123 = {
+    name = "Tom Wieczorek";
+    email = "tom@bibbu.net";
+    github = "twz123";
+    githubId = 1215104;
+    keys = [{
+      fingerprint = "B1FD 4E2A 84B2 2379 F4BF  2EF5 FE33 A228 2371 E831";
+    }];
+  };
   tylerjl = {
     email = "tyler+nixpkgs@langlois.to";
     github = "tylerjl";

--- a/pkgs/tools/text/yx/default.nix
+++ b/pkgs/tools/text/yx/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitLab, libyaml }:
+stdenv.mkDerivation rec {
+  pname = "yx";
+  version = "1.0.0";
+
+  src = fetchFromGitLab {
+    owner = "tomalok";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-oY61V9xP0DwRooabzi0XtaFsQa2GwYbuvxfERXQtYcA=";
+  };
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  strictDeps = true;
+
+  buildInputs = [ libyaml ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "YAML Data Extraction Tool";
+    homepage = "https://gitlab.com/tomalok/yx";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ twz123 ];
+    mainProgram = pname;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15078,6 +15078,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  yx = callPackage ../tools/text/yx { };
+
   zarchive = callPackage ../tools/archivers/zarchive { };
 
   zprint = callPackage ../development/tools/zprint { };


### PR DESCRIPTION
## Description of changes

Add yx from https://gitlab.com/tomalok/yx.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```console
$ nix-build -A yx
/nix/store/dax284sw028dkrp93c8ik48lr0vyzm17-yx-1.0.0

$ ls /nix/store/dax284sw028dkrp93c8ik48lr0vyzm17-yx-1.0.0/*/*
/nix/store/dax284sw028dkrp93c8ik48lr0vyzm17-yx-1.0.0/bin/yx

$ /nix/store/dax284sw028dkrp93c8ik48lr0vyzm17-yx-1.0.0/bin/yx --version
yx v1.0.0

$ /nix/store/dax284sw028dkrp93c8ik48lr0vyzm17-yx-1.0.0/bin/yx --help
YAML Data Extraction Tool
Usage: yx [<options>] [<path>]
<options> :-
  -h|--help         : show this help
  -d|--doc <n>      : parse <n>th YAML document, default: 1
  -f|--file <file>  : parse YAML from <file>, default: STDIN
  -v|--version      : display version
  --                : end of command options
<path> :-
  <key>|<index> ... : path to the data to extract
<key>               : map key value
<index>             : sequence <index> number, starts with 1
```