### PR TITLE
pkgsNative: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -311,3 +311,7 @@ The module update takes care of the new config syntax and the data itself (user 
   `virtualisation.fileSystems."/".autoFormat = true;`.
 
 - The `electron` packages now places its application files in `$out/libexec/electron` instead of `$out/lib/electron`. Packages using electron-builder will fail to build and need to be adjusted by changing `lib` to `libexec`.
+
+- A new package set called `pkgsNative` was added, which provides access to host native binaries under cross compilation contexts. This adds more flexibility while writing expressions, such as doing lazy cross compilation (the practice of only cross compiling a subset of dependencies of a closure, to take better advantage of the cache).
+
+  In effect this cancels out the cross compilation entirely, so that `(import <nixpkgs> { localSystem.config = "aarch64-unknown-linux-gnu"; }).hello` is equal to `(import <nixpkgs> { localSystem.config = "x86_64-unknown-linux-gnu"; }).pkgsCross.aarch64-multiplatform.pkgsNative.hello`.

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -177,8 +177,12 @@ let
   # following package sets are provided:
   #
   # - pkgsCross.<system> where system is a member of lib.systems.examples
+  # - pkgsNative
+  # - pkgsLLVM
   # - pkgsMusl
   # - pkgsi686Linux
+  # - pkgsx86_64Darwin
+  # - pkgsStatic
   otherPackageSets = self: super: {
     # This maps each entry in lib.systems.examples to its own package
     # set. Each of these will contain all packages cross compiled for

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -189,6 +189,19 @@ let
                               nixpkgsFun { inherit crossSystem; })
                               lib.systems.examples;
 
+    # The logical inverse of pkgsCross, so that pkgs.pkgsCross.*.pkgsNative == pkgs,
+    # (and pkgs.pkgsNative == pkgs).
+    # This way, you can cross compile most things; but replace that one specific
+    # package that fails to be cross compiled with the native one.
+    pkgsNative = nixpkgsFun {
+      overlays = [
+        (self': super': {
+          pkgsNative = super'.pkgsNative or super';
+        })
+      ] ++ overlays;
+      localSystem = stdenv.hostPlatform; crossSystem = null;
+    };
+
     pkgsLLVM = nixpkgsFun {
       overlays = [
         (self': super': {


### PR DESCRIPTION
## Description of changes

Before this, there is no way of getting a native version (build == host) of a cross-compiling nixpkgs. I looked through `/pkgs/top-level` as well as run the expression below, and did not find anything that could give me non-cross compiled packages.

```nix
> pkgs = import <nixpkgs> { crossSystem.config = "aarch64-unknown-linux-gnu"; }
> builtins.filter (x: (builtins.tryEval pkgs.${x}).success && (pkgs.${x}.buildPlatform or { }).isAarch64 or false) (builtins.attrNames pkgs)
[ ]
```

This PR adds a new entry called `pkgsNative`, that gives you access to these packages. This can be helpful on the somewhat common scenario when one specific package does not cross-compile, and can unblock work that would otherwise be dependent on fixing the cross-compiling of the package first. It can also help reduce the number of rebuilds, by using some non-cross-compiled packages from `cache.nixos.org` (somewhat like it's described on [the lazy cross compiling entry of nixos.wiki](https://nixos.wiki/wiki/Cross_Compiling#Lazy_cross-compiling)), without having to manually instantiate 2 versions of nixpkgs.

```nix
> pkgs = import ./. { crossSystem.config = "aarch64-unknown-linux-gnu"; }
> with pkgs; buildPlatform == hostPlatform
false
> with pkgs.pkgsNative; buildPlatform == hostPlatform
true
```

Just a sanity check, but as expected it produces the same hashes.
```nix
> pkgs = import ./. { localSystem.config = "x86_64-unknown-linux-gnu"; }
> pkgs.pkgsCross.aarch64-multiplatform.pkgsNative.hello
«derivation /nix/store/440grns9r25bhcs6jcw16lr6glszgpw4-hello-2.12.1.drv»
> pkgs = import ./. { localSystem.config = "aarch64-unknown-linux-gnu"; }
> pkgs.pkgsNative.hello
«derivation /nix/store/440grns9r25bhcs6jcw16lr6glszgpw4-hello-2.12.1.drv»
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
