### PR TITLE
python311Packages.mkdocs-swagger-ui-tag: 0.6.2 -> 0.6.4

### DIFF
--- a/pkgs/development/python-modules/mkdocs-swagger-ui-tag/default.nix
+++ b/pkgs/development/python-modules/mkdocs-swagger-ui-tag/default.nix
@@ -1,22 +1,26 @@
 { lib
+, beautifulsoup4
 , buildPythonPackage
 , drawio-headless
-, fetchPypi
-, pythonOlder
+, fetchFromGitHub
 , mkdocs
-, beautifulsoup4
+, pathspec
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "mkdocs-swagger-ui-tag";
-  version = "0.6.2";
+  version = "0.6.4";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-H/eqrwlZntEYoKkJZKiRV+KyzkrDKRirMDDSciFNIGo=";
+  src = fetchFromGitHub {
+    owner = "Blueswen";
+    repo = "mkdocs-swagger-ui-tag";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/Spvj3lt7p+ZUbA/7xaQMLCSmHOOsoCRliqaAN+YU3g=";
   };
 
   propagatedBuildInputs = [
@@ -24,8 +28,20 @@ buildPythonPackage rec {
     beautifulsoup4
   ];
 
+  nativeCheckInputs = [
+    pathspec
+    pytestCheckHook
+  ];
+
   pythonImportsCheck = [
     "mkdocs_swagger_ui_tag"
+  ];
+
+  disabledTests = [
+    # Don't actually build results
+    "test_material"
+    "test_material_dark_scheme_name"
+    "test_template"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/Blueswen/mkdocs-swagger-ui-tag/compare/refs/tags/v0.6.2...v0.6.4

Changelog: https://github.com/blueswen/mkdocs-swagger-ui-tag/blob/v0.6.4/CHANGELOG

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
