### PR TITLE
nixos/prometheus-node-exporter: Add textfile directory option

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -26,17 +26,29 @@ in
         Collectors to disable which are enabled by default.
       '';
     };
+    textfileDir = mkOption {
+      type = types.path;
+      default = "/var/lib/prometheus-node-exporter/textfile";
+      description = lib.mdDoc ''
+        Path that the textfile collector will read from, if it is not disabled.
+        This directory will _not_ automatically be created.
+      '';
+    };
   };
   serviceOpts = {
     serviceConfig = {
       DynamicUser = false;
       RuntimeDirectory = "prometheus-node-exporter";
-      ExecStart = ''
-        ${pkgs.prometheus-node-exporter}/bin/node_exporter \
-          ${concatMapStringsSep " " (x: "--collector." + x) cfg.enabledCollectors} \
-          ${concatMapStringsSep " " (x: "--no-collector." + x) cfg.disabledCollectors} \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} ${concatStringsSep " " cfg.extraFlags}
-      '';
+      ExecStart = lib.concatStringsSep " \\\n  " (
+        [ "${pkgs.prometheus-node-exporter}/bin/node_exporter"
+          "--web.listen-address ${cfg.listenAddress}:${toString cfg.port}" ]
+        ++ (map (x: "--collector."    + x) cfg.enabledCollectors)
+        ++ (map (x: "--no-collector." + x) cfg.disabledCollectors)
+        ++ cfg.extraFlags
+        # textfile is enabled by default, so we only check if it is explicitly disabled
+        ++ (optional (!collectorIsDisabled "textfile")
+              "--collector.textfile.directory ${cfg.textfileDir}")
+      );
       RestrictAddressFamilies = optionals (collectorIsEnabled "logind" || collectorIsEnabled "systemd") [
         # needs access to dbus via unix sockets (logind/systemd)
         "AF_UNIX"


### PR DESCRIPTION
## Description of changes

- add services.prometheus.exporters.node.textfileDir option
- Re-format execStart options nicely

Nothing in nixos requires this yet, but it will be useful for writing timers/cronjobs that produce textfile metrics.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
