### PR TITLE
migra: init at 3.0.1647431138

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16136,6 +16136,16 @@
       fingerprint = "E067 520F 5EF2 C175 3F60  50C0 BA46 725F 6A26 7442";
     }];
   };
+  soispha = {
+    name = "Soispha";
+    email = "soispha@vhack.eu";
+    matrix = "@soispha:vhack.eu";
+    github = "soispha";
+    githubId = 132207423;
+    keys = [{
+      fingerprint = "9606 FC74 9FCE 1636 0723  D4AD A5E9 4010 C3A6 42AD";
+    }];
+  };
   solson = {
     email = "scott@solson.me";
     matrix = "@solson:matrix.org";

--- a/pkgs/by-name/mi/migra/package.nix
+++ b/pkgs/by-name/mi/migra/package.nix
@@ -1,0 +1,59 @@
+{ lib
+, python3
+, fetchFromGitHub
+, postgresql
+, postgresqlTestHook
+,
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "migra";
+  version = "3.0.1647431138";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "djrobstep";
+    repo = pname;
+    rev = version;
+    hash = "sha256-LSCJA5Ym1LuV3EZl6gnl9jTHGc8A1LXmR1fj0ZZc+po=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    schemainspect
+    six
+    sqlbag
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+    postgresql
+    postgresqlTestHook
+  ];
+  preCheck = ''
+    export PGUSER="nixbld";
+  '';
+  disabledTests = [
+    # These all fail with "List argument must consist only of tuples or dictionaries":
+    # See this issue: https://github.com/djrobstep/migra/issues/232
+    "test_excludeschema"
+    "test_fixtures"
+    "test_rls"
+    "test_singleschema"
+  ];
+
+  pytestFlagsArray = [
+    "-x"
+    "-svv"
+    "tests"
+  ];
+
+  meta = with lib; {
+    description = "Like diff but for PostgreSQL schemas";
+    homepage = "https://github.com/djrobstep/migra";
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ soispha ];
+  };
+}

--- a/pkgs/development/python-modules/schemainspect/default.nix
+++ b/pkgs/development/python-modules/schemainspect/default.nix
@@ -1,0 +1,118 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pythonOlder
+, sqlalchemy
+, sqlbag
+, setuptools
+, poetry-core
+, pytestCheckHook
+, pytest-xdist
+, pytest-sugar
+, postgresql
+, postgresqlTestHook
+,
+}:
+buildPythonPackage rec {
+  pname = "schemainspect";
+  version = "3.1.1663587362";
+  format = "pyproject";
+  disable = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "djrobstep";
+    repo = pname;
+    # no tags on github, version patch number is unix time.
+    rev = "066262d6fb4668f874925305a0b7dbb3ac866882";
+    hash = "sha256-SYpQQhlvexNc/xEgSIk8L8J+Ta+3OZycGLeZGQ6DWzk=";
+  };
+
+  patches = [
+    # https://github.com/djrobstep/schemainspect/pull/87
+    (fetchpatch
+      {
+        name = "specify_poetry.patch";
+        url = "https://github.com/djrobstep/schemainspect/commit/bdcd001ef7798236fe0ff35cef52f34f388bfe68.patch";
+        hash = "sha256-/SEmcV9GjjvzfbszeGPkfd2DvYenl7bZyWdC0aI3M4M=";
+      })
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+    sqlalchemy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-xdist
+    pytest-sugar
+
+    postgresql
+    postgresqlTestHook
+
+    sqlbag
+  ];
+
+  preCheck = ''
+    export PGUSER="nixbld";
+    export postgresqlEnableTCP=1;
+  '';
+  disabledTests = [
+    # These all fail with "List argument must consist only of tuples or dictionaries":
+    # Related issue: https://github.com/djrobstep/schemainspect/issues/88
+    "test_can_replace"
+    "test_collations"
+    "test_constraints"
+    "test_dep_order"
+    "test_enum_deps"
+    "test_exclusion_constraint"
+    "test_fk_col_order"
+    "test_fk_info"
+    "test_generated_columns"
+    "test_identity_columns"
+    "test_indexes"
+    "test_inherit"
+    "test_kinds"
+    "test_lineendings"
+    "test_long_identifiers"
+    "test_partitions"
+    "test_postgres_inspect"
+    "test_postgres_inspect_excludeschema"
+    "test_postgres_inspect_sigleschema"
+    "test_raw_connection"
+    "test_relationship"
+    "test_replica_trigger"
+    "test_rls"
+    "test_separate_validate"
+    "test_sequences"
+    "test_table_dependency_order"
+    "test_types_and_domains"
+    "test_view_trigger"
+    "test_weird_names"
+  ];
+
+  pytestFlagsArray = [
+    "-x"
+    "-svv"
+    "tests"
+  ];
+  pythonImportsCheck = [
+    "schemainspect"
+  ];
+
+  postUnpack = ''
+    # this dir is used to bump the version number, having it here fails the build
+    rm -r ./source/deploy
+  '';
+
+  meta = with lib; {
+    description = "Schema inspection for PostgreSQL, and potentially others";
+    homepage = "https://github.com/djrobstep/schemainspect";
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ soispha ];
+  };
+}

--- a/pkgs/development/python-modules/sqlbag/default.nix
+++ b/pkgs/development/python-modules/sqlbag/default.nix
@@ -1,0 +1,95 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, psycopg2
+, pymysql
+, sqlalchemy
+, pathlib
+, six
+, flask
+, pendulum
+, packaging
+, setuptools
+, poetry-core
+, pytestCheckHook
+, pytest-xdist
+, pytest-sugar
+, postgresql
+, postgresqlTestHook
+,
+}:
+buildPythonPackage rec {
+  pname = "sqlbag";
+  version = "0.1.1617247075";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "djrobstep";
+    repo = pname;
+    # no tags on github, version patch number is unix time.
+    rev = "eaaeec4158ffa139fba1ec30d7887f4d836f4120";
+    hash = "sha256-lipgnkqrzjzqwbhtVcWDQypBNzq6Dct/qoM8y/FNiNs=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs =
+    [
+      sqlalchemy
+      six
+      packaging
+
+      psycopg2
+      pymysql
+
+      setuptools # needed for 'pkg_resources'
+    ]
+    ++ lib.optional isPy27 pathlib;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-xdist
+    pytest-sugar
+
+    postgresql
+    postgresqlTestHook
+
+    flask
+    pendulum
+  ];
+
+  preCheck = ''
+    export PGUSER="nixbld";
+  '';
+  disabledTests = [
+    # These all fail with "List argument must consist only of tuples or dictionaries":
+    # Related issue: https://github.com/djrobstep/sqlbag/issues/14
+    "test_basic"
+    "test_createdrop"
+    "test_errors_and_messages"
+    "test_flask_integration"
+    "test_orm_stuff"
+    "test_pendulum_for_time_types"
+    "test_transaction_separation"
+  ];
+
+  pytestFlagsArray = [
+    "-x"
+    "-svv"
+    "tests"
+  ];
+
+  pythonImportsCheck = [
+    "sqlbag"
+  ];
+
+  meta = with lib; {
+    description = "Handy python code for doing database things";
+    homepage = "https://github.com/djrobstep/sqlbag";
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ soispha ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11576,6 +11576,8 @@ self: super: with self; {
 
   schema = callPackage ../development/python-modules/schema { };
 
+  schemainspect = callPackage ../development/python-modules/schemainspect { };
+
   schema-salad = callPackage ../development/python-modules/schema-salad { };
 
   schemdraw = callPackage ../development/python-modules/schemdraw { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12344,6 +12344,8 @@ self: super: with self; {
 
   sqlalchemy-views = callPackage ../development/python-modules/sqlalchemy-views { };
 
+  sqlbag = callPackage ../development/python-modules/sqlbag { };
+
   sqlglot = callPackage ../development/python-modules/sqlglot { };
 
   sqlitedict = callPackage ../development/python-modules/sqlitedict { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds migra, a diff and migration tool for PostgreSQL schemas, closing package request #196732.  
Additionally I added both the `schemainspect` and `sqlbag` python libraries, as they are requirements for [migra](https://github.com/djrobstep/migra) and written by the same author.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
