### PR TITLE
coq_8_18: init at 8.18+rc1

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -55,6 +55,7 @@ let
    "8.16.1".sha256   = "sha256-n7830+zfZeyYHEOGdUo57bH6bb2/SZs8zv8xJhV+iAc=";
    "8.17.0".sha256   = "sha256-TGwm7S6+vkeZ8cidvp8pkiAd9tk008jvvPvYgfEOXhM=";
    "8.17.1".sha256   = "sha256-x+RwkbxMg9aR0L3WSCtpIz8jwA5cJA4tXAtHMZb20y4=";
+   "8.18+rc1".sha256   = "sha256-TmV0lzfzhpSnBoVyfTfVFUyBrXpUWSnyN1Le7b8IPTs=";
   };
   releaseRev = v: "V${v}";
   fetched = import ../../../../build-support/coq/meta-fetch/default.nix
@@ -73,7 +74,7 @@ let
   '';
   ocamlPackages = if customOCamlPackages != null then customOCamlPackages
     else with versions; switch coq-version [
-      { case = range "8.16" "8.17"; out = ocamlPackages_4_14; }
+      { case = range "8.16" "8.18"; out = ocamlPackages_4_14; }
       { case = range "8.14" "8.15"; out = ocamlPackages_4_12; }
       { case = range "8.11" "8.13"; out = ocamlPackages_4_10; }
       { case = range "8.7" "8.10";  out = ocamlPackages_4_09; }

--- a/pkgs/development/coq-modules/Cheerios/default.nix
+++ b/pkgs/development/coq-modules/Cheerios/default.nix
@@ -5,7 +5,7 @@ mkCoqDerivation {
   owner   = "uwplse";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.version [
-    { case = range "8.14" "8.17"; out = "20230107"; }
+    { case = range "8.14" "8.18"; out = "20230107"; }
     { case = range "8.6"  "8.16"; out = "20200201"; }
   ] null;
   release."20230107".rev    = "bad8ad2476e14df6b5a819b7aaddc27a7c53fb69";

--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -5,7 +5,7 @@ mkCoqDerivation {
   owner = "fblanqui";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.version [
-    {case = range "8.14" "8.17"; out = "1.8.4"; }
+    {case = range "8.14" "8.18"; out = "1.8.4"; }
     {case = range "8.12" "8.16"; out = "1.8.2"; }
     {case = range "8.10" "8.11"; out = "1.7.0"; }
     {case = range "8.8"  "8.9";  out = "1.6.0"; }

--- a/pkgs/development/coq-modules/HoTT/default.nix
+++ b/pkgs/development/coq-modules/HoTT/default.nix
@@ -6,19 +6,20 @@ mkCoqDerivation {
   owner = "HoTT";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.14" "8.17"; out = coq.coq-version; }
+    { case = range "8.14" "8.18"; out = coq.coq-version; }
   ] null;
   releaseRev = v: "V${v}";
   release."8.14".sha256 = "sha256-7kXk2pmYsTNodHA+Qts3BoMsewvzmCbYvxw9Sgwyvq0=";
   release."8.15".sha256 = "sha256-JfeiRZVnrjn3SQ87y6dj9DWNwCzrkK3HBogeZARUn9g=";
   release."8.16".sha256 = "sha256-xcEbz4ZQ+U7mb0SEJopaczfoRc2GSgF2BGzUSWI0/HY=";
   release."8.17".sha256 = "sha256-GjTUpzL9UzJm4C2ilCaYEufLG3hcj7rJPc5Op+OMal8=";
+  release."8.18".sha256 = "sha256-URoUoQOsG0432wg9i6pTRomWQZ+ewutq2+V29TBrVzc=";
 
   # versions of HoTT for Coq 8.17 and onwards will use dune
   # opam-name = if lib.versions.isLe "8.17" coq.coq-version then "coq-hott" else null;
   opam-name = "coq-hott";
   useDune = lib.versions.isGe "8.17" coq.coq-version;
-  
+
   patchPhase = ''
     patchShebangs etc
   '';

--- a/pkgs/development/coq-modules/InfSeqExt/default.nix
+++ b/pkgs/development/coq-modules/InfSeqExt/default.nix
@@ -5,7 +5,7 @@ mkCoqDerivation {
   owner = "DistributedComponents";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.version [
-    { case = range "8.9" "8.17"; out = "20230107"; }
+    { case = range "8.9" "8.18"; out = "20230107"; }
     { case = range "8.5" "8.16"; out = "20200131"; }
   ] null;
   release."20230107".rev    = "601e89ec019501c48c27fcfc14b9a3c70456e408";

--- a/pkgs/development/coq-modules/LibHyps/default.nix
+++ b/pkgs/development/coq-modules/LibHyps/default.nix
@@ -4,7 +4,7 @@ mkCoqDerivation {
   pname = "LibHyps";
   owner = "Matafou";
   inherit version;
-  defaultVersion = if (lib.versions.range "8.11" "8.17") coq.version then "2.0.4.1" else null;
+  defaultVersion = if (lib.versions.range "8.11" "8.18") coq.version then "2.0.4.1" else null;
   release = {
     "2.0.4.1".sha256 = "09p89701zhrfdmqlpxw3mziw8yylj1w1skb4b0xpbdwd1vsn4k3h";
   };

--- a/pkgs/development/coq-modules/StructTact/default.nix
+++ b/pkgs/development/coq-modules/StructTact/default.nix
@@ -5,7 +5,7 @@ mkCoqDerivation {
   owner = "uwplse";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.9" "8.17"; out = "20230107"; }
+    { case = range "8.9" "8.18"; out = "20230107"; }
     { case = range "8.6" "8.16"; out = "20210328"; }
     { case = range "8.5" "8.13"; out = "20181102"; }
   ] null;

--- a/pkgs/development/coq-modules/Verdi/default.nix
+++ b/pkgs/development/coq-modules/Verdi/default.nix
@@ -6,7 +6,7 @@ mkCoqDerivation {
   owner = "uwplse";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.9" "8.17"; out = "20230503"; }
+    { case = range "8.9" "8.18"; out = "20230503"; }
     { case = range "8.7" "8.16"; out = "20211026"; }
     { case = range "8.7" "8.14"; out = "20210524"; }
     { case = range "8.7" "8.13"; out = "20200131"; }

--- a/pkgs/development/coq-modules/aac-tactics/default.nix
+++ b/pkgs/development/coq-modules/aac-tactics/default.nix
@@ -5,6 +5,7 @@ mkCoqDerivation {
 
   releaseRev = v: "v${v}";
 
+  release."8.18.0".sha256 = "sha256-Vpe79qCyFLOdOtFFvLKR0N+MMpGD661Q01yx4gxRhZo=";
   release."8.17.0".sha256 = "sha256-c8DtD21QFDZEVyCQc7ScPZEMTmolxlT3+Db3gStofF8=";
   release."8.16.0".sha256 = "sha256-sE1w8q/60adNF9yMJQO70CEk3D8QUopvgiszdHt5Wsw=";
   release."8.15.1".sha256 = "sha256:0k2sl3ns897a5ll11bazgpv4ppgi1vmx4n89v2dnxabm5dglyglp";
@@ -22,6 +23,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = "8.18"; out = "8.18.0"; }
     { case = "8.17"; out = "8.17.0"; }
     { case = "8.16"; out = "8.16.0"; }
     { case = "8.15"; out = "8.15.1"; }

--- a/pkgs/development/coq-modules/addition-chains/default.nix
+++ b/pkgs/development/coq-modules/addition-chains/default.nix
@@ -12,7 +12,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.13" "8.17"; out = "0.6"; }
+    { case = range "8.13" "8.18"; out = "0.6"; }
     { case = range "8.11" "8.12"; out = "0.4"; }
   ] null;
 

--- a/pkgs/development/coq-modules/autosubst/default.nix
+++ b/pkgs/development/coq-modules/autosubst/default.nix
@@ -11,7 +11,7 @@ mkCoqDerivation {
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.10" "8.13"; out = "1.7"; }
-    { case = range "8.14" "8.17"; out = "1.8"; }
+    { case = range "8.14" "8.18"; out = "1.8"; }
   ] null;
 
   propagatedBuildInputs = [ mathcomp-ssreflect ];

--- a/pkgs/development/coq-modules/bignums/default.nix
+++ b/pkgs/development/coq-modules/bignums/default.nix
@@ -5,10 +5,11 @@ mkCoqDerivation {
   owner = "coq";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.13" "8.17"; out = "9.0.0+coq${coq.coq-version}"; }
+    { case = range "8.13" "8.18"; out = "9.0.0+coq${coq.coq-version}"; }
     { case = range "8.6" "8.17"; out = "${coq.coq-version}.0"; }
   ] null;
 
+  release."9.0.0+coq8.18".sha256 = "sha256-vLeJ0GNKl4M84Uj2tAwlrxJOSR6VZoJQvdlDhxJRge8=";
   release."9.0.0+coq8.17".sha256 = "sha256-Mn85LqxJKPDIfpxRef9Uh5POwOKlTQ7jsMVz1wnQwuY=";
   release."9.0.0+coq8.16".sha256 = "sha256-pwFTl4Unr2ZIirAB3HTtfhL2YN7G/Pg88RX9AhKWXbE=";
   release."9.0.0+coq8.15".sha256 = "sha256-2oGOANn3XULHNIlyqjZ5ppQTQa2QF1zzf3YjHAd/pjo=";

--- a/pkgs/development/coq-modules/ceres/default.nix
+++ b/pkgs/development/coq-modules/ceres/default.nix
@@ -8,7 +8,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.version [
-    { case = range "8.14" "8.17"; out = "0.4.1"; }
+    { case = range "8.14" "8.18"; out = "0.4.1"; }
     { case = range "8.8"  "8.16"; out = "0.4.0"; }
   ] null;
   release."0.4.1".sha256 = "sha256-9vyk8/8IVsqNyhw3WPzl8w3L9Wu7gfaMVa3n2nWjFiA=";

--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -9,6 +9,7 @@ with builtins; with lib; let
     { case = "8.15"; out = { version = "1.15.0"; };}
     { case = "8.16"; out = { version = "1.17.0"; };}
     { case = "8.17"; out = { version = "1.17.0"; };}
+    { case = "8.18"; out = { version = "1.17.0"; };}
   ] {} );
 in mkCoqDerivation {
   pname = "elpi";
@@ -16,6 +17,7 @@ in mkCoqDerivation {
   owner = "LPCIC";
   inherit version;
   defaultVersion = lib.switch coq.coq-version [
+    { case = "8.18"; out = "1.19.0"; }
     { case = "8.17"; out = "1.18.0"; }
     { case = "8.16"; out = "1.15.6"; }
     { case = "8.15"; out = "1.14.0"; }
@@ -24,6 +26,7 @@ in mkCoqDerivation {
     { case = "8.12"; out = "1.8.3_8.12"; }
     { case = "8.11"; out = "1.6.3_8.11"; }
   ] null;
+  release."1.19.0".sha256     = "sha256-kGoo61nJxeG/BqV+iQaV3iinwPStND+7+fYMxFkiKrQ=";
   release."1.18.0".sha256     = "sha256-2fCOlhqi4YkiL5n8SYHuc3pLH+DArf9zuMH7IhpBc2Y=";
   release."1.17.0".sha256     = "sha256-J8GatRKFU0ekNCG3V5dBI+FXypeHcLgC5QJYGYzFiEM=";
   release."1.15.6".sha256     = "sha256-qc0q01tW8NVm83801HHOBHe/7H1/F2WGDbKO6nCXfno=";

--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -5,7 +5,7 @@ mkCoqDerivation rec {
   owner = "coq-ext-lib";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.11" "8.17"; out = "0.11.8"; }
+    { case = range "8.11" "8.18"; out = "0.11.8"; }
     { case = range "8.8" "8.16"; out = "0.11.6"; }
     { case = range "8.8" "8.14"; out = "0.11.4"; }
     { case = range "8.8" "8.13"; out = "0.11.3"; }

--- a/pkgs/development/coq-modules/coq-record-update/default.nix
+++ b/pkgs/development/coq-modules/coq-record-update/default.nix
@@ -5,7 +5,7 @@
   owner = "tchajed";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.10" "8.17";  out = "0.3.1"; }
+    { case = range "8.10" "8.18";  out = "0.3.1"; }
   ] null;
   release."0.3.1".sha256 = "sha256-DyGxO2tqmYZZluXN6Oy5Tw6fuLMyuyxonj8CCToWKkk=";
   release."0.3.0".sha256 = "1ffr21dd6hy19gxnvcd4if2450iksvglvkd6q5713fajd72hmc0z";

--- a/pkgs/development/coq-modules/coqeal/default.nix
+++ b/pkgs/development/coq-modules/coqeal/default.nix
@@ -8,7 +8,7 @@
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ]  [
-      { cases = [ (range "8.15" "8.17") (isGe "1.15.0") ]; out = "1.1.3"; }
+      { cases = [ (range "8.15" "8.18") (isGe "1.15.0") ]; out = "1.1.3"; }
       { cases = [ (range "8.13" "8.17") (isGe "1.13.0") ]; out = "1.1.1"; }
       { cases = [ (range "8.10" "8.15") (isGe "1.12.0") ]; out = "1.1.0"; }
       { cases = [ (isGe "8.10") (range "1.11.0" "1.12.0") ]; out = "1.0.5"; }

--- a/pkgs/development/coq-modules/coqprime/default.nix
+++ b/pkgs/development/coq-modules/coqprime/default.nix
@@ -6,7 +6,7 @@ mkCoqDerivation {
   owner = "thery";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.14" "8.17"; out = "8.17"; }
+    { case = range "8.14" "8.18"; out = "8.17"; }
     { case = range "8.12" "8.16"; out = "8.15"; }
     { case = range "8.10" "8.11"; out = "8.10"; }
     { case = range "8.8"  "8.9";  out = "8.8"; }

--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -7,7 +7,7 @@ mkCoqDerivation {
   domain = "gitlab.inria.fr";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.12" "8.17"; out = "3.4.0"; }
+    { case = range "8.12" "8.18"; out = "3.4.0"; }
     { case = range "8.12" "8.17"; out = "3.3.0"; }
     { case = range "8.8" "8.16"; out = "3.2.0"; }
     { case = range "8.8" "8.13"; out = "3.1.0"; }

--- a/pkgs/development/coq-modules/deriving/default.nix
+++ b/pkgs/development/coq-modules/deriving/default.nix
@@ -8,7 +8,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.11" "8.17"; out = "0.1.1"; }
+    { case = range "8.11" "8.18"; out = "0.1.1"; }
   ] null;
 
   releaseRev = v: "v${v}";

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -6,6 +6,7 @@
   repo = "Coq-Equations";
   inherit version;
   defaultVersion = lib.switch coq.coq-version [
+    { case = "8.18"; out = "1.3+8.18"; }
     { case = "8.17"; out = "1.3+8.17"; }
     { case = "8.16"; out = "1.3+8.16"; }
     { case = "8.15"; out = "1.3+8.15"; }
@@ -57,6 +58,8 @@
     release."1.3+8.16".sha256         = "sha256-zyMGeRObtSGWh7n3WCqesBZL5EgLvKwmnTy09rYpxyE=";
     release."1.3+8.17".rev            = "v1.3-8.17";
     release."1.3+8.17".sha256         = "sha256-yNotSIxFkhTg3reZIchGQ7cV9WmTJ7p7hPfKGBiByDw=";
+    release."1.3+8.18".rev            = "v1.3-8.18";
+    release."1.3+8.18".sha256         = "sha256-8MZO9vWdr8wlAov0lBTYMnde0RuMyhaiM99zp7Zwfao=";
 
   mlPlugin = true;
 

--- a/pkgs/development/coq-modules/extructures/default.nix
+++ b/pkgs/development/coq-modules/extructures/default.nix
@@ -9,7 +9,7 @@
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch [coq.coq-version ssreflect.version] [
-    { cases = [(range "8.11" "8.17") (isGe "1.12.0") ]; out = "0.3.1"; }
+    { cases = [(range "8.11" "8.18") (isGe "1.12.0") ]; out = "0.3.1"; }
     { cases = [(range "8.11" "8.14") (isLe "1.12.0") ]; out = "0.3.0"; }
     { cases = [(range "8.10" "8.12") (isLe "1.12.0") ]; out = "0.2.2"; }
   ] null;

--- a/pkgs/development/coq-modules/fourcolor/default.nix
+++ b/pkgs/development/coq-modules/fourcolor/default.nix
@@ -9,10 +9,12 @@ mkCoqDerivation {
   release."1.2.3".sha256 = "sha256-gwKfUa74fIP7j+2eQgnLD7AswjCtOFGHGaIWb4qI0n4=";
   release."1.2.4".sha256 = "sha256-iSW2O1kuunvOqTolmGGXmsYTxo2MJYCdW3BnEhp6Ksg=";
   release."1.2.5".sha256 = "sha256-3qOPNCRjGK2UdHGMSqElpIXhAPVCklpeQgZwf9AFals=";
+  release."1.3.0".sha256 = "sha256-h9pa6vaKT6jCEaIdEdcu0498Ou5kEXtZdb9P7WXK1DQ=";
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ] [
-    { cases = [ (isGe "8.11") (isGe "1.12") ]; out = "1.2.5"; }
+    { cases = [ (isGe "8.16") (isGe "2.0") ]; out = "1.3.0"; }
+    { cases = [ (isGe "8.11") (range "1.12" "1.17") ]; out = "1.2.5"; }
     { cases = [ (isGe "8.11") (range "1.11" "1.14") ]; out = "1.2.4"; }
     { cases = [ (isLe "8.13") (lib.pred.inter (isGe "1.11.0") (isLt "1.13")) ]; out = "1.2.3"; }
   ] null;

--- a/pkgs/development/coq-modules/mathcomp-algebra-tactics/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-algebra-tactics/default.nix
@@ -9,7 +9,7 @@ mkCoqDerivation {
 
   defaultVersion = with lib.versions;
      lib.switch [ coq.coq-version mathcomp-algebra.version ] [
-       { cases = [ (range "8.16" "8.17") (isGe "1.15") ]; out = "1.1.1"; }
+       { cases = [ (range "8.16" "8.18") (isGe "1.15") ]; out = "1.1.1"; }
        { cases = [ (range "8.13" "8.16") (isGe "1.12") ]; out = "1.0.0"; }
      ] null;
 

--- a/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
@@ -12,7 +12,7 @@ mkCoqDerivation {
   };
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.version [
-    { case = range "8.10" "8.17"; out = "1.0.1"; }
+    { case = range "8.10" "8.18"; out = "1.0.1"; }
     { case = range "8.5"  "8.14"; out = "1.0.0"; }
   ] null;
 

--- a/pkgs/development/coq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-finmap/default.nix
@@ -7,8 +7,9 @@ mkCoqDerivation {
   owner = "math-comp";
   inherit version;
   defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ]  [
-      { cases = [ (range "8.13" "8.18")  (isGe "1.12") ];         out = "1.5.2"; }
-      { cases = [ (isGe "8.10")          (isGe "1.11") ];         out = "1.5.1"; }
+      { cases = [ (range "8.16" "8.18")  (isGe "2.0") ];          out = "2.0.0"; }
+      { cases = [ (range "8.13" "8.18")  (range "1.12" "1.17") ]; out = "1.5.2"; }
+      { cases = [ (isGe "8.10")          (range "1.11" "1.17") ]; out = "1.5.1"; }
       { cases = [ (range "8.7" "8.11")   "1.11.0" ];              out = "1.5.0"; }
       { cases = [ (isEq "8.11")          (range "1.8" "1.10") ];  out = "1.4.0+coq-8.11"; }
       { cases = [ (range "8.7" "8.11.0") (range "1.8" "1.10") ];  out = "1.4.0"; }
@@ -17,6 +18,7 @@ mkCoqDerivation {
       { cases = [ (range "8.6" "8.7")    (range "1.6.1" "1.7") ]; out = "1.0.0"; }
     ] null;
   release = {
+    "2.0.0".sha256          = "sha256-0Wr1ZUYVuZH74vawO4EZlZ+K3kq+s1xEz/BfzyKj+wk=";
     "1.5.2".sha256          = "sha256-0KmmSjc2AlUo6BKr9RZ4FjL9wlGISlTGU0X1Eu7l4sw=";
     "1.5.1".sha256          = "0ryfml4pf1dfya16d8ma80favasmrygvspvb923n06kfw9v986j7";
     "1.5.0".sha256          = "0vx9n1fi23592b3hv5p5ycy7mxc8qh1y5q05aksfwbzkk5zjkwnq";

--- a/pkgs/development/coq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-finmap/default.nix
@@ -7,7 +7,7 @@ mkCoqDerivation {
   owner = "math-comp";
   inherit version;
   defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ]  [
-      { cases = [ (range "8.13" "8.17")  (isGe "1.12") ];         out = "1.5.2"; }
+      { cases = [ (range "8.13" "8.18")  (isGe "1.12") ];         out = "1.5.2"; }
       { cases = [ (isGe "8.10")          (isGe "1.11") ];         out = "1.5.1"; }
       { cases = [ (range "8.7" "8.11")   "1.11.0" ];              out = "1.5.0"; }
       { cases = [ (isEq "8.11")          (range "1.8" "1.10") ];  out = "1.4.0+coq-8.11"; }

--- a/pkgs/development/coq-modules/mathcomp-tarjan/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-tarjan/default.nix
@@ -9,9 +9,13 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with lib.versions;
-    lib.switch [ coq.version mathcomp-ssreflect.version ] [{
-      cases = [ (range "8.10" "8.16") (isGe "1.12.0") ]; out = "1.0.0";
-  }] null;
+    lib.switch [ coq.version mathcomp-ssreflect.version ] [
+      { cases = [ (range "8.16" "8.18") (isGe "2.0.0") ]; out = "1.0.2"; }
+      { cases = [ (range "8.12" "8.18") (range "1.12.0" "1.17.0") ]; out = "1.0.1"; }
+      { cases = [ (range "8.10" "8.16") (range "1.12.0" "1.17.0") ]; out = "1.0.0"; }
+  ] null;
+  release."1.0.2".sha256 = "sha256-U20xgA+e9KTRdvILD1cxN6ia+dlA8uBTIbc4QlKz9ss=";
+  release."1.0.1".sha256 = "sha256-utNjFCAqC5xOuhdyKhfMZkRYJD0xv9Gt6U3ZdQ56mek=";
   release."1.0.0".sha256 = "sha256:0r459r0makshzwlygw6kd4lpvdjc43b3x5y9aa8x77f2z5gymjq1";
 
   propagatedBuildInputs = [ mathcomp-ssreflect mathcomp-fingroup ];

--- a/pkgs/development/coq-modules/mathcomp-word/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-word/default.nix
@@ -16,7 +16,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ] [
-    { cases = [ (range "8.12" "8.17") (isGe "1.12") ]; out = "2.1"; }
+    { cases = [ (range "8.12" "8.18") (isGe "1.12") ]; out = "2.1"; }
   ] null;
 
   propagatedBuildInputs = [ mathcomp.algebra mathcomp.ssreflect mathcomp.fingroup ];

--- a/pkgs/development/coq-modules/mathcomp-zify/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-zify/default.nix
@@ -9,13 +9,15 @@ mkCoqDerivation rec {
 
   defaultVersion = with lib.versions;
      lib.switch [ coq.coq-version mathcomp-algebra.version ] [
-       { cases = [ (range "8.13" "8.18") (isGe "1.12") ]; out = "1.3.0+1.12+8.13"; }
-       { cases = [ (range "8.13" "8.16") (isGe "1.12") ]; out = "1.1.0+1.12+8.13"; }
+       { cases = [ (range "8.16" "8.18") (isGe "2.0.0") ]; out = "1.5.0+2.0+8.16"; }
+       { cases = [ (range "8.13" "8.18") (range "1.12" "1.17.0") ]; out = "1.3.0+1.12+8.13"; }
+       { cases = [ (range "8.13" "8.16") (range "1.12" "1.17.0") ]; out = "1.1.0+1.12+8.13"; }
      ] null;
 
   release."1.0.0+1.12+8.13".sha256 = "1j533vx6lacr89bj1bf15l1a0s7rvrx4l00wyjv99aczkfbz6h6k";
   release."1.1.0+1.12+8.13".sha256 = "1plf4v6q5j7wvmd5gsqlpiy0vwlw6hy5daq2x42gqny23w9mi2pr";
   release."1.3.0+1.12+8.13".sha256 = "sha256-ebfY8HatP4te44M6o84DSLpDCkMu4IroPCy+HqzOnTE=";
+  release."1.5.0+2.0+8.16".sha256 = "sha256-boBYGvXdGFc6aPnjgSZYSoW4kmN5khtNrSV3DUv9DqM=";
 
   propagatedBuildInputs = [ mathcomp-algebra mathcomp-ssreflect mathcomp-fingroup ];
 

--- a/pkgs/development/coq-modules/mathcomp-zify/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-zify/default.nix
@@ -9,7 +9,7 @@ mkCoqDerivation rec {
 
   defaultVersion = with lib.versions;
      lib.switch [ coq.coq-version mathcomp-algebra.version ] [
-       { cases = [ (range "8.13" "8.17") (isGe "1.12") ]; out = "1.3.0+1.12+8.13"; }
+       { cases = [ (range "8.13" "8.18") (isGe "1.12") ]; out = "1.3.0+1.12+8.13"; }
        { cases = [ (range "8.13" "8.16") (isGe "1.12") ]; out = "1.1.0+1.12+8.13"; }
      ] null;
 

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -20,8 +20,8 @@ let
   withDoc = single && (args.withDoc or false);
   defaultVersion = with versions; lib.switch coq.coq-version [
       { case = isGe "8.15"; out = "1.17.0"; }
-      { case = range "8.16" "8.17"; out = "2.0.0"; }
-      { case = range "8.13" "8.17"; out = "1.16.0"; }
+      { case = range "8.16" "8.18"; out = "2.0.0"; }
+      { case = range "8.13" "8.18"; out = "1.16.0"; }
       { case = range "8.14" "8.16"; out = "1.15.0"; }
       { case = range "8.11" "8.15"; out = "1.14.0"; }
       { case = range "8.11" "8.15"; out = "1.13.0"; }

--- a/pkgs/development/coq-modules/metalib/default.nix
+++ b/pkgs/development/coq-modules/metalib/default.nix
@@ -5,7 +5,7 @@
   owner = "plclub";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.14" "8.17"; out = "8.15"; }
+    { case = range "8.14" "8.18"; out = "8.15"; }
     { case = range "8.10" "8.13"; out = "8.10"; }
   ] null;
   releaseRev = v: "coq${v}";

--- a/pkgs/development/coq-modules/multinomials/default.nix
+++ b/pkgs/development/coq-modules/multinomials/default.nix
@@ -9,8 +9,9 @@
 
   inherit version;
   defaultVersion =  with lib.versions; lib.switch [ coq.version mathcomp.version ] [
-      { cases = [ (isGe "8.15") (isGe "1.15.0") ];      out = "1.6.0"; }
-      { cases = [ (isGe "8.10") (isGe "1.13.0") ];      out = "1.5.6"; }
+      { cases = [ (isGe "8.16") (isGe "2.0.0") ];               out = "2.0.0"; }
+      { cases = [ (isGe "8.15") (range "1.15.0" "1.17.0") ];    out = "1.6.0"; }
+      { cases = [ (isGe "8.10") (range "1.13.0" "1.17.0") ];    out = "1.5.6"; }
       { cases = [ (range "8.10" "8.16") (range "1.12.0" "1.15.0") ]; out = "1.5.5"; }
       { cases = [ (range "8.10" "8.12") "1.12.0" ];             out = "1.5.3"; }
       { cases = [ (range "8.7" "8.12")  "1.11.0" ];             out = "1.5.2"; }
@@ -19,6 +20,7 @@
       { cases = [ "8.6"                 (range "1.6" "1.7") ];  out = "1.1"; }
     ] null;
   release = {
+    "2.0.0".sha256 = "sha256-2zWHzMBsO2j8EjN7CgCmKQcku9Be8aVlme0LD5p4ab8=";
     "1.6.0".sha256 = "sha256-lEM+sjqajIOm1c3lspHqcSIARgMR9RHbTQH4veHLJfU=";
     "1.5.6".sha256 = "sha256-cMixgc34T9Ic6v+tYmL49QUNpZpPV5ofaNuHqblX6oY=";
     "1.5.5".sha256 = "sha256-VdXA51vr7DZl/wT/15YYMywdD7Gh91dMP9t7ij47qNQ=";

--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -5,7 +5,7 @@ mkCoqDerivation {
   owner = "snu-sf";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.13" "8.17"; out = "4.2.0"; }
+    { case = range "8.13" "8.18"; out = "4.2.0"; }
     { case = range "8.12" "8.17"; out = "4.1.2"; }
     { case = range "8.9" "8.13"; out = "4.1.1"; }
     { case = range "8.6" "8.13"; out = "4.0.2"; }

--- a/pkgs/development/coq-modules/paramcoq/default.nix
+++ b/pkgs/development/coq-modules/paramcoq/default.nix
@@ -4,10 +4,11 @@ mkCoqDerivation {
   pname = "paramcoq";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.version [
-    { case = range "8.10" "8.17"; out = "1.1.3+coq${coq.coq-version}"; }
+    { case = range "8.10" "8.18"; out = "1.1.3+coq${coq.coq-version}"; }
     { case = range "8.7"  "8.13"; out = "1.1.2+coq${coq.coq-version}"; }
   ] null;
   displayVersion = { paramcoq = "..."; };
+  release."1.1.3+coq8.18".sha256 = "sha256-hNBaj9hB+OzwXsOX+TOXtDLjA5oP4EmEgseLwxFxW+I=";
   release."1.1.3+coq8.17".sha256 = "sha256-m8QGGuwj1lHzDprf4LHgAuzwfoblxtDIHunHBdpmiuM=";
   release."1.1.3+coq8.16".sha256 = "sha256-K7/8hXH6DwiW7Gw41sgQF8UDAO3c32xBGWQQapzG8Mo=";
   release."1.1.3+coq8.15".sha256 = "0sl7ihznwz05d2x2v78w1zd4q55c1sgy06vxasbcls4v2pkw53hl";

--- a/pkgs/development/coq-modules/parsec/default.nix
+++ b/pkgs/development/coq-modules/parsec/default.nix
@@ -11,7 +11,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.version [
-    { case = range "8.14" "8.17"; out = "0.1.2"; }
+    { case = range "8.14" "8.18"; out = "0.1.2"; }
     { case = range "8.12" "8.16"; out = "0.1.1"; }
     { case = range "8.12" "8.13"; out = "0.1.0"; }
   ] null;

--- a/pkgs/development/coq-modules/reglang/default.nix
+++ b/pkgs/development/coq-modules/reglang/default.nix
@@ -10,7 +10,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.10" "8.17"; out = "1.1.3"; }
+    { case = range "8.10" "8.18"; out = "1.1.3"; }
   ] null;
 
 

--- a/pkgs/development/coq-modules/semantics/default.nix
+++ b/pkgs/development/coq-modules/semantics/default.nix
@@ -15,7 +15,7 @@ mkCoqDerivation rec {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.10" "8.17"; out = "8.14.0"; }
+    { case = range "8.10" "8.18"; out = "8.14.0"; }
     { case = "8.9"; out = "8.9.0"; }
     { case = "8.8"; out = "8.8.0"; }
     { case = "8.7"; out = "8.7.0"; }

--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -6,7 +6,7 @@
   repo = "coq-simple-io";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
-    { case = range "8.11" "8.17"; out = "1.8.0"; }
+    { case = range "8.11" "8.18"; out = "1.8.0"; }
     { case = range "8.7"  "8.13"; out = "1.3.0"; }
   ] null;
   release."1.8.0".sha256 = "sha256-3ADNeXrBIpYRlfUW+LkLHUWV1w1HFrVc/TZISMuwvRY=";

--- a/pkgs/development/coq-modules/topology/default.nix
+++ b/pkgs/development/coq-modules/topology/default.nix
@@ -5,6 +5,7 @@ mkCoqDerivation rec {
 
   releaseRev = v: "v${v}";
 
+  release."10.2.0".sha256 = "sha256-xLi3uRQBKL9KiLd4FBnbTPxh8TjdN8IEW/1D7n2B+xY=";
   release."9.0.0".sha256 = "sha256:03lgy53xg9pmrdd3d8qb4087k5qjnk260655svp6d79x4p2lxr8c";
   release."8.12.0".sha256 = "sha256-ypHmHwzwZ6MQPYwuS3QyZmVOEPUCSbO2lhVaA6TypgQ=";
   release."8.10.0".sha256 = "sha256-mCLF3JYIiO3AEW9yvlcLeF7zN4SjW3LG+Y5vYB0l55A=";
@@ -15,6 +16,7 @@ mkCoqDerivation rec {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = range "8.12" "8.18"; out = "10.2.0"; }
     { case = range "8.10" "8.16"; out = "9.0.0"; }
     { case = "8.9"; out = "8.9.0"; }
     { case = "8.8"; out = "8.8.0"; }

--- a/pkgs/development/coq-modules/trakt/default.nix
+++ b/pkgs/development/coq-modules/trakt/default.nix
@@ -11,7 +11,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch [ coq.version ] [
-    { cases = [ (range "8.15" "8.17") ]; out = "1.2"; }
+    { cases = [ (range "8.15" "8.18") ]; out = "1.2"; }
     { cases = [ (isEq "8.13") ]; out = "1.2+8.13"; }
     { cases = [ (range "8.13" "8.17") ]; out = "1.1"; }
   ] null;

--- a/pkgs/development/coq-modules/zorns-lemma/default.nix
+++ b/pkgs/development/coq-modules/zorns-lemma/default.nix
@@ -2,9 +2,11 @@
 
 (mkCoqDerivation {
   pname = "zorns-lemma";
+  repo  = "topology";
 
   releaseRev = v: "v${v}";
 
+  release."10.2.0".sha256 = "sha256-xLi3uRQBKL9KiLd4FBnbTPxh8TjdN8IEW/1D7n2B+xY=";
   release."9.0.0".sha256 = "sha256:03lgy53xg9pmrdd3d8qb4087k5qjnk260655svp6d79x4p2lxr8c";
   release."8.11.0".sha256 = "sha256-2Hf7YwRcFmP/DqwFtF1p78MCNV50qUWfMVQtZbwKd0k=";
   release."8.10.0".sha256 = "sha256-qLPLK2ZLJQ4SmJX2ADqFiP4kgHuQFJTeNXkBbjiFS+4=";
@@ -16,6 +18,7 @@
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = range "8.12" "8.18"; out = "10.2.0"; }
     { case = range "8.10" "8.16"; out = "9.0.0"; }
     { case = "8.9"; out = "8.9.0"; }
     { case = "8.8"; out = "8.8.0"; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39671,6 +39671,7 @@ with pkgs;
     coqPackages_8_15 coq_8_15
     coqPackages_8_16 coq_8_16
     coqPackages_8_17 coq_8_17
+    coqPackages_8_18 coq_8_18
     coqPackages      coq
   ;
 

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -181,6 +181,7 @@ in rec {
   coq_8_15 = mkCoq "8.15";
   coq_8_16 = mkCoq "8.16";
   coq_8_17 = mkCoq "8.17";
+  coq_8_18 = mkCoq "8.18";
 
   coqPackages_8_5 = mkCoqPackages coq_8_5;
   coqPackages_8_6 = mkCoqPackages coq_8_6;
@@ -195,6 +196,7 @@ in rec {
   coqPackages_8_15 = mkCoqPackages coq_8_15;
   coqPackages_8_16 = mkCoqPackages coq_8_16;
   coqPackages_8_17 = mkCoqPackages coq_8_17;
+  coqPackages_8_18 = mkCoqPackages coq_8_18;
   coqPackages = recurseIntoAttrs coqPackages_8_17;
   coq = coqPackages.coq;
 


### PR DESCRIPTION
## Description of changes

https://coq.github.io/doc/V8.18+rc1/refman/changes.html#version-8-18

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

