### PR TITLE
xdg-desktop-portal-shana: init at 0.3.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17052,6 +17052,15 @@
     githubId = 132835;
     name = "Samuel Dionne-Riel";
   };
+  samuelefacenda = {
+    name = "Samuele Facenda";
+    email = "samuele.facenda@gmail.com";
+    github = "SamueleFacenda";
+    githubId = 92163673;
+    keys = [{
+      fingerprint = "3BA5 A3DB 3239 E2AC 1F3B  68A0 0DB8 3F58 B259 6271";
+    }];
+  };
   samuel-martineau = {
     name = "Samuel Martineau";
     email = "samuel@smartineau.me";

--- a/pkgs/by-name/xd/xdg-desktop-portal-shana/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-shana/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, meson
+, ninja
+, xdg-desktop-portal
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "xdg-desktop-portal-shana";
+  version = "0.3.9";
+
+  src = fetchFromGitHub {
+    owner = "Decodetalkers";
+    repo = "xdg-desktop-portal-shana";
+    rev = "v${version}";
+    sha256 = "cgiWlZbM0C47CisR/KlSV0xqfeKgM41QaQihjqSy9CU=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    xdg-desktop-portal
+  ];
+
+  # Needed for letting meson run. rustPackage will overwrite it otherwise.
+  configurePhase = "";
+
+  mesonBuildType = "release";
+
+  cargoHash = "sha256-uDM4a7AB0753c/H1nfic/LjWrLmjEvi/p2S/tLIDXaQ=";
+
+  meta = with lib; {
+    description = "A filechooser portal backend for any desktop environment";
+    homepage = "https://github.com/Decodetalkers/xdg-desktop-portal-shana";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [  maintainers.samuelefacenda ];
+  };
+
+}


### PR DESCRIPTION
## Description of changes

Adding an [xdg-desktop-portal implementation](https://github.com/Decodetalkers/xdg-desktop-portal-shana)
Also adding myself as maintainer of the package


The package is in the [AUR](https://aur.archlinux.org/packages/xdg-desktop-portal-shana). I've taken the license and description from there.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
