### PR TITLE
python310Packages.logilab-common: 1.9.7 -> 1.10.0

### DIFF
--- a/pkgs/development/python-modules/logilab/common.nix
+++ b/pkgs/development/python-modules/logilab/common.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "logilab-common";
-  version = "1.9.7";
+  version = "1.10.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-/JlN9RlIRLbi9TL9V6SgO6ddPeKqLzK402DqkLBRuxM=";
+    hash = "sha256-MoXt3tta5OimJUjOkWSMDCmXV0aS8N0W5bcANwAelYY=";
   };
 
   nativeBuildInputs = [
@@ -27,6 +27,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools
     mypy-extensions
     typing-extensions
   ] ++ lib.optionals (pythonOlder "3.8") [

--- a/pkgs/development/python-modules/logilab/constraint.nix
+++ b/pkgs/development/python-modules/logilab/constraint.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, logilab-common, six }:
+{ lib, buildPythonPackage, fetchPypi, logilab-common, six, importlib-metadata, pip }:
 
 buildPythonPackage rec {
   pname = "logilab-constraint";
@@ -8,6 +8,11 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-Jk6wvvcDEeHfy7dUcjbnzFIeGBYm5tXzCI26yy+t2qs=";
   };
+
+  nativeBuildInputs = [
+    importlib-metadata
+    pip
+  ];
 
   propagatedBuildInputs = [
     logilab-common six

--- a/pkgs/development/python-modules/logilab/constraint.nix
+++ b/pkgs/development/python-modules/logilab/constraint.nix
@@ -1,8 +1,18 @@
-{ lib, buildPythonPackage, fetchPypi, logilab-common, six, importlib-metadata, pip }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, importlib-metadata
+, logilab-common
+, pip
+, six
+, pytestCheckHook
+, setuptools
+}:
 
 buildPythonPackage rec {
   pname = "logilab-constraint";
   version = "0.6.2";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
@@ -15,13 +25,33 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    logilab-common six
+    logilab-common
+    setuptools
+    six
   ];
 
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # avoid ModuleNotFoundError: No module named 'logilab.common' due to namespace
+    rm -r logilab
+  '';
+
+  disabledTests = [
+    # these tests are abstract test classes intended to be inherited
+    "Abstract"
+  ];
+
+  pythonImportsCheck = [ "logilab.constraint" ];
 
   meta = with lib; {
     description = "logilab-database provides some classes to make unified access to different";
-    homepage = "https://www.logilab.org/project/logilab-database";
+    homepage = "https://forge.extranet.logilab.fr/open-source/logilab-constraint";
+    changelog = "https://forge.extranet.logilab.fr/open-source/logilab-constraint/-/blob/${version}/CHANGELOG.md";
+    license = licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ ];
   };
 }
 


### PR DESCRIPTION
supersedes #252857

Diff: https://forge.extranet.logilab.fr/open-source/logilab-common/-/compare/1.9.7...1.10.0

Changelog: https://forge.extranet.logilab.fr/open-source/logilab-common/-/blob/1.10.0/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
