### PR TITLE
sudo-rs: init at 0.2.0

### DIFF
--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -192,6 +192,10 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
+    assertions = [
+      { assertion = cfg.package.pname != "sudo-rs";
+        message = "The NixOS `sudo` module does not work with `sudo-rs` yet."; }
+    ];
 
     # We `mkOrder 600` so that the default rule shows up first, but there is
     # still enough room for a user to `mkBefore` it.

--- a/pkgs/tools/security/sudo-rs/default.nix
+++ b/pkgs/tools/security/sudo-rs/default.nix
@@ -1,6 +1,7 @@
 { lib
 , bash
 , fetchFromGitHub
+, fetchpatch
 , installShellFiles
 , pam
 , pandoc
@@ -22,6 +23,15 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ installShellFiles pandoc ];
 
   buildInputs = [ pam ];
+
+  patches = [
+    (fetchpatch {
+      # @R-VdP's patch to work with NixOS' suid wrappers
+      name = "Skip self_check when executed as root.patch";
+      url = "https://github.com/R-VdP/sudo-rs/commit/a44541dcb36b94f938daaed66b3ff06cfc1c2b40.patch";
+      hash = "sha256-PdmOqp/NDjFy8ve4jEOi58e0N9xUnaVKioQwdC5Jf1U=";
+    })
+  ];
 
   # Don't attempt to generate the docs in a (pan)Docker container
   postPatch = ''

--- a/pkgs/tools/security/sudo-rs/default.nix
+++ b/pkgs/tools/security/sudo-rs/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, bash
+, fetchFromGitHub
+, installShellFiles
+, pam
+, pandoc
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sudo-rs";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "memorysafety";
+    repo = "sudo-rs";
+    rev = "v${version}";
+    hash = "sha256-Kk5D3387hdl6eGWTSV003r+XajuDh6YgHuqYlj9NnaQ=";
+  };
+  cargoHash = "sha256-yeMK37tOgJcs9pW3IclpR5WMXx0gMDJ2wcmInxJYbQ8=";
+
+  nativeBuildInputs = [ installShellFiles pandoc ];
+
+  buildInputs = [ pam ];
+
+  # Don't attempt to generate the docs in a (pan)Docker container
+  postPatch = ''
+    substituteInPlace util/generate-docs.sh \
+      --replace "/usr/bin/env bash" ${lib.getExe bash} \
+      --replace util/pandoc.sh pandoc
+  '';
+
+  postInstall = ''
+    ./util/generate-docs.sh
+    installManPage target/docs/man/*
+  '';
+
+  checkFlags = map (t: "--skip=${t}") [
+    # Those tests make path assumptions
+    "common::command::test::test_build_command_and_args"
+    "common::context::tests::test_build_context"
+    "common::resolve::test::canonicalization"
+    "common::resolve::tests::test_resolve_path"
+    "system::tests::kill_test"
+
+    # Assumes $SHELL is an actual shell
+    "su::context::tests::su_to_root"
+
+    # Attempts to access /etc files from the build sandbox
+    "system::audit::test::secure_open_is_predictable"
+
+    # Assume there is a `daemon` user and group
+    "system::interface::test::test_unix_group"
+    "system::interface::test::test_unix_user"
+    "system::tests::test_get_user_and_group_by_id"
+
+    # This expects some PATH_TZINFO environment var
+    "env::environment::tests::test_tzinfo"
+
+    # Unsure why those are failing
+    "env::tests::test_environment_variable_filtering"
+    "su::context::tests::invalid_shell"
+  ];
+
+  meta = with lib; {
+    description = "A memory safe implementation of sudo and su.";
+    homepage = "https://github.com/memorysafety/sudo-rs";
+    changelog = "${meta.homepage}/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ nicoo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13433,6 +13433,8 @@ with pkgs;
 
   sudo = callPackage ../tools/security/sudo { };
 
+  sudo-rs = callPackage ../tools/security/sudo-rs { };
+
   suidChroot = callPackage ../tools/system/suid-chroot { };
 
   sundtek = callPackage ../misc/drivers/sundtek { };


### PR DESCRIPTION
## Description of changes

- [x] packaged `sudo-rs`, a pure-Rust, mostly-compatible implementation of sudo
- [ ] *didn't* work (in this PRs) on the NixOS modules to allow users to switch to it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

