### PR TITLE
gnuradio: add soapysdr plugin dependencies

### DIFF
--- a/pkgs/applications/radio/gnuradio/3.9.nix
+++ b/pkgs/applications/radio/gnuradio/3.9.nix
@@ -21,7 +21,7 @@
 , uhd
 , SDL
 , gsl
-, soapysdr
+, soapysdr-with-plugins
 , libsodium
 , libsndfile
 , libunwind
@@ -238,7 +238,7 @@ let
     gr-soapy = {
       cmakeEnableFlag = "GR_SOAPY";
       runtime = [
-        soapysdr
+        soapysdr-with-plugins
       ];
     };
   };

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -23,7 +23,7 @@
 , uhd
 , SDL
 , gsl
-, soapysdr
+, soapysdr-with-plugins
 , libsodium
 , libsndfile
 , libunwind
@@ -258,7 +258,7 @@ let
     gr-soapy = {
       cmakeEnableFlag = "GR_SOAPY";
       runtime = [
-        soapysdr
+        soapysdr-with-plugins
       ];
     };
   };

--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -84,9 +84,7 @@ let
         at-spi2-core
       ]}"
     ]
-    ++ lib.optionals (extraPackages != []) [
-      "--prefix" "GRC_BLOCKS_PATH" ":" "${lib.makeSearchPath "share/gnuradio/grc/blocks" extraPackages}"
-    ]
+    ++ [ "--prefix" "GRC_BLOCKS_PATH" ":" "${lib.makeSearchPath "share/gnuradio/grc/blocks" (extraPackages ++ [ unwrapped ])}" ]
     ++ lib.optionals (unwrapped.hasFeature "gr-qtgui")
       # 3.7 builds with qt4
       (if lib.versionAtLeast unwrapped.versionAttr.major "3.8" then


### PR DESCRIPTION
This PR adds the missing dependency on the soapysdr plugins, which made the blocks based on the different sdr plugins fail when running a gnuradio flowgraph containing them.

Also the gnuradio-companion wrapper was missing the path to the gnuradio core blocks and failed with the following error message:
```
RuntimeError: Failed to find built-in GRC blocks (specifically, the 'options' block). Ensure your GRC block paths are correct and at least one points to your prefix installation:
/home/wirew0rm/.grc_gnuradio
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).