### PR TITLE
python3Packages.restinstance: init at 1.3.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -141,6 +141,8 @@ In addition to numerous new and updated packages, this release has the following
 
 - [ReGreet](https://github.com/rharish101/ReGreet), a clean and customizable greeter for greetd. Available as [programs.regreet](#opt-programs.regreet.enable).
 
+- [RESTinstnace](https://github.com/asyrjasalo/RESTinstance), robotframework library for REST interfaces.
+
 - [rshim](https://github.com/Mellanox/rshim-user-space), the user-space rshim driver for the BlueField SoC. Available as [services.rshim](options.html#opt-services.rshim.enable).
 
 - [SFTPGo](https://github.com/drakkan/sftpgo), a fully featured and highly configurable SFTP server with optional HTTP/S, FTP/S and WebDAV support. Available as [services.sftpgo](options.html#opt-services.sftpgo.enable).

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -141,8 +141,6 @@ In addition to numerous new and updated packages, this release has the following
 
 - [ReGreet](https://github.com/rharish101/ReGreet), a clean and customizable greeter for greetd. Available as [programs.regreet](#opt-programs.regreet.enable).
 
-- [RESTinstnace](https://github.com/asyrjasalo/RESTinstance), robotframework library for REST interfaces.
-
 - [rshim](https://github.com/Mellanox/rshim-user-space), the user-space rshim driver for the BlueField SoC. Available as [services.rshim](options.html#opt-services.rshim.enable).
 
 - [SFTPGo](https://github.com/drakkan/sftpgo), a fully featured and highly configurable SFTP server with optional HTTP/S, FTP/S and WebDAV support. Available as [services.sftpgo](options.html#opt-services.sftpgo.enable).

--- a/pkgs/development/python-modules/restinstance/default.nix
+++ b/pkgs/development/python-modules/restinstance/default.nix
@@ -6,7 +6,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "RESTinstance";
+  pname = "restinstance";
   version = "1.3.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/restinstance/default.nix
+++ b/pkgs/development/python-modules/restinstance/default.nix
@@ -22,6 +22,9 @@ buildPythonPackage rec {
     nox -s test
   '';
 
+  pythonImportsCheck = [
+    "REST"
+  ];
   meta = with lib; {
     description = "Robot Framework library for RESTful JSON APIs";
     homepage = "https://asyrjasalo.github.io/RESTinstance";

--- a/pkgs/development/python-modules/restinstance/default.nix
+++ b/pkgs/development/python-modules/restinstance/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, buildPythonPackage, jsonschema, nox }:
+
+buildPythonPackage rec {
+  pname = "RESTinstance";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "asyrjasalo";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-ed0gJy0ns+Xs7DO0P7c8Jea9qI5A+tImUEG5Xz8Q3Ng=";
+  };
+
+  nativeCheckInputs = [ jsonschema nox ];
+
+  checkPhase = ''
+    nox -s test
+  '';
+
+  meta = with lib; {
+    description = "Robot Framework library for RESTful JSON APIs";
+    homepage = "https://asyrjasalo.github.io/RESTinstance";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ asyrjasalo ];
+  };
+}

--- a/pkgs/development/python-modules/restinstance/default.nix
+++ b/pkgs/development/python-modules/restinstance/default.nix
@@ -8,6 +8,9 @@
 buildPythonPackage rec {
   pname = "restinstance";
   version = "1.3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "asyrjasalo";

--- a/pkgs/development/python-modules/restinstance/default.nix
+++ b/pkgs/development/python-modules/restinstance/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , jsonschema
 , nox
+, pythonOlder
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/restinstance/default.nix
+++ b/pkgs/development/python-modules/restinstance/default.nix
@@ -1,4 +1,9 @@
-{ lib, fetchFromGitHub, buildPythonPackage, jsonschema, nox }:
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, jsonschema
+, nox
+}:
 
 buildPythonPackage rec {
   pname = "RESTinstance";

--- a/pkgs/development/python-modules/restinstance/default.nix
+++ b/pkgs/development/python-modules/restinstance/default.nix
@@ -1,8 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
-, jsonschema
-, nox
+, python3Packages
 , pythonOlder
 }:
 
@@ -13,6 +12,39 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
+  flex = python3Packages.buildPythonPackage rec {
+    pname = "flex";
+    version = "6.14.1";
+    src = python3Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-KS7Wo38awKEK2GafXOuC6LoxBsFsVAkIIJJ7rIsLKes=";
+    };
+    doCheck = false;
+    propagatedBuildInputs = with python3Packages; [
+      rfc3987
+      click
+      jsonpointer
+      setuptools
+      six
+      strict-rfc3339
+      pyyaml
+      requests
+      validate-email
+   ];
+  };
+
+  genson = python3Packages.buildPythonPackage rec {
+      pname = "genson";
+      version = "v.1.2.2";
+      src = fetchFromGitHub {
+          owner = "wolverdude";
+          repo = "GenSON";
+          rev = "6bf083488de2804c3ff5bb03b05761ff31fac30c";
+          sha256 = "sha256-3RaGY/F//Zt3aOH5ZO+jvRc6vn0+yT14MTYg6yCzO3w=";
+      };
+      doCheck = false;
+  };
+
   src = fetchFromGitHub {
     owner = "asyrjasalo";
     repo = pname;
@@ -20,15 +52,31 @@ buildPythonPackage rec {
     hash = "sha256-ed0gJy0ns+Xs7DO0P7c8Jea9qI5A+tImUEG5Xz8Q3Ng=";
   };
 
-  nativeCheckInputs = [ jsonschema nox ];
+  nativeCheckInputs = with python3Packages; [
+    jsonschema
+    nox
+  ];
 
   checkPhase = ''
     nox -s test
   '';
 
+  propagatedBuildInputs = with python3Packages; [
+    flex
+    genson
+    jsonpath-ng
+    pyyaml
+    pygments
+    pytz
+    requests
+    robotframework
+    tzlocal
+  ];
+
   pythonImportsCheck = [
     "REST"
   ];
+
   meta = with lib; {
     description = "Robot Framework library for RESTful JSON APIs";
     homepage = "https://asyrjasalo.github.io/RESTinstance";

--- a/pkgs/development/python-modules/restinstance/default.nix
+++ b/pkgs/development/python-modules/restinstance/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Robot Framework library for RESTful JSON APIs";
     homepage = "https://asyrjasalo.github.io/RESTinstance";
+    changelog = "https://github.com/asyrjasalo/RESTinstance/releases/tag/${version}";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [ asyrjasalo ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11178,6 +11178,8 @@ self: super: with self; {
 
   restfly = callPackage ../development/python-modules/restfly { };
 
+  restinstance = callPackage ../development/python-modules/restinstance { };
+
   restrictedpython = callPackage ../development/python-modules/restrictedpython { };
 
   restructuredtext_lint = callPackage ../development/python-modules/restructuredtext_lint { };


### PR DESCRIPTION
## Description of changes

Add python package RESTinstance in version 1.3.0 to default python packages.
Some of the robotframework libraries are already added and the RESTinstance module  is another part of that system.
Tested building of derivation with `nix-build -A python3Packages.restinstance`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
