### PR TITLE
juce: init at 7.0.7

### DIFF
--- a/pkgs/development/misc/juce/default.nix
+++ b/pkgs/development/misc/juce/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+
+# Native build inputs
+, cmake
+, pkg-config
+, makeWrapper
+
+# Dependencies
+, alsa-lib
+, freetype
+, curl
+, libglvnd
+, webkitgtk
+, pcre
+, darwin
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "juce";
+  version = "7.0.7";
+
+  src = fetchFromGitHub {
+    owner = "juce-framework";
+    repo = "juce";
+    rev = finalAttrs.version;
+    hash = "sha256-r+Wf/skPDexm3rsrVBoWrygKvV9HGlCQd7r0iHr9avM=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "juce-6.1.2-cmake_install.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/juce/-/raw/4e6d34034b102af3cd762a983cff5dfc09e44e91/juce-6.1.2-cmake_install.patch";
+      hash = "sha256-fr2K/dH0Zam5QKS63zos7eq9QLwdr+bvQL5ZxScagVU=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    freetype # libfreetype.so
+    curl # libcurl.so
+    stdenv.cc.cc.lib # libstdc++.so libgcc_s.so
+    pcre # libpcre2.pc
+  ] ++ lib.optionals stdenv.isLinux [
+    alsa-lib # libasound.so
+    libglvnd # libGL.so
+    webkitgtk # webkit2gtk-4.0
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk_11_0.frameworks.Cocoa
+    darwin.apple_sdk_11_0.frameworks.MetalKit
+    darwin.apple_sdk_11_0.frameworks.WebKit
+  ];
+
+  meta = with lib; {
+    description = "Cross-platform C++ application framework";
+    longDescription = "JUCE is an open-source cross-platform C++ application framework for desktop and mobile applications, including VST, VST3, AU, AUv3, RTAS and AAX audio plug-ins";
+    homepage = "https://github.com/juce-framework/JUCE";
+    license = with licenses; [ isc gpl3Plus ];
+    maintainers = with maintainers; [ kashw2 ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5762,6 +5762,8 @@ with pkgs;
 
   joystickwake = callPackage ../tools/games/joystickwake { };
 
+  juce = darwin.apple_sdk_11_0.callPackage ../development/misc/juce { };
+
   jumppad = callPackage ../tools/virtualization/jumppad { };
 
   jwt-cli = callPackage ../tools/security/jwt-cli {


### PR DESCRIPTION
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/252737

https://github.com/juce-framework/JUCE

JUCE is an open-source cross-platform C++ application framework for desktop and mobile applications, including VST, VST3, AU, AUv3, RTAS and AAX audio plug-ins. 

Provides CLI binaries for creating and managing modules, a future followup could be done to also include Projucer and DemoRunner GUI applications.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
