### PR TITLE
jack-example-tools: init at 4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -85,6 +85,8 @@
 
 - The `services.ananicy.extraRules` option now has the type of `listOf attrs` instead of `string`.
 
+- JACK tools (`jack_*` except `jack_control`) have moved from the `jack2` package to `jack-example-tools`
+
 - The `matrix-synapse` package & module have undergone some significant internal changes, for most setups no intervention is needed, though:
   - The option [`services.matrix-synapse.package`](#opt-services.matrix-synapse.package) is now read-only. For modifying the package, use an overlay which modifies `matrix-synapse-unwrapped` instead. More on that below.
   - The `enableSystemd` & `enableRedis` arguments have been removed and `matrix-synapse` has been renamed to `matrix-synapse-unwrapped`. Also, several optional dependencies (such as `psycopg2` or `authlib`) have been removed.

--- a/pkgs/misc/jackaudio/tools.nix
+++ b/pkgs/misc/jackaudio/tools.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, lib
+
+, fetchFromGitHub
+
+, pkg-config
+, meson
+, ninja
+
+, jack
+, alsa-lib
+, libopus
+, libsamplerate
+, libsndfile
+, readline
+, zita-alsa-pcmi
+, zita-resampler
+}:
+
+stdenv.mkDerivation (final: {
+  pname = "jack-example-tools";
+  version = "4";
+
+  src = fetchFromGitHub {
+    owner = "jackaudio";
+    repo = "jack-example-tools";
+    rev = "tags/${final.version}";
+    hash = "sha256-5jmynNxwNVLxEZ1MaqQUG6kRwipDkjhrdDCbZHtmAHk=";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [
+    jack
+    alsa-lib
+    libopus
+    libsamplerate
+    libsndfile
+    readline
+    zita-alsa-pcmi
+    zita-resampler
+  ];
+
+  postPatch = ''
+    patchShebangs scripts
+  '';
+
+  # no tests defined, but prepare for some in the future.
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Official examples and tools from the JACK project";
+    homepage = "https://jackaudio.org";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
+    maintainers = with maintainers; [ pennae ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40551,6 +40551,11 @@ with pkgs;
 
   libjack2 = jack2.override { prefix = "lib"; };
 
+  jack-example-tools = callPackage ../misc/jackaudio/tools.nix {
+    libopus = libopus.override { withCustomModes = true; };
+    jack = jack2;
+  };
+
   jack-autoconnect = libsForQt5.callPackage ../applications/audio/jack-autoconnect { };
   jack_autoconnect = jack-autoconnect;
 


### PR DESCRIPTION
## Description of changes

jack2 dropped its tools from the main package recently. they now live here. examples are included too as previously, and unlike previously we also include `zalsa` plugins. they're tiny though, adding them won't hurt anything.

darwin is marked as broken because we have no clue where to even start with darwin, not because it's actually known to not work.

fixes  #253188

@cillianderoiste @matthiasbeyer  @risicle

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
