### PR TITLE
Submit/hax11 pkg

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1747,6 +1747,15 @@
     githubId = 135230;
     name = "Aycan iRiCAN";
   };
+  ayham = {
+    email = "me@ayham.xyz";
+    name = "ayham";
+    github = "ayham";
+    githubId = 56314286;
+    keys = [{
+      fingerprint = "8C38 DD3A 3030 F8AE B8A9  A2BC 783F 6DE2 77DA 7BFF";
+    }];
+  };
   aynish = {
     github = "Chickensoupwithrice";
     githubId = 22575913;

--- a/pkgs/games/hax11/default.nix
+++ b/pkgs/games/hax11/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, multiStdenv
+, fetchFromGitHub
+, glibc
+, pkgs
+}:
+
+multiStdenv.mkDerivation {
+  pname = "hax11";
+
+  src = fetchFromGitHub {
+    owner = "ayham-1";
+    repo = "hax11";
+    rev = "fd2fc5c88ae45161ad67500d74cec018c02b9bc1";
+    sha256 = "1kc0rnips5640pqk6rxjvrd1ssgzgvivimck9ajl4kjm6yvc0l6m";
+  };
+
+  strictDeps = true;
+
+  buildInputs = with pkgs; [
+    gcc
+    glibc
+    xorg.gccmakedep
+    xorg.xorgproto
+    xorg.libXxf86vm
+    xorg.libX11
+    xorg.libXi
+    xorg.libXxf86vm
+  ];
+
+  outputs = [ "out" ];
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Hackbrary to Hook and Augment X11 protocol calls";
+    homepage = "https://github.com/ayham-1/hax11";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with lib.maintainers; [ ayham ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5599,6 +5599,8 @@ with pkgs;
 
   has = callPackage ../applications/misc/has { };
 
+  hax11 = callPackage ../games/hax11 { };
+
   hdate = callPackage ../applications/misc/hdate { };
 
   headache = callPackage ../development/tools/headache { };


### PR DESCRIPTION
Add hax11 library.

Used to alter how applications interact with X11.

Useful for games that don't correctly confine mouse movements.