### PR TITLE
bitmask-vpn: 0.21.6 -> 0.21.11

### DIFF
--- a/pkgs/tools/networking/bitmask-vpn/default.nix
+++ b/pkgs/tools/networking/bitmask-vpn/default.nix
@@ -16,6 +16,7 @@
 , qmltermwidget
 , qtbase
 , qtdeclarative
+, qtgraphicaleffects
 , qtinstaller
 , qtquickcontrols
 , qtquickcontrols2
@@ -25,14 +26,14 @@
 , provider ? "riseup"
 }:
 let
-  version = "0.21.6";
+  version = "0.21.11";
 
   src = fetchFromGitLab {
     domain = "0xacab.org";
     owner = "leap";
     repo = "bitmask-vpn";
     rev = version;
-    sha256 = "sha256-LMz+ZgQVFGujoLA8rlyZ3VnW/NSlPipD5KwCe+cFtnY=";
+    sha256 = "sha256-mhmKG6Exxh64oeeeLezJYWEw61iIHLasHjLomd2L8P4=";
   };
 
   # bitmask-root is only used on GNU/Linux
@@ -98,7 +99,6 @@ buildGoModule rec {
     pkg-config
     python3Packages.wrapPython
     qmake
-    qtquickcontrols
     qtquickcontrols2
     qttools
     which
@@ -109,6 +109,9 @@ buildGoModule rec {
     qtbase
     qmltermwidget
     qtdeclarative
+    qtgraphicaleffects
+    qtquickcontrols
+    qtquickcontrols2
   ] ++ lib.optionals stdenv.isDarwin [ CoreFoundation Security ];
   # FIXME: building on Darwin currently fails
   # due to missing debug symbols for Qt,


### PR DESCRIPTION
## Description of changes

Update to latest version [`0.21.11`](https://github.com/leapcode/bitmask-vpn/tags).

Problems with this upgrade were reported in upstream issue [#545](https://0xacab.org/leap/bitmask-vpn/-/issues/545#note_353186) "NixOS packages" which is why this update is being packaged more than a year after it landed upstream. 

Since then, there are also additional Qt-related errors that have emerged for version `0.21.6`:
```
QQmlApplicationEngine failed to load component
qrc:/qml/main.qml:6:1: module "Qt.labs.platform" is not installed
qrc:/qml/main.qml:4:1: module "QtQuick.Controls" is not installed
qrc:/qml/main.qml:2:1: module "QtQuick.Dialogs" is not installed
qrc:/qml/main.qml:6:1: module "Qt.labs.platform" is not installed
qrc:/qml/main.qml:4:1: module "QtQuick.Controls" is not installed
qrc:/qml/main.qml:2:1: module "QtQuick.Dialogs" is not installed
qrc:/qml/main.qml:6:1: module "Qt.labs.platform" is not installed
qrc:/qml/main.qml:4:1: module "QtQuick.Controls" is not installed
qrc:/qml/main.qml:2:1: module "QtQuick.Dialogs" is not installed
```

The changes to the Qt dependencies in this PR have resolved all of these problems and I have been able to build and run `riseup-vpn` successfully. Since the previous version is broken, this update could also be worth backporting to 23.05.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
