### PR TITLE
LuaJIT: 2.0.5-2022-09-13, 2.1.0-2022-10-04 -> 2.0.1693340858, 2.1.1693350652

### DIFF
--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -1,13 +1,15 @@
 { self, callPackage, fetchFromGitHub, lib, passthruFun }:
 
-callPackage ./default.nix {
-  version = "2.0.5-2022-09-13";
+callPackage ./default.nix rec {
+  # The patch version is the timestamp of the git commit,
+  # obtain via `cat $(nix-build -A luajit_2_0.src)/.relver`
+  version = "2.0.1693340858";
 
   src = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
-    rev = "46e62cd963a426e83a60f691dcbbeb742c7b3ba2";
-    hash = "sha256-/XR9+6NjXs2TrUVKJNkH2h970BkDNFqMDJTWcy/bswU=";
+    rev = "c6ee7e19d107b4f9a140bb2ccf99162e26318c69";
+    hash = "sha256-3/7ASZRniytw5RkOy0F9arHkZevq6dxmya+Ba3A5IIA=";
   };
 
   extraMeta = { # this isn't precise but it at least stops the useless Hydra build

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -1,13 +1,15 @@
 { self, callPackage, fetchFromGitHub, passthruFun }:
 
-callPackage ./default.nix {
-  version = "2.1.0-2022-10-04";
+callPackage ./default.nix rec {
+  # The patch version is the timestamp of the git commit,
+  # obtain via `cat $(nix-build -A luajit_2_1.src)/.relver`
+  version = "2.1.1693350652";
 
   src = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
-    rev = "6c4826f12c4d33b8b978004bc681eb1eef2be977";
-    hash = "sha256-GMgoSVHrfIuLdk8mW9XgdemNFsAkkQR4wiGGjaAXAKg=";
+    rev = "41fb94defa8f830ce69a8122b03f6ac3216d392a";
+    hash = "sha256-iY80CA97RqJ9gF1Kl7ms/lC6m6KScjxWmljh5Gy7Brg=";
   };
 
   inherit self passthruFun;

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -24,6 +24,7 @@
 , enableGDBJITSupport ? false
 , enableAPICheck ? false
 , enableVMAssertions ? false
+, enableRegisterAllocationRandomization ? false
 , useSystemMalloc ? false
 # Upstream generates randomized string id's by default for security reasons
 # https://github.com/LuaJIT/LuaJIT/issues/626. Deterministic string id's should
@@ -50,6 +51,7 @@ let
     ++ optional enableGDBJITSupport "-DLUAJIT_USE_GDBJIT"
     ++ optional enableAPICheck "-DLUAJIT_USE_APICHECK"
     ++ optional enableVMAssertions "-DLUAJIT_USE_ASSERT"
+    ++ optional enableRegisterAllocationRandomization "-DLUAJIT_RANDOM_RA"
     ++ optional deterministicStringIds "-DLUAJIT_SECURITY_STRID=0"
   ;
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

LuaJIT officially switched to rolling releases: https://www.freelists.org/post/luajit/LuaJIT-uses-rolling-releases, add optional arg `enableRegisterAllocationRandomization`.

~New logic for reading `relver` can be moved to default.nix when the OpenResty fork catches up with upstream.~ cc @SuperSandro2000 

Changelog:

*luajit_2_0*
https://github.com/LuaJIT/LuaJIT/compare/46e62cd963a426e83a60f691dcbbeb742c7b3ba2...c6ee7e19d107b4f9a140bb2ccf99162e26318c69

*luajit_2_1*
https://github.com/LuaJIT/LuaJIT/compare/6c4826f12c4d33b8b978004bc681eb1eef2be977...41fb94defa8f830ce69a8122b03f6ac3216d392a


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
