### PR TITLE
_86Box: 3.11 -> 4.0

### DIFF
--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkg-config, makeWrapper, freetype, SDL2
 , glib, pcre2, openal, rtmidi, fluidsynth, jack2, alsa-lib, qt5, libvncserver
-, discord-gamesdk, libpcap
+, discord-gamesdk, libpcap, libslirp
 
 , enableDynarec ? with stdenv.hostPlatform; isx86 || isAarch
 , enableNewDynarec ? enableDynarec && stdenv.hostPlatform.isAarch
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "86Box";
-  version = "3.11";
+  version = "4.0";
 
   src = fetchFromGitHub {
     owner = "86Box";
     repo = "86Box";
     rev = "v${version}";
-    hash = "sha256-n3Q/NUiaC6/EZyBUn6jUomnQCqr8tvYKPI5JrRRFScI=";
+    hash = "sha256-VTfYCVEbArcYVzh3NkX1yBXhtRnGZ/+khk0KG42fs24=";
   };
 
   nativeBuildInputs = [
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     freetype
+    fluidsynth
     SDL2
     glib
     openal
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
     pcre2
     jack2
     libpcap
+    libslirp
     qt5.qtbase
     qt5.qttools
   ] ++ lib.optional stdenv.isLinux alsa-lib
@@ -60,7 +62,6 @@ stdenv.mkDerivation rec {
   postFixup = let
     libPath = lib.makeLibraryPath ([
       libpcap
-      fluidsynth
     ] ++ lib.optional unfreeEnableDiscord discord-gamesdk);
     libPathVar = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
   in


### PR DESCRIPTION
## Description of changes

Many improvements, for example support for Pipewire, support for emulating ACPI machines with soft power, a large number of fixes for both emulation bugs and other various issues. [Full changelog](https://86box.net/2023/08/26/86box-v4-0.html) here.

As far as changes relevant to Nixpkgs go:

[Fluidsynth is now dynamically linked](https://github.com/86Box/86Box/commit/4ecfdb48349526ee448eff634fb17f17436aa4cd) instead of being resolved at runtime using `QLibrary`, allowing us to remove it from the `postFixup` patch. It now also uses the fluidsynth headers, so it needs to be added to `buildInputs`.

libslirp is now an external dependency, so it needs to be added to `buildInputs`.

The VNC renderer is currently broken in 86Box 4.0, and `discord-gamesdk` doesn't "build" in NixOS currently, but otherwise I did not notice any issues needing attention.

Closes #252553.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
