### PR TITLE
meletrix-udev-rules: init at 0-unstable-2023-10-20

### DIFF
--- a/pkgs/by-name/me/meletrix-udev-rules/meletrix.rules
+++ b/pkgs/by-name/me/meletrix-udev-rules/meletrix.rules
@@ -1,0 +1,26 @@
+# Download VIA jsons from https://drive.google.com/drive/folders/1ky4kmGxZo1i0WyRZiY9V6FQlGzjegcPk for USB vendor and product ids
+
+# Zoom 65 Olivia Wired
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="806c", ATTRS{idProduct}=="0005", MODE:="0660", GROUP="input"
+
+# Zoom 65 EE
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea7", ATTRS{idProduct}=="7777", MODE:="0660", GROUP="input"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea7", ATTRS{idProduct}=="cc65", MODE:="0660", GROUP="input"
+
+# Zoom 65 V2
+# also 1ea7:7777
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea7", ATTRS{idProduct}=="ccbb", MODE:="0660", GROUP="input"
+
+# Zoom 65 V2.5
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea7", ATTRS{idProduct}=="ccc3", MODE:="0660", GROUP="input"
+
+# Zoom 75 (production unit)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea7", ATTRS{idProduct}=="ced3", MODE:="0660", GROUP="input"
+
+# Zoom 75 (prototype)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea7", ATTRS{idProduct}=="ce81", MODE:="0660", GROUP="input"
+
+# ZoomTKL
+# also 1ea7:7777
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea7", ATTRS{idProduct}=="cd87", MODE:="0660", GROUP="input"
+

--- a/pkgs/by-name/me/meletrix-udev-rules/package.nix
+++ b/pkgs/by-name/me/meletrix-udev-rules/package.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "meletrix-udev-rules";
+  version = "0-unstable-2023-10-20";
+
+  src = [./meletrix.rules];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dpm644 $src $out/lib/udev/rules.d/70-meletrix.rules
+  '';
+
+  meta = with lib; {
+    description = "udev rules to configure Meletrix keyboards";
+    license = licenses.cc0;
+    maintainers = with maintainers; [Scrumplex];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

These udev rules are helpful for configuring Zoom65 (and other Meletrix) keyboards using utilities like VIA.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
