### PR TITLE
privacyidea: fix build by pinning factory_boy to 3.2.1

### DIFF
--- a/pkgs/applications/misc/privacyidea/default.nix
+++ b/pkgs/applications/misc/privacyidea/default.nix
@@ -7,6 +7,8 @@ let
     outputs = lib.filter (x: x != "doc") outputs;
   };
 
+  # Follow issue below for Python 3.11 support
+  # https://github.com/privacyidea/privacyidea/issues/3593
   python3' = python310.override {
     packageOverrides = self: super: {
       django = super.django_3;
@@ -19,6 +21,15 @@ let
           hash = "sha256-67t3fL+TEjWbiXv4G6ANrg9ctp+6KhgmXcwYpvXvdRk=";
         };
         doCheck = false;
+      });
+      # version 3.3.0+ does not support SQLAlchemy 1.3
+      factory_boy = super.factory_boy.overridePythonAttrs (oldAttrs: rec {
+        version = "3.2.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          hash = "sha256-qY0newwEfHXrbkq4UIp/gfsD0sshmG9ieRNUbveipV4=";
+        };
+        postPatch = "";
       });
       # fails with `no tests ran in 1.75s`
       alembic = super.alembic.overridePythonAttrs (lib.const {
@@ -180,6 +191,7 @@ in
 python3'.pkgs.buildPythonPackage rec {
   pname = "privacyIDEA";
   version = "3.8.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = pname;


### PR DESCRIPTION
## Description of changes

According to Hydra, [this package](https://hydra.nixos.org/build/233333525/nixlog/59) is failing because factory_boy 3.3.0 changed some imports that were deprecated in SQLAlchemy 2 and no longer works with SQLAlchemy 1.3 (it might not even with 1.4, that remains to be seen). SQLAlchemy 1.4 support will be released in v3.9 of privacyidea, and 2.0 still will take some time, and we can reevaluate then.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
