### PR TITLE
flexbar: init at 3.5.0

### DIFF
--- a/pkgs/by-name/fl/flexbar/package.nix
+++ b/pkgs/by-name/fl/flexbar/package.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, cmake
+, fetchFromGitHub
+, bzip2
+, tbb
+, zlib
+}:
+
+let
+  seqanSrc = fetchFromGitHub {
+    owner = "seqan";
+    repo = "seqan";
+    sparseCheckout = [
+      "include"
+    ];
+    rev = "seqan-v2.4.0";
+    sha256 = "sha256-tfwlEbTK99FfufhKFORwv3I8t68djeWmA4E2PpOEqzQ=";
+  };
+in
+
+stdenv.mkDerivation rec {
+  pname = "flexbar";
+  version = "3.5.0";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ tbb zlib bzip2 ];
+
+  src = fetchFromGitHub {
+    owner = "seqan";
+    repo = "flexbar";
+    rev = "v${version}";
+    sha256 = "sha256-CYJTo8eOZtkIjMkPCm3SwyF3bq87LcqFjX3EykUqDPA=";
+  };
+
+  postUnpack = ''
+    cp -r ${seqanSrc}/include source/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp flexbar $out/bin/flexbar
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Flexible DNA barcode and adapter removal tool";
+    longDescription = ''
+      The program Flexbar preprocesses high-throughput sequencing data
+      efficiently. It demultiplexes barcoded runs and removes adapter
+      sequences. Several adapter removal presets for Illumina libraries are
+      included. Flexbar computes exact overlap alignments using SIMD and
+      multicore parallelism. Moreover, trimming and filtering features are
+      provided, e.g. trimming of homopolymers at read ends. Flexbar increases
+      read mapping rates and improves genome as well as transcriptome
+      assemblies. Unique molecular identifiers can be extracted in a flexible
+      way. The software supports data in fasta and fastq format from multiple
+      sequencing platforms. '';
+    homepage = "https://github.com/seqan/flexbar/wiki";
+    downloadPage = "https://github.com/seqan/flexbar/releases";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.kupac ];
+  };
+}


### PR DESCRIPTION
## Description of changes

     The program Flexbar preprocesses high-throughput sequencing data
      efficiently. It demultiplexes barcoded runs and removes adapter
      sequences. Several adapter removal presets for Illumina libraries are
      included. Flexbar computes exact overlap alignments using SIMD and
      multicore parallelism. Moreover, trimming and filtering features are
      provided, e.g. trimming of homopolymers at read ends. Flexbar increases
      read mapping rates and improves genome as well as transcriptome
      assemblies. Unique molecular identifiers can be extracted in a flexible
      way. The software supports data in fasta and fastq format from multiple
      sequencing platforms. 

Homepage: https://github.com/seqan/flexbar/wiki

Resolves https://github.com/NixOS/nixpkgs/issues/253710

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
