### PR TITLE
lomiri.geonames: Use devdoc for documentation instead

### DIFF
--- a/pkgs/desktops/lomiri/development/geonames/default.nix
+++ b/pkgs/desktops/lomiri/development/geonames/default.nix
@@ -36,16 +36,16 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals withExamples [
     "bin"
   ] ++ lib.optionals withDocumentation [
-    "doc"
+    "devdoc"
   ];
 
   patches = [
     # Improves install locations of demo & docs
     # Remove when https://gitlab.com/ubports/development/core/geonames/-/merge_requests/3 merged & in release
     (fetchpatch {
-      name = "0001-geonames-Use-GNUInstallDirs-more.patch";
-      url = "https://gitlab.com/OPNA2608/geonames/-/commit/e64a391fc213b2629da1c8bbf975fd62a2973c51.patch";
-      hash = "sha256-HPYDtIy1WUrZLPzvKh4aezrT/LniZkNX+PeQ9YB85RY=";
+      name = "0001-geonames-Use-CMAKE_INSTALL_BINDIR-for-install.patch";
+      url = "https://gitlab.com/OPNA2608/geonames/-/commit/3bca6d4d02843aed851a0a7480d5cd5ac02b4cda.patch";
+      hash = "sha256-vwffuMKpIqymYaiGEvnNeVXLmnz5e4aBpg55fnNbjKs=";
     })
   ];
 


### PR DESCRIPTION
## Description of changes

Which is apparently a thing that already handles gtk-doc documentation moving, and more closely aligns with upstream's feedback on the merge request.

https://gitlab.com/ubports/development/core/geonames/-/merge_requests/3#note_1519432694

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
