### PR TITLE
i3wsr: set meta.mainProgram

### DIFF
--- a/pkgs/applications/window-managers/i3/wsr.nix
+++ b/pkgs/applications/window-managers/i3/wsr.nix
@@ -20,6 +20,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   meta = with lib; {
+    mainProgram = "i3wsr";
     description = "Automatically change i3 workspace names based on their contents";
     longDescription = ''
       Automatically sets the workspace names to match the windows on the workspace.


### PR DESCRIPTION
## Description of changes

Set the meta.mainProgram attribute for i3wsr to i3wsr

### Why?

https://github.com/NixOS/nixpkgs/pull/246386 introduced warnings for getExe use when this attribute isn't specified