### PR TITLE
pixinsight: 1.8.9-2-20230814 -> 1.8.9-2-20230828

### DIFF
--- a/pkgs/applications/graphics/pixinsight/default.nix
+++ b/pkgs/applications/graphics/pixinsight/default.nix
@@ -10,9 +10,9 @@ stdenv.mkDerivation rec {
   version = "1.8.9-2";
 
   src = requireFile rec {
-    name = "PI-linux-x64-${version}-20230814-c.tar.xz";
+    name = "PI-linux-x64-${version}-20230828-c.tar.xz";
     url = "https://pixinsight.com/";
-    sha256 = "sha256-4Jspkl5riMlbeJX/h1zhVfVymORPK1X4l0LyOgXm05Y=";
+    sha256 = "sha256-f4E6F3LeEolDGcN9Uo/n8GlIuwMIVI26fW9NYtEesd4=";
     message = ''
       PixInsight is available from ${url} and requires a commercial (or trial) license.
       After a license has been obtained, PixInsight can be downloaded from the software distribution


### PR DESCRIPTION
## Description of changes

New build of the latest PixInsight release as the previous one seemed to be buggy: https://pixinsight.com/forum/index.php?threads/pixinsight-1-8-9-2-build-1579-released.21437/

The previous download is not available for download anymore.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
