### PR TITLE
ell: 0.57 -> 0.58

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -3,18 +3,20 @@
 , autoreconfHook
 , pkg-config
 , dbus
+, fetchpatch
+, sysctl
 }:
 
 stdenv.mkDerivation rec {
   pname = "ell";
-  version = "0.57";
+  version = "0.58";
 
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/libs/ell/ell.git";
     rev = version;
-    sha256 = "sha256-9d9WMCByQ1TKWpzWe5msts1LG+BKKqwCgaMBbD74/+4=";
+    hash = "sha256-CwUwwvyT541aIvypVMqRhHkVJLna121Cme+v7c0FLWo=";
   };
 
   nativeBuildInputs = [
@@ -24,8 +26,18 @@ stdenv.mkDerivation rec {
 
   nativeCheckInputs = [
     dbus
+    # required as the sysctl test works on some machines
+    sysctl
   ];
 
+  patches = [
+    # /proc/sys/net/core/somaxconn doesn't always exist in the nix build environment
+    (fetchpatch {
+      name = "skip-sysctl-test-if-sysfs-not-available.patch";
+      url = "https://patchwork.kernel.org/project/ell/patch/526DA75D-01AB-4D85-BF5C-5F25E5C39480@kloenk.dev/raw/";
+      hash = "sha256-YYGYWQ67cbMLt6RnqZmHt+tpvVIDKPbSCqPIouk6alU=";
+    })
+  ];
   enableParallelBuilding = true;
 
   # tests sporadically fail on musl


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

changelog: https://git.kernel.org/pub/scm/libs/ell/ell.git/tree/ChangeLog?id=3b743fc1a1d6bab9cefc764f00a50b77c877ec1f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
