### PR TITLE
cinny, cinny-desktop: build from source

### DIFF
--- a/pkgs/applications/networking/instant-messengers/cinny-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/cinny-desktop/default.nix
@@ -1,45 +1,74 @@
-{ stdenv
-, lib
-, dpkg
-, fetchurl
-, autoPatchelfHook
-, glib-networking
-, openssl
-, webkitgtk
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, cinny
+, copyDesktopItems
 , wrapGAppsHook
+, pkg-config
+, openssl
+, dbus
+, glib
+, glib-networking
+, webkitgtk
+, makeDesktopItem
 }:
 
-stdenv.mkDerivation rec {
+rustPlatform.buildRustPackage rec {
   pname = "cinny-desktop";
   version = "2.2.6";
 
-  src = fetchurl {
-    url = "https://github.com/cinnyapp/cinny-desktop/releases/download/v${version}/Cinny_desktop-x86_64.deb";
-    sha256 = "sha256-Bh7qBlHh2bQ6y2HnI4TtxMU6N3t04tr1Juoul2KMrqs=";
+  src = fetchFromGitHub {
+    owner = "cinnyapp";
+    repo = "cinny-desktop";
+    rev = "v${version}";
+    hash = "sha256-RW6LeItIAHJk1e7qMa1MLIGb3jHvJ/KM8E9l1qR48w8=";
   };
 
+  sourceRoot = "${src.name}/src-tauri";
+
+  cargoHash = "sha256-Iab/icQ9hFVh/o6egZVPa2zeKgO5WxzkluhRckcayvw=";
+
+  postPatch = ''
+    substituteInPlace tauri.conf.json \
+      --replace '"distDir": "../cinny/dist",' '"distDir": "${cinny}",'
+  '';
+
+  postInstall = ''
+    install -DT icons/128x128@2x.png $out/share/icons/hicolor/256x256@2/apps/cinny.png
+    install -DT icons/128x128.png $out/share/icons/hicolor/128x128/apps/cinny.png
+    install -DT icons/32x32.png $out/share/icons/hicolor/32x32/apps/cinny.png
+  '';
+
   nativeBuildInputs = [
-    autoPatchelfHook
-    dpkg
+    copyDesktopItems
+    wrapGAppsHook
+    pkg-config
   ];
 
   buildInputs = [
-    glib-networking
     openssl
+    dbus
+    glib
+    glib-networking
     webkitgtk
-    wrapGAppsHook
   ];
 
-  unpackCmd = "dpkg-deb -x $curSrc source";
-
-  installPhase = "mv usr $out";
+  desktopItems = [
+    (makeDesktopItem {
+      name = "cinny";
+      exec = "cinny";
+      icon = "cinny";
+      desktopName = "Cinny";
+      comment = meta.description;
+      categories = [ "Network" "InstantMessaging" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Yet another matrix client for desktop";
     homepage = "https://github.com/cinnyapp/cinny-desktop";
     maintainers = [ maintainers.aveltras ];
     license = licenses.agpl3Only;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     platforms = platforms.linux;
     mainProgram = "cinny";
   };

--- a/pkgs/applications/networking/instant-messengers/cinny/default.nix
+++ b/pkgs/applications/networking/instant-messengers/cinny/default.nix
@@ -1,22 +1,30 @@
-{ lib, stdenv, fetchurl, writeText, jq, conf ? {} }:
+{ lib, buildNpmPackage, fetchFromGitHub, writeText, jq, conf ? { } }:
 
 let
   configOverrides = writeText "cinny-config-overrides.json" (builtins.toJSON conf);
-in stdenv.mkDerivation rec {
+in
+buildNpmPackage rec {
   pname = "cinny";
   version = "2.2.6";
 
-  src = fetchurl {
-    url = "https://github.com/ajbura/cinny/releases/download/v${version}/cinny-v${version}.tar.gz";
-    hash = "sha256-AvYM8++PqKmm7CJN5hmg9GSC72IoHX+rRxuT3GflvjU=";
+  src = fetchFromGitHub {
+    owner = "cinnyapp";
+    repo = "cinny";
+    rev = "v${version}";
+    hash = "sha256-Da/gbq9piKvkIMiamoafcRrqxF7128GXoswk2C43An8=";
   };
+
+  npmDepsHash = "sha256-3wgB/dQmLtwxbRsk+OUcyfx98vpCvhvseEOCrJIFohY=";
+
+  nativeBuildInputs = [
+    jq
+  ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/
-    cp -R . $out/
-    ${jq}/bin/jq -s '.[0] * .[1]' "config.json" "${configOverrides}" > "$out/config.json"
+    cp -r dist $out
+    jq -s '.[0] * .[1]' "config.json" "${configOverrides}" > "$out/config.json"
 
     runHook postInstall
   '';
@@ -25,7 +33,7 @@ in stdenv.mkDerivation rec {
     description = "Yet another Matrix client for the web";
     homepage = "https://cinny.in/";
     maintainers = with maintainers; [ abbe ];
-    license = licenses.mit;
+    license = licenses.agpl3Only;
     platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4612,11 +4612,9 @@ with pkgs;
 
   cht-sh = callPackage ../tools/misc/cht.sh { };
 
-  cinny = callPackage ../applications/networking/instant-messengers/cinny { stdenv = stdenvNoCC; };
+  cinny = callPackage ../applications/networking/instant-messengers/cinny { };
 
-  cinny-desktop = callPackage ../applications/networking/instant-messengers/cinny-desktop {
-    openssl = openssl_1_1;
-  };
+  cinny-desktop = callPackage ../applications/networking/instant-messengers/cinny-desktop { };
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };
 


### PR DESCRIPTION
## Description of changes
Builds cinny and cinny-desktop from source using `buildNpmPackage` and `buildRustPackage`. This allows cinny to use OpenSSL 3 and not be marked outdated anymore.

Didn't do too much testing of `cinny` but building it from source as `cinny-desktop` needs it to build from source.

@wahjava 
@aveltras
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
