### PR TITLE
maintainers: add vilsol, latvia-eid-middleware: init at 2.1.1, eparakstitajs3: init at 1.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18013,6 +18013,12 @@
     githubId = 90482;
     name = "Viktor Nordling";
   };
+  vilsol = {
+    email = "me@vil.so";
+    github = "vilsol";
+    githubId = 1759390;
+    name = "Vilsol";
+  };
   viluon = {
     email = "nix@viluon.me";
     github = "viluon";

--- a/pkgs/applications/misc/eparakstitajs3/default.nix
+++ b/pkgs/applications/misc/eparakstitajs3/default.nix
@@ -1,0 +1,129 @@
+{
+  lib,
+  pkgs,
+  stdenv,
+  fetchurl,
+  buildFHSEnv,
+  bash,
+  writeText,
+  makeDesktopItem,
+  copyDesktopItems,
+  writeScriptBin,
+  runtimeShell,
+  autoPatchelfHook
+}:
+
+let
+  eparakstitajs = (
+    stdenv.mkDerivation rec {
+      pname = "eparakstitajs3";
+      version = "1.7.1";
+
+      src = fetchurl {
+        url = "https://www.eparaksts.lv/files/ep3updates/eparakstitajs3-${version}_amd64.tar.gz";
+        sha256 = "sha256-OdoJqZvw3umqEpvzbKN2qmF4Mq0XSC7AIu8DlJ061L4=";
+      };
+
+      nativeBuildInputs = [
+        copyDesktopItems
+      ];
+
+      desktopItems = [
+        (makeDesktopItem {
+          name = "eparakstitajs3";
+          desktopName = "eParakstītājs 3.0";
+          exec = "eparakstitajs3";
+          icon = "eparakstitajs3";
+          comment = "LVRTC signed document authoring tool";
+          categories = [
+            "Application"
+            "Viewer"
+          ];
+          mimeTypes = [
+            "application/pdf"
+            "application/lv.eme.edoc"
+            "application/vnd.etsi.asic-e+zip"
+          ];
+        })
+      ];
+
+      fakeDPKG = writeScriptBin "dpkg" ''
+        #!${runtimeShell}
+
+        # A dpkg shim
+        # This app has hardcoded calls for version checks
+
+        usage() {
+            echo 'dpkg -s <pkg-name>'
+            exit 1
+        }
+
+        if [ -z "$1" ] || [ "$1" != "-s" ] || [ -z "$2" ]; then usage; fi
+
+        if [ "$2" = "latvia-eid-middleware" ]; then
+          echo "Package: latvia-eid-middleware"
+          echo "Version: ${pkgs.latvia-eid-middleware.version}"
+          echo "Status: install ok installed"
+          exit 0
+        fi
+
+        exit 1
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp -r ./ $out
+
+        mkdir -p $out/lib/app/lib/native/linux64
+        cp -r ./lib/native/linux64/* $out/lib/app/lib/native/linux64/
+
+        mkdir -p $out/bin/special
+        ln -s ${fakeDPKG}/bin/dpkg $out/bin/special/dpkg
+
+        runHook postInstall
+      '';
+    }
+  );
+in
+buildFHSEnv rec {
+  name = "eparakstitajs3";
+
+  targetPkgs = pkgs: with pkgs; [
+    alsa-lib
+    glib
+    gtk2
+    gtk2-x11
+    gtk3
+    gtk3-x11
+    latvia-eid-middleware
+    opensc
+    pango
+    pcscliteWithPolkit
+    xdg-utils
+    xorg.libX11
+    xorg.libXext
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXtst
+    zlib
+  ];
+
+  runScript = "${bash}/bin/bash ${
+    writeText "eparakstitajs3-wrapper"
+    ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${eparakstitajs}/lib/native/linux64
+    export PATH=$PATH:${eparakstitajs}/bin/special
+    ${eparakstitajs}/bin/eparakstitajs3
+    ''
+  }";
+
+  meta = with lib; {
+    description = "Application software to sign and validate documents in EDOC and PDF formats.";
+    homepage = "https://www.eparaksts.lv/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ vilsol ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/latvia-eid-middleware/default.nix
+++ b/pkgs/tools/misc/latvia-eid-middleware/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchurl, pkgs, autoPatchelfHook }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkgs,
+  autoPatchelfHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "latvia-eid-middleware";

--- a/pkgs/tools/misc/latvia-eid-middleware/default.nix
+++ b/pkgs/tools/misc/latvia-eid-middleware/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchurl, pkgs, autoPatchelfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "latvia-eid-middleware";
+  version = "2.1.1";
+
+  src = fetchurl {
+    url = "https://www.eparaksts.lv/files/ep3updates/debian/pool/eparaksts/l/latvia-eid-middleware/latvia-eid-middleware_${version}-1_amd64.deb";
+    sha256 = "sha256-k91y90INXeiRGm5ATW9k0094c72Yij23afSLGGRk0Lg=";
+  };
+
+  nativeBuildInputs = [
+    pkgs.dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = with pkgs; [
+    at-spi2-atk
+    glib
+    gtk2
+    gcc
+    libGLU
+    pcsclite
+    xorg.libSM
+    xorg.libXxf86vm
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r ./opt/latvia-eid/* $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Middleware for using Latvia-eid smart cards.";
+    homepage = "https://www.pmlp.gov.lv";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ vilsol ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31539,6 +31539,8 @@ with pkgs;
 
   eos-installer = callPackage ../applications/misc/eos-installer { };
 
+  latvia-eid-middleware = callPackage ../tools/misc/latvia-eid-middleware { };
+
   epdfview = callPackage ../applications/misc/epdfview { };
 
   epeg = callPackage ../applications/graphics/epeg { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31539,6 +31539,8 @@ with pkgs;
 
   eos-installer = callPackage ../applications/misc/eos-installer { };
 
+  eparakstitajs3 = callPackage ../applications/misc/eparakstitajs3 { };
+
   latvia-eid-middleware = callPackage ../tools/misc/latvia-eid-middleware { };
 
   epdfview = callPackage ../applications/misc/epdfview { };


### PR DESCRIPTION
## Description of changes

Add Latvian [eParaksts](https://www.eparaksts.lv/en/) signing tools and application.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
