### PR TITLE
python3Packages.auditok: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/auditok/default.nix
+++ b/pkgs/development/python-modules/auditok/default.nix
@@ -1,0 +1,44 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, matplotlib
+, numpy
+, pyaudio
+, pydub
+, pythonOlder
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "auditok";
+  version = "0.1.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "auditok";
+    hash = "sha256-HNsw9VLP7XEgs8E2X6p7ygDM47AwWxMYjptipknFig4=";
+  };
+
+  propagatedBuildInputs = [ matplotlib numpy pyaudio pydub ];
+
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
+
+  pythonImportsCheck = [ "auditok" ];
+
+  # The most recent version is 0.2.0, but the only dependent package is
+  # ffsubsync, which is pinned at 0.1.5.
+  passthru.skipBulkUpdate = true;
+
+  meta = with lib; {
+    description = "Audio Activity Detection tool that can process online data as well as audio files";
+    homepage = "https://github.com/amsehili/auditok/";
+    changelog = "https://github.com/amsehili/auditok/blob/v${version}/CHANGELOG";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Benjamin-L ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -852,6 +852,8 @@ self: super: with self; {
     inherit (pkgs.darwin.apple_sdk.frameworks) AudioToolbox AudioUnit CoreServices;
   };
 
+  auditok = callPackage ../development/python-modules/auditok { };
+
   augeas = callPackage ../development/python-modules/augeas {
     inherit (pkgs) augeas;
   };


### PR DESCRIPTION
## Description of changes

Add version 0.1.5 of the [auditok](https://github.com/amsehili/auditok/) package, needed for [ffsubsync](https://github.com/smacke/ffsubsync).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Original version of the PR was written by @Arguggi: https://github.com/NixOS/nixpkgs/pull/209430.

The most recent version of the package is 0.2.0, but ffsubsync pins the dependency at 0.1.5. Since there are no other dependents, I'm just adding a package for 0.1.5. Notably, 0.2.0 uses a different test framework (genty) which is not in nixpkgs. I'm not really sure what the standard way to handle this is, so let me know if I should do it differently.

In addition to the tests for this package, I also packaged ffsubsync in a separate [branch](https://github.com/Benjamin-L/nixpkgs/commit/26ef5516adf8df91ce72739a6e5d77755c6c374e) and tested it.

<details>
<summary>nixpkgs-review output</summary>

```
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   a187151e27a2..469b34a242da  master     -> refs/nixpkgs-review/0
$ git worktree add /Users/benjamin/.cache/nixpkgs-review/rev-5bd4a7ec990c5d8e49325199ad169fa5027f4f76/nixpkgs 469b34a242dab7e989cc7993513c7a3e7649f7b9
Preparing worktree (detached HEAD 469b34a242da)
Updating files: 100% (37070/37070), done.
HEAD is now at 469b34a242da Merge pull request #252803 from adamcstephens/river/mainProgram
$ nix-env --extra-experimental-features no-url-literals --option system aarch64-darwin -f <nixpkgs> --nix-path nixpkgs=/Users/benjamin/.cache/nixpkgs-review/rev-5bd4a7ec990c5d8e49325199ad169fa5027f4f76/nixpkgs nixpkgs-overlays=/tmp/tmp8tc
tg1eq -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff 5bd4a7ec990c5d8e49325199ad169fa5027f4f76
Auto-merging pkgs/top-level/python-packages.nix
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system aarch64-darwin -f <nixpkgs> --nix-path nixpkgs=/Users/benjamin/.cache/nixpkgs-review/rev-5bd4a7ec990c5d8e49325199ad169fa5027f4f76/nixpkgs nixpkgs-overlays=/tmp/tmp8tctg1eq -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
2 packages added:
python310Packages.auditok (init at 0.1.5) python311Packages.auditok (init at 0.1.5)

$ nix build --nix-path nixpkgs=/Users/benjamin/.cache/nixpkgs-review/rev-5bd4a7ec990c5d8e49325199ad169fa5027f4f76/nixpkgs nixpkgs-overlays=/tmp/tmp8tctg1eq --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation -f /Users/benjamin/.cache/nixpkgs-review/rev-5bd4a7ec990c5d8e49325199ad169fa5027f4f76/build.nix
4 packages built:
python310Packages.auditok python310Packages.auditok.dist python311Packages.auditok python311Packages.auditok.dist

$ /nix/store/6qr5z1f6dhi0w7agzw59flyf5sfpw4g8-nix-2.17.0/bin/nix-shell /Users/benjamin/.cache/nixpkgs-review/rev-5bd4a7ec990c5d8e49325199ad169fa5027f4f76/shell.nix --nix-path nixpkgs=/Users/benjamin/.cache/nixpkgs-review/rev-5bd4a7ec990c5d8e49325199ad169fa5027f4f76/nixpkgs nixpkgs-overlays=/tmp/tmp8tctg1eq
this path will be fetched (1.00 MiB download, 7.91 MiB unpacked):
  /nix/store/lpfc1myy7zrfwypvzw56jz58s0c8msx9-bash-interactive-5.2-p15
copying path '/nix/store/lpfc1myy7zrfwypvzw56jz58s0c8msx9-bash-interactive-5.2-p15' from 'https://cache.nixos.org'...
```
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
