### PR TITLE
picard: disable autoupdate

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -58,6 +58,8 @@ pythonPackages.buildPythonApplication rec {
     pyyaml
   ];
 
+  setupPyGlobalFlags = [ "build" "--disable-autoupdate" ];
+
   preCheck = ''
     export HOME=$(mktemp -d)
   '';


### PR DESCRIPTION
## Description of changes

Picard currently prompts the user to update outside of the package manager:

> <img src="https://github.com/NixOS/nixpkgs/assets/1844746/fb75d9a9-c2ad-4c1e-9cc7-b9d7d31b7fe2" width="415" alt="Picard Update · A new version of Picard is available." />

This change applies `--disable-autoupdate` as described in metabrainz/picard#1024:

| Before | After |
|-|-|
| <img src="https://github.com/NixOS/nixpkgs/assets/1844746/706700e9-8017-4218-83dd-ce3b26be0ed8" width="337" alt="Help: Check for Update" /> | <img src="https://github.com/NixOS/nixpkgs/assets/1844746/e12c8fdd-1bbf-4fd1-8863-006f65529f18" width="337" alt="Help" /> |

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev picard/disable-autoupdate`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).