### PR TITLE
nodePackages.terser: use buildNpmPackage

### DIFF
--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -110,6 +110,7 @@ mapAliases {
   stf = throw "stf was removed because it was broken"; # added 2023-08-21
   surge = pkgs.surge-cli; # Added 2023-09-08
   swagger = throw "swagger was removed because it was broken and abandoned upstream"; # added 2023-09-09
+  inherit (pkgs) terser; # Added 2023-08-31
   thelounge = pkgs.thelounge; # Added 2023-05-22
   three = throw "three was removed because it was no longer needed"; # Added 2023-09-08
   inherit (pkgs) titanium; # added 2023-08-17

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -242,7 +242,6 @@
 , {"tedicross": "git+https://github.com/TediCross/TediCross.git#v0.8.7"}
 , "teck-programmer"
 , "tern"
-, "terser"
 , "textlint"
 , "textlint-plugin-latex"
 , "textlint-rule-abbr-within-parentheses"

--- a/pkgs/development/tools/misc/terser/default.nix
+++ b/pkgs/development/tools/misc/terser/default.nix
@@ -1,0 +1,22 @@
+{ buildNpmPackage, fetchFromGitHub, lib }:
+
+buildNpmPackage rec {
+  pname = "terser";
+  version = "5.19.3";
+
+  src = fetchFromGitHub {
+    owner = "terser";
+    repo = "terser";
+    rev = "v${version}";
+    hash = "sha256-ZI5ElHnQwoCJspGL/v0PqddMUAAhQGWDZA9utWZD/nM=";
+  };
+
+  npmDepsHash = "sha256-M7LGXoZFBQrXpkiofnam7tgFkk6+N7ckPxTcwAAuqxU=";
+
+  meta = with lib; {
+    description = "JavaScript parser, mangler and compressor toolkit for ES6+";
+    homepage = "https://terser.org";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ talyz ];
+  };
+}

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -41,6 +41,7 @@
 , dart-sass-embedded
 , jq
 , moreutils
+, terser
 
 , plugins ? []
 }@args:
@@ -223,7 +224,7 @@ let
       postgresql
       redis
       nodePackages.uglify-js
-      nodePackages.terser
+      terser
       nodePackages.patch-package
       yarn
       nodejs_16

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20430,6 +20430,8 @@ with pkgs;
 
   terrascan = callPackage ../tools/security/terrascan { };
 
+  terser = callPackage ../development/tools/misc/terser { };
+
   tesh = callPackage ../tools/text/tesh {};
 
   texinfo413 = callPackage ../development/tools/misc/texinfo/4.13a.nix { };


### PR DESCRIPTION
## Description of changes
See https://github.com/NixOS/nixpkgs/issues/229475.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
