### PR TITLE
[next] wasmtime: fix build due to cargo-auditable issue

### DIFF
--- a/pkgs/development/interpreters/wasmtime/default.nix
+++ b/pkgs/development/interpreters/wasmtime/default.nix
@@ -15,6 +15,10 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-SG/SFskr6ywCtJu2WVWTJC9GUKJJB0fUb+hZUaxag0M=";
 
   cargoBuildFlags = [ "--package" "wasmtime-cli" "--package" "wasmtime-c-api" ];
+  cargoPatches = [
+    # this patch is necessary until cargo-auditable is bumped on the rust platform
+    ./patches/0001-Use-dep-dependency-due-to-cargo-auditable-limitation.patch
+  ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/interpreters/wasmtime/patches/0001-Use-dep-dependency-due-to-cargo-auditable-limitation.patch
+++ b/pkgs/development/interpreters/wasmtime/patches/0001-Use-dep-dependency-due-to-cargo-auditable-limitation.patch
@@ -1,0 +1,26 @@
+From a59bb5f9deeff156bd7bc9d22bc199e0f902b7dc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafael=20Fern=C3=A1ndez=20L=C3=B3pez?=
+ <ereslibre@ereslibre.es>
+Date: Mon, 4 Sep 2023 15:25:15 +0200
+Subject: [PATCH] Use `dep:` dependency due to `cargo-auditable` limitation
+
+`cargo-auditable` fails to process the current `Cargo.toml` as it
+is (cargo/rustc 1.72.0 is able to process this crate without any
+issues).
+---
+ crates/c-api/Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crates/c-api/Cargo.toml b/crates/c-api/Cargo.toml
+index a464c0dbd..1e793432c 100644
+--- a/crates/c-api/Cargo.toml
++++ b/crates/c-api/Cargo.toml
+@@ -37,4 +37,4 @@ default = ['jitdump', 'wat', 'wasi', 'cache', 'parallel-compilation']
+ jitdump = ["wasmtime/jitdump"]
+ cache = ["wasmtime/cache"]
+ parallel-compilation = ['wasmtime/parallel-compilation']
+-wasi = ['wasi-cap-std-sync', 'wasmtime-wasi', 'cap-std', 'wasi-common']
++wasi = ['wasi-cap-std-sync', 'wasmtime-wasi', 'dep:cap-std', 'wasi-common']
+-- 
+2.40.1
+


### PR DESCRIPTION
`cargo-auditable` is not able to process the `c-api` crate `Cargo.toml` due to the inclusion of the new `dep:` keyword in crate features.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
