### PR TITLE
wonderdraft: init at 1.1.7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8570,6 +8570,12 @@
     name = "John Soo";
     githubId = 10039785;
   };
+  jsusk = {
+    email = "joshua@suskalo.org";
+    github = "IGJoshua";
+    name = "Joshua Suskalo";
+    githubId = 27734541;
+  };
   jtbx = {
     email = "jtbx@duck.com";
     name = "Jeremy Baxter";

--- a/pkgs/by-name/wo/wonderdraft/package.nix
+++ b/pkgs/by-name/wo/wonderdraft/package.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, requireFile
+, dpkg
+, xorg
+, libGL
+, alsa-lib
+, pulseaudio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wonderdraft";
+  version = "1.1.7.3";
+
+  src = requireFile {
+    name = "Wonderdraft-${version}-Linux64.deb";
+    url = "https://wonderdraft.net/";
+    hash = "sha256-i8YZF5w1dIWUyk99SUhHU7eJRjPXJDPbYUzGC1uN8JQ=";
+  };
+  sourceRoot = ".";
+  unpackCmd = "${dpkg}/bin/dpkg-deb -x $curSrc .";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -R usr/share opt $out/
+    substituteInPlace \
+      $out/share/applications/Wonderdraft.desktop \
+      --replace /opt/ $out/opt/
+    ln -s $out/opt/Wonderdraft/Wonderdraft.x86_64 $out/bin/Wonderdraft.x86_64
+    runHook postInstall
+  '';
+  preFixup = let
+    libPath = lib.makeLibraryPath [
+      xorg.libXcursor
+      xorg.libXinerama
+      xorg.libXrandr
+      xorg.libX11
+      xorg.libXi
+      libGL
+      alsa-lib
+      pulseaudio
+    ];
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}" \
+      $out/opt/Wonderdraft/Wonderdraft.x86_64
+  '';
+
+  meta = with lib; {
+    homepage = "https://wonderdraft.net/";
+    description = "A mapmaking tool for Tabletop Roleplaying Games, designed for city, region, or world scale";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jsusk ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes
This PR adds a package for the dungeon mapping tool Wonderdraft by Megasploot.

I'm adding myself as a maintainer for this package, I hope that's alright. I also have another PR for Dungeondraft. #253034

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

