### PR TITLE
jimtcl: Fix cross compilation and allow disable of SDL

### DIFF
--- a/pkgs/development/interpreters/jimtcl/default.nix
+++ b/pkgs/development/interpreters/jimtcl/default.nix
@@ -5,12 +5,15 @@
 , asciidoc
 , pkg-config
 , inetutils
+, tcl
 
 , sqlite
 , readline
 , SDL
 , SDL_gfx
 , openssl
+
+, SDLSupport ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -27,15 +30,17 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     asciidoc
+    tcl
   ];
 
   buildInputs = [
     sqlite
     readline
+    openssl
+  ] ++ (lib.optionals SDLSupport [
     SDL
     SDL_gfx
-    openssl
-  ];
+  ]);
 
   configureFlags = [
     "--shared"
@@ -44,11 +49,10 @@ stdenv.mkDerivation rec {
     "--with-ext=binary"
     "--with-ext=sqlite3"
     "--with-ext=readline"
-    "--with-ext=sdl"
     "--with-ext=json"
     "--enable-utf8"
     "--ipv6"
-  ];
+  ] ++ (lib.optional SDLSupport "--with-ext=sdl");
 
   enableParallelBuilding = true;
 
@@ -58,6 +62,9 @@ stdenv.mkDerivation rec {
     rm tests/exec2.test
     # requires internet access
     rm tests/ssl.test
+    # test fails due to timing in some environments
+    # https://github.com/msteveb/jimtcl/issues/282
+    rm tests/timer.test
   '';
 
   # test posix-1.6 needs the "hostname" command


### PR DESCRIPTION
Jimtcl is dependency of OpenOCD that does not need SDL. For some embedded systems it is beneficial to not pull in graphics related dependencies to reduce the size. The second reason is that right now SDL_gfx is not cross compiling and thus OpenOCD can't be cross compiled either.

This also fixes cross compilation of Jimtcl itself. The attempt to cross compile resulted in:
```
  No installed jimsh or tclsh, building local bootstrap jimsh0
```
The solution here is to add jimtcl to native build dependencies in case of cross compilation.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
