### PR TITLE
python311Packages.resolvelib: 0.5.5 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     packaging
     passlib
     pyyaml
-    resolvelib # This library is a PITA, since ansible requires a very old version of it
+    resolvelib
     # optional dependencies
     junit-xml
     lxml

--- a/pkgs/development/python-modules/resolvelib/default.nix
+++ b/pkgs/development/python-modules/resolvelib/default.nix
@@ -8,19 +8,14 @@
 
 buildPythonPackage rec {
   pname = "resolvelib";
-  # Currently this package is only used by Ansible and breaking changes
-  # are frequently introduced, so when upgrading ensure the new version
-  # is compatible with Ansible
-  # https://github.com/NixOS/nixpkgs/pull/128636
-  # https://github.com/ansible/ansible/blob/devel/requirements.txt
-  version = "0.5.5";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sarugaku";
     repo = "resolvelib";
     rev = version;
-    sha256 = "198vfv78hilpg0d0mjzchzp9zk6239wnra61vlsgwpcgz66d2bgv";
+    hash = "sha256-oxyPn3aFPOyx/2aP7Eg2ThtPbyzrFT1JzWqy6GqNbzM=";
   };
 
   build-system = [
@@ -30,17 +25,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     commentjson
     pytestCheckHook
-  ];
-  # TODO: reenable after updating to >= 1.0.0
-  # https://github.com/sarugaku/resolvelib/issues/114
-  disabledTests = [
-    "shared_parent_dependency"
-    "deep_complex_conflict"
-    "shared_parent_dependency_with_swapping"
-    "spapping_and_rewinding"
-    "pruned_unresolved_orphan"
-    "conflict_common_parent"
-    "same-package"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/resolvelib/default.nix
+++ b/pkgs/development/python-modules/resolvelib/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , commentjson
 , pytestCheckHook
 }:
@@ -13,7 +14,7 @@ buildPythonPackage rec {
   # https://github.com/NixOS/nixpkgs/pull/128636
   # https://github.com/ansible/ansible/blob/devel/requirements.txt
   version = "0.5.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sarugaku";
@@ -21,6 +22,10 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "198vfv78hilpg0d0mjzchzp9zk6239wnra61vlsgwpcgz66d2bgv";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   nativeCheckInputs = [
     commentjson
@@ -45,6 +50,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Resolve abstract dependencies into concrete ones";
     homepage = "https://github.com/sarugaku/resolvelib";
+    changelog = "https://github.com/sarugaku/resolvelib/blob/${src.rev}/CHANGELOG.rst";
     license = licenses.isc;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/tools/package-management/pdm/default.nix
+++ b/pkgs/tools/package-management/pdm/default.nix
@@ -1,6 +1,5 @@
 { lib
 , python3
-, fetchFromGitHub
 , fetchPypi
 , nix-update-script
 , runtimeShell
@@ -8,29 +7,8 @@
 , testers
 , pdm
 }:
-let
-  python = python3.override {
-    # override resolvelib due to
-    # 1. pdm requiring a later version of resolvelib
-    # 2. Ansible being packaged as a library
-    # 3. Ansible being unable to upgrade to a later version of resolvelib
-    # see here for more details: https://github.com/NixOS/nixpkgs/pull/155380/files#r786255738
-    packageOverrides = self: super: {
-      resolvelib = super.resolvelib.overridePythonAttrs rec {
-        version = "1.0.1";
-        src = fetchFromGitHub {
-          owner = "sarugaku";
-          repo = "resolvelib";
-          rev = "/refs/tags/${version}";
-          hash = "sha256-oxyPn3aFPOyx/2aP7Eg2ThtPbyzrFT1JzWqy6GqNbzM=";
-        };
-      };
-    };
-    self = python;
-  };
-in
 
-with python.pkgs;
+with python3.pkgs;
 buildPythonApplication rec {
   pname = "pdm";
   version = "2.13.2";


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/sarugaku/resolvelib/compare/0.5.5...1.0.1

Changelog: https://github.com/sarugaku/resolvelib/blob/1.0.1/CHANGELOG.rst

The [concern](https://github.com/NixOS/nixpkgs/pull/133064) about resolvelib in ansible has already been resolved.
https://github.com/ansible/ansible/pull/80196

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
