### PR TITLE
build-support/emacs: fix name when overrideAttrs is used

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/control-lock/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/control-lock/default.nix
@@ -8,6 +8,8 @@ trivialBuild {
     hash = "sha256-JCrmS3FSGDHSR+eAR0X/uO0nAgd3TUmFxwEVH5+KV+4=";
   };
 
+  version = "1.1.2";
+
   meta = {
     description = "Like caps-lock, but for your control key.  Give your pinky a rest!";
     homepage = "https://www.emacswiki.org/emacs/control-lock.el";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/perl-completion/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/perl-completion/default.nix
@@ -10,6 +10,8 @@ trivialBuild {
     sha256 = "0x6qsgs4hm87k0z9q3g4p6508kc3y123j5jayll3jf3lcl2vm6ks";
   };
 
+  version = "1.10";
+
   meta = {
     broken = true;
     description = "Minor mode provides useful features for editing perl codes";

--- a/pkgs/build-support/emacs/generic.nix
+++ b/pkgs/build-support/emacs/generic.nix
@@ -19,8 +19,8 @@ let
   };
 in
 
-stdenv.mkDerivation ({
-  name = "emacs-${pname}-${version}";
+stdenv.mkDerivation (finalAttrs: ({
+  name = "emacs-${pname}-${finalAttrs.version}";
 
   unpackCmd = ''
     case "$curSrc" in
@@ -83,4 +83,4 @@ stdenv.mkDerivation ({
   '';
 }
 
-// removeAttrs args [ "buildInputs" "packageRequires" "meta" ])
+// removeAttrs args [ "buildInputs" "packageRequires" "meta" ]))

--- a/pkgs/build-support/emacs/generic.nix
+++ b/pkgs/build-support/emacs/generic.nix
@@ -3,7 +3,7 @@
 { lib, stdenv, emacs, texinfo, writeText, gcc, ... }:
 
 { pname
-, version ? null
+, version
 , buildInputs ? []
 , packageRequires ? []
 , meta ? {}
@@ -20,7 +20,7 @@ let
 in
 
 stdenv.mkDerivation ({
-  name = "emacs-${pname}${lib.optionalString (version != null) "-${version}"}";
+  name = "emacs-${pname}-${version}";
 
   unpackCmd = ''
     case "$curSrc" in


### PR DESCRIPTION
Before:

nix-repl> (pkgs.emacs.pkgs.eglot.overrideAttrs { version = "6.0"; }).name "emacs-eglot-1.15"

After:

nix-repl> (pkgs.emacs.pkgs.eglot.overrideAttrs { version = "6.0"; }).name "emacs-eglot-6.0"

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
