### PR TITLE
prismlauncher: support for glfw-wayland at runtime

### DIFF
--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -25,8 +25,20 @@
 , msaClientID ? null
 , gamemodeSupport ? stdenv.isLinux
 , textToSpeechSupport ? stdenv.isLinux
+
+# The flag `withWaylandGLFW` enables runtime-checking of `WAYLAND_DISPLAY`;
+# if the option is enabled, a patched version of GLFW will be added to
+# `LD_LIBRARY_PATH` so that the launcher can use the correct one
+# depending on the desktop environment used.
 , withWaylandGLFW ? false
+# By default, this package uses a binary wrapper for `wrapQtAppsHook`.
+# Enabling `shellWrapper` will add `makeWrapper` to `nativeBuildInputs`,
+# causing `wrapQtAppsHook` to output a shell wrapper instead.
+# This is needed for checking environment variables at runtime
+# and modifying others if necessary (see above option for example).
+# Warning: This can make the program start slower, by about four milliseconds.
 , shellWrapper ? withWaylandGLFW
+
 , jdks ? [ jdk17 jdk8 ]
 , additionalLibs ? [ ]
 , additionalPrograms ? [ ]


### PR DESCRIPTION
- Introduced hand-written wrapper to accomplish:
- Add support for checking `$XDG_CURRENT_SESSION` at runtime and using `glfw-wayland` if necessary.

Previously all wrapper args were in `qtWrapperArgs`.

This is undesireable for a few reasons:
1. Makes it hard to wrap again.
2. Makes it hard to debug.
3. The Qt wrapper should be focused on Qt.

I have introduced `makeWrapper` instead:
1. Less cryptic, less indirection.
2. Causes `wrapQtAppsHook` to produce a bash wrapper.
3. Allows wrapping further for
   environment-dependant runtime dependencies.## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
