### PR TITLE
Add virtualxt package at version 0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5720,6 +5720,12 @@
     githubId = 74379;
     name = "Florian Pester";
   };
+  fmahnke = {
+    email = "bulk@mahnke.tech";
+    github = "fmahnke";
+    githubId = 610099;
+    name = "Fritz Mahnke";
+  };
   fmoda3 = {
     email = "fmoda3@mac.com";
     github = "fmoda3";

--- a/pkgs/applications/emulators/virtualxt/default.nix
+++ b/pkgs/applications/emulators/virtualxt/default.nix
@@ -1,0 +1,63 @@
+{ lib, stdenv, fetchFromGitHub
+, makeWrapper, premake5
+, libpcap
+, SDL2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "virtualxt";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "andreas-jonsson";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-RFafBwYhBtUILnZ9wSwMd+7jUIGh+yMMXu5SAK7AYHw=";
+  };
+
+  nativeBuildInputs = [ makeWrapper premake5 ];
+  buildInputs = [ SDL2 libpcap ];
+
+  buildFlags = [ "sdl2-frontend modules" ];
+
+  premakeFlags = [ "--modules" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    set -e
+
+    share=$out/share; bin=$out/bin
+    modules=$share/modules
+
+    mkdir -p $share/bios $share/boot $modules $bin
+
+    cp build/bin/* $bin
+    cp boot/* $share/boot
+    cp bios/*.bin bios/*.ROM $share/bios
+    cp modules/*.vxt $modules
+
+    wrapProgram $bin/virtualxt \
+        --run 'XDG_DATA_HOME="''${XDG_DATA_HOME:-$HOME/.local/share}"' \
+        --run 'VXT_DATA="$XDG_DATA_HOME/virtualxt"' \
+        --run 'mkdir -p "$VXT_DATA"' \
+        --run "cp $share/boot/*.img"' "$VXT_DATA"' \
+        --run 'chmod 644 "$VXT_DATA"/*.img' \
+        --set VXT_DEFAULT_MODULES_PATH $modules \
+        --set VXT_DEFAULT_BIOS_PATH $share/bios/GLABIOS.ROM \
+        --set VXT_DEFAULT_VXTX_BIOS_PATH $share/bios/vxtx.bin \
+        --run 'export VXT_DEFAULT_HD_IMAGE="$VXT_DATA/freedos_hd.img"'
+
+    set +e
+
+    runHook postInstall
+  '';
+
+  meta = {
+      homepage = "https://virtualxt.org";
+      description = "A portable, lightweight IBM PC/XT emulator written in C.";
+      license = lib.licenses.zlib;
+      maintainers = with lib.maintainers; [ fmahnke ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2762,6 +2762,8 @@ with pkgs;
 
   vice = callPackage ../applications/emulators/vice { };
 
+  virtualxt = callPackage ../applications/emulators/virtualxt { };
+
   winetricks = callPackage ../applications/emulators/wine/winetricks.nix {
     inherit (gnome) zenity;
   };


### PR DESCRIPTION
## Description of changes

This package is the VirtualXT emulator.

https://virtualxt.org/
https://github.com/andreas-jonsson/virtualxt/tree/develop

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
