### PR TITLE
calibre-web: fix static environ method in tornado

### DIFF
--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -63,6 +63,8 @@ python.pkgs.buildPythonApplication rec {
     # and exit. This is gonna be used to configure calibre-web declaratively, as most of its configuration parameters
     # are stored in the DB.
     ./db-migrations.patch
+    # environ in tornado.wsgi.WSGIContainer no longer a static method from 6.3 version
+    ./static_environ.patch
   ];
 
   # calibre-web doesn't follow setuptools directory structure. The following is taken from the script

--- a/pkgs/servers/calibre-web/static_environ.patch
+++ b/pkgs/servers/calibre-web/static_environ.patch
@@ -1,0 +1,25 @@
+diff --git a/cps/tornado_wsgi.py b/cps/tornado_wsgi.py
+index af93219c..cf302042 100644
+--- a/cps/tornado_wsgi.py
++++ b/cps/tornado_wsgi.py
+@@ -53,7 +53,7 @@ class MyWSGIContainer(WSGIContainer):
+             return response.append
+ 
+         app_response = self.wsgi_application(
+-            MyWSGIContainer.environ(request), start_response
++            self.environ(request), start_response
+         )
+         try:
+             response.extend(app_response)
+@@ -86,9 +86,8 @@ class MyWSGIContainer(WSGIContainer):
+         request.connection.finish()
+         self._log(status_code, request)
+ 
+-    @staticmethod
+-    def environ(request: httputil.HTTPServerRequest) -> Dict[Text, Any]:
+-        environ = WSGIContainer.environ(request)
++    def environ(self, request: httputil.HTTPServerRequest) -> Dict[Text, Any]:
++        environ = super().environ(request)
+         environ['RAW_URI'] = request.path
+         return environ
+ 


### PR DESCRIPTION
## Description of changes

Fix #253289. Problem with static environ method, but from tornado==6.3 environ is not static method: https://www.tornadoweb.org/en/stable/wsgi.html#tornado.wsgi.WSGIContainer.environ

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
