### PR TITLE
python3Packages.magic-wormhole: fix tests in darwin sandbox

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , fetchpatch
@@ -47,6 +48,12 @@ buildPythonPackage rec {
     mock
     twisted
   ];
+
+  # Fails in Darwin's sandbox
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    echo 'LogRequests.skip = "Operation not permitted"' >> src/wormhole_mailbox_server/test/test_web.py
+    echo 'WebSocketAPI.skip = "Operation not permitted"' >> src/wormhole_mailbox_server/test/test_web.py
+  '';
 
   checkPhase = ''
     trial -j$NIX_BUILD_CORES wormhole_mailbox_server

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -56,6 +56,31 @@ buildPythonPackage rec {
   disabledTests = [
     # Expected: (<class 'wormhole.errors.WrongPasswordError'>,) Got: Failure instance: Traceback (failure with no frames): <class 'wormhole.errors.LonelyError'>:
     "test_welcome"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # These tests doesn't work within Darwin's sandbox
+    "test_version"
+    "test_text"
+    "test_receiver"
+    "test_sender"
+    "test_sender_allocation"
+    "test_text_wrong_password"
+    "test_override"
+    "test_allocate_port"
+    "test_allocate_port_no_reuseaddr"
+    "test_ignore_localhost_hint"
+    "test_ignore_localhost_hint_orig"
+    "test_keep_only_localhost_hint"
+    "test_get_direct_hints"
+    "test_listener"
+    "test_success_direct"
+    "test_direct"
+    "test_relay"
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.isDarwin [
+    # These tests doesn't work within Darwin's sandbox
+    "src/wormhole/test/test_xfer_util.py"
+    "src/wormhole/test/test_wormhole.py"
   ];
 
   postPatch = lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- `python3Packages.magic-wormhole-mailbox-server`: disable tests on darwin
- `python3Packages.magic-wormhole`: disable certains tests on darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
