### PR TITLE
hashcat: Patch building on Apple Silicon

### DIFF
--- a/pkgs/tools/security/hashcat/default.nix
+++ b/pkgs/tools/security/hashcat/default.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
     "VERSION_TAG=${version}"
     "USE_SYSTEM_OPENCL=1"
     "USE_SYSTEM_XXHASH=1"
+  ] ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform) [
+    "IS_APPLE_SILICON='${if stdenv.hostPlatform.isAarch64 then "1" else "0"}'"
   ];
 
   enableParallelBuilding = true;
@@ -76,6 +78,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://hashcat.net/hashcat/";
     license     = licenses.mit;
     platforms   = platforms.unix;
-    maintainers = with maintainers; [ kierdavis zimbatm ];
+    maintainers = with maintainers; [ felixalbrigtsen kierdavis zimbatm ];
   };
 }


### PR DESCRIPTION
## Description of changes

This allows hashcat to build on aarch64-darwin for aarch64-darwin.
The makefile depends on the `lipo` and `/bin/zsh` binaries to determine the IS_APPLE_SILICON flag, and does not work in the build environment.
Cross compilation doesn't seem to work even when overriding the darwin/apple silicon flags, so my changes just force the variable when compiling natively on Apple silicon.
I also added myself as maintainer.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

