### PR TITLE
xandikos: 0.2.8 -> 0.2.10

### DIFF
--- a/nixos/tests/xandikos.nix
+++ b/nixos/tests/xandikos.nix
@@ -15,8 +15,6 @@ import ./make-test-python.nix (
         xandikos_proxy = {
           networking.firewall.allowedTCPPorts = [ 80 8080 ];
           services.xandikos.enable = true;
-          services.xandikos.address = "localhost";
-          services.xandikos.port = 8080;
           services.xandikos.routePrefix = "/xandikos-prefix/";
           services.xandikos.extraOptions = [
             "--defaults"
@@ -39,9 +37,7 @@ import ./make-test-python.nix (
         start_all()
 
         with subtest("Xandikos default"):
-            xandikos_default.wait_for_unit("multi-user.target")
-            xandikos_default.wait_for_unit("xandikos.service")
-            xandikos_default.wait_for_open_port(8080)
+            xandikos_default.wait_for_unit("sockets.target")
             xandikos_default.succeed("curl --fail http://localhost:8080/")
             xandikos_default.succeed(
                 "curl -s --fail --location http://localhost:8080/ | grep -i Xandikos"
@@ -50,9 +46,7 @@ import ./make-test-python.nix (
             xandikos_client.fail("curl --fail http://xandikos_default:8080/")
 
         with subtest("Xandikos proxy"):
-            xandikos_proxy.wait_for_unit("multi-user.target")
-            xandikos_proxy.wait_for_unit("xandikos.service")
-            xandikos_proxy.wait_for_open_port(8080)
+            xandikos_proxy.wait_for_unit("sockets.target")
             xandikos_proxy.succeed("curl --fail http://localhost:8080/")
             xandikos_proxy.succeed(
                 "curl -s --fail --location http://localhost:8080/ | grep -i Xandikos"

--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -17,7 +17,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.21.5";
+  version = "0.21.6";
   pname = "dulwich";
   format = "setuptools";
 
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-cJVeTiSd3abjSkY2uQ906THlWPmTsXxSVw+mFEuZMQM=";
+    hash = "sha256-MPvofotR84E8Ex4oQchtAHQ00WC9FttYa0DUfzHdBbA=";
   };
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/servers/xandikos/default.nix
+++ b/pkgs/servers/xandikos/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonApplication
 , fetchFromGitHub
+, fetchpatch
 , nixosTests
 , pythonOlder
 # dependencies
@@ -11,6 +12,7 @@
 , icalendar
 , jinja2
 , multidict
+, systemd
 , vobject
 # build dependencies
 , setuptools
@@ -32,6 +34,14 @@ buildPythonApplication rec {
     sha256 = "sha256-SqU/K3b8OML3PvFmP7L5R3Ub9vbW66xRpf79mgFZPfc=";
   };
 
+  patches = [
+    # do not listen on default address
+    (fetchpatch {
+      url = "https://github.com/jelmer/xandikos/pull/262.diff";
+      sha256 = "sha256-FiwaY0zWPjofuzmhX39rR5RELqiUYWtxySFlmKjWnDY=";
+    })
+  ];
+
   nativeBuildInputs = [
     setuptools
     wheel
@@ -45,6 +55,7 @@ buildPythonApplication rec {
     icalendar
     jinja2
     multidict
+    systemd
     vobject
   ];
 

--- a/pkgs/servers/xandikos/default.nix
+++ b/pkgs/servers/xandikos/default.nix
@@ -17,12 +17,12 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     aiohttp
+    aiohttp-openmetrics
     dulwich
     defusedxml
     icalendar
     jinja2
     multidict
-    prometheus-client
   ];
 
   passthru.tests.xandikos = nixosTests.xandikos;

--- a/pkgs/servers/xandikos/default.nix
+++ b/pkgs/servers/xandikos/default.nix
@@ -1,21 +1,43 @@
 { lib
+, buildPythonApplication
 , fetchFromGitHub
-, python3Packages
 , nixosTests
+, pythonOlder
+# dependencies
+, aiohttp
+, aiohttp-openmetrics
+, defusedxml
+, dulwich
+, icalendar
+, jinja2
+, multidict
+, vobject
+# build dependencies
+, setuptools
+, wheel
+, pytestCheckHook
 }:
 
-python3Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "xandikos";
-  version = "0.2.8";
+  version = "0.2.10";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "jelmer";
     repo = "xandikos";
     rev = "v${version}";
-    sha256 = "sha256-KDDk0QSOjwivJFz3vLk+g4vZMlSuX2FiOgHJfDJkpwg=";
+    sha256 = "sha256-SqU/K3b8OML3PvFmP7L5R3Ub9vbW66xRpf79mgFZPfc=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
     aiohttp
     aiohttp-openmetrics
     dulwich
@@ -23,16 +45,27 @@ python3Packages.buildPythonApplication rec {
     icalendar
     jinja2
     multidict
+    vobject
   ];
 
   passthru.tests.xandikos = nixosTests.xandikos;
 
-  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
   disabledTests = [
     # these tests are failing due to the following error:
-    # TypeError: expected str, bytes or os.PathLike object, not int
-    "test_iter_with_etag"
-    "test_iter_with_etag_missing_uid"
+    # TypeError: index_entry_from_stat() missing 1 required positional argument
+    "test_backend"
+    "test_delete_one"
+    "test_delete_one_invalid_etag"
+    "test_delete_one_with_etag"
+    "test_get_by_index"
+    "test_get_file"
+    "test_get_raw"
+    "test_import_one"
+    "test_import_one_duplicate_name"
+    "test_import_one_duplicate_uid"
+    "test_import_only_once"
+    "test_with_filter"
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25742,7 +25742,7 @@ with pkgs;
 
   x265 = callPackage ../development/libraries/x265 { };
 
-  xandikos = callPackage ../servers/xandikos { };
+  xandikos = python3.pkgs.callPackage ../servers/xandikos { };
 
   inherit (callPackages ../development/libraries/xapian { })
     xapian_1_4;


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/jelmer/xandikos/compare/v0.2.8...v0.2.10

Changelog: https://github.com/jelmer/xandikos/blob/v0.2.10/NEWS

Use systemd socket activation, this way systemd takes care of the owner and the permissions of the socket.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
