### PR TITLE
turbo: 1.10.7 -> 1.10.13

### DIFF
--- a/pkgs/tools/misc/turbo/default.nix
+++ b/pkgs/tools/misc/turbo/default.nix
@@ -24,12 +24,12 @@
 , CoreFoundation
 }:
 let
-  version = "1.10.7";
+  version = "1.10.13";
   src = fetchFromGitHub {
     owner = "vercel";
     repo = "turbo";
     rev = "v${version}";
-    sha256 = "sha256-AkrwaaXUiFPZqOO1mX/1XBOZRFRtCdgI7glzdv8ZOfU=";
+    sha256 = "sha256-7bEHE/bHRVOXMP7+oo+4k8yn6d+LkXBi8JcDeR0ajww";
   };
 
   ffi = rustPlatform.buildRustPackage {
@@ -37,7 +37,7 @@ let
     inherit src version;
     cargoBuildFlags = [ "--package" "turborepo-ffi" ];
 
-    cargoHash = "sha256-j+r1irE0OGMfr9TAYhTOsFjBNzxjmF5/e7EebtshuG8=";
+    cargoHash = "sha256-CIKuW8qKJiqgDBPfuCIBcWUP41BHwAa1m9vmcQ9ZmAY=";
 
     RUSTC_BOOTSTRAP = 1;
     nativeBuildInputs = [
@@ -138,7 +138,7 @@ rustPlatform.buildRustPackage {
   ];
   RELEASE_TURBO_CLI = "true";
 
-  cargoHash = "sha256-GCo1PRB4JkHSXz7nBiKhJsC1xhMTlA136gGpUblPpVk=";
+  cargoHash = "sha256-rKdonANA6WvXPMpK8sC95hsX9Yb5zedeBezY4LWzsZE=";
 
   RUSTC_BOOTSTRAP = 1;
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Bump turbo to 1.10.13 to fix the regressions due to rustc update https://github.com/NixOS/nixpkgs/pull/251174

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
