### PR TITLE
systemd: suggest using `--runtime` on `systemctl edit`

### DIFF
--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -76,6 +76,17 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     # wait for user services
     machine.wait_for_unit("default.target", "alice")
 
+    with subtest("systemctl edit suggests --runtime"):
+        # --runtime is suggested when using `systemctl edit`
+        ret, out = machine.execute("systemctl edit testservice1.service 2>&1")
+        assert ret == 1
+        assert out.rstrip("\n") == "The unit-directory '/etc/systemd/system' is read-only on NixOS, so it's not possible to edit system-units directly. Use 'systemctl edit --runtime' instead."
+        # editing w/o `--runtime` is possible for user-services, however
+        # it's not possible because we're not in a tty when grepping
+        # (i.e. hacky way to ensure that the error from above doesn't appear here).
+        _, out = machine.execute("systemctl --user edit testservice2.service 2>&1")
+        assert out.rstrip("\n") == "Cannot edit units if not on a tty."
+
     # Regression test for https://github.com/NixOS/nixpkgs/issues/105049
     with subtest("systemd reads timezone database in /etc/zoneinfo"):
         timer = machine.succeed("TZ=UTC systemctl show --property=TimersCalendar oncalendar-test.timer")

--- a/pkgs/os-specific/linux/systemd/0019-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
+++ b/pkgs/os-specific/linux/systemd/0019-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Fri, 1 Sep 2023 09:57:02 +0200
+Subject: [PATCH] systemctl-edit: suggest `systemdctl edit --runtime` on system
+ scope
+
+This is a NixOS-specific change. When trying to modify a unit with
+`systemctl edit` on NixOS, it'll fail with "Read-only file system":
+
+    $ systemctl edit libvirtd
+    Failed to open "/etc/systemd/system/libvirtd.service.d/.#override.conffa9825a0c9a249eb": Read-only file system
+
+This is because `/etc/systemd/system` is a symlink into the store. In
+fact, I'd consider this a feature rather than a bug since this ensures I
+don't introduce state imperatively.
+
+However, people wrongly assume that it's not possible to edit units
+ad-hoc and re-deploy their system for quick&dirty debugging where this
+would be absolutely fine (and doable with `--runtime` which adds a
+transient and non-persistent unit override in `/run`).
+
+To make sure that people learn about it quicker, this patch
+throws an error which suggests using `--runtime` when running
+`systemctl edit` on the system scope.
+
+For the user scope this isn't needed because user-level unit overrides
+are written into `$XDG_CONFIG_HOME/systemd/user`.
+---
+ src/systemctl/systemctl-edit.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/systemctl/systemctl-edit.c b/src/systemctl/systemctl-edit.c
+index e3f25d52d5..81c9c6f6b7 100644
+--- a/src/systemctl/systemctl-edit.c
++++ b/src/systemctl/systemctl-edit.c
+@@ -323,6 +323,9 @@ int verb_edit(int argc, char *argv[], void *userdata) {
+         sd_bus *bus;
+         int r;
+ 
++        if (!arg_runtime && arg_runtime_scope == RUNTIME_SCOPE_SYSTEM)
++                return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "The unit-directory '/etc/systemd/system' is read-only on NixOS, so it's not possible to edit system-units directly. Use 'systemctl edit --runtime' instead.");
++
+         if (!on_tty())
+                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Cannot edit units if not on a tty.");
+ 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -201,6 +201,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0016-inherit-systemd-environment-when-calling-generators.patch
     ./0017-core-don-t-taint-on-unmerged-usr.patch
     ./0018-tpm2_context_init-fix-driver-name-checking.patch
+    ./0019-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
   ] ++ lib.optional stdenv.hostPlatform.isMusl (
     let
       oe-core = fetchzip {


### PR DESCRIPTION
## Description of changes

__Note:__ this is based on #243242 so that I don't have to rebase again when 254 is out, hence this is a draft, it's still reviewable though ;-)

------

`systemctl edit foobar.service` attempts to write into
`/etc/systemd/system`. This is impossible on purpose, for such a
configuration change the `configuration.nix(8)` should be modified.

However, sometimes it's still a handy feature, for instance when
debugging a broken service. For such a purpose,
`systemctl edit --runtime` is still working on NixOS and an even better
solution because it only overrides the unit temporarily by placing the
override config into `/run` rather than `/etc`.

Unfortunately, this flag isn't well-known in my experience. So inspired
by PEP668[1], RaitoBezarius nerd-sniped me into implementing a similar
warning:

    $ ./result/bin/systemctl edit libvirtd.service
    The unit-directory '/etc/systemd/system' is read-only on NixOS, so it's not possible to edit system-units directly. Use 'systemctl edit --runtime' instead.

This only applies to system-level units. Overrides for user-units are
written into `$XDG_CONFIG_HOME/systemd/user` which is not managed by
NixOS (even when using home-manager it's possible to write into that
directory).

[1] https://peps.python.org/pep-0668/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
