### PR TITLE
which: enable 64-bit API on 32-bit systems

### DIFF
--- a/pkgs/tools/system/which/default.nix
+++ b/pkgs/tools/system/which/default.nix
@@ -12,6 +12,13 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   enableParallelBuilding = true;
 
+  env.NIX_CFLAGS_COMPILE = toString (
+    # Enable 64-bit file API. Otherwise `which` fails to find tools
+    # on filesystems with 64-bit inodes (like `btrfs`) when running
+    # binaries from 32-bit systems (like `i686-linux`).
+    lib.optional stdenv.hostPlatform.is32bit "-D_FILE_OFFSET_BITS=64"
+  );
+
   meta = with lib; {
     homepage = "https://www.gnu.org/software/which/";
     description = "Shows the full path of (shell) commands";


### PR DESCRIPTION
Without the change `which` fails to find programs on filesystems with 64-bit inodes when `which` itself is 32-bit.

In my case it is `btrfs` and `i686-linux`.

`bison` is in the PATH:

    $ dev>bison
    bison: missing operand
    Try 'bison --help' for more information.

But `which` fails to find it:

    $ which bison
    which: no bison in ...

`bison` is a file with an inode number that overflows 2^31 limit:

    $ stat ~/bin/bison
      File: ~/bin/bison
      Size: 674260          Blocks: 1320       IO Block: 4096   regular file
    Device: 0,29    Inode: 4384368825  Links: 2
    Access: (0555/-r-xr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)
    Access: 2023-09-05 04:48:43.000000000 +0100
    Modify: 1970-01-01 01:00:01.000000000 +0100
    Change: 2023-09-05 04:48:43.821566578 +0100
     Birth: 2023-09-05 04:48:43.772565733 +0100

The change fixes `which` run.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
