### PR TITLE
vala: work around clang 16 function pointer errors

### DIFF
--- a/pkgs/development/compilers/vala/setup-hook.sh
+++ b/pkgs/development/compilers/vala/setup-hook.sh
@@ -7,6 +7,15 @@ make_vala_find_vapi_files() {
 
 addEnvHooks "$hostOffset" make_vala_find_vapi_files
 
+disable_incompabile_pointer_conversion_warning() {
+    # Work around incompatible function pointer conversion errors with clang 16
+    # by setting ``-Wno-incompatible-function-pointer-types` in an env hook.
+    # See https://gitlab.gnome.org/GNOME/vala/-/issues/1413.
+    NIX_CFLAGS_COMPILE+=" -Wno-incompatible-function-pointer-types"
+}
+
+addEnvHooks "$hostOffset" disable_incompabile_pointer_conversion_warning
+
 _multioutMoveVapiDirs() {
   moveToOutput share/vala/vapi "${!outputDev}"
   moveToOutput share/vala-@apiVersion@/vapi "${!outputDev}"


### PR DESCRIPTION
## Description of changes

Clang 16 makes casting function pointers between incompatible types an error, which causes Vala to fail to build things using glib-2.0.vapi.

See https://gitlab.gnome.org/GNOME/vala/-/issues/1413.

I tested that libsecret built using Vala with this patch and a clang 16 stdenv from #241692.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
