### PR TITLE
python3Packages.pybind11: work around clang check

### DIFF
--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -12,6 +12,7 @@
 , pytestCheckHook
 , libxcrypt
 , makeSetupHook
+, darwin
 }: let
   setupHook = makeSetupHook {
     name = "pybind11-setup-hook";
@@ -22,6 +23,19 @@
       pythonSitePackages = "${python}/${python.sitePackages}";
     };
   } ./setup-hook.sh;
+
+  # clang 16 defaults to C++17, which results in the use of aligned allocations by pybind11.
+  # libc++ supports aligned allocations via `posix_memalign`, which is available since 10.6,
+  # but clang has a check hard-coded requiring 10.13 because that’s when Apple first shipped a
+  # support for C++17 aligned allocations on macOS.
+  # Tell clang we’re targeting 10.13 on x86_64-darwin while continuing to use the default SDK.
+  stdenv' = if stdenv.isDarwin && stdenv.isx86_64
+    then python.stdenv.override (oldStdenv: {
+      buildPlatform = oldStdenv.buildPlatform // { darwinMinVersion = "10.13"; };
+      targetPlatform = oldStdenv.targetPlatform // { darwinMinVersion = "10.13"; };
+      hostPlatform = oldStdenv.hostPlatform // { darwinMinVersion = "10.13"; };
+    })
+    else python.stdenv;
 in buildPythonPackage rec {
   pname = "pybind11";
   version = "2.11.1";
@@ -40,6 +54,8 @@ in buildPythonPackage rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = lib.optionals (pythonOlder "3.9") [ libxcrypt ];
   propagatedBuildInputs = [ setupHook ];
+
+  stdenv = stdenv';
 
   dontUseCmakeBuildDir = true;
 


### PR DESCRIPTION
## Description of changes

This is required for the upcoming clang 16 bump for Darwin. clang 16 defaults to C++17, which results in aligned allocations in pybind11. These are supported in libc++ with the 10.12 SDK, but clang has a hard-coded check for 10.13.

While the only rebuilds should be x86_64-darwin, targeting staging because there are 2000+.

pybind11’s check phase was run for testing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
