### PR TITLE
pigz: 2.7 -> 2.8

### DIFF
--- a/pkgs/tools/compression/pigz/default.nix
+++ b/pkgs/tools/compression/pigz/default.nix
@@ -1,23 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, zlib, util-linux }:
+{ lib, stdenv, fetchFromGitHub, zlib, util-linux }:
 
 stdenv.mkDerivation rec {
   pname = "pigz";
-  version = "2.7";
+  version = "2.8";
 
   src = fetchFromGitHub {
       owner = "madler";
       repo = pname;
       rev = "refs/tags/v${version}";
-      sha256 = "sha256-RYp3vRwlI6S/lcib+3t7qLYFWv11GUnj1Cmxm9eaVro=";
+      sha256 = "sha256-PzdxyO4mCg2jE/oBk1MH+NUdWM95wIIIbncBg71BkmQ=";
   };
-
-  patches = [
-    # needed to build the pigzn test binary
-    (fetchpatch {
-      url = "https://github.com/madler/pigz/commit/67fd6e436f4f479aead529a719e24d6864cf1dfa.patch";
-      sha256 = "sha256-FkzLYob/WIVIB7eh03cdzpLy6SzoHLqEMsWyHdMTjbU=";
-    })
-  ];
 
   enableParallelBuilding = true;
 
@@ -28,11 +20,15 @@ stdenv.mkDerivation rec {
   doCheck = stdenv.isLinux;
   checkTarget = "tests";
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 pigz "$out/bin/pigz"
     ln -s pigz "$out/bin/unpigz"
     install -Dm755 pigz.1 "$out/share/man/man1/pigz.1"
     ln -s pigz.1 "$out/share/man/man1/unpigz.1"
     install -Dm755 pigz.pdf "$out/share/doc/pigz/pigz.pdf"
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Changes: https://github.com/madler/pigz/compare/v2.7...v2.8

Most notable change is glib-1.3 compatibility.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
