### PR TITLE
poetry-plugin-up: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/tools/package-management/poetry/plugins/poetry-plugin-up.nix
+++ b/pkgs/tools/package-management/poetry/plugins/poetry-plugin-up.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
 , buildPythonPackage
 , poetry-core
 , pytestCheckHook
@@ -10,23 +9,15 @@
 
 buildPythonPackage rec {
   pname = "poetry-plugin-up";
-  version = "0.3.0";
+  version = "0.4.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "MousaZeidBaker";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-QDfXgLkwh5rfyNZv0S7+cq6ubldXsbuCiTr6VYx8ZQs=";
+    hash = "sha256-ENw+6DdQkRLnAlIuIEdZzIsFP7ILqA9WatlVZYNJSxw=";
   };
-
-  patches = [
-    # https://github.com/MousaZeidBaker/poetry-plugin-up/pull/24
-    (fetchpatch {
-      url = "https://github.com/MousaZeidBaker/poetry-plugin-up/commit/31d78c547896efd27c2be0956a982638f32b07f8.patch";
-      hash = "sha256-CkZgX/ES+VkfxBofxWeparXNjsdP4qcQ1I32zaBBmWo=";
-    })
-  ];
 
   nativeBuildInputs = [
     poetry-core


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/MousaZeidBaker/poetry-plugin-up/releases/tag/0.4.0

Also removed a patch that is included in this new version.

Currently cannot build the package on macOS due to an error with `poetry` itself:

```log
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing pytest-check-hook
Using pytestCheckPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/9z8f8cqkhbdq6pr4xcmx2c77byk3nfc2-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/vendors/pyproject.toml
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
applying patch /nix/store/b4w2fblzs0xfpmr6wp4abka4cmnipr51-0bdf29e9631fda9436066a07ca8e69a4aa97a31e.patch
patching file Makefile
patching file src/poetry/core/_vendor/pkgutil_resolve_name.LICENSE
patching file src/poetry/core/_vendor/pkgutil_resolve_name.py
patching file src/poetry/core/_vendor/vendor.txt
Hunk #1 FAILED at 2.
1 out of 1 hunk FAILED -- saving rejects to file src/poetry/core/_vendor/vendor.txt.rej
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
