### PR TITLE
Revert "garage: 0.8.2 -> 0.8.3"

### DIFF
--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -57,7 +57,7 @@ let
       "sqlite"
     ]);
 
-    passthru.tests = nixosTests.garage;
+    passthru = nixosTests.garage;
 
     meta = {
       description = "S3-compatible object store for small self-hosted geo-distributed deployments";
@@ -83,13 +83,13 @@ in
 
     garage_0_7 = garage_0_7_3;
 
-    garage_0_8_3 = generic {
-      version = "0.8.3";
-      sha256 = "sha256-NxkFj76L+LpCWzOWbnN3zdhw9Q16uzPibDs+C+voM/0=";
-      cargoSha256 = "sha256-hbBuUjdlw//s6d24dPBu3R/BTJvmOW1B7tSIXNxLXlU=";
+    garage_0_8_2 = generic {
+      version = "0.8.2";
+      sha256 = "sha256-IlDWbNWI1yXvPPF3HIqQvo79M2FQCtoX1wRLJrDbd9k=";
+      cargoSha256 = "sha256-6l4tDBMcOvckTkEO05rman4hHlmVbBt1nCeX5/dETKk=";
     };
 
-    garage_0_8 = garage_0_8_3;
+    garage_0_8 = garage_0_8_2;
 
     garage = garage_0_8;
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8416,7 +8416,7 @@ with pkgs;
   })
     garage
       garage_0_7 garage_0_8
-      garage_0_7_3 garage_0_8_3;
+      garage_0_7_3 garage_0_8_2;
 
   garmin-plugin = callPackage ../applications/misc/garmin-plugin { };
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#252142

While upgrading my NixOS hosts, I ran into an issue where hosts running the new garage 0.8.3 are not able to talk to hosts still running 0.8.2. After talking to the upstream developers, we have figured out that this is a bug, and 0.8.3 will be yanked and a new 0.8.4 released with some changes that broke RPC protocol compatibility reverted.
See the matrix channel for more info: https://matrix.to/#/#garage:deuxfleurs.fr