### PR TITLE
libpfm: Fix windows build

### DIFF
--- a/pkgs/development/libraries/libpfm/default.nix
+++ b/pkgs/development/libraries/libpfm/default.nix
@@ -1,15 +1,29 @@
-{ lib, stdenv, fetchurl
+{ lib
+, stdenv
+, fetchurl
 , enableShared ? !stdenv.hostPlatform.isStatic
+, windows
 }:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "4.13.0";
   pname = "libpfm";
 
   src = fetchurl {
-    url = "mirror://sourceforge/perfmon2/libpfm4/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/perfmon2/libpfm4/libpfm-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-0YuXdkx1VSjBBR03bjNUXQ62DG6/hWgENoE/pbBMw9E=";
   };
+
+  # Don't install libpfm.so on windows as it doesn't exist
+  # This target is created only if `ifeq ($(SYS),Linux)` passes
+  patches = [ ./fix-windows.patch ];
+
+  # Upstream uses "WINDOWS" instead of "Windows" which is incorrect
+  # See: https://github.com/NixOS/nixpkgs/pull/252982#discussion_r1314346216
+  postPatch = ''
+    substituteInPlace config.mk examples/Makefile \
+      --replace '($(SYS),WINDOWS)' '($(SYS),Windows)'
+  '';
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
@@ -19,6 +33,9 @@ stdenv.mkDerivation (rec {
   ];
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
+  env.CONFIG_PFMLIB_SHARED = if enableShared then "y" else "n";
+
+  buildInputs = lib.optional stdenv.hostPlatform.isWindows windows.libgnurx;
 
   meta = with lib; {
     description = "Helper library to program the performance monitoring events";
@@ -29,11 +46,7 @@ stdenv.mkDerivation (rec {
       (PMU) of modern processors.
     '';
     license = licenses.gpl2;
-    maintainers = [ maintainers.pierron ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ pierron t4ccer ];
+    platforms = platforms.linux ++ platforms.windows;
   };
-} // lib.optionalAttrs ( ! enableShared )
-{
-  CONFIG_PFMLIB_SHARED = "n";
-}
-)
+})

--- a/pkgs/development/libraries/libpfm/fix-windows.patch
+++ b/pkgs/development/libraries/libpfm/fix-windows.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/Makefile b/lib/Makefile
+index 5ca71e3..cd0717f 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -428,11 +428,13 @@ install:
+ 	-mkdir -p $(DESTDIR)$(LIBDIR)
+ 	$(INSTALL) -m 644 $(ALIBPFM) $(DESTDIR)$(LIBDIR)
+ ifeq ($(CONFIG_PFMLIB_SHARED),y)
++ifeq ($(SYS),Linux)
+ 	$(INSTALL) $(SLIBPFM) $(DESTDIR)$(LIBDIR)
+ 	cd $(DESTDIR)$(LIBDIR); $(LN) $(SLIBPFM) $(VLIBPFM)
+ 	cd $(DESTDIR)$(LIBDIR); $(LN) $(SLIBPFM) libpfm.$(SOLIBEXT)
+ 	-$(LDCONFIG)
+ endif
++endif
+ 
+ tags:
+ 	$(CTAGS) -o $(TOPDIR)/tags --tag-relative=yes $(SRCS) $(INCDEP)


### PR DESCRIPTION
## Description of changes

I've tested `nix-build -A libpfm -A pkgsCross.mingw32.libpfm -A pkgsStatic.libpfm`, can't run `nixpkgs-review` unfortunately, too overwhelming for my laptop

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
