### PR TITLE
libretro.same_cdi: init at unstable-2023-02-28

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -842,6 +842,16 @@ in
     };
   };
 
+  same_cdi = mkLibretroCore {
+    core = "same_cdi";
+    extraNativeBuildInputs = [ python3 ];
+    extraBuildInputs = [ alsa-lib libGLU libGL portaudio xorg.libX11 ];
+    meta = {
+      description = "SAME_CDI is a libretro core to play CD-i games";
+      license = with lib.licenses; [ bsd3 gpl2Plus ];
+    };
+  };
+
   scummvm = mkLibretroCore rec {
     core = "scummvm";
     version = "unstable-2022-04-06";

--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -412,6 +412,12 @@
         "rev": "75d501a87ec2074e8d2f7256fb0359513c263c29",
         "hash": "sha256-yAHVTgOt8SGyPXihp4YNKKAvxl9VBBAvHyzLW86zSCw="
     },
+    "same_cdi": {
+        "owner": "libretro",
+        "repo": "same_cdi",
+        "rev": "54cf493c2dee4c46666059c452f8aaaa0bd7c8e0",
+        "hash": "sha256-/+4coMzj/o82Q04Z65DQiPaykK6N56W6PRQLtyJOd8E="
+    },
     "sameboy": {
         "owner": "libretro",
         "repo": "sameboy",

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -81,6 +81,7 @@ CORES = {
     "puae": {"repo": "libretro-uae"},
     "quicknes": {"repo": "QuickNES_Core"},
     "sameboy": {"repo": "sameboy"},
+    "same_cdi": {"repo": "same_cdi"},
     "scummvm": {"repo": "scummvm"},
     "smsplus-gx": {"repo": "smsplus-gx"},
     "snes9x": {"repo": "snes9x", "owner": "snes9xgit"},


### PR DESCRIPTION
## Description of changes

Trying to get CDI games to be playable in Retroarch, so packaged the `same_cdi` libretro core

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
