### PR TITLE
cronopete: init at 4.15.1

### DIFF
--- a/pkgs/tools/backup/cronopete/default.nix
+++ b/pkgs/tools/backup/cronopete/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, meson
+, ninja
+, pkg-config
+
+, cairo
+, gdk-pixbuf
+, gobject-introspection
+, gtk3
+, libXdmcp
+, libXtst
+, libayatana-appindicator
+, libdatrie
+, libepoxy
+, libgee
+, libnotify
+, libselinux
+, libsepol
+, libthai
+, libxkbcommon
+, pango
+, pcre
+, pcre2
+, udisks2
+, util-linuxMinimal
+, rsync
+, vala
+, wrapGAppsHook
+, makeWrapper
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cronopete";
+  version = "4.15.1";
+
+  src = fetchFromGitLab {
+    owner = "rastersoft";
+    repo = "cronopete";
+    rev = finalAttrs.version;
+    hash = "sha256-vXvAkQPxwy9Dnt+IC7mdLJCFenCFIvhjbirY7WPSFKs=";
+  };
+
+  patches = [
+    ./fix-hardcoded-paths.patch
+  ];
+
+  buildInputs = [
+    cairo
+    gdk-pixbuf
+    gtk3
+    udisks2
+    gobject-introspection
+    libnotify
+    pango
+    libayatana-appindicator
+    libgee
+    pcre2
+    util-linuxMinimal # provides libmount
+    libselinux
+    libsepol
+    pcre
+    libthai
+    libdatrie
+    libXdmcp
+    libxkbcommon
+    libepoxy
+    libXtst
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    meson
+    ninja
+    pkg-config
+    vala
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/cronopete --prefix PATH : ${lib.makeBinPath [rsync]}
+  '';
+
+  meta = with lib; {
+    description = "An Apple's TimeMachine clone for Linux";
+    homepage = "https://gitlab.com/rastersoft/cronopete";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ dit7ya ];
+    mainProgram = "cronopete";
+  };
+})

--- a/pkgs/tools/backup/cronopete/fix-hardcoded-paths.patch
+++ b/pkgs/tools/backup/cronopete/fix-hardcoded-paths.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ae90d4e..1f658fd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -56,10 +56,6 @@ set(MODULES_TO_CHECK ${MODULES_TO_CHECK} udisks2)
+ 
+ pkg_check_modules(DEPS REQUIRED ${MODULES_TO_CHECK})
+ 
+-if ( (NOT EXISTS "/usr/bin/rsync"))
+-	message(FATAL_ERROR "Can't find any of the files /usr/bin/rsync")
+-endif()
+-
+ find_program ( WHERE_gtk_update_icon_cache gtk-update-icon-cache )
+ if ( NOT WHERE_gtk_update_icon_cache )
+ 	find_program ( WHERE_gtk_update_icon_cache gtk-update-icon-cache.3.0 )
+diff --git a/data/CMakeLists.txt b/data/CMakeLists.txt
+index a73a639..b57bcee 100644
+--- a/data/CMakeLists.txt
++++ b/data/CMakeLists.txt
+@@ -6,7 +6,7 @@ install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/cronopete_restore.sh DESTINATION ${
+ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cronopete_preferences.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications/ )
+ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cronopete_restore.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications/ )
+ if( NOT ( ${CMAKE_INSTALL_PREFIX} MATCHES "^/home/" ) )
+-	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cronopete.desktop DESTINATION /etc/xdg/autostart/ )
++	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cronopete.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+ else()
+ 	MESSAGE(STATUS "[33mAutostart file data/cronopete.desktop will not be installed. You must create your own .desktop file and put it at ~/.config/autostart[39m")
+ endif()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7163,6 +7163,8 @@ with pkgs;
 
   cron = callPackage ../tools/system/cron { };
 
+  cronopete = callPackage ../tools/backup/cronopete { };
+
   ctlptl = callPackage ../development/tools/ctlptl { };
 
   dumpnar = callPackage ../tools/archivers/dumpnar { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/252826.

I don't want to maintain this package since I will never use it - if someone steps up as a maintainer that would be great.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
