### PR TITLE
zoom-us: 5.15.11.7239 -> 5.15.12.7665

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -48,23 +48,23 @@ let
   # and often with different versions.  We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "5.15.11.22019";
-  versions.x86_64-darwin = "5.15.11.22019";
-  versions.x86_64-linux = "5.15.11.7239";
+  versions.aarch64-darwin = "5.15.12.22445";
+  versions.x86_64-darwin = "5.15.12.22445";
+  versions.x86_64-linux = "5.15.12.7665";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-R3QD2jo0+kwgOZ0PwHbFxAlbutSpxyDr+CzEwdKxioY=";
+      hash = "sha256-pTpNbKmJGTxRIrfD/zWIrkouhCbErxu9Gjy9mDdTtHc=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-nSiG2n8oN1k0xyBw4jWbrZT6AiP5VVJXkeBXppvNcAk=";
+      hash = "sha256-EItKg22id/e7OfJaWxxJdl9B+3nDHNl6ENvfGR4QJ6Y=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-pnVy+rS3NxMPwm86+ERLf1oSrsniP3i+FhSg16BuO38=";
+      hash = "sha256-DMFMLwxPt1LV4Qhhrw6gdToe0z9743hGcxVWeR4O1YU=";
     };
   };
 


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc: @fpletz @wegank 