### PR TITLE
bind: disable tests on *all* 32-bit platforms

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -79,7 +79,9 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   # TODO: investigate the aarch64-linux failures; see this and linked discussions:
   # https://github.com/NixOS/nixpkgs/pull/192962
-  doCheck = with stdenv.hostPlatform; !isStatic && !(isAarch64 && isLinux) && !isi686;
+  doCheck = with stdenv.hostPlatform; !isStatic && !(isAarch64 && isLinux)
+    # https://gitlab.isc.org/isc-projects/bind9/-/issues/4269
+    && !is32bit;
   checkTarget = "unit";
   checkInputs = [
     cmocka


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/250563#issuecomment-1702271179
https://gitlab.isc.org/isc-projects/bind9/-/issues/4269#note_397062

_The usual checklist doesn't really apply here._