### PR TITLE
python310Packages.wandb: 0.15.5 -> 0.15.9; remove broken tensorflow from nativeCheckInputs

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -29,7 +29,6 @@
 , pandas
 , parameterized
 , pathtools
-, promise
 , protobuf
 , psutil
 , pydantic
@@ -46,7 +45,6 @@
 , sentry-sdk
 , setproctitle
 , setuptools
-, shortuuid
 , substituteAll
 , torch
 , tqdm
@@ -54,8 +52,8 @@
 
 buildPythonPackage rec {
   pname = "wandb";
-  version = "0.15.5";
-  format = "setuptools";
+  version = "0.15.10";
+  format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
@@ -63,7 +61,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-etS1NkkskA5Lg/38QIdzCVWgqZpjpT2LwaWF1k7WVXs=";
+    hash = "sha256-MuYaeg7+lMOOSalnLyKsCw+f44daDDayvyKvY8z697c=";
   };
 
   patches = [
@@ -76,6 +74,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     pythonRelaxDepsHook
+    setuptools
   ];
 
   # setuptools is necessary since pkg_resources is required at runtime.
@@ -85,7 +84,6 @@ buildPythonPackage rec {
     docker_pycreds
     gitpython
     pathtools
-    promise
     protobuf
     psutil
     pyyaml
@@ -93,7 +91,6 @@ buildPythonPackage rec {
     sentry-sdk
     setproctitle
     setuptools
-    shortuuid
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -139,6 +136,11 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [ "protobuf" ];
 
+  pytestFlagsArray = [
+    # We want to run only unit tests
+    "tests/pytest_tests"
+  ];
+
   disabledTestPaths = [
     # Tests that try to get chatty over sockets or spin up servers, not possible in the nix build environment.
     "tests/pytest_tests/system_tests/test_notebooks/test_notebooks.py"
@@ -165,7 +167,6 @@ buildPythonPackage rec {
     "tests/pytest_tests/unit_tests_old/tests_launch/test_launch_aws.py"
     "tests/pytest_tests/unit_tests_old/tests_launch/test_launch_cli.py"
     "tests/pytest_tests/unit_tests_old/tests_launch/test_launch_docker.py"
-    "tests/pytest_tests/unit_tests_old/tests_launch/test_launch_kubernetes.py"
     "tests/pytest_tests/unit_tests_old/tests_launch/test_launch.py"
     "tests/pytest_tests/unit_tests/test_cli.py"
     "tests/pytest_tests/unit_tests/test_data_types.py"
@@ -207,6 +208,7 @@ buildPythonPackage rec {
     "tests/pytest_tests/system_tests/test_core/test_time_resolution.py"
     "tests/pytest_tests/system_tests/test_core/test_torch_full.py"
     "tests/pytest_tests/system_tests/test_core/test_validation_data_logger.py"
+    "tests/pytest_tests/system_tests/test_core/test_wandb_init.py"
     "tests/pytest_tests/system_tests/test_core/test_wandb_integration.py"
     "tests/pytest_tests/system_tests/test_core/test_wandb_run.py"
     "tests/pytest_tests/system_tests/test_core/test_wandb_settings.py"
@@ -214,6 +216,7 @@ buildPythonPackage rec {
     "tests/pytest_tests/system_tests/test_core/test_wandb_verify.py"
     "tests/pytest_tests/system_tests/test_core/test_wandb.py"
     "tests/pytest_tests/system_tests/test_importers/test_import_mlflow.py"
+    "tests/pytest_tests/system_tests/test_nexus/test_nexus.py"
     "tests/pytest_tests/system_tests/test_sweep/test_public_api.py"
     "tests/pytest_tests/system_tests/test_sweep/test_sweep_scheduler.py"
     "tests/pytest_tests/system_tests/test_sweep/test_sweep_utils.py"
@@ -228,6 +231,7 @@ buildPythonPackage rec {
     "tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py"
     "tests/pytest_tests/system_tests/test_launch/test_launch_local_container.py"
     "tests/pytest_tests/system_tests/test_launch/test_launch_run.py"
+    "tests/pytest_tests/system_tests/test_launch/test_launch_sagemaker.py"
     "tests/pytest_tests/system_tests/test_launch/test_launch_sweep_cli.py"
     "tests/pytest_tests/system_tests/test_launch/test_launch_sweep.py"
     "tests/pytest_tests/system_tests/test_launch/test_launch.py"
@@ -241,7 +245,7 @@ buildPythonPackage rec {
     "tests/pytest_tests/unit_tests_old/tests_launch/test_launch_jobs.py"
 
     # Requires google-cloud-aiplatform which is not packaged as of 2023-04-25.
-    "tests/pytest_tests/unit_tests_old/tests_launch/test_launch_gcp.py"
+    "tests/pytest_tests/unit_tests/test_launch/test_runner/test_vertex.py"
 
     # Requires google-cloud-artifact-registry which is not packaged as of 2023-04-25.
     "tests/pytest_tests/unit_tests_old/tests_launch/test_kaniko_build.py"
@@ -255,6 +259,9 @@ buildPythonPackage rec {
 
     # Requires tensorflow which is broken as of 2023-09-03
     "tests/pytest_tests/unit_tests/test_keras.py"
+
+    # Try to get hardware information, not possible in the nix build environment
+    "tests/pytest_tests/unit_tests/test_system_metrics/test_disk.py"
 
     # See https://github.com/wandb/wandb/issues/5423
     "tests/pytest_tests/unit_tests/test_docker.py"

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -48,7 +48,6 @@
 , setuptools
 , shortuuid
 , substituteAll
-, tensorflow
 , torch
 , tqdm
 }:
@@ -128,7 +127,6 @@ buildPythonPackage rec {
     pytestCheckHook
     responses
     scikit-learn
-    tensorflow
     torch
     tqdm
   ];
@@ -254,6 +252,9 @@ buildPythonPackage rec {
 
     # Requires metaflow which is not packaged as of 2023-04-25.
     "tests/pytest_tests/unit_tests/test_metaflow.py"
+
+    # Requires tensorflow which is broken as of 2023-09-03
+    "tests/pytest_tests/unit_tests/test_keras.py"
 
     # See https://github.com/wandb/wandb/issues/5423
     "tests/pytest_tests/unit_tests/test_docker.py"


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/wandb/wandb/compare/refs/tags/v0.15.5...v0.15.9
Changelog: https://github.com/wandb/wandb/raw/v0.15.9/CHANGELOG.md

remove broken tensorflow from nativeCheckInputs and remove a relevant test.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
