### PR TITLE
nixos/sshd: don't validate mock host key, permit `RequiredRSASize`

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -33,8 +33,7 @@ let
     ${cfg.extraConfig}
     EOL
 
-    ssh-keygen -q -f mock-hostkey -N ""
-    sshd -t -f $out -h mock-hostkey
+    sshd -G -f $out
   '';
 
   cfg  = config.services.openssh;


### PR DESCRIPTION
## Description of changes

Currently one cannot set the option `services.openssh.settings.RequiredRSASize` to anything higher than 3072.  This is due to the validation step in https://github.com/NixOS/nixpkgs/blob/9999996fd6f33c12f2f341dcdbac7a9c926d0a87/nixos/modules/services/networking/ssh/sshd.nix#L31 which generates a fake rsa host key with 3072 bits length: If the host key does not satisfy the `RequiredRSASize`, the validation step fails.

With [OpenSSH 9.3](https://www.openssh.com/txt/release-9.3) `sshd` learned the `-G` option that "allows usage of the option before keys have been generated and for configuration evaluation and verification by unprivileged users", which is what we need to avoid testing a mock host key.  A quick check (adding an "abc abc" line to `sshd_config`) shows that configuration errors are also caught by this method.

Alternatively, one could add a `-b` option to increase the key length for the mock host key, but even then we would have to choose an arbitrary size and thereby an arbitrary limit of `RequiredRSASize`.  Also, higher key lengths require a considerable amount of CPU time to be generated.

Notifying author of validation mechanism: @Ma27


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>