### PR TITLE
mailsend-go: init at 1.0.10

### DIFF
--- a/pkgs/tools/networking/mailsend-go/default.nix
+++ b/pkgs/tools/networking/mailsend-go/default.nix
@@ -1,0 +1,38 @@
+{ lib, fetchFromGitHub, gitUpdater, buildGoModule }:
+let
+  pname = "mailsend-go";
+
+  version = "1.0.10";
+
+  owner = "muquit";
+
+  rev-prefix = "v";
+
+  url = "https://github.com/${owner}/${pname}";
+in
+
+buildGoModule {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = pname;
+    rev = "${rev-prefix}${version}";
+    hash = "sha256-0coNy7gUhnC9LFVYUrgecmnwq7yW2UzisWc9iQdnh/Q=";
+  };
+
+  vendorHash = "sha256-Y6aAeMvQtWrTWHeNPymbUvwFQbEgdHy2DWm6emtZuxg=";
+
+  passthru.updateScript = gitUpdater {
+    inherit url rev-prefix;
+  };
+
+  meta = with lib; {
+    description = "Multi-platform command line tool to send mail via SMTP protocol";
+    homepage = url;
+    changelog = "https://raw.githubusercontent.com/${owner}/${pname}/${rev-prefix}${version}/ChangeLog.md";
+    license = licenses.mit;
+    maintainers = [ maintainers.jsoo1 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10636,6 +10636,8 @@ with pkgs;
 
   mailsend = callPackage ../tools/networking/mailsend { };
 
+  mailsend-go = callPackage ../tools/networking/mailsend-go { };
+
   mailutils = callPackage ../tools/networking/mailutils {
     sasl = gsasl;
   };


### PR DESCRIPTION
mailsend-go is a rewrite of mailsend in go.

mailsend is not receiving feature updates as of 2019-02-11.

## Description of changes
Adds https://github.com/muquit/mailsend-go

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
