### PR TITLE
python310Packages.jupyter-server: 2.7.0 -> 2.7.3

### DIFF
--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "jupyter-server";
-  version = "2.7.0";
+  version = "2.7.3";
   format = "pyproject";
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "jupyter_server";
     inherit version;
-    hash = "sha256-NtoKJm0xpBrDNaNmyIkzwX36W7gXpI9cAsFtMDvJR38=";
+    hash = "sha256-1JFshYHE67xTTOvaqOyiR42fO/3Yjq4p/KsBIOrFdkk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/send2trash/default.nix
+++ b/pkgs/development/python-modules/send2trash/default.nix
@@ -7,24 +7,15 @@
 
 buildPythonPackage rec {
   pname = "Send2Trash";
-  version = "1.8.1b0";
+  version = "1.8.2";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "hsoft";
     repo = "send2trash";
     rev = "refs/tags/${version}";
-    hash = "sha256-kDUEfyMTk8CXSxTEi7E6kl09ohnWHeaoif+EIaIJh9Q=";
+    hash = "sha256-p0Pd9g+nLoT+oruthwjBn2E9rznvcx35VmzOAce2iTY=";
   };
-
-  postPatch = ''
-    # Confuses setuptools validation
-    # setuptools.extern.packaging.requirements.InvalidRequirement: One of the parsed requirements in `extras_require[win32]` looks like a valid environment marker: 'sys_platform == "win32"'
-    sed -i '/win32 =/d' setup.cfg
-
-    # setuptools.extern.packaging.requirements.InvalidRequirement: One of the parsed requirements in `extras_require[objc]` looks like a valid environment marker: 'sys_platform == "darwin"'
-    sed -i '/objc =/d' setup.cfg
-  '';
 
   nativeBuildInputs = [
     setuptools


### PR DESCRIPTION
## Description of changes

- python310Packages.jupyter-server: 2.7.0 -> 2.7.3
Changelog: https://github.com/jupyter-server/jupyter_server/blob/v2.7.3/CHANGELOG.md
  - fix https://nvd.nist.gov/vuln/detail/CVE-2023-39968
  - fix https://nvd.nist.gov/vuln/detail/CVE-2023-40170

- python310Packages.send2trash: 1.8.1b0 -> 1.8.2
Diff: https://github.com/arsenetar/send2trash/compare/refs/tags/1.8.1b0...1.8.2
Changelog: https://github.com/arsenetar/send2trash/blob/1.8.2/CHANGES.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
