### PR TITLE
add more `meta.mainProgram`

### DIFF
--- a/pkgs/applications/misc/tvbrowser/default.nix
+++ b/pkgs/applications/misc/tvbrowser/default.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryBytecode fromSource ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
+    mainProgram = "tvbrowser";
     maintainers = with maintainers; [ jfrankenau yarny ];
     longDescription = ''
       TV-Browser shows TV program data arranged like in printed

--- a/pkgs/applications/networking/mailreaders/betterbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/betterbird/default.nix
@@ -102,6 +102,7 @@ in ((buildMozillaMach {
   meta = with lib; {
     description = "Betterbird is a fine-tuned version of Mozilla Thunderbird, Thunderbird on steroids, if you will";
     homepage = "https://www.betterbird.eu/";
+    mainProgram = "betterbird";
     maintainers = with maintainers; [ SuperSandro2000 ];
     inherit (thunderbird-unwrapped.meta) platforms badPlatforms broken license;
   };

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -213,6 +213,7 @@ stdenv.mkDerivation {
     changelog = "https://www.thunderbird.net/en-US/thunderbird/${version}/releasenotes/";
     description = "Mozilla Thunderbird, a full-featured email client (binary package)";
     homepage = "http://www.mozilla.org/thunderbird/";
+    mainProgram = "thunderbird";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.mpl20;
     maintainers = with lib.maintainers; [ lovesegfault ];

--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -78,6 +78,7 @@ stdenv.mkDerivation rec {
     description = "LUKS for dm-crypt";
     changelog = "https://gitlab.com/cryptsetup/cryptsetup/-/raw/v${version}/docs/v${version}-ReleaseNotes";
     license = lib.licenses.gpl2;
+    mainProgram = "cryptsetup";
     maintainers = with lib.maintainers; [ raitobezarius ];
     platforms = with lib.platforms; linux;
   };

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -156,6 +156,7 @@ let
       description = "Software implementation of a telephone private branch exchange (PBX)";
       homepage = "https://www.asterisk.org/";
       license = licenses.gpl2Only;
+      mainProgram = "asterisk";
       maintainers = with maintainers; [ auntie DerTim1 yorickvp ];
     };
   };

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -110,6 +110,7 @@ stdenv.mkDerivation rec {
     homepage = "https://dovecot.org/";
     description = "Open source IMAP and POP3 email server written with security primarily in mind";
     license = with licenses; [ mit publicDomain lgpl21Only bsd3 bsdOriginal ];
+    mainProgram = "dovecot";
     maintainers = with maintainers; [ fpletz globin ajs124 ];
     platforms = platforms.unix;
   };

--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -122,6 +122,7 @@ stdenv.mkDerivation rec {
     homepage = "https://exim.org/";
     description = "A mail transfer agent (MTA)";
     license = with licenses; [ gpl2Plus bsd3 ];
+    mainProgram = "exim";
     platforms = platforms.linux;
     maintainers = with maintainers; [ tv ajs124 das_j ];
     changelog = "https://github.com/Exim/exim/blob/exim-${version}/doc/doc-txt/ChangeLog";

--- a/pkgs/tools/misc/expect/default.nix
+++ b/pkgs/tools/misc/expect/default.nix
@@ -41,6 +41,7 @@ tcl.mkTclDerivation rec {
     homepage = "https://expect.sourceforge.net/";
     license = licenses.publicDomain;
     platforms = platforms.unix;
+    mainProgram = "expect";
     maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -90,6 +90,7 @@ stdenv.mkDerivation rec {
     description = "An integrated DNS, DHCP and TFTP server for small networks";
     homepage = "https://www.thekelleys.org.uk/dnsmasq/doc.html";
     license = licenses.gpl2;
+    mainProgram = "dnsmasq";
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ eelco fpletz globin ];
   };

--- a/pkgs/tools/text/xml/xmlstarlet/default.nix
+++ b/pkgs/tools/text/xml/xmlstarlet/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     description = "A command line tool for manipulating and querying XML data";
     homepage = "https://xmlstar.sourceforge.net/";
     license = lib.licenses.mit;
+    mainProgram = "xmlstarlet";
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

Due to https://github.com/NixOS/nixpkgs/pull/246386, many packages need a `meta.mainProgram` setting to silence warnings.

The pull request at hand adds those entries to some packages where I encountered the warning message:

* `asterisk`
* `thunderbird`, `thunderbird-bin`, and `betterbird`
* `cryptsetup`
* `dnsmasq`
* `dovecot`
* `exim`
* `expect`
* `tvbrowser` (maintained by me)
* `xmlstarlet`

This should not break anything, as all `mainProgram` attributes are set to their respective package's name, with one exception: `thunderbird-bin` does not exist as an executable file; the `mainProgram` of `thunderbird-bin` is also `thunderbird`.


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

(nothing)