### PR TITLE
npmHooks: use adjacent packages, not buildPackages

### DIFF
--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchNpmDeps, npmHooks, nodejs }:
+{ lib, stdenv, fetchNpmDeps, buildPackages, nodejs }:
 
 { name ? "${args.pname}-${args.version}"
 , src ? null
@@ -44,7 +44,12 @@ let
     hash = npmDepsHash;
   };
 
-  inherit (npmHooks.override { inherit nodejs; }) npmConfigHook npmBuildHook npmInstallHook;
+  # .override {} negates splicing, so we need to use buildPackages explicitly
+  npmHooks = buildPackages.npmHooks.override {
+    inherit nodejs;
+  };
+
+  inherit (npmHooks) npmConfigHook npmBuildHook npmInstallHook;
 in
 stdenv.mkDerivation (args // {
   inherit npmDeps npmBuildScript;

--- a/pkgs/build-support/node/build-npm-package/hooks/default.nix
+++ b/pkgs/build-support/node/build-npm-package/hooks/default.nix
@@ -1,4 +1,13 @@
-{ lib, makeSetupHook, nodejs, srcOnly, buildPackages, makeWrapper }:
+{ lib
+, srcOnly
+, makeSetupHook
+, makeWrapper
+, nodejs
+, jq
+, prefetch-npm-deps
+, diffutils
+, installShellFiles
+}:
 
 {
   npmConfigHook = makeSetupHook
@@ -6,13 +15,13 @@
       name = "npm-config-hook";
       substitutions = {
         nodeSrc = srcOnly nodejs;
-        nodeGyp = "${buildPackages.nodejs}/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js";
+        nodeGyp = "${nodejs}/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js";
 
         # Specify `diff`, `jq`, and `prefetch-npm-deps` by abspath to ensure that the user's build
         # inputs do not cause us to find the wrong binaries.
-        diff = "${buildPackages.diffutils}/bin/diff";
-        jq = "${buildPackages.jq}/bin/jq";
-        prefetchNpmDeps = "${buildPackages.prefetch-npm-deps}/bin/prefetch-npm-deps";
+        diff = "${diffutils}/bin/diff";
+        jq = "${jq}/bin/jq";
+        prefetchNpmDeps = "${prefetch-npm-deps}/bin/prefetch-npm-deps";
 
         nodeVersion = nodejs.version;
         nodeVersionMajor = lib.versions.major nodejs.version;
@@ -27,13 +36,13 @@
   npmInstallHook = makeSetupHook
     {
       name = "npm-install-hook";
-      propagatedBuildInputs = with buildPackages; [
+      propagatedBuildInputs = [
         installShellFiles
         makeWrapper
       ];
       substitutions = {
         hostNode = "${nodejs}/bin/node";
-        jq = "${buildPackages.jq}/bin/jq";
+        jq = "${jq}/bin/jq";
       };
     } ./npm-install-hook.sh;
 }


### PR DESCRIPTION
Hooks are essentially implemented as special shell packages that run on their respective host platform. When they are used, they appear as nativeBuildInputs (as they need to be executed as part of the build of a package using them) so are taken from buildPackages relative to the derivation using them.

Since the override in buildNpmPackage nullifies splicing, we take npmHooks from buildPackages manually.

Fixes pkgsCross.ghcjs.buildPackages.emscripten and thus pkgsCross.ghcjs.haskellPackages.ghc.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
