### PR TITLE
focuswriter: 1.7.6 -> 1.8.5

### DIFF
--- a/pkgs/applications/editors/focuswriter/default.nix
+++ b/pkgs/applications/editors/focuswriter/default.nix
@@ -1,18 +1,30 @@
-{ lib, fetchurl, pkg-config, qmake, qttools, hunspell, qtbase, qtmultimedia, mkDerivation }:
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, cmake
+, hunspell
+, qtbase
+, qtmultimedia
+, qttools
+, qt5compat
+}:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "focuswriter";
-  version = "1.7.6";
+  version = "1.8.5";
 
   src = fetchurl {
-    url = "https://gottcode.org/focuswriter/focuswriter-${version}-src.tar.bz2";
-    sha256 = "0h85f6cs9zbxv118mjfxqfv41j19zkx2xq36mpnlmrlzkjj7dx9l";
+    url = "https://gottcode.org/focuswriter/focuswriter-${version}.tar.bz2";
+    sha256 = "sha256-O0GHzpA8Vap/rWiLF2j9zMyfAm2ko1Vk3KqZyyvudlQ=";
   };
 
-  nativeBuildInputs = [ pkg-config qmake qttools ];
-  buildInputs = [ hunspell qtbase qtmultimedia ];
+  nativeBuildInputs = [ pkg-config cmake qttools ];
+  buildInputs = [ hunspell qtbase qtmultimedia qt5compat ];
 
-  qmakeFlags = [ "PREFIX=/" ];
+  # Causes an error during compilation if not set
+  dontWrapQtApps = true;
+
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 
   meta = with lib; {

--- a/pkgs/applications/editors/focuswriter/default.nix
+++ b/pkgs/applications/editors/focuswriter/default.nix
@@ -8,6 +8,8 @@
 , qtmultimedia
 , qttools
 , qt5compat
+, qtwayland
+, wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -21,10 +23,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-6wvTlC/NCCcN2jpwqtoOsCln3ViY/vj7NpMsbYHBGiI=";
   };
 
-  nativeBuildInputs = [ pkg-config cmake qttools ];
-  buildInputs = [ hunspell qtbase qtmultimedia qt5compat ];
-
-  dontWrapQtApps = true;
+  nativeBuildInputs = [ pkg-config cmake qttools wrapQtAppsHook ];
+  buildInputs = [ hunspell qtbase qtmultimedia qt5compat qtwayland ];
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 

--- a/pkgs/applications/editors/focuswriter/default.nix
+++ b/pkgs/applications/editors/focuswriter/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Simple, distraction-free writing environment";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ madjar ];
+    maintainers = with maintainers; [ madjar kashw2 ];
     platforms = platforms.linux;
     homepage = "https://gottcode.org/focuswriter/";
   };

--- a/pkgs/applications/editors/focuswriter/default.nix
+++ b/pkgs/applications/editors/focuswriter/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitHub
 , pkg-config
 , cmake
 , hunspell
@@ -14,15 +14,16 @@ stdenv.mkDerivation rec {
   pname = "focuswriter";
   version = "1.8.5";
 
-  src = fetchurl {
-    url = "https://gottcode.org/focuswriter/focuswriter-${version}.tar.bz2";
-    sha256 = "sha256-O0GHzpA8Vap/rWiLF2j9zMyfAm2ko1Vk3KqZyyvudlQ=";
+  src = fetchFromGitHub {
+    owner = "gottcode";
+    repo = "focuswriter";
+    rev = "v${version}";
+    hash = "sha256-6wvTlC/NCCcN2jpwqtoOsCln3ViY/vj7NpMsbYHBGiI=";
   };
 
   nativeBuildInputs = [ pkg-config cmake qttools ];
   buildInputs = [ hunspell qtbase qtmultimedia qt5compat ];
 
-  # Causes an error during compilation if not set
   dontWrapQtApps = true;
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31724,7 +31724,7 @@ with pkgs;
 
   focus-stack = callPackage ../applications/graphics/focus-stack { };
 
-  focuswriter = libsForQt5.callPackage ../applications/editors/focuswriter { };
+  focuswriter = qt6Packages.callPackage ../applications/editors/focuswriter { };
 
   foliate = callPackage ../applications/office/foliate { };
 


### PR DESCRIPTION
## Description of changes

change log: https://github.com/gottcode/focuswriter/releases/tag/v1.8.5

diff: https://github.com/gottcode/focuswriter/compare/v1.7.6...v1.8.5

- added myself as a maintainer of focuswriter
- changed `all-packages.nix` call to focuswriter to use `qt6Packages.callPackage` over `libsForQt5.callPackage` as focuswriter now uses qt6 predominantly. 
- swapped out `fetchurl` to `fetchFromGitHub` as the GitHub acts as a sort of mirror and has interop with `nix-update` for ease of updates in the future
- wrapped application

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
