### PR TITLE
nixos/machine-info: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -201,6 +201,8 @@
 
 - A new option was added to the virtualisation module that enables specifying explicitly named network interfaces in QEMU VMs. The existing `virtualisation.vlans` is still supported for cases where the name of the network interface is irrelevant.
 
+- A new `environment.machineInfo` module allows setting common options in [`/etc/machine-info`](https://www.freedesktop.org/software/systemd/man/machine-info.html).
+
 - DocBook option documentation is no longer supported, all module documentation now uses markdown.
 
 - `buildGoModule` `go-modules` attrs have been renamed to `goModules`.

--- a/nixos/modules/misc/machine-info.nix
+++ b/nixos/modules/misc/machine-info.nix
@@ -1,0 +1,83 @@
+{ config, lib, ... }:
+let
+  cfg = config.environment.machineInfo;
+
+  needsEscaping = s: builtins.match "[a-zA-Z0-9]+" s == null;
+  escapeIfNecessary = s: if needsEscaping s then ''"${lib.escape [ "\$" "\"" "\\" "\`" ] s}"'' else s;
+  attrsToText = attrs:
+    lib.concatLines (lib.mapAttrsToList
+      (name: value: "${name}=${escapeIfNecessary value}")
+      (lib.filterAttrs (_: value: value != null) attrs));
+
+  text = attrsToText {
+    PRETTY_HOSTNAME = cfg.prettyHostname;
+    ICON_NAME = cfg.iconName;
+    CHASSIS = cfg.chassis;
+    DEPLOYMENT = cfg.deployment;
+    LOCATION = cfg.location;
+    HARDWARE_VENDOR = cfg.hardwareVendor;
+    HARDWARE_MODEL = cfg.hardwareModel;
+  };
+
+  mkVarOption = description: lib.mkOption {
+    type = lib.types.nullOr lib.types.singleLineStr;
+    default = null;
+    description = lib.mdDoc description;
+  };
+in
+{
+  options.environment.machineInfo = {
+    prettyHostname = mkVarOption ''
+      A pretty human-readable machine identifier string. If possible, the
+      internet hostname as configured in {option}`networking.hostName` should
+      be kept similar to this one.
+    '';
+
+    iconName = mkVarOption ''
+      An icon identifying this machine according to the [XDG Icon Naming
+      Specification].
+
+      [XDG Icon Naming Specification]: https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
+    '';
+
+    chassis = mkVarOption ''
+      The chassis type. Currently, the following chassis types are defined:
+      "desktop", "laptop", "convertible", "server", "tablet", "handset",
+      "watch", and "embedded", as well as the special chassis types "vm" and
+      "container" for virtualized systems that lack an immediate physical
+      chassis.
+
+      Note that most systems allow detection of the chassis type automatically
+      (based on firmware information or suchlike). This setting should only be
+      used to override a misdetection or to manually configure the chassis
+      type where automatic detection is not available.
+    '';
+
+    deployment = mkVarOption ''
+      System deployment environment. One of the following is suggested:
+      "development", "integration", "staging", "production".
+    '';
+
+    location = mkVarOption ''
+      A free-form human-readable string that describes system location.
+    '';
+
+    hardwareVendor = mkVarOption ''
+      Specifies the hardware vendor. If unspecified, the hardware vendor set
+      in DMI or [hwdb] will be used.
+
+      [hwdb]: https://www.freedesktop.org/software/systemd/man/hwdb.html
+    '';
+
+    hardwareModel = mkVarOption ''
+      Specifies the hardware model. If unspecified, the hardware model set in
+      DMI or [hwdb] will be used.
+
+      [hwdb]: https://www.freedesktop.org/software/systemd/man/hwdb.html
+    '';
+  };
+
+  config = lib.mkIf (text != "") {
+    environment.etc.machine-info = { inherit text; };
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -123,6 +123,7 @@
   ./misc/label.nix
   ./misc/lib.nix
   ./misc/locate.nix
+  ./misc/machine-info.nix
   ./misc/man-db.nix
   ./misc/mandoc.nix
   ./misc/meta.nix

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -450,6 +450,7 @@ in {
   lxd-image-server = handleTest ./lxd-image-server.nix {};
   #logstash = handleTest ./logstash.nix {};
   lorri = handleTest ./lorri/default.nix {};
+  machine-info = runTest ./machine-info.nix;
   maddy = discoverTests (import ./maddy { inherit handleTest; });
   maestral = handleTest ./maestral.nix {};
   magic-wormhole-mailbox-server = handleTest ./magic-wormhole-mailbox-server.nix {};

--- a/nixos/tests/machine-info.nix
+++ b/nixos/tests/machine-info.nix
@@ -1,0 +1,32 @@
+let
+  machineInfo = {
+    prettyHostname = "コンピュータ";
+    iconName = "computer-vm";
+    chassis = "vm";
+    deployment = "integration";
+    location = "Nixpkgs";
+    hardwareVendor = "NixOS";
+    hardwareModel = "tests";
+  };
+in
+{ lib, ... }: {
+  name = "machine-info";
+  meta.maintainers = [ lib.maintainers.tie ];
+
+  nodes.machine.environment = { inherit machineInfo; };
+
+  testScript = ''
+    import json
+
+    start_all()
+
+    machineInfo = json.loads(machine.succeed("hostnamectl --json=short"))
+    assert machineInfo["PrettyHostname"] == "${machineInfo.prettyHostname}"
+    assert machineInfo["IconName"] == "${machineInfo.iconName}"
+    assert machineInfo["Chassis"] == "${machineInfo.chassis}"
+    assert machineInfo["Deployment"] == "${machineInfo.deployment}"
+    assert machineInfo["Location"] == "${machineInfo.location}"
+    assert machineInfo["HardwareVendor"] == "${machineInfo.hardwareVendor}"
+    assert machineInfo["HardwareModel"] == "${machineInfo.hardwareModel}"
+  '';
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/219017

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
