### PR TITLE
gf2x: switch to inria gitlab as predicted before

### DIFF
--- a/pkgs/development/libraries/gf2x/default.nix
+++ b/pkgs/development/libraries/gf2x/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchgit
+, fetchFromGitLab
 , autoreconfHook
 , buildPackages
 , optimize ? false # impure hardware optimizations
@@ -9,9 +9,11 @@ stdenv.mkDerivation rec {
   pname = "gf2x";
   version = "1.3.0";
 
-  src = fetchgit {
-    url = "https://gitlab.inria.fr/gf2x/gf2x";
-    rev = "gf2x-${version}";
+  src = fetchFromGitLab {
+    domain = "gitlab.inria.fr";
+    owner = "gf2x";
+    repo = pname;
+    rev = "${pname}-${version}";
     sha256 = "04g5jg0i4vz46b4w2dvbmahwzi3k6b8g515mfw7im1inc78s14id";
   };
 

--- a/pkgs/development/libraries/gf2x/default.nix
+++ b/pkgs/development/libraries/gf2x/default.nix
@@ -9,10 +9,8 @@ stdenv.mkDerivation rec {
   pname = "gf2x";
   version = "1.3.0";
 
-  # upstream has plans to move to gitlab:
-  # https://github.com/NixOS/nixpkgs/pull/45299#issuecomment-564477936
   src = fetchgit {
-    url = "https://scm.gforge.inria.fr/anonscm/git/gf2x/gf2x.git";
+    url = "https://gitlab.inria.fr/gf2x/gf2x";
     rev = "gf2x-${version}";
     sha256 = "04g5jg0i4vz46b4w2dvbmahwzi3k6b8g515mfw7im1inc78s14id";
   };


### PR DESCRIPTION
## Description of changes

The `fetchgit` URL has been pointed to the INRIA GitLab instance as `scm.gforge.inria.fr` doesn't seem accessible anymore. This change has been expected: https://github.com/NixOS/nixpkgs/pull/45299#issuecomment-564477936

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


