### PR TITLE
conmon-rs: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/applications/virtualization/conmon-rs/Cargo.lock.patch
+++ b/pkgs/applications/virtualization/conmon-rs/Cargo.lock.patch
@@ -1,0 +1,31 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 4cd154b..fee3267 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -323,7 +323,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "conmon-common"
+-version = "0.5.1"
++version = "0.6.0"
+ dependencies = [
+  "capnp",
+  "capnpc",
+@@ -331,7 +331,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "conmonrs"
+-version = "0.5.1"
++version = "0.6.0"
+ dependencies = [
+  "anyhow",
+  "capnp",
+@@ -376,7 +376,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "conmonrs-cli"
+-version = "0.5.1"
++version = "0.6.0"
+ dependencies = [
+  "capnp",
+  "capnp-rpc",

--- a/pkgs/applications/virtualization/conmon-rs/default.nix
+++ b/pkgs/applications/virtualization/conmon-rs/default.nix
@@ -7,19 +7,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "conmon-rs";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-mngs5ivRyMJ927VV00mFNIG+nD9EuE3qLyN+OHMMkHQ=";
+    sha256 = "sha256-RQ3cVM7aEuCCmOCr4UWkxBMr66tdYFl0nNO7tXY05vE=";
   };
+
+  # Cargo.lock is out of date for this release.
+  cargoPatches = [ ./Cargo.lock.patch ];
 
   nativeBuildInputs = [ capnproto protobuf ];
   doCheck = false;
 
-  cargoSha256 = "sha256-ruChRz2rnPalBiXcpco/WS/eDgg52ckPBLBuoQa9us4=";
+  cargoHash = "sha256-BNowZkD+y1jh25EvfhQzvT5BZzrq46KBd69AJ//9enE=";
 
   meta = with lib; {
     description = "An OCI container runtime monitor written in Rust";


### PR DESCRIPTION
## Description of changes

cc @NixOS/podman 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


