### PR TITLE
ocamlPackages.tar: 2.2.2 → 2.5.1

### DIFF
--- a/pkgs/development/ocaml-modules/tar/default.nix
+++ b/pkgs/development/ocaml-modules/tar/default.nix
@@ -2,30 +2,24 @@
 , fetchurl
 , buildDunePackage
 , camlp-streams
-, ppx_cstruct
 , cstruct
 , decompress
 }:
 
 buildDunePackage rec {
   pname = "tar";
-  version = "2.2.2";
+  version = "2.5.1";
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-tar/releases/download/v${version}/tar-${version}.tbz";
-    hash = "sha256-Q+41LPFZFHi9sXKFV3F13FZZNO3KXRSElEmr+nH58Uw=";
+    hash = "sha256-00QPSIZnoFvhZEnDcdEDJUqhE0uKLxNMM2pUE8aMPfQ=";
   };
 
-  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [
     camlp-streams
     cstruct
     decompress
-  ];
-
-  buildInputs = [
-    ppx_cstruct
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/tar/unix.nix
+++ b/pkgs/development/ocaml-modules/tar/unix.nix
@@ -3,17 +3,21 @@
 , tar
 , cstruct-lwt
 , lwt
+, git
 }:
 
 buildDunePackage rec {
   pname = "tar-unix";
   inherit (tar) version src doCheck;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     tar
     cstruct-lwt
     lwt
+  ];
+
+  nativeCheckInputs = [
+    git
   ];
 
   meta = tar.meta // {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1693,7 +1693,9 @@ let
 
     tar = callPackage ../development/ocaml-modules/tar { };
 
-    tar-unix = callPackage ../development/ocaml-modules/tar/unix.nix { };
+    tar-unix = callPackage ../development/ocaml-modules/tar/unix.nix {
+      inherit (pkgs) git;
+    };
 
     tcpip = callPackage ../development/ocaml-modules/tcpip { };
 


### PR DESCRIPTION
## Description of changes

https://github.com/mirage/ocaml-tar/blob/v2.5.1/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
