### PR TITLE
nixos/syncoid: use string type for sshKey options

### DIFF
--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -123,9 +123,7 @@ in
     };
 
     sshKey = mkOption {
-      type = types.nullOr types.path;
-      # Prevent key from being copied to store
-      apply = mapNullable toString;
+      type = with types; nullOr (coercedTo path toString str);
       default = null;
       description = lib.mdDoc ''
         SSH private key file to use to login to the remote system. Can be
@@ -205,9 +203,7 @@ in
           recursive = mkEnableOption (lib.mdDoc ''the transfer of child datasets'');
 
           sshKey = mkOption {
-            type = types.nullOr types.path;
-            # Prevent key from being copied to store
-            apply = mapNullable toString;
+            type = with types; nullOr (coercedTo path toString str);
             description = lib.mdDoc ''
               SSH private key file to use to login to the remote system.
               Defaults to {option}`services.syncoid.sshKey` option.


### PR DESCRIPTION
The sshKey options do not need to be a valid path at build time. Using string instead allow use case when the path is not known at build time such as when using systemd credentials (e.g. `sshKey = "\${CREDENTIALS_DIRECTORY}/zfs-replication_ed25519";`).

This PR allows the following use case that leverages NixOps `deployment.keys` and systemd credentials:

```nix
{ config, ... }:
{
  services.syncoid = {
    enable = true;
    interval = "*-*-* *:00/15:00";
    sshKey = "\${CREDENTIALS_DIRECTORY}/zfs-replication_ed25519";
    commands = let
      targetHost = "mybackupserver.example.com";
      user = "me";
      machine = "nixos1";
      replicationUser = "repl-${machine}";
      parentDataset = "tank1/backup-ext/${user}/${machine}";
      destination = "${replicationUser}@${targetHost}:${parentDataset}";
    in {
      "rpool/root" = {
        target = "${destination}/root";
      };
      "rpool/home" = {
        target = "${destination}/home";
      };
    };
    commonArgs = [
      "--compress=none"
      "--no-sync-snap"
    ];
    service = {
      serviceConfig = {
        LoadCredential = [
          "zfs-replication_ed25519:${config.deployment.keys."syncoid-zfs-replication_ed25519".path}"
          "zfs-replication_ed25519.pub:${config.deployment.keys."syncoid-zfs-replication_ed25519.pub".path}"
        ];
      };
    };
  };

  deployment.keys = {
    "syncoid-zfs-replication_ed25519" = {
      keyFile = ../secrets/syncoid-zfs-replication_ed25519;
      destDir = "/etc/credstore/syncoid";
    };
    "syncoid-zfs-replication_ed25519.pub" = {
      keyFile = ../secrets/syncoid-zfs-replication_ed25519.pub;
      destDir = "/etc/credstore/syncoid";
    };
  };

  programs.ssh.knownHostsFiles = [
    ../secrets/ssh_known_hosts
  ];
}

```


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
