### PR TITLE
Set default `clojure tools` version used by babashka to the same version provided by Clojure

### DIFF
--- a/pkgs/development/interpreters/babashka/default.nix
+++ b/pkgs/development/interpreters/babashka/default.nix
@@ -8,11 +8,11 @@
 
 buildGraalvmNativeImage rec {
   pname = "babashka-unwrapped";
-  version = "1.3.181";
+  version = "1.3.184";
 
   src = fetchurl {
     url = "https://github.com/babashka/babashka/releases/download/v${version}/babashka-${version}-standalone.jar";
-    sha256 = "sha256-NzchlHRxOCSyUf9U0Jv8h4bgKd2Jwp+LmxIfeV8+8+M=";
+    sha256 = "sha256-O3pLELYmuuB+Bf1vHTWQ+u7Ymi3qYiMRpCwvEq+GeBQ=";
   };
 
   graalvmDrv = graalvmCEPackages.graalvm19-ce;

--- a/pkgs/development/interpreters/babashka/wrapped.nix
+++ b/pkgs/development/interpreters/babashka/wrapped.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
       makeWrapper "${babashka-unwrapped}/bin/bb" "$out/bin/bb" \
         --inherit-argv0 \
         --set-default DEPS_CLJ_TOOLS_DIR $out/clojure_tools \
+        --set-default DEPS_CLJ_TOOLS_VERSION ${clojure.version} \
         --set-default JAVA_HOME ${jdkBabashka}
 
       substituteInPlace $out/bin/bb \


### PR DESCRIPTION
## Description of changes

`clojure tools` version is hard-coded in babashka, see:
https://github.com/borkdude/deps.clj/blob/441a53821f6106ea86f33c0e9431110cb713c2e7/src/borkdude/deps.clj#L16C8-L19

That can be an issue if we don't update clojure and babashka at the same time. Many releases just bump the `clojure tools` version and do not have new features, see https://github.com/borkdude/deps.clj/blob/441a53821f6106ea86f33c0e9431110cb713c2e7/CHANGELOG.md

This PR sets the default `clojure tools` version used by babashka to the same version provided by Clojure. 

I'm also bumping babashka the latest version. 



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
