### PR TITLE
dungeondraft: init at 1.1.0.6

### DIFF
--- a/pkgs/by-name/du/dungeondraft/package.nix
+++ b/pkgs/by-name/du/dungeondraft/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  requireFile,
+  dpkg,
+  xorg,
+  libGL,
+  udev,
+  pulseaudio,
+  libkrb5,
+  zenity,
+  zlib,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dungeondraft";
+  version = "1.1.0.6";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  src = requireFile {
+    name = "Dungeondraft-${finalAttrs.version}-Linux64.deb";
+    url = "https://dungeondraft.net/";
+    hash = "sha256-ffT2zOQWKb6W6dQGuKbfejNCl6dondo4CB6JKTReVDs=";
+  };
+  sourceRoot = ".";
+  unpackCmd = "${dpkg}/bin/dpkg-deb -x $curSrc .";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -R usr/share opt $out/
+    substituteInPlace \
+      $out/share/applications/Dungeondraft.desktop \
+      --replace /opt/ $out/opt/
+    ln -s $out/opt/Dungeondraft/Dungeondraft.x86_64 $out/bin/Dungeondraft.x86_64
+    runHook postInstall
+  '';
+  preFixup =
+    let
+      binaryLibPath = lib.makeLibraryPath [
+        xorg.libXcursor
+        xorg.libXinerama
+        xorg.libXext
+        xorg.libXrandr
+        xorg.libXrender
+        xorg.libX11
+        xorg.libXi
+        libGL
+        udev
+        pulseaudio
+        zenity
+      ];
+      libmonoNativeLibPath = lib.makeLibraryPath [ libkrb5 ];
+      libmonoPosixHelperLibPath = lib.makeLibraryPath [ zlib ];
+    in
+    ''
+      patchelf \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${binaryLibPath}" \
+        $out/opt/Dungeondraft/Dungeondraft.x86_64
+
+      chmod +x \
+        $out/opt/Dungeondraft/data_Dungeondraft/Mono/lib/*
+
+      patchelf \
+        --set-rpath "${libmonoNativeLibPath}" \
+        $out/opt/Dungeondraft/data_Dungeondraft/Mono/lib/libmono-native.so
+
+      patchelf \
+        --set-rpath "${libmonoPosixHelperLibPath}" \
+        $out/opt/Dungeondraft/data_Dungeondraft/Mono/lib/libMonoPosixHelper.so
+    '';
+  postInstall = ''
+    wrapProgram $out/bin/Dungeondraft.x86_64 \
+      --prefix PATH : ${lib.makeBinPath [ zenity ]}
+  '';
+
+  meta = {
+    homepage = "https://dungeondraft.net/";
+    description = "A mapmaking tool for Tabletop Roleplaying Games, designed for battlemap scale";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ jsusk ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description of changes
This PR adds a package for the dungeon mapping tool Dungeondraft by Megasploot.

I'm adding myself as a maintainer for this package, I hope that's alright. I also have another PR for Wonderdraft. #253035

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
