### PR TITLE
maim: set meta.mainProgram

### DIFF
--- a/pkgs/tools/graphics/maim/default.nix
+++ b/pkgs/tools/graphics/maim/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = with lib; {
+    mainProgram = "maim";
     inherit (src.meta) homepage;
     description = "A command-line screenshot utility";
     longDescription = ''


### PR DESCRIPTION
## Description of changes

Set the meta.mainProgram attribute for maim to maim

### Why?

https://github.com/NixOS/nixpkgs/pull/246386 introduced warnings for getExe use when this attribute isn't specified