### PR TITLE
dmenu-wayland: unstable-2022-11-04 -> unstable-2023-05-18

### DIFF
--- a/pkgs/applications/misc/dmenu/wayland.nix
+++ b/pkgs/applications/misc/dmenu/wayland.nix
@@ -4,14 +4,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "dmenu-wayland-unstable";
-  version = "2022-11-04";
+  pname = "dmenu-wayland";
+  version = "unstable-2023-05-18";
 
   src = fetchFromGitHub {
     owner = "nyyManni";
     repo = "dmenu-wayland";
-    rev = "b60047236ef7a4e5dcde6c4ac0dcfaa070d90041";
-    sha256 = "sha256-CeJWLBPAzE3JITVuS6f4CQxLz9v09WvfG3O0wErJJS4=";
+    rev = "a380201dff5bfac2dace553d7eaedb6cea6855f9";
+    hash = "sha256-dqFvU2mRYEw7n8Fmbudwi5XMLQ7mQXFkug9D9j4FIrU=";
   };
 
   outputs = [ "out" "man" ];
@@ -20,10 +20,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ meson ninja pkg-config makeWrapper wayland-scanner ];
   buildInputs = [ cairo pango wayland-protocols glib wayland libxkbcommon ];
 
-  # Patch to support cross-compilation, see https://github.com/nyyManni/dmenu-wayland/pull/23/
   patches = [
     # can be removed when https://github.com/nyyManni/dmenu-wayland/pull/23 is included
     (fetchpatch {
+      name = "support-cross-compilation.patch";
       url = "https://github.com/nyyManni/dmenu-wayland/commit/3434410de5dcb007539495395f7dc5421923dd3a.patch";
       sha256 = "sha256-im16kU8RWrCY0btYOYjDp8XtfGEivemIPlhwPX0C77o=";
     })
@@ -37,8 +37,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     license = licenses.mit;
     platforms = platforms.linux;
-    description = "dmenu for wayland-compositors";
+    description = "An efficient dynamic menu for wayland (wlroots)";
     homepage = "https://github.com/nyyManni/dmenu-wayland";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ rewine ];
   };
 }


### PR DESCRIPTION
## Description of changes
No substantial updates to upstream：https://github.com/nyyManni/dmenu-wayland/commit/a380201dff5bfac2dace553d7eaedb6cea6855f9

just add explicit info that Gnome and KDE are not supported in Readme

1. Update `meta.description` from upstream Readme

2. `unstable` should not part of `pname`






<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
