### PR TITLE
phpPackages.castor: init at 0.8.0

### DIFF
--- a/pkgs/development/php-packages/castor/default.nix
+++ b/pkgs/development/php-packages/castor/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchurl
+, makeBinaryWrapper
+, installShellFiles
+, php
+, nix-update-script
+, testers
+, castor
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "castor";
+  version = "0.8.0";
+
+
+  src = fetchurl {
+    url = "https://github.com/jolicode/castor/releases/download/v${finalAttrs.version}/castor.linux-amd64.phar";
+    hash = "sha256-0lnn4mS1/DgUoRoMFvCjwQ0j9CX9XWlskbtX9roFCfc=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeBinaryWrapper installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src $out/libexec/castor/castor.phar
+    makeWrapper ${php}/bin/php $out/bin/castor \
+      --add-flags "$out/libexec/castor/castor.phar"
+    runHook postInstall
+  '';
+
+  # castor requires to be initialized to generate completion files
+  postInstall = ''
+    echo "yes" | ${php}/bin/php $src
+    installShellCompletion --cmd castor \
+      --bash <($out/bin/castor completion bash) \
+      --fish <($out/bin/castor completion fish) \
+      --zsh <($out/bin/castor completion zsh)
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      inherit (finalAttrs) version;
+      package = castor;
+      command = "castor --version";
+    };
+  };
+
+  meta = with lib; {
+    description = "DX oriented task runner and command launcher built with PHP";
+    homepage = "https://github.com/jolicode/castor";
+    changelog = "https://github.com/jolicode/castor/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gaelreyrol ];
+  };
+})

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -169,6 +169,8 @@ lib.makeScope pkgs.newScope (self: with self; {
   tools = {
     box = callPackage ../development/php-packages/box { };
 
+    castor = callPackage ../development/php-packages/castor { };
+
     composer = callPackage ../development/php-packages/composer { };
 
     deployer = callPackage ../development/php-packages/deployer { };


### PR DESCRIPTION
## Description of changes

This PR adds the PHP package castor at its latest version: https://github.com/jolicode/castor/releases/tag/v0.8.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
