### PR TITLE
localsend: 1.11.0 -> 1.11.1

### DIFF
--- a/pkgs/applications/networking/localsend/default.nix
+++ b/pkgs/applications/networking/localsend/default.nix
@@ -2,16 +2,21 @@
 
 let
   pname = "localsend";
-  version = "1.11.0";
+  version = "1.11.1";
+
+  hashes = {
+    x86_64-linux = "sha256-K4M9cks0FNsCLIqQhSgUAz3tRMKng6JkZ/ZfwG2hZJA=";
+    x86_64-darwin = "sha256-Cixo00I4BBAmUnszsz+CxPX3EY175UTufCmwQmIsEgg=";
+  };
 
   srcs = rec {
     x86_64-linux = fetchurl {
       url = "https://github.com/localsend/localsend/releases/download/v${version}/LocalSend-${version}-linux-x86-64.AppImage";
-      hash = "sha256-IIxknLzlAjH27o54R0Zm7T8bhDRAIgh58Evs7zPMrPk=";
+      hash = hashes.x86_64-linux;
     };
     x86_64-darwin = fetchurl {
       url = "https://github.com/localsend/localsend/releases/download/v${version}/LocalSend-${version}.dmg";
-      hash = "sha256-NSwyyfFPQpcVZLKGqZbaBCYSQdlNxxpI8EJo49eYB/A=";
+      hash = hashes.x86_64-darwin;
     };
     aarch64-darwin = x86_64-darwin;
   };

--- a/pkgs/applications/networking/localsend/update.sh
+++ b/pkgs/applications/networking/localsend/update.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -I nixpkgs=./. -i bash -p curl gnused
+
+set -eou pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+
+latestVersion=$(curl --fail --silent https://api.github.com/repos/localsend/localsend/releases/latest | jq --raw-output .tag_name | sed 's/^v//')
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; localsend.version or (lib.getVersion localsend)" | tr -d '"')
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+  echo "package is up-to-date: $currentVersion"
+  exit 0
+fi
+
+sed -i "s/version = \".*\"/version = \"${latestVersion}\"/" "$ROOT/default.nix"
+
+LINUX_x64_URL="https://github.com/localsend/localsend/releases/download/v${latestVersion}/LocalSend-${latestVersion}-linux-x86-64.AppImage"
+LINUX_X64_SHA=$(nix hash to-sri --type sha256 $(nix-prefetch-url ${LINUX_x64_URL}))
+sed -i "0,/x86_64-linux/{s|x86_64-linux = \".*\"|x86_64-linux = \"${LINUX_X64_SHA}\"|}" "$ROOT/default.nix"
+
+DARWIN_x64_URL="https://github.com/localsend/localsend/releases/download/v${latestVersion}/LocalSend-${latestVersion}.dmg"
+DARWIN_X64_SHA=$(nix hash to-sri --type sha256 $(nix-prefetch-url ${DARWIN_x64_URL}))
+sed -i "0,/x86_64-darwin/{s|x86_64-darwin = \".*\"|x86_64-darwin = \"${DARWIN_X64_SHA}\"|}" "$ROOT/default.nix"


### PR DESCRIPTION
Diff: https://github.com/localsend/localsend/compare/None...v1.11.1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
