### PR TITLE
trrntzip: init at 1.1

### DIFF
--- a/pkgs/by-name/tr/trrntzip/package.nix
+++ b/pkgs/by-name/tr/trrntzip/package.nix
@@ -1,0 +1,53 @@
+# This is a revival of the old trrntzip at
+# https://sourceforge.net/projects/trrntzip
+#
+# See https://sourceforge.net/p/trrntzip/discussion/457469/thread/d3610ea3b6/
+# there hasn't been any response
+#
+# Besides the new one is on github instead of sourceforge
+# which makes life for us easier
+
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, zlib
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "trrntzip";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "0-wiz-0";
+    repo = "trrntzip";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-7BrTJCQH9x9cNqm7tGOLxQlbTmlxs5S2hAD4ZWIady8=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ zlib ];
+
+  meta = with lib; {
+    description = "The goal of the program is to use standard values when creating zips to create identical files over multiple systems";
+    longDescription = ''
+      Torrentzip converts zip archives to a standard format with some
+      pre-defined values, sorting the files, and using particular compression
+      settings so that running it on zip archives created by other tools will
+      always result in the same output. This helps e.g. with sharing
+      zip archives using BitTorrent (which is where the name comes from).
+
+      This is a revival of https://sourceforge.net/projects/trrntzip.
+    '';
+    homepage = "https://github.com/0-wiz-0/trrntzip";
+    license = with licenses; [
+      # "This software includes code from minizip, which is part of zlib"
+      licenses.zlib
+
+      gpl2Plus
+    ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ TheBrainScrambler ];
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The goal of Torrentzip is to use standard values when creating zips to create identical files over multiple systems. In other words, when zipping a file you should always get the same zip, no matter what implementation of Torrentzip you're using. trrntzip is an implementation of that.

https://github.com/0-wiz-0/trrntzip

This is a revival of the old trrntzip at https://sourceforge.net/projects/trrntzip, see https://sourceforge.net/p/trrntzip/discussion/457469/thread/d3610ea3b6/ . There hasn't been any response, and besides the new one is on github instead of sourceforge which makes life for us easier.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
