### PR TITLE
nixos/xandikos: use systemd socket activation

### DIFF
--- a/nixos/modules/services/networking/xandikos.nix
+++ b/nixos/modules/services/networking/xandikos.nix
@@ -9,8 +9,18 @@ with lib;
 
 let
   cfg = config.services.xandikos;
+
+  nginxProxyAddress =
+    let
+      first = head (toList cfg.address);
+    in
+    if hasInfix "/" first then "unix:${first}" else first;
 in
 {
+
+  imports = [
+    (mkRemovedOptionModule [ "services" "xandikos" "port" ] "Use services.xandikos.address")
+  ];
 
   options = {
     services.xandikos = {
@@ -19,18 +29,24 @@ in
       package = mkPackageOption pkgs "xandikos" { };
 
       address = mkOption {
-        type = types.str;
-        default = "localhost";
         description = ''
-          The IP address on which Xandikos will listen.
-          By default listens on localhost.
+          systemd ListenStream where Xandikos shall listen, see {manpage}`systemd.socket(5)`
         '';
-      };
-
-      port = mkOption {
-        type = types.port;
-        default = 8080;
-        description = "The port of the Xandikos web application";
+        type =
+          with types;
+          oneOf [
+            str
+            (listOf str)
+          ];
+        default = [
+          "127.0.0.1:8080"
+          "[::1]:8080"
+        ];
+        example = [
+          "0.0.0.0:8080"
+          "[::]:8080"
+          "/run/xandikos/socket"
+        ];
       };
 
       routePrefix = mkOption {
@@ -83,6 +99,31 @@ in
         };
       };
 
+      metrics = {
+        enable = mkEnableOption "Xandikos' metrics";
+
+        address = mkOption {
+          description = ''
+            systemd ListenStream where the Xandikos metrics shall listen, see {manpage}`systemd.socket(5)`
+          '';
+          type =
+            with types;
+            oneOf [
+              str
+              (listOf str)
+            ];
+          default = [
+            "127.0.0.1:8081"
+            "[::1]:8081"
+          ];
+          example = [
+            "0.0.0.0:8081"
+            "[::]:8081"
+            "/run/xandikos/metrics.socket"
+          ];
+        };
+      };
+
     };
 
   };
@@ -92,10 +133,15 @@ in
   config = mkIf cfg.enable (mkMerge [
     {
 
+      systemd.sockets.xandikos = {
+        wantedBy = [ "sockets.target" ];
+        socketConfig.ListenStream = cfg.address;
+      };
+
       systemd.services.xandikos = {
         description = "A Simple Calendar and Contact Server";
-        after = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
+        requires = [ "xandikos.socket" ];
+        after = [ "xandikos.socket" ];
 
         serviceConfig = {
           User = "xandikos";
@@ -105,6 +151,19 @@ in
           StateDirectory = "xandikos";
           StateDirectoryMode = "0700";
           PrivateDevices = true;
+          # Systemd socket activation was broken time and again and bugs with
+          # default listening addresses introduced. See
+          #   * https://github.com/jelmer/xandikos/issues/134
+          #   * https://github.com/jelmer/xandikos/pull/133
+          #   * https://github.com/jelmer/xandikos/pull/136
+          #   * https://github.com/jelmer/xandikos/pull/155
+          #   * https://github.com/jelmer/xandikos/issues/260
+          #   * https://github.com/jelmer/xandikos/pull/262
+          # Additionally --metrics-port reuses --listen-address, which
+          # defaults to 0.0.0.0/::. To avoid all this behaviour having
+          # unwanted side-effects we run it in a private network namespace.
+          # The metrics are made accesible through `xandikos-metrics.socket`.
+          PrivateNetwork = true;
           # Sandboxing
           CapabilityBoundingSet = "CAP_NET_RAW CAP_NET_ADMIN";
           ProtectSystem = "strict";
@@ -122,21 +181,51 @@ in
           ExecStart = ''
             ${cfg.package}/bin/xandikos \
               --directory /var/lib/xandikos \
-              --listen-address ${cfg.address} \
-              --port ${toString cfg.port} \
               --route-prefix ${cfg.routePrefix} \
-              ${lib.concatStringsSep " " cfg.extraOptions}
+              ${lib.concatStringsSep " " (
+                lib.optionals cfg.metrics.enable [
+                  "--metrics-port"
+                  "8081"
+                ]
+                ++ cfg.extraOptions
+              )}
           '';
         };
       };
     }
+
+    (mkIf cfg.metrics.enable {
+      systemd.sockets.xandikos-metrics = {
+        wantedBy = [ "sockets.target" ];
+        socketConfig.ListenStream = cfg.metrics.address;
+      };
+
+      systemd.services.xandikos-metrics = {
+        description = "A proxy to Xandikos' metrics";
+        # see https://www.freedesktop.org/software/systemd/man/systemd-socket-proxyd.html#Namespace%20Example
+        requires = [
+          "xandikos.service"
+          "xandikos-metrics.socket"
+        ];
+        after = [
+          "xandikos.service"
+          "xandikos-metrics.socket"
+        ];
+        unitConfig.JoinsNamespaceOf = "xandikos.service";
+        serviceConfig = {
+          Type = "notify";
+          ExecStart = "${config.systemd.package}/lib/systemd/systemd-socket-proxyd localhost:8081";
+          PrivateNetwork = true; # required by JoinsNamespaceOf
+        };
+      };
+    })
 
     (mkIf cfg.nginx.enable {
       services.nginx = {
         enable = true;
         virtualHosts."${cfg.nginx.hostName}" = {
           locations."/" = {
-            proxyPass = "http://${cfg.address}:${toString cfg.port}/";
+            proxyPass = "http://${nginxProxyAddress}";
           };
         };
       };

--- a/nixos/tests/xandikos.nix
+++ b/nixos/tests/xandikos.nix
@@ -8,21 +8,32 @@
   nodes = {
     xandikos_client = { };
     xandikos_default = {
-      networking.firewall.allowedTCPPorts = [ 8080 ];
-      services.xandikos.enable = true;
+      networking.firewall.allowedTCPPorts = [
+        8080
+        8081
+      ];
+      services.xandikos = {
+        enable = true;
+        metrics.enable = true;
+      };
     };
     xandikos_proxy = {
       networking.firewall.allowedTCPPorts = [
         80
         8080
       ];
-      services.xandikos.enable = true;
-      services.xandikos.address = "localhost";
-      services.xandikos.port = 8080;
-      services.xandikos.routePrefix = "/xandikos-prefix/";
-      services.xandikos.extraOptions = [
-        "--defaults"
-      ];
+      services.xandikos = {
+        enable = true;
+        address = [
+          "127.0.0.1:8080"
+          "[::1]:8080"
+          "/run/xandikos/socket"
+        ];
+        routePrefix = "/xandikos-prefix/";
+        extraOptions = [
+          "--defaults"
+        ];
+      };
       services.nginx = {
         enable = true;
         recommendedProxySettings = true;
@@ -30,7 +41,7 @@
           serverName = "xandikos.local";
           basicAuth.xandikos = "snakeOilPassword";
           locations."/xandikos/" = {
-            proxyPass = "http://localhost:8080/xandikos-prefix/";
+            proxyPass = "http://unix:/run/xandikos/socket:/xandikos-prefix/";
           };
         };
       };
@@ -41,24 +52,23 @@
     start_all()
 
     with subtest("Xandikos default"):
-        xandikos_default.wait_for_unit("multi-user.target")
-        xandikos_default.wait_for_unit("xandikos.service")
-        xandikos_default.wait_for_open_port(8080)
+        xandikos_default.wait_for_unit("sockets.target")
         xandikos_default.succeed("curl --fail http://localhost:8080/")
         xandikos_default.succeed(
             "curl -s --fail --location http://localhost:8080/ | grep -i Xandikos"
         )
+        xandikos_default.succeed("curl -s --fail --location http://localhost:8081/metrics")
         xandikos_client.wait_for_unit("network.target")
         xandikos_client.fail("curl --fail http://xandikos_default:8080/")
+        xandikos_client.fail("curl --fail http://xandikos_default:8081/metrics")
 
     with subtest("Xandikos proxy"):
-        xandikos_proxy.wait_for_unit("multi-user.target")
-        xandikos_proxy.wait_for_unit("xandikos.service")
-        xandikos_proxy.wait_for_open_port(8080)
+        xandikos_proxy.wait_for_unit("sockets.target")
         xandikos_proxy.succeed("curl --fail http://localhost:8080/")
         xandikos_proxy.succeed(
             "curl -s --fail --location http://localhost:8080/ | grep -i Xandikos"
         )
+        xandikos_client.fail("curl --fail http://xandikos_default:8081/metrics")
         xandikos_client.wait_for_unit("network.target")
         xandikos_client.fail("curl --fail http://xandikos_proxy:8080/")
         xandikos_client.succeed(

--- a/pkgs/by-name/xa/xandikos/package.nix
+++ b/pkgs/by-name/xa/xandikos/package.nix
@@ -32,6 +32,7 @@ python3Packages.buildPythonApplication rec {
     jinja2
     multidict
     pytz
+    systemd-python
     vobject
   ];
 


### PR DESCRIPTION
## Description of changes

Xandikos' handling of listening addresses is quite buggy. There were multiple bugs regarding socket activation, which caused it to also listen on unwanted default ports. Additionally the metrics port reuses the listen address.

To avoid all this unexpected behaviour we run Xandikos in a private network namespace and let systemd handle our *wanted* listening adresses. Optionally the metrics are made accessible in the host's network namespace through `xandikos-metrics.service` using systemd-socket-proxyd.

Depends on <https://github.com/NixOS/nixpkgs/pull/253612>.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
