### PR TITLE
btrfsmaintenance: init at 0.5

### DIFF
--- a/pkgs/tools/misc/btrfsmaintenance/default.nix
+++ b/pkgs/tools/misc/btrfsmaintenance/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, btrfs-progs
+, coreutils
+, findutils
+, gnugrep
+, gnused
+, makeWrapper
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "btrfsmaintenance";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "kdave";
+    repo = "btrfsmaintenance";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-wD9AWOaYtCZqU2YIxO6vEDIHCNQBygvFzRHW3LOQRqk=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    btrfs-progs
+    coreutils
+    findutils
+    gnused
+    gnugrep
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 sysconfig.btrfsmaintenance "$out/etc/default/btrfsmaintenance"
+    install -dm755 "$out/"{usr/lib/systemd/system,usr/share/btrfsmaintenance}
+    install -Dm755 btrfs-*.sh btrfsmaintenance-{functions,refresh-cron.sh} README.md "$out/usr/share/btrfsmaintenance"
+    install -Dm644 *.service *.timer *.path "$out/usr/lib/systemd/system"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    for f in $out/usr/share/btrfsmaintenance/*; do
+      substituteInPlace $f \
+        --replace "PATH=/sbin:/bin:/usr/sbin:/usr/bin" "" \
+        --replace "export PATH" "" \
+        --replace "$(dirname $(realpath "$0"))/btrfsmaintenance-functions" ". $out/usr/share/btrfsmaintenance/btrfsmaintenance-functions"
+
+      wrapProgram $f --prefix PATH : ${lib.makeBinPath finalAttrs.buildInputs}
+    done
+  '';
+
+  # Just a collection of scripts and systemd services
+  dontConfigure = true;
+  dontBuild = true;
+
+  meta = {
+    description = "A set of scripts supplementing the btrfs filesystem and aims to automate a few maintenance tasks";
+    homepage = "https://github.com/kdave/btrfsmaintenance";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ khaneliman ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3551,6 +3551,8 @@ with pkgs;
 
   btrfs-heatmap = callPackage ../tools/filesystems/btrfs-heatmap { };
 
+  btrfsmaintenance = callPackage ../tools/misc/btrfsmaintenance { };
+
   bucklespring = bucklespring-x11;
   bucklespring-libinput = callPackage ../applications/audio/bucklespring { };
   bucklespring-x11 = callPackage ../applications/audio/bucklespring { legacy = true; };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
