### PR TITLE
portmod: 2.1.0 -> 2.6.2

### DIFF
--- a/pkgs/games/portmod/default.nix
+++ b/pkgs/games/portmod/default.nix
@@ -12,20 +12,20 @@
 }:
 
 let
-  version = "2.1.0";
+  version = "2.6.2";
 
   src = fetchFromGitLab {
     owner = "portmod";
     repo = "Portmod";
     rev = "v${version}";
-    hash = "sha256-b/ENApFovMPNUMbJhwY+TZCnSzpr1e/IKJ/5XAGTQjE=";
+    hash = "sha256-ufr2guaPdCvI5JOicL/lTrT3t6UlaY1hEB2xbwzhw6A=";
   };
 
   portmod-rust = rustPlatform.buildRustPackage rec {
     inherit src version;
     pname = "portmod-rust";
 
-    cargoHash = "sha256-3EfMMpSWSYsB3nXaoGGDuKQ9duyCKzbrT6oeATnzqLE=";
+    cargoHash = "sha256-sAjgGVVjgXaWbmN/eGEvatYjkHeFTZNX1GXFcJqs3GI=";
 
     nativeBuildInputs = [
       python3Packages.python
@@ -49,15 +49,24 @@ python3Packages.buildPythonApplication rec {
   inherit src version;
 
   pname = "portmod";
+  format = "pyproject";
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   # build the rust library independantly
   prePatch = ''
     substituteInPlace setup.py \
-      --replace "from setuptools_rust import Binding, RustExtension" "" \
-      --replace "RustExtension(\"portmodlib.portmod\", binding=Binding.PyO3, strip=True)" ""
+      --replace "from setuptools_rust import Binding, RustExtension, Strip" "" \
+      --replace "RustExtension(\"portmodlib.portmod\", binding=Binding.PyO3, strip=Strip.Debug)" ""
+
+    substituteInPlace pyproject.toml \
+      --replace '"setuptools-rust"' ""
   '';
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools
+    wheel
+  ];
 
   propagatedBuildInputs = with python3Packages; [
     setuptools-scm
@@ -65,6 +74,7 @@ python3Packages.buildPythonApplication rec {
     requests
     chardet
     colorama
+    deprecated
     restrictedpython
     appdirs
     gitpython
@@ -95,6 +105,9 @@ python3Packages.buildPythonApplication rec {
     "test_sync"
     "test_manifest"
     "test_add_repo"
+    "test_init_prefix_interactive"
+    "test_scan_sources"
+    "test_unpack"
   ];
 
   # for some reason, installPhase doesn't copy the compiled binary


### PR DESCRIPTION
## Description of changes

Lots of change in https://gitlab.com/portmod/portmod/-/blob/master/CHANGELOG.md?ref_type=heads#262-2023-05-06.

This is needed for Python 3.11 support. Since this derivation is a bit complex, I tried to leave the structure of it as untouched as possible for expediency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
