### PR TITLE
edk2: 202305 -> 202308

### DIFF
--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -2,6 +2,7 @@
 , clangStdenv
 , fetchFromGitHub
 , fetchpatch
+, runCommand
 , libuuid
 , python3
 , bc
@@ -28,9 +29,9 @@ buildType = if stdenv.isDarwin then
   else
     "GCC5";
 
-edk2 = stdenv.mkDerivation {
+edk2 = stdenv.mkDerivation rec {
   pname = "edk2";
-  version = "202305";
+  version = "202308";
 
   patches = [
     # pass targetPrefix as an env var
@@ -40,14 +41,23 @@ edk2 = stdenv.mkDerivation {
     })
   ];
 
-  # submodules
-  src = fetchFromGitHub {
+  srcWithVendoring = fetchFromGitHub {
     owner = "tianocore";
     repo = "edk2";
     rev = "edk2-stable${edk2.version}";
     fetchSubmodules = true;
-    hash = "sha256-htOvV43Hw5K05g0SF3po69HncLyma3BtgpqYSdzRG4s=";
+    hash = "sha256-Eoi1xf/hw/Knr7n0f0rgVof7wTgrHkmvV4eJjJV1NhM=";
   };
+
+  # We don't want EDK2 to keep track of OpenSSL,
+  # they're frankly bad at it.
+  src = runCommand "edk2-unvendored-src" { } ''
+    cp --no-preserve=mode -r ${srcWithVendoring} $out
+    rm -rf $out/CryptoPkg/Library/OpensslLib/openssl
+    mkdir -p $out/CryptoPkg/Library/OpensslLib/openssl
+    tar --strip-components=1 -xf ${buildPackages.openssl.src} -C $out/CryptoPkg/Library/OpensslLib/openssl
+    chmod -R +w $out/
+  '';
 
   nativeBuildInputs = [ pythonEnv ];
   depsBuildBuild = [ buildPackages.stdenv.cc buildPackages.util-linux buildPackages.bash ];
@@ -69,6 +79,7 @@ edk2 = stdenv.mkDerivation {
     # patchShebangs fails to see these when cross compiling
     for i in $out/BaseTools/BinWrappers/PosixLike/*; do
       substituteInPlace $i --replace '/usr/bin/env bash' ${buildPackages.bash}/bin/bash
+      chmod +x "$i"
     done
   '';
 


### PR DESCRIPTION
## Description of changes

This attempts to perform the long awaited EDK2 bump while doing the unvendoring of OpenSSL as EDK2 maintainers does not perform any upgrade of them, nor backport them.

It is hard to get it right because a lot of things reuse EDK2 source all around, so really it's `edk2.src` that should be patched.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux via cross compilation: already broken
  - [x] aarch64-linux via native compilation
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
