### PR TITLE
nodejs: fix build with clang 16

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -53,6 +53,12 @@ let
 
     strictDeps = true;
 
+    env = lib.optionalAttrs (stdenv.isDarwin && stdenv.isx86_64) {
+      # Make sure libc++ uses `posix_memalign` instead of `aligned_alloc` on x86_64-darwin.
+      # Otherwise, nodejs would require the 11.0 SDK and macOS 10.15+.
+      NIX_CFLAGS_COMPILE = "-D__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__=101300";
+    };
+
     CC_host = "cc";
     CXX_host = "c++";
     depsBuildBuild = [ buildPackages.stdenv.cc openssl libuv zlib icu ];

--- a/pkgs/development/web/nodejs/v14.nix
+++ b/pkgs/development/web/nodejs/v14.nix
@@ -1,8 +1,20 @@
-{ callPackage, python3, lib, stdenv, openssl, enableNpm ? true }:
+{ callPackage, lib, overrideCC, pkgs, buildPackages, openssl, python3, enableNpm ? true }:
 
 let
+  # Clang 16+ cannot build Node v14 due to -Wenum-constexpr-conversion errors.
+  # Use an older version of clang with the current libc++ for compatibility (e.g., with icu).
+  ensureCompatibleCC = packages:
+    if packages.stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion packages.stdenv.cc.cc) "16"
+      then overrideCC packages.llvmPackages_15.stdenv (packages.llvmPackages_15.stdenv.cc.override {
+        inherit (packages.llvmPackages) libcxx;
+        extraPackages = [ packages.llvmPackages.libcxxabi ];
+      })
+      else packages.stdenv;
+
   buildNodejs = callPackage ./nodejs.nix {
     inherit openssl;
+    stdenv = ensureCompatibleCC pkgs;
+    buildPackages = buildPackages // { stdenv = ensureCompatibleCC buildPackages; };
     python = python3;
   };
 in
@@ -10,5 +22,5 @@ in
     inherit enableNpm;
     version = "14.21.3";
     sha256 = "sha256-RY7AkuYK1wDdzwectj1DXBXaTHuz0/mbmo5YqZ5UB14=";
-    patches = lib.optional stdenv.isDarwin ./bypass-xcodebuild.diff;
+    patches = lib.optional pkgs.stdenv.isDarwin ./bypass-xcodebuild.diff;
   }

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -1,8 +1,20 @@
-{ callPackage, openssl, python3, fetchpatch, enableNpm ? true }:
+{ callPackage, lib, overrideCC, pkgs, buildPackages, openssl, python3, fetchpatch, enableNpm ? true }:
 
 let
+  # Clang 16+ cannot build Node v14 due to -Wenum-constexpr-conversion errors.
+  # Use an older version of clang with the current libc++ for compatibility (e.g., with icu).
+  ensureCompatibleCC = packages:
+    if packages.stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion packages.stdenv.cc.cc) "16"
+      then overrideCC packages.llvmPackages_15.stdenv (packages.llvmPackages_15.stdenv.cc.override {
+        inherit (packages.llvmPackages) libcxx;
+        extraPackages = [ packages.llvmPackages.libcxxabi ];
+      })
+      else packages.stdenv;
+
   buildNodejs = callPackage ./nodejs.nix {
     inherit openssl;
+    stdenv = ensureCompatibleCC pkgs;
+    buildPackages = buildPackages // { stdenv = ensureCompatibleCC buildPackages; };
     python = python3;
   };
 


### PR DESCRIPTION
## Description of changes

Node.js requires severals fixes to build with clang 16:

* Use `posix_memalign` on x86_64-darwin. Otherwise, libc++ will try to use `aligned_alloc`, which is not available until 10.15. This is done by defining it as using the 10.13 SDK even though the 10.12 SDK is sufficient;
* Use clang <16 with v14 and v16. The v18 patch doesn’t apply, but `-Wenum-constexpr-conversion` may become a hard error in a future clang release. Using an older version ensures it builds until these versions are dropped from nixpkgs.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
