### PR TITLE
zon2nix: 0.1.1 -> 0.1.2

### DIFF
--- a/pkgs/tools/nix/zon2nix/default.nix
+++ b/pkgs/tools/nix/zon2nix/default.nix
@@ -1,36 +1,37 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, makeBinaryWrapper
 , zig_0_11
 , nix
 }:
 
 stdenv.mkDerivation rec {
   pname = "zon2nix";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
-    owner = "figsoda";
+    owner = "nix-community";
     repo = "zon2nix";
     rev = "v${version}";
-    hash = "sha256-VzlLoToZ+5beHt9mFsuCxlSZ8RrBodPO6YKtsugAaik=";
+    hash = "sha256-pS0D+wdebtpNaGpDee9aBwEKTDvNU56VXer9uzULXcM=";
   };
 
   nativeBuildInputs = [
-    makeBinaryWrapper
     zig_0_11.hook
   ];
 
-  postInstall = ''
-    wrapProgram $out/bin/zon2nix \
-      --prefix PATH : ${lib.makeBinPath [ nix ]}
-  '';
+  zigBuildFlags = [
+    "-Dnix=${lib.getExe nix}"
+  ];
+
+  zigCheckFlags = [
+    "-Dnix=${lib.getExe nix}"
+  ];
 
   meta = with lib; {
     description = "Convert the dependencies in `build.zig.zon` to a Nix expression";
-    homepage = "https://github.com/figsoda/zon2nix";
-    changelog = "https://github.com/figsoda/zon2nix/blob/${src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/nix-community/zon2nix";
+    changelog = "https://github.com/nix-community/zon2nix/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mpl20;
     maintainers = with maintainers; [ figsoda ];
     inherit (zig_0_11.meta) platforms;


### PR DESCRIPTION
Diff: https://github.com/nix-community/zon2nix/compare/v0.1.1...v0.1.2

Changelog: https://github.com/nix-community/zon2nix/blob/v0.1.2/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
