### PR TITLE
ztags: unstable-2023-08-03 -> unstable-2023-08-29

### DIFF
--- a/pkgs/development/tools/misc/ztags/default.nix
+++ b/pkgs/development/tools/misc/ztags/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation {
   pname = "ztags";
-  version = "unstable-2023-08-03";
+  version = "unstable-2023-08-29";
 
   src = fetchFromGitHub {
     owner = "gpanders";
     repo = "ztags";
-    rev = "6ef039047f6580772c5ff97e8770d919dc07a4fa";
-    hash = "sha256-WuDEHzNU3I4VPHEAkRdIUE5LPbQEKbUnITdFutGV58Y=";
+    rev = "87dbc4ba7993fa1537ddce942c6ce4cf90ce0809";
+    hash = "sha256-FZZZnTmz4mxhiRXs16A41fz0WYIg6oGM7xj2cECRkrM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Diff: https://github.com/gpanders/ztags/compare/6ef039047f6580772c5ff97e8770d919dc07a4fa...87dbc4ba7993fa1537ddce942c6ce4cf90ce0809

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
