### PR TITLE
nixos/terminfo: Add missing terminfo outputs

### DIFF
--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -22,9 +22,11 @@ with lib;
       foot
       kitty
       mtm
+      rio
       rxvt-unicode-unwrapped
       rxvt-unicode-unwrapped-emoji
       termite
+      tmux
       wezterm
     ]));
 

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -22,6 +22,7 @@ with lib;
     #  pkgs)
     environment.systemPackages = mkIf config.environment.enableAllTerminfo (map (x: x.terminfo) (with pkgs; [
       alacritty
+      contour
       foot
       kitty
       mtm

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -16,7 +16,10 @@ with lib;
 
   config = {
 
-    # can be generated with: filter (drv: (builtins.tryEval (drv ? terminfo)).value) (attrValues pkgs)
+    # can be generated with:
+    # attrNames (filterAttrs
+    #  (_: drv: (builtins.tryEval (isDerivation drv && drv ? terminfo)).value)
+    #  pkgs)
     environment.systemPackages = mkIf config.environment.enableAllTerminfo (map (x: x.terminfo) (with pkgs; [
       alacritty
       foot

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -33,6 +33,7 @@ with lib;
       termite
       tmux
       wezterm
+      yaft
     ]));
 
     environment.pathsToLink = [

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -29,6 +29,7 @@ with lib;
       rio
       rxvt-unicode-unwrapped
       rxvt-unicode-unwrapped-emoji
+      st
       termite
       tmux
       wezterm

--- a/pkgs/applications/terminal-emulators/contour/default.nix
+++ b/pkgs/applications/terminal-emulators/contour/default.nix
@@ -47,6 +47,8 @@ mkDerivation rec {
     sha256 = "sha256-TpxVC0GFZD3jGISnDWHKEetgVVpznm5k/Vc2dwVfSG4=";
   };
 
+  outputs = [ "out" "terminfo" ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -84,6 +86,12 @@ mkDerivation rec {
 
     # Don't fix Darwin app bundle
     sed -i '/fixup_bundle/d' src/contour/CMakeLists.txt
+  '';
+
+  postInstall = ''
+    mkdir -p $out/nix-support $terminfo/share
+    mv $out/share/terminfo $terminfo/share/
+    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
   '';
 
   passthru.tests.test = nixosTests.terminal-emulators.contour;

--- a/pkgs/applications/terminal-emulators/st/default.nix
+++ b/pkgs/applications/terminal-emulators/st/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-82NZeZc06ueFvss3QGPwvoM88i+ItPFpzSUbmTJOCOc=";
   };
 
+  outputs = [ "out" "terminfo" ];
+
   inherit patches;
 
   configFile = lib.optionalString (conf != null)
@@ -51,7 +53,9 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ extraLibs;
 
   preInstall = ''
-    export TERMINFO=$out/share/terminfo
+    export TERMINFO=$terminfo/share/terminfo
+    mkdir -p $TERMINFO $out/nix-support
+    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
   '';
 
   installFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/applications/terminal-emulators/yaft/default.nix
+++ b/pkgs/applications/terminal-emulators/yaft/default.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation rec {
   version = "0.2.9";
   pname = "yaft";
 
+  outputs = [ "out" "terminfo" ];
+
   src = fetchFromGitHub {
     owner = "uobikiemukot";
     repo = "yaft";
@@ -14,6 +16,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses ];
 
   installFlags = [ "PREFIX=$(out)" "MANPREFIX=$(out)/share/man" ];
+
+  postInstall = ''
+    mkdir -p $out/nix-support $terminfo/share
+    mv $out/share/terminfo $terminfo/share/
+    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
+  '';
 
   meta = {
     homepage = "https://github.com/uobikiemukot/yaft";


### PR DESCRIPTION
## Description of changes

- In NixOS' `terminfo` module, added missing pkgs (`rio` and `tmux`) which already had a `terminfo` output.
  According to `git log`, that list wasn't updated since it was added in 2021.
- Improved the nixlang snippet used to generate the list.
- Added missing `terminfo` outputs to `contour`, `st`, and `yaft`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    - [x] `allTerminfo`
    - [x] `terminal-emulators.st`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all new `terminfo` outputs.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).