### PR TITLE
asciiquarium-transparent: init at unstable-2023-02-19

### DIFF
--- a/pkgs/by-name/as/asciiquarium-transparent/package.nix
+++ b/pkgs/by-name/as/asciiquarium-transparent/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  perlPackages,
+  ...
+}:
+stdenv.mkDerivation {
+  pname = "asciiquarium-transparent";
+  version = "unstable-2023-02-19";
+  src = fetchFromGitHub {
+    owner = "nothub";
+    repo = "asciiquarium";
+    rev = "653cd99a611080c776d18fc7991ae5dd924c72ce";
+    hash = "sha256-72LRFydbObFDXJllmlRjr5O8qjDqtlp3JunE3kwb5aU=";
+  };
+  nativeBuildInputs = [makeWrapper];
+  buildInputs = [perlPackages.perl];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp asciiquarium $out/bin/asciiquarium
+    wrapProgram $out/bin/asciiquarium --set PERL5LIB ${perlPackages.makeFullPerlPath [perlPackages.TermAnimation]}
+  '';
+  meta = with lib; {
+    description = mdDoc ''
+      Asciiquarum with a few patches
+    '';
+    mainProgram = "asciiquarium";
+    homepage = "https://github.com/nothub/asciiquarium";
+    license = with licenses; [gpl2Only];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [quantenzitrone];
+  };
+}

--- a/pkgs/by-name/as/asciiquarium-transparent/package.nix
+++ b/pkgs/by-name/as/asciiquarium-transparent/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   makeWrapper,
   perlPackages,
-  ...
 }:
 stdenv.mkDerivation {
   pname = "asciiquarium-transparent";
@@ -18,14 +17,14 @@ stdenv.mkDerivation {
   nativeBuildInputs = [makeWrapper];
   buildInputs = [perlPackages.perl];
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp asciiquarium $out/bin/asciiquarium
     wrapProgram $out/bin/asciiquarium --set PERL5LIB ${perlPackages.makeFullPerlPath [perlPackages.TermAnimation]}
+    runHook postInstall
   '';
   meta = with lib; {
-    description = mdDoc ''
-      Asciiquarum with a few patches
-    '';
+    description = "An aquarium/sea animation in ASCII art (with option of transparent background)";
     mainProgram = "asciiquarium";
     homepage = "https://github.com/nothub/asciiquarium";
     license = with licenses; [gpl2Only];


### PR DESCRIPTION
## Description of changes

Asciiquarium with a few patches, notably background transparency

(use the --transparent flag to test it out)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
