### PR TITLE
multus-cni: 3.9.3 -> 4.0.2

### DIFF
--- a/pkgs/applications/networking/cluster/multus-cni/default.nix
+++ b/pkgs/applications/networking/cluster/multus-cni/default.nix
@@ -23,8 +23,7 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  # Some of the tests require accessing a k8s cluster
-  doCheck = false;
+  doCheck = true;
 
   meta = with lib; {
     description = "Multus CNI is a container network interface (CNI) plugin for Kubernetes that enables attaching multiple network interfaces to pods";

--- a/pkgs/applications/networking/cluster/multus-cni/default.nix
+++ b/pkgs/applications/networking/cluster/multus-cni/default.nix
@@ -17,9 +17,12 @@ buildGoModule rec {
     "-X=gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/multus.version=${version}"
   ];
 
-  preInstall = ''
-    mv $GOPATH/bin/cmd $GOPATH/bin/multus
-  '';
+  subPackages = [
+    "cmd/multus-daemon"
+    "cmd/multus-shim"
+    "cmd/multus"
+    "cmd/thin_entrypoint"
+  ];
 
   vendorHash = null;
 

--- a/pkgs/applications/networking/cluster/multus-cni/default.nix
+++ b/pkgs/applications/networking/cluster/multus-cni/default.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
     homepage = "https://github.com/k8snetworkplumbingwg/multus-cni";
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ onixie ];
+    maintainers = with maintainers; [ onixie kashw2 ];
     mainProgram = "multus";
   };
 }

--- a/pkgs/applications/networking/cluster/multus-cni/default.nix
+++ b/pkgs/applications/networking/cluster/multus-cni/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "multus-cni";
-  version = "3.9.3";
+  version = "4.0.2";
 
   src = fetchFromGitHub {
     owner = "k8snetworkplumbingwg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-43cFBrFM2jvD/SJ+QT1JQkr593jkdzAAvYlVUAQArEw=";
+    sha256 = "sha256-Q6ACXOv1E3Ouki4ksdlUZFbWcDgo9xbCiTfEiVG5l18=";
   };
 
   ldflags = [


### PR DESCRIPTION
## Description of changes

change log: https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2

diff: https://github.com/k8snetworkplumbingwg/multus-cni/compare/v3.9.3...v4.0.2

re-enabled tests as multus no longer requires a running cluster to perform tests and [only performs configuration checking now](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/cmd/thin_entrypoint/main_test.go)
added myself as a maintainer of multus-cni
explicitly defined subpackages as multus now ships a daemon, shim, core (multus), entrypoint and an installer (not included); this also allowed for the removal of the `preInstall` stage.

I've split all these changes into different commits to make it easier to bisect specific changes in an atomic manner if needed however can squash them into one with no worries.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
