### PR TITLE
plugdata: init at 0.8.0

### DIFF
--- a/pkgs/applications/audio/plugdata/default.nix
+++ b/pkgs/applications/audio/plugdata/default.nix
@@ -1,0 +1,122 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, ensureNewerSourcesForZipFilesHook
+, makeDesktopItem
+, imagemagick
+, cmake
+, pkg-config
+, alsa-lib
+, freetype
+, webkitgtk
+, gnome
+, curl
+, xorg
+, python3
+, makeWrapper
+}:
+
+let
+  # data copied from build system: https://build.opensuse.org/package/view_file/home:plugdata/plugdata/PlugData.desktop
+  desktopItem = makeDesktopItem {
+    name = "PlugData";
+    desktopName = "PlugData";
+    exec = "plugdata";
+    icon = "plugdata_logo.png";
+    comment = "Pure Data as a plugin, with a new GUI";
+    type = "Application";
+    categories = [ "AudioVideo" "Music" ];
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "plugdata";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "plugdata-team";
+    repo = "plugdata";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-qG9fH5C42jiHj03p/KM28jmDIkJkrQMe7fxg92Lg7B4=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ensureNewerSourcesForZipFilesHook
+    imagemagick
+    python3
+    makeWrapper
+  ];
+  buildInputs = [
+    alsa-lib
+    curl
+    freetype
+    webkitgtk
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXinerama
+    xorg.libXrender
+    xorg.libXrandr
+  ];
+  # Standard fix for JUCE programs: https://github.com/NixOS/nixpkgs/blob/5014727e62ae7b22fb1afc61d789ca6ad9170435/pkgs/applications/audio/bespokesynth/default.nix#L137
+  env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux "-rpath ${lib.makeLibraryPath ([
+    xorg.libX11
+    xorg.libXrandr
+    xorg.libXinerama
+    xorg.libXext
+    xorg.libXcursor
+    xorg.libXrender
+  ])}";
+  dontPatchELF = true; # needed or nix will try to optimize the binary by removing "useless" rpath
+
+  postPatch = ''
+    # Don't build LV2 plugin (it hangs), and don't automatically install
+    sed -i 's/ LV2 / /g' CMakeLists.txt
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cd .. # build artifacts are placed inside the source directory for some reason
+    mkdir -p $out/{bin,lib/{clap,vst3}}
+    cp    Plugins/Standalone/plugdata      $out/bin
+    cp -r Plugins/CLAP/plugdata{,-fx}.clap $out/lib/clap
+    cp -r Plugins/VST3/plugdata{,-fx}.vst3 $out/lib/vst3
+
+    icon_name="plugdata_logo.png"
+    icon_path="Resources/Icons/$icon_name"
+
+    install -m644 -D "${desktopItem}"/share/applications/* -t $out/share/applications
+    for size in 16 24 32 48 64 128 256 512; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert -resize "$size"x"$size" "$icon_path" $out/share/icons/hicolor/"$size"x"$size"/apps/"$icon_name"
+    done
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+      # Ensure zenity is available, or it won't be able to open new files.
+      # These X11 libs get dlopen'd, they cause visual bugs when unavailable.
+      wrapProgram $out/bin/plugdata \
+        --prefix PATH : '${lib.makeBinPath [
+          gnome.zenity
+        ]}' \
+        --prefix LD_LIBRARY_PATH : '${lib.makeLibraryPath [
+        xorg.libXrandr
+        xorg.libXinerama
+        xorg.libXcursor
+        xorg.libXrender
+      ]}'
+  '';
+
+  meta = with lib; {
+    description = "Plugin wrapper around Pure Data to allow patching in a wide selection of DAWs";
+    homepage = "https://plugdata.org/";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ PowerUser64 ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34901,6 +34901,8 @@ with pkgs;
 
   plover = recurseIntoAttrs (libsForQt5.callPackage ../applications/misc/plover { });
 
+  plugdata = callPackage ../applications/audio/plugdata { };
+
   plugin-torture = callPackage ../applications/audio/plugin-torture { };
 
   poke = callPackage ../applications/editors/poke { };


### PR DESCRIPTION
## Description of changes

This PR adds [plugdata](https://plugdata.org/), a wrapper around Pure Data that enables running it as a plugin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
