### PR TITLE
ocamlPackages.krb: add v0.16

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.16.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.16.nix
@@ -5,6 +5,7 @@
 , lib
 , openssl
 , zstd
+, krb5
 }:
 
 with self;
@@ -426,6 +427,13 @@ with self;
     '';
   };
 
+  hex_encode = janePackage {
+    pname = "hex_encode";
+    hash = "sha256-jnsf5T1D1++AUdrato/NO3gTVXu14klXozHFIG9HH/o=";
+    meta.description = "Hexadecimal encoding library";
+    propagatedBuildInputs = [ core ppx_jane ounit ];
+  };
+
   higher_kinded = janePackage {
     pname = "higher_kinded";
     hash = "sha256-aCpYc7f4mrPsGp038YabEyw72cA6GbCKsok+5Hej5P0=";
@@ -523,6 +531,13 @@ with self;
     hash = "sha256-GviY+zYza7UNYOlAnfAz0aH4LH2B5xA+7iELLuZLgQQ=";
     meta.description = "Compile-time configuration for Jane Street libraries";
     buildInputs = [ dune-configurator ppx_assert stdio ];
+  };
+
+  krb = janePackage {
+    pname = "krb";
+    hash = "sha256-+XwYKwpl668fZ23YEbL1wW9PlaIIjbP/hHwNanf3dAY=";
+    meta.description = "A library for using Kerberos for both Rpc and Tcp communication";
+    propagatedBuildInputs = [ async base core env_config hex_encode ppx_jane protocol_version_header username_kernel dune-configurator krb5 ];
   };
 
   lru_cache = janePackage {
@@ -1182,6 +1197,13 @@ with self;
     hash = "sha256-iJnIjWZYCTaH29x7nFviCrbnTmHRChZkkj6E5sgi4mU=";
     meta.description = "Typerep is a library for runtime types";
     propagatedBuildInputs = [ base ];
+  };
+
+  username_kernel = janePackage {
+    pname = "username_kernel";
+    hash = "sha256-UvFL/M9OsD+SOs9MYMKiKzZilLJHzriop6SPA4bOhZQ=";
+    meta.description = "An identifier for a user";
+    propagatedBuildInputs = [ core ppx_jane ];
   };
 
   variantslib = janePackage {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -730,7 +730,7 @@ let
       if lib.versionOlder "4.13.1" ocaml.version
       then import ../development/ocaml-modules/janestreet/0.16.nix {
         inherit self;
-        inherit (pkgs) bash fetchpatch fzf lib openssl zstd;
+        inherit (pkgs) bash fetchpatch fzf lib openssl zstd krb5;
       }
       else if lib.versionOlder "4.10.2" ocaml.version
       then import ../development/ocaml-modules/janestreet/0.15.nix {


### PR DESCRIPTION
## Description of changes

A library for using Kerberos for both Rpc and Tcp communication.

https://github.com/janestreet/krb

Two more libraries added as dependencies, also at v0.16:
- [username_kernel](https://github.com/janestreet/username_kernel)
- [hex_encode](https://github.com/janestreet/hex_encode)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).