### PR TITLE
appflowy: remove openssl_1_1 dependency

### DIFF
--- a/pkgs/applications/office/appflowy/default.nix
+++ b/pkgs/applications/office/appflowy/default.nix
@@ -6,7 +6,6 @@
 , copyDesktopItems
 , makeDesktopItem
 , gtk3
-, openssl_1_1
 , xdg-user-dirs
 , keybinder3
 }:
@@ -29,7 +28,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3
-    openssl_1_1
     keybinder3
   ];
 


### PR DESCRIPTION
## Description of changes

It's EOL and no longer required.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```console
$ nix-build -A appflowy
/nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0

$ ldd /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/AppFlowy
        linux-vdso.so.1 (0x00007f68d0a69000)
        libflowy_infra_ui_plugin.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/libflowy_infra_ui_plugin.so (0x00007f68d0a5c000)
        libhotkey_manager_plugin.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/libhotkey_manager_plugin.so (0x00007f68d0a4e000)
        libirondash_engine_context_plugin.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/libirondash_engine_context_plugin.so (0x00007f68d0a46000)
        librich_clipboard_linux_plugin.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/librich_clipboard_linux_plugin.so (0x00007f68d0a3c000)
        libscreen_retriever_plugin.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/libscreen_retriever_plugin.so (0x00007f68d0a34000)
        libsuper_native_extensions_plugin.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/libsuper_native_extensions_plugin.so (0x00007f68d0a2e000)
        liburl_launcher_linux_plugin.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/liburl_launcher_linux_plugin.so (0x00007f68d0a27000)
        libwindow_manager_plugin.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/libwindow_manager_plugin.so (0x00007f68d0a18000)
        libflutter_linux_gtk.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/libflutter_linux_gtk.so (0x00007f68cfa00000)
        libgtk-3.so.0 => /nix/store/lb8j1vb0kvh48bs7s0c6ryn97fkx0c7k-gtk+3-3.24.38/lib/libgtk-3.so.0 (0x00007f68cf200000)
        libgdk-3.so.0 => /nix/store/lb8j1vb0kvh48bs7s0c6ryn97fkx0c7k-gtk+3-3.24.38/lib/libgdk-3.so.0 (0x00007f68cf0f3000)
        libpangocairo-1.0.so.0 => /nix/store/6z19j0n1zhx73cc1cm580gc89si4c9g2-pango-1.50.14/lib/libpangocairo-1.0.so.0 (0x00007f68d0a05000)
        libpango-1.0.so.0 => /nix/store/6z19j0n1zhx73cc1cm580gc89si4c9g2-pango-1.50.14/lib/libpango-1.0.so.0 (0x00007f68d099a000)
        libharfbuzz.so.0 => /nix/store/r50ygp3piiiqx7iwyzfv39pnmjjry5sd-harfbuzz-7.3.0/lib/libharfbuzz.so.0 (0x00007f68cefd7000)
        libatk-1.0.so.0 => /nix/store/hhif4fd7sbafkwfcwfqzqgzycn0x2bvh-at-spi2-core-2.48.3/lib/libatk-1.0.so.0 (0x00007f68d096f000)
        libcairo-gobject.so.2 => /nix/store/rm72wvy4kjk50aa3hfkjkbah5gas2xwb-cairo-1.16.0/lib/libcairo-gobject.so.2 (0x00007f68d0964000)
        libcairo.so.2 => /nix/store/rm72wvy4kjk50aa3hfkjkbah5gas2xwb-cairo-1.16.0/lib/libcairo.so.2 (0x00007f68cee9b000)
        libgdk_pixbuf-2.0.so.0 => /nix/store/l31sjlbk7fhsysbvvwqybbnjssz7xx2g-gdk-pixbuf-2.42.10/lib/libgdk_pixbuf-2.0.so.0 (0x00007f68d0937000)
        libgio-2.0.so.0 => /nix/store/nr7qxmdvpjhff4fiqib66x557n7cb5y6-glib-2.76.4/lib/libgio-2.0.so.0 (0x00007f68cecb0000)
        libgobject-2.0.so.0 => /nix/store/nr7qxmdvpjhff4fiqib66x557n7cb5y6-glib-2.76.4/lib/libgobject-2.0.so.0 (0x00007f68cec4f000)
        libglib-2.0.so.0 => /nix/store/nr7qxmdvpjhff4fiqib66x557n7cb5y6-glib-2.76.4/lib/libglib-2.0.so.0 (0x00007f68ceb07000)
        libstdc++.so.6 => /nix/store/ci51zm09w9skb92zkc5x9x2vr1pkb0h6-gcc-12.3.0-lib/lib/../lib64/libstdc++.so.6 (0x00007f68ce800000)
        libm.so.6 => /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib/libm.so.6 (0x00007f68ce720000)
        libgcc_s.so.1 => /nix/store/ci51zm09w9skb92zkc5x9x2vr1pkb0h6-gcc-12.3.0-lib/lib/../lib64/libgcc_s.so.1 (0x00007f68ceae6000)
        libc.so.6 => /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib/libc.so.6 (0x00007f68ce53a000)
        libkeybinder-3.0.so.0 => /nix/store/3hbc93pp9nmik718j6ndpkksr62i8qyr-keybinder3-0.3.2/lib/libkeybinder-3.0.so.0 (0x00007f68cf9f8000)
        libsuper_native_extensions.so => /nix/store/rb0clnm7aykz8gm24c1pmmhka0g2kj05-appflowy-0.3.0/opt/lib/libsuper_native_extensions.so (0x00007f68ce3b3000)
        libdl.so.2 => /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib/libdl.so.2 (0x00007f68cf9f1000)
        libepoxy.so.0 => /nix/store/dfxsgwiihsknfdgi54kkzgnqzyl2indl-libepoxy-1.5.10/lib/libepoxy.so.0 (0x00007f68ce27e000)
        libpthread.so.0 => /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib/libpthread.so.0 (0x00007f68cf9ec000)
        /nix/store/9la894yvmmksqlapd4v16wvxpaw3rg70-glibc-2.37-8/lib/ld-linux-x86-64.so.2 => /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib64/ld-linux-x86-64.so.2 (0x00007f68d0a6b000)
        libgmodule-2.0.so.0 => /nix/store/nr7qxmdvpjhff4fiqib66x557n7cb5y6-glib-2.76.4/lib/libgmodule-2.0.so.0 (0x00007f68ceadf000)
        libpangoft2-1.0.so.0 => /nix/store/6z19j0n1zhx73cc1cm580gc89si4c9g2-pango-1.50.14/lib/libpangoft2-1.0.so.0 (0x00007f68ceac6000)
        libfontconfig.so.1 => /nix/store/pjkyd8r9qks9b3h2zpfkfv7apfyqci7a-fontconfig-2.14.2-lib/lib/libfontconfig.so.1 (0x00007f68cea79000)
        libfribidi.so.0 => /nix/store/ypim0y270f8fgxnzx24dkba26qynpkci-fribidi-1.0.13/lib/libfribidi.so.0 (0x00007f68cea57000)
        libXi.so.6 => /nix/store/rgmmsbmbkhaxjr4s83qipcg2ishxxhqy-libXi-1.8.1/lib/libXi.so.6 (0x00007f68cea43000)
        libX11.so.6 => /nix/store/pj3w2hz3jii57q481z4drv2vybpsaxap-libX11-1.8.6/lib/libX11.so.6 (0x00007f68ce139000)
        libatk-bridge-2.0.so.0 => /nix/store/hhif4fd7sbafkwfcwfqzqgzycn0x2bvh-at-spi2-core-2.48.3/lib/libatk-bridge-2.0.so.0 (0x00007f68ce0fc000)
        libtracker-sparql-3.0.so.0 => /nix/store/2459yrfbbx73y86dma4kcgpn4fgvipkc-tracker-3.5.3/lib/libtracker-sparql-3.0.so.0 (0x00007f68ce02a000)
        libXfixes.so.3 => /nix/store/11br2anikdav0q4qpkw2fy6z71gr5crm-libXfixes-6.0.1/lib/libXfixes.so.3 (0x00007f68cea39000)
        libxkbcommon.so.0 => /nix/store/mkczxmyjz0sr5baivy8i7zc78h888bwq-libxkbcommon-1.5.0/lib/libxkbcommon.so.0 (0x00007f68cdfe4000)
        libwayland-client.so.0 => /nix/store/5krz3xqcjgxgr7x8pd1z5xms9dkc0wjh-wayland-1.22.0/lib/libwayland-client.so.0 (0x00007f68cdfd2000)
        libwayland-cursor.so.0 => /nix/store/5krz3xqcjgxgr7x8pd1z5xms9dkc0wjh-wayland-1.22.0/lib/libwayland-cursor.so.0 (0x00007f68cea2d000)
        libwayland-egl.so.1 => /nix/store/5krz3xqcjgxgr7x8pd1z5xms9dkc0wjh-wayland-1.22.0/lib/libwayland-egl.so.1 (0x00007f68cea28000)
        libXext.so.6 => /nix/store/1wav5f555lnhksrnmzl07ikf7jayd3g0-libXext-1.3.5/lib/libXext.so.6 (0x00007f68cdfbd000)
        libXcursor.so.1 => /nix/store/q8pzj4qn44ny46y2jzyyam364npmfd8d-libXcursor-1.2.1/lib/libXcursor.so.1 (0x00007f68cdfb0000)
        libXdamage.so.1 => /nix/store/c2zd8ww67vkp8xnxnamvp2532kina3z4-libXdamage-1.1.6/lib/libXdamage.so.1 (0x00007f68cdfab000)
        libXcomposite.so.1 => /nix/store/ab3l3faglbri3lfqbvxsxp608g0mpgld-libXcomposite-0.4.6/lib/libXcomposite.so.1 (0x00007f68cdfa4000)
        libXrandr.so.2 => /nix/store/mym8dl7pjpqk3dp54g7kziw4z80ria7y-libXrandr-1.5.3/lib/libXrandr.so.2 (0x00007f68cdf97000)
        libXinerama.so.1 => /nix/store/b623vlvv55jbs249mpibwnysniawq6j6-libXinerama-1.1.5/lib/libXinerama.so.1 (0x00007f68cdf92000)
        libthai.so.0 => /nix/store/wqhbsgigghggvc4gca6iq4gbhizsjdmr-libthai-0.1.29/lib/libthai.so.0 (0x00007f68cdf86000)
        libfreetype.so.6 => /nix/store/y7d15rwm8gv54a8lfs14i9k8i7vm32vb-freetype-2.13.1/lib/libfreetype.so.6 (0x00007f68cdeb7000)
        libgraphite2.so.3 => /nix/store/rkgfjxgrm5pn2fmm6v3j5zqqkjy1mfna-graphite2-1.3.14/lib/libgraphite2.so.3 (0x00007f68cde8e000)
        libpixman-1.so.0 => /nix/store/il59v28gchkxs2xhn1llin96ci60y1zh-pixman-0.42.2/lib/libpixman-1.so.0 (0x00007f68cdde3000)
        libEGL.so.1 => /nix/store/yqb35zp6adsxlmpbhfm2gzygbcpq1v5a-libglvnd-1.6.0/lib/libEGL.so.1 (0x00007f68cddcb000)
        libpng16.so.16 => /nix/store/p0wkz9mzdjsh7r0yy716am1xgaqdfgs0-libpng-apng-1.6.39/lib/libpng16.so.16 (0x00007f68cdd92000)
        libxcb-shm.so.0 => /nix/store/gvmrpcdrm4mwpy6yyxsx122ynmjb1avn-libxcb-1.15/lib/libxcb-shm.so.0 (0x00007f68cdd8d000)
        libxcb.so.1 => /nix/store/gvmrpcdrm4mwpy6yyxsx122ynmjb1avn-libxcb-1.15/lib/libxcb.so.1 (0x00007f68cdd62000)
        libxcb-render.so.0 => /nix/store/gvmrpcdrm4mwpy6yyxsx122ynmjb1avn-libxcb-1.15/lib/libxcb-render.so.0 (0x00007f68cdd53000)
        libXrender.so.1 => /nix/store/kxisi0zl4r8i3a6ljzjq1kiw2wpql260-libXrender-0.9.11/lib/libXrender.so.1 (0x00007f68cdd44000)
        libz.so.1 => /nix/store/i039srr9s4li309rclbm3421ifavgl0g-zlib-1.2.13/lib/libz.so.1 (0x00007f68cdd26000)
        libGL.so.1 => /nix/store/yqb35zp6adsxlmpbhfm2gzygbcpq1v5a-libglvnd-1.6.0/lib/libGL.so.1 (0x00007f68cdc98000)
        librt.so.1 => /nix/store/9la894yvmmksqlapd4v16wvxpaw3rg70-glibc-2.37-8/lib/librt.so.1 (0x00007f68cdc93000)
        libjpeg.so.62 => /nix/store/ajvawmnjd5r2lfwivmk9rxqmfl0ddv0m-libjpeg-turbo-2.1.5.1/lib/libjpeg.so.62 (0x00007f68cdbe2000)
        libmount.so.1 => /nix/store/zkm7fjn87hp45zn7p0srvjr617lk8ckc-util-linux-minimal-2.39.1-lib/lib/libmount.so.1 (0x00007f68cdb72000)
        libselinux.so.1 => /nix/store/8y68wi72mc8zx5f66hn1gk5vyifdmh3m-libselinux-3.3/lib/libselinux.so.1 (0x00007f68cdb45000)
        libffi.so.8 => /nix/store/86wfcbx4zg1dmgrfs2d54flvsdadgb0p-libffi-3.4.4/lib/libffi.so.8 (0x00007f68cdb38000)
        libpcre2-8.so.0 => /nix/store/k1129sixmk24qqc30paf9adx895y9mnz-pcre2-10.42/lib/libpcre2-8.so.0 (0x00007f68cda9d000)
        libbz2.so.1 => /nix/store/pjk8v6xrvfdv7mb7ahsrip5scgf6jbif-bzip2-1.0.8/lib/libbz2.so.1 (0x00007f68cda88000)
        libbrotlidec.so.1 => /nix/store/1f2aahqnd71c4fwggizkg75vav38zqc3-brotli-1.0.9-lib/lib/libbrotlidec.so.1 (0x00007f68cda7a000)
        libexpat.so.1 => /nix/store/ms04w36fj5v565h4sr1giig9ilkhmx4z-expat-2.5.0/lib/libexpat.so.1 (0x00007f68cda4f000)
        libatspi.so.0 => /nix/store/hhif4fd7sbafkwfcwfqzqgzycn0x2bvh-at-spi2-core-2.48.3/lib/libatspi.so.0 (0x00007f68cda12000)
        libdbus-1.so.3 => /nix/store/n9mj4g8jhrdhn2y6dyr3gc8nksxxw2gw-dbus-1.14.8-lib/lib/libdbus-1.so.3 (0x00007f68cd9bb000)
        libjson-glib-1.0.so.0 => /nix/store/jv5i2y3dlwqnj4v7493ps6lrnm1w3pbl-json-glib-1.6.6/lib/libjson-glib-1.0.so.0 (0x00007f68cd990000)
        libxml2.so.2 => /nix/store/57ilg207pwyynwbnfggwdvgy6yjpg25a-libxml2-2.11.4/lib/libxml2.so.2 (0x00007f68cd82f000)
        libsqlite3.so.0 => /nix/store/s71iqh14mpkga588y5fvsv13d7qdpz45-sqlite-3.42.0/lib/libsqlite3.so.0 (0x00007f68cd6d9000)
        libdatrie.so.1 => /nix/store/h03fhg9f7nibfw0kwbgs66cb755nkswc-libdatrie-2019-12-20-lib/lib/libdatrie.so.1 (0x00007f68cd6cf000)
        libGLdispatch.so.0 => /nix/store/yqb35zp6adsxlmpbhfm2gzygbcpq1v5a-libglvnd-1.6.0/lib/libGLdispatch.so.0 (0x00007f68cd616000)
        libXau.so.6 => /nix/store/d2jlkszkl2jwiqvkp9647arfd9r0ma1h-libXau-1.0.11/lib/libXau.so.6 (0x00007f68cd611000)
        libXdmcp.so.6 => /nix/store/fk3m0m22alz25vr7cmpdfzwldqg1pf8l-libXdmcp-1.1.4/lib/libXdmcp.so.6 (0x00007f68cd607000)
        libGLX.so.0 => /nix/store/yqb35zp6adsxlmpbhfm2gzygbcpq1v5a-libglvnd-1.6.0/lib/libGLX.so.0 (0x00007f68cd5d3000)
        libblkid.so.1 => /nix/store/zkm7fjn87hp45zn7p0srvjr617lk8ckc-util-linux-minimal-2.39.1-lib/lib/libblkid.so.1 (0x00007f68cd577000)
        libpcre.so.1 => /nix/store/1r4nn1v03id8q2634ykid55afllzmiiq-pcre-8.45/lib/libpcre.so.1 (0x00007f68cd4fd000)
        libbrotlicommon.so.1 => /nix/store/1f2aahqnd71c4fwggizkg75vav38zqc3-brotli-1.0.9-lib/lib/libbrotlicommon.so.1 (0x00007f68cd4d8000)
        libsystemd.so.0 => /nix/store/0fz0wm99d76nlx6zvgrnrn8wzb7lmk42-systemd-minimal-253.6/lib/libsystemd.so.0 (0x00007f68cd3e6000)
        libcap.so.2 => /nix/store/za93vzw7adhj0lgrs3z6mqqcqqxwllm1-libcap-2.69-lib/lib/libcap.so.2 (0x00007f68cd3da000)
```