### PR TITLE
supersonic: init at 0.5.2

### DIFF
--- a/pkgs/applications/audio/supersonic/default.nix
+++ b/pkgs/applications/audio/supersonic/default.nix
@@ -1,0 +1,62 @@
+{ lib, pkgs, buildGoModule, fetchFromGitHub, makeDesktopItem, xorg
+, forceWayland ? false }:
+
+buildGoModule rec {
+  pname = "supersonic" + lib.optionalString forceWayland "-wayland";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "dweymouth";
+    repo = "supersonic";
+    rev = "v${version}";
+    hash = "sha256-4SLAUqLMoUxTSi4I/QeHqudO62Gmhpm1XbCGf+3rPlc=";
+  };
+
+  vendorHash = "sha256-6Yp5OoybFpoBuIKodbwnyX3crLCl8hJ2r4plzo0plsY=";
+
+  nativeBuildInputs = with pkgs; [ pkg-config copyDesktopItems ];
+
+  # go-glfw doesn't support both X11 and Wayland in single build
+  tags = "" + lib.optionalString forceWayland "wayland";
+
+  buildInputs = with pkgs;
+    [ mpv glfw libglvnd ] ++ (with xorg; [
+      libXi
+      libXxf86vm
+      libX11
+      libXcursor
+      libXrandr
+      libXinerama
+      xinput
+    ]) ++ lib.optionals forceWayland [ wayland wayland-protocols libxkbcommon ];
+
+  postInstall = ''
+    for dimension in 128 256 512;do
+        dimensions=''${dimension}x''${dimension}
+        mkdir -p $out/share/icons/hicolor/$dimensions/apps
+        cp res/appicon-$dimension.png $out/share/icons/hicolor/$dimensions/apps/${pname}.png
+    done
+  '' + lib.optionalString forceWayland ''
+    mv $out/bin/supersonic $out/bin/${pname}
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      desktopName = "Supersonic" + lib.optionalString forceWayland " (Wayland)";
+      comment = meta.description;
+      categories = [ "Audio" "AudioVideo" ];
+    })
+  ];
+
+  meta = with lib; {
+    description =
+      "A lightweight cross-platform desktop client for Subsonic music servers";
+    homepage = "https://github.com/dweymouth/supersonic";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux; # Technically MacOS should be supported though
+    maintainers = with maintainers; [ sochotnicky ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35803,6 +35803,11 @@ with pkgs;
 
   sunvox = callPackage ../applications/audio/sunvox { };
 
+  supersonic = callPackage ../applications/audio/supersonic { };
+  supersonic-wayland = supersonic.override {
+    forceWayland = true;
+  };
+
   svkbd = callPackage ../applications/accessibility/svkbd { };
 
   swaglyrics = callPackage ../tools/misc/swaglyrics { };


### PR DESCRIPTION
## Description of changes

This adds a new package:
A lightweight cross-platform desktop client for Subsonic music servers

Closes https://github.com/NixOS/nixpkgs/issues/224658

Release info: https://github.com/dweymouth/supersonic/releases/tag/v0.5.2

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->