### PR TITLE
mariadb-connector-odbc: fix build with clang 16 on Darwin

### DIFF
--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -41,8 +41,14 @@
       fetchSubmodules = true;
     };
 
+    patches = [
+      # Fix `call to undeclared function 'sleep'` with clang 16
+      ./mariadb-connector-odbc-unistd.patch
+    ];
+
     nativeBuildInputs = [ cmake ];
-    buildInputs = [ unixODBC openssl libiconv ];
+    buildInputs = [ unixODBC openssl libiconv zlib ]
+      ++ lib.optionals stdenv.isDarwin [ libkrb5 ];
 
     preConfigure = ''
       # we don't want to build a .pkg
@@ -52,6 +58,7 @@
     '';
 
     cmakeFlags = [
+      "-DWITH_EXTERNAL_ZLIB=ON"
       "-DODBC_LIB_DIR=${lib.getLib unixODBC}/lib"
       "-DODBC_INCLUDE_DIR=${lib.getDev unixODBC}/include"
       "-DWITH_OPENSSL=ON"

--- a/pkgs/development/libraries/unixODBCDrivers/mariadb-connector-odbc-unistd.patch
+++ b/pkgs/development/libraries/unixODBCDrivers/mariadb-connector-odbc-unistd.patch
@@ -1,0 +1,12 @@
+diff -ur a/test/use_result.c b/test/use_result.c
+--- a/test/use_result.c	1969-12-31 19:00:01.000000000 -0500
++++ b/test/use_result.c	2023-09-05 00:08:12.979889343 -0400
+@@ -23,6 +23,8 @@
+   51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+ 
++#include <unistd.h>
++
+ #include "tap.h"
+ 
+ SQLINTEGER my_max_rows= 100;


### PR DESCRIPTION
## Description of changes

* Use libkrb5 on Darwin;
* Use nixpkgs zlib instead of vendored zlib to fix call to undeclared function `close`; and
* Include `unistd.h` for `sleep`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
