### PR TITLE
python3Packages.argon2-cffi: 21.3.0 -> 23.1.0, cleanup

### DIFF
--- a/pkgs/development/python-modules/argon2-cffi-bindings/default.nix
+++ b/pkgs/development/python-modules/argon2-cffi-bindings/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
+    cffi
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/argon2-cffi-bindings/default.nix
+++ b/pkgs/development/python-modules/argon2-cffi-bindings/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, libargon2
 , cffi
 , setuptools-scm
 }:
@@ -14,6 +15,8 @@ buildPythonPackage rec {
     sha256 = "bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3";
   };
 
+  buildInputs = [ libargon2 ];
+
   nativeBuildInputs = [
     setuptools-scm
     cffi
@@ -22,6 +25,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cffi
   ];
+
+  env.ARGON2_CFFI_USE_SYSTEM = 1;
 
   # tarball doesn't include tests, but the upstream tests are minimal
   doCheck = false;

--- a/pkgs/development/python-modules/argon2-cffi/default.nix
+++ b/pkgs/development/python-modules/argon2-cffi/default.nix
@@ -1,5 +1,4 @@
-{ cffi
-, six
+{ six
 , enum34
 , hypothesis
 , pytest
@@ -27,13 +26,8 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  propagatedBuildInputs = [ cffi six argon2-cffi-bindings ]
+  propagatedBuildInputs = [ six argon2-cffi-bindings ]
     ++ lib.optional (!isPy3k) enum34;
-
-  propagatedNativeBuildInputs = [
-    argon2-cffi-bindings
-    cffi
-  ];
 
   ARGON2_CFFI_USE_SSE2 = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) "0";
 
@@ -41,6 +35,8 @@ buildPythonPackage rec {
   checkPhase = ''
     pytest tests
   '';
+
+  pythonImportsCheck = [ "argon2" ];
 
   meta = with lib; {
     description = "Secure Password Hashes for Python";

--- a/pkgs/development/python-modules/argon2-cffi/default.nix
+++ b/pkgs/development/python-modules/argon2-cffi/default.nix
@@ -1,12 +1,8 @@
-{ six
-, enum34
-, hypothesis
+{ hypothesis
 , pytest
-, wheel
 , buildPythonPackage
 , fetchPypi
 , flit-core
-, isPy3k
 , lib
 , stdenv
 , argon2-cffi-bindings
@@ -26,10 +22,9 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  propagatedBuildInputs = [ six argon2-cffi-bindings ]
-    ++ lib.optional (!isPy3k) enum34;
+  propagatedBuildInputs = [ argon2-cffi-bindings ];
 
-  nativeCheckInputs = [ hypothesis pytest wheel ];
+  nativeCheckInputs = [ hypothesis pytest ];
   checkPhase = ''
     pytest tests
   '';

--- a/pkgs/development/python-modules/argon2-cffi/default.nix
+++ b/pkgs/development/python-modules/argon2-cffi/default.nix
@@ -2,25 +2,25 @@
 , pytest
 , buildPythonPackage
 , fetchPypi
-, flit-core
 , lib
-, stdenv
+, hatchling
+, hatch-vcs
+, hatch-fancy-pypi-readme
 , argon2-cffi-bindings
 }:
 
 buildPythonPackage rec {
   pname = "argon2-cffi";
-  version = "21.3.0";
+  version = "23.1.0";
   format = "pyproject";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "d384164d944190a7dd7ef22c6aa3ff197da12962bd04b17f64d4e93d934dba5b";
+    pname = "argon2_cffi";
+    inherit version;
+    hash = "sha256-h5w+eaJynOdo67fTbUYJ46eKTKLsOp8SKGygV+PQ2wg=";
   };
 
-  nativeBuildInputs = [
-    flit-core
-  ];
+  nativeBuildInputs = [ hatchling hatch-vcs hatch-fancy-pypi-readme ];
 
   propagatedBuildInputs = [ argon2-cffi-bindings ];
 

--- a/pkgs/development/python-modules/argon2-cffi/default.nix
+++ b/pkgs/development/python-modules/argon2-cffi/default.nix
@@ -1,5 +1,5 @@
 { hypothesis
-, pytest
+, pytestCheckHook
 , buildPythonPackage
 , fetchPypi
 , lib
@@ -24,10 +24,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ argon2-cffi-bindings ];
 
-  nativeCheckInputs = [ hypothesis pytest ];
-  checkPhase = ''
-    pytest tests
-  '';
+  nativeCheckInputs = [ hypothesis pytestCheckHook ];
 
   pythonImportsCheck = [ "argon2" ];
 

--- a/pkgs/development/python-modules/argon2-cffi/default.nix
+++ b/pkgs/development/python-modules/argon2-cffi/default.nix
@@ -29,8 +29,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ six argon2-cffi-bindings ]
     ++ lib.optional (!isPy3k) enum34;
 
-  ARGON2_CFFI_USE_SSE2 = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) "0";
-
   nativeCheckInputs = [ hypothesis pytest wheel ];
   checkPhase = ''
     pytest tests


### PR DESCRIPTION
## Description of changes

https://github.com/hynek/argon2-cffi/releases/tag/23.1.0

Also, apply some general cleanups and improvements to the package, notably removing a problematic usage of `propagatedNativeBuildInputs` that was introduced in #142301. See the individual commit messages for more details.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @legendofmiracles @ether42 @jonringer 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv7l-linux (cross)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
