### PR TITLE
cryptowatch-desktop: 0.5.0 -> 0.7.1

### DIFF
--- a/pkgs/applications/finance/cryptowatch/default.nix
+++ b/pkgs/applications/finance/cryptowatch/default.nix
@@ -11,15 +11,16 @@
 , libXrandr
 , udev
 , unzip
+, alsa-lib
 }:
 
 stdenv.mkDerivation rec {
   pname = "cryptowatch-desktop";
-  version = "0.5.0";
+  version = "0.7.1";
 
   src = fetchurl {
     url = "https://cryptowat.ch/desktop/download/linux/${version}";
-    sha256 = "0lr5fsd0f44b1v9f2dvx0a0lmz9dyivyz5d98qx2gcv3jkngw34v";
+    hash = "sha256-ccyHfjp00CgQH+3SiDWx9yE1skOj0RWxnBomHWY/IaU=";
   };
 
   unpackPhase = "unzip $src";
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     dbus
     udev
+    alsa-lib
   ];
 
   sourceRoot = ".";
@@ -53,6 +55,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ livnev ];
+    maintainers = with maintainers; [ livnev kashw2 ];
   };
 }


### PR DESCRIPTION
## Description of changes

change log: https://docs.cryptowat.ch/cryptowatch-docs/desktop/desktop-changelog (doesn't actually list 0.7.1)

changed `sha256` yo `hash` in `src`
added `alsa-lib` buildInput as `libasound.so.2` is required and found in `alsa-lib`
added myself as a maintainer to cryptowatch-desktop

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
