### PR TITLE
vault-ssh-helper: init at 0.2.1, nixosTests.vault-ssh-helper: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10033,6 +10033,15 @@
     githubId = 10626;
     name = "Andreas Wagner";
   };
+  lpostula = {
+    email = "lois@postu.la";
+    github = "loispostula";
+    githubId = 1423612;
+    name = "Loïs Postula";
+    keys = [{
+      fingerprint = "0B4A E7C7 D3B7 53F5 3B3D  774C 3819 3C6A 09C3 9ED1";
+    }];
+  };
   lrewega = {
     email = "lrewega@c32.ca";
     github = "lrewega";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -846,6 +846,7 @@ in {
   vault-agent = handleTest ./vault-agent.nix {};
   vault-dev = handleTest ./vault-dev.nix {};
   vault-postgresql = handleTest ./vault-postgresql.nix {};
+  vault-ssh-helper = handleTest ./vault-ssh-helper.nix {};
   vaultwarden = handleTest ./vaultwarden.nix {};
   vector = handleTest ./vector.nix {};
   vengi-tools = handleTest ./vengi-tools.nix {};

--- a/nixos/tests/vault-ssh-helper.nix
+++ b/nixos/tests/vault-ssh-helper.nix
@@ -1,0 +1,38 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+{
+  name = "vault-ssh-helper";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ lpostula ];
+  };
+  nodes.machine = { pkgs, config, ... }: {
+    environment.systemPackages = [ pkgs.vault pkgs.vault-ssh-helper ];
+    environment.variables.VAULT_ADDR = "http://127.0.0.1:8200";
+    environment.variables.VAULT_TOKEN = "phony-secret";
+
+    services.vault = {
+      enable = true;
+      dev = true;
+      devRootTokenID = config.environment.variables.VAULT_TOKEN;
+    };
+  };
+
+  testScript = let
+    config = pkgs.writeText "config.hcl" ''
+      vault_addr = "http://127.0.0.1:8200"
+      tls_skip_verify = false
+      ssh_mount_point = "ssh"
+      allowed_roles = "*"
+    '';
+  in ''
+    import json
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("vault.service")
+    machine.wait_for_open_port(8200)
+    out = machine.succeed("vault status -format=json")
+    status = json.loads(out)
+    assert status.get("initialized") == True
+    machine.succeed("vault secrets enable ssh")
+    machine.succeed("vault-ssh-helper -dev -verify-only -config=${config}")
+  '';
+})

--- a/pkgs/tools/security/vault-ssh-helper/default.nix
+++ b/pkgs/tools/security/vault-ssh-helper/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, lib, fetchFromGitHub, buildGoModule, installShellFiles, nixosTests
+, makeWrapper
+, gawk
+, glibc
+}:
+
+buildGoModule rec {
+  pname = "vault-ssh-helper";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = "vault-ssh-helper";
+    rev = "v${version}";
+    sha256 = "sha256-TY+0EqQW2vUh6JIDHI+98leOwBT9ZhsVTJL0FpZrXjo=";
+  };
+
+  vendorHash = null;
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  tags = [ "vault-ssh-helper" ];
+
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/hashicorp/vault-ssh-helper/sdk/version.GitCommit=${src.rev}"
+    "-X github.com/hashicorp/vault-ssh-helper/sdk/version.Version=${version}"
+    "-X github.com/hashicorp/vault-ssh-helper/sdk/version.VersionPrerelease="
+  ];
+
+  postInstall = ''
+    echo "complete -C $out/bin/vault-ssh-helper vault-ssh-helper" > vault-ssh-helper.bash
+    installShellCompletion vault-ssh-helper.bash
+  '' + lib.optionalString stdenv.isLinux ''
+    wrapProgram $out/bin/vault-ssh-helper \
+      --prefix PATH ${lib.makeBinPath [ gawk glibc ]}
+  '';
+
+  passthru.tests = { inherit (nixosTests) vault-ssh-helper; };
+
+  meta = with lib; {
+    description = "Vault SSH Agent is used to enable one time keys and passwords ";
+    homepage = "https://github.com/hashicorp/vault-ssh-helper";
+    license = licenses.mpl20;
+    changelog = "https://github.com/hashicorp/vault-ssh-helper/blob/v${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ lpostula ];
+  };
+}

--- a/pkgs/tools/security/vault-ssh-helper/default.nix
+++ b/pkgs/tools/security/vault-ssh-helper/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, lib, fetchFromGitHub, buildGoModule, installShellFiles, nixosTests
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildGoModule
+, installShellFiles
+, nixosTests
 , makeWrapper
 , gawk
 , glibc

--- a/pkgs/tools/security/vault-ssh-helper/default.nix
+++ b/pkgs/tools/security/vault-ssh-helper/default.nix
@@ -39,7 +39,7 @@ buildGoModule rec {
   passthru.tests = { inherit (nixosTests) vault-ssh-helper; };
 
   meta = with lib; {
-    description = "Vault SSH Agent is used to enable one time keys and passwords ";
+    description = "SSH agent to use one time keys and passwords with HashiCorp Vault";
     homepage = "https://github.com/hashicorp/vault-ssh-helper";
     license = licenses.mpl20;
     changelog = "https://github.com/hashicorp/vault-ssh-helper/blob/v${version}/CHANGELOG.md";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41465,6 +41465,8 @@ with pkgs;
 
   vault-medusa = callPackage ../tools/security/vault-medusa { };
 
+  vault-ssh-helper = callPackage ../tools/security/vault-ssh-helper { };
+
   vault-ssh-plus = callPackage ../tools/security/vault-ssh-plus { };
 
   vault-bin = callPackage ../tools/security/vault/vault-bin.nix { };


### PR DESCRIPTION
## Description of changes

Add [`vault-ssh-helper`](https://github.com/hashicorp/vault-ssh-helper) package: Vault SSH Agent is used to enable one time keys and passwords 

Follow-up on #252638  wherre the rebase went wrong

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
