### PR TITLE
emacs: allow using as shebang on darwin (`#!/... --script`)

### DIFF
--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -32,7 +32,7 @@ in customEmacsPackages.withPackages (epkgs: [ epkgs.evil epkgs.magit ])
 
 */
 
-{ lib, lndir, runCommand, gcc }:
+{ lib, lndir, makeBinaryWrapper, runCommand, gcc }:
 self:
 let
   inherit (self) emacs;
@@ -50,7 +50,7 @@ runCommand
   (lib.appendToName "with-packages" emacs).name
   {
     inherit emacs explicitRequires;
-    nativeBuildInputs = [ emacs lndir ];
+    nativeBuildInputs = [ emacs lndir makeBinaryWrapper ];
 
     preferLocalBuild = true;
     allowSubstitutes = false;
@@ -201,6 +201,11 @@ runCommand
         --subst-var-by wrapperSiteLispNative "$deps/share/emacs/native-lisp" \
         --subst-var prog
       chmod +x $out/bin/$progname
+      # Create a “NOP” binary wrapper for the pure sake of it becoming a
+      # non-shebang, actual binary. See the makeBinaryWrapper docs for rationale
+      # (summary: it allows you to use emacs as a shebang itself on Darwin,
+      # e.g. #!$ {emacs}/bin/emacs --script)
+      wrapProgramBinary $out/bin/$progname
     done
 
     # Wrap MacOS app
@@ -220,6 +225,7 @@ runCommand
         --subst-var-by wrapperSiteLispNative "$deps/share/emacs/native-lisp" \
         --subst-var-by prog "$emacs/Applications/Emacs.app/Contents/MacOS/Emacs"
       chmod +x $out/Applications/Emacs.app/Contents/MacOS/Emacs
+      wrapProgramBinary $out/Applications/Emacs.app/Contents/MacOS/Emacs
     fi
 
     mkdir -p $out/share

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -32,7 +32,7 @@ in customEmacsPackages.withPackages (epkgs: [ epkgs.evil epkgs.magit ])
 
 */
 
-{ lib, lndir, makeWrapper, runCommand, gcc }:
+{ lib, lndir, runCommand, gcc }:
 self:
 let
   inherit (self) emacs;
@@ -50,7 +50,7 @@ runCommand
   (lib.appendToName "with-packages" emacs).name
   {
     inherit emacs explicitRequires;
-    nativeBuildInputs = [ emacs lndir makeWrapper ];
+    nativeBuildInputs = [ emacs lndir ];
 
     preferLocalBuild = true;
     allowSubstitutes = false;

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -47,8 +47,7 @@ let
     inherit lib pkgs;
   };
 
-  emacsWithPackages = { pkgs, lib }: import ../build-support/emacs/wrapper.nix {
-    inherit (pkgs) makeWrapper runCommand gcc;
+  emacsWithPackages = { pkgs, lib }: pkgs.callPackage ../build-support/emacs/wrapper.nix {
     inherit (pkgs.xorg) lndir;
     inherit lib;
   };


### PR DESCRIPTION
## Description of changes

From the manual:

> Using the makeBinaryWrapper implementation is usually preferred, as it creates a tiny compiled wrapper executable, that can be used as a shebang interpreter. This is needed mostly on Darwin, where shebangs cannot point to scripts, [due to a limitation with the execve-syscall](https://stackoverflow.com/questions/67100831/macos-shebang-with-absolute-path-not-working). Compiled wrappers generated by makeBinaryWrapper can be inspected with less <path-to-wrapper> - by scrolling past the binary data you should be able to see the shell command that generated the executable and there see the environment variables that were injected into the wrapper.

- https://nixos.org/manual/nixpkgs/stable/#fun-makeWrapper

## Example

flake.nix:

```nix
{
  inputs = {
    nixpkgs.url = "nixpkgs";
  };

  outputs = inputs@{ flake-parts, ... }:
    flake-parts.lib.mkFlake { inherit inputs; } {
      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
      perSystem = { config, self', inputs', pkgs, system, ... }:
        {
          packages = {
            emacs = (pkgs.emacsPackagesFor pkgs.emacs29).emacsWithPackages (epkgs: with epkgs; [
              dash
            ]);
          };
          apps = {
            default.program = pkgs.writeScriptBin "emacs-example" ''
              #!${self'.packages.emacs}/bin/emacs --script
              (require 'dash)
              (-> "Hello" message)
            '';
          };
        };
    };
}

```

Broken:
```
$ nix run
/nix/store/ijc37f9jky0inj0hrx8flac8drv7s4hd-emacs-example/bin/emacs-example: line 2: unexpected EOF while looking for matching `''
/nix/store/ijc37f9jky0inj0hrx8flac8drv7s4hd-emacs-example/bin/emacs-example: line 4: syntax error: unexpected end of file
```

Fixed:
```
$ nix run --override-input nixpkgs github:NixOS/nixpkgs/pull/253227/head
warning: not writing modified lock file of flake 'path:/private/tmp/z':
• Updated input 'nixpkgs':
    'path:/nix/store/8pzx1g0mp7lr31jn62f0gjjp65mwsnps-source?lastModified=1693594656&narHash=sha256-JgUQkso4tbQDaE5SJic/EDDrehAQ/xoOSGCuakGE6OM%3D&rev=cdceca7fb009a8ca0b7c4539f00b106ed21e86dc' (2023-09-01)
  → 'github:NixOS/nixpkgs/ffdda35f751378f48ae423343e8e750b8b418175' (2023-09-04)
Loading /nix/store/iacjk56yvklsw1p9nmfvml08yzzqpfkk-emacs-29.1/share/emacs/site-lisp/site-start...
Hello
```

## Things done

Wrap all Emacs binaries in an (otherwise transparent) call to makeBinaryWrapper.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
