### PR TITLE
gitui: 0.23.0 -> 0.24.1

### DIFF
--- a/pkgs/applications/version-management/gitui/default.nix
+++ b/pkgs/applications/version-management/gitui/default.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gitui";
-  version = "0.23.0";
+  version = "0.24.1";
 
   src = fetchFromGitHub {
     owner = "extrawurst";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-Mz4/Q1EmTg3vXIYbIdr5MtemGrBSkvBBwcfz+McEaJ8=";
+    hash = "sha256-FcOpLCLoeY+uZA+IMWNxUUbu9yieNVqPl4iiV8BDpTE=";
   };
 
-  cargoHash = "sha256-hsu3WQfqMnD5frJP6wDcexG7HafXmzs5ZIGePGOBRVs=";
+  cargoHash = "sha256-UvMtA+2inMLBjQA+17nozI/VrU1NR0A7eym1VyjYoAg=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -37,10 +37,18 @@ rustPlatform.buildRustPackage rec {
   # environment: delete them.
   postPatch = "rm .cargo/config";
 
+
+  # Getting app_config_path fails with a permission denied
+  checkFlags = [
+    "--skip=keys::key_config::tests::test_symbolic_links"
+  ];
+
+
   meta = with lib; {
     description = "Blazing fast terminal-ui for Git written in Rust";
     homepage = "https://github.com/extrawurst/gitui";
     changelog = "https://github.com/extrawurst/gitui/blob/${version}/CHANGELOG.md";
+    mainProgram = "gitui";
     license = licenses.mit;
     maintainers = with maintainers; [ Br1ght0ne yanganto mfrw ];
   };

--- a/pkgs/applications/version-management/gitui/default.nix
+++ b/pkgs/applications/version-management/gitui/default.nix
@@ -42,6 +42,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/extrawurst/gitui";
     changelog = "https://github.com/extrawurst/gitui/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne yanganto ];
+    maintainers = with maintainers; [ Br1ght0ne yanganto mfrw ];
   };
 }


### PR DESCRIPTION

## Description of changes
Changelog: https://github.com/extrawurst/gitui/blob/0.24.1/CHANGELOG.md
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
