### PR TITLE
[23.05] trilium-desktop: 0.59.4 -> 0.60.4

### DIFF
--- a/pkgs/applications/office/trilium/desktop.nix
+++ b/pkgs/applications/office/trilium/desktop.nix
@@ -6,13 +6,13 @@
 
 let
   pname = "trilium-desktop";
-  version = "0.59.4";
+  version = "0.60.3";
 
   linuxSource.url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
-  linuxSource.sha256 = "0vv58bcwx62slrc6f7ra61m71nqh6pb2rg4h99f8krj2h56zhrij";
+  linuxSource.sha256 = "0hfrww1r4s2rga8wzwhcfk60jy4b4xwglgflbc5jbxk3jalvk73x";
 
   darwinSource.url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-mac-x64-${version}.zip";
-  darwinSource.sha256 = "18jdz32i0blh3hrdyh558fmqncjrnv1j1g3hwjcph8hi90pqycdr";
+  darwinSource.sha256 = "0scwq4fmllhjmcj0621rlaaniib3nabfwjmsxdfc5hfnlhjzq7qs";
 
   meta = metaCommon // {
     mainProgram = "trilium";

--- a/pkgs/applications/office/trilium/desktop.nix
+++ b/pkgs/applications/office/trilium/desktop.nix
@@ -6,13 +6,13 @@
 
 let
   pname = "trilium-desktop";
-  version = "0.60.3";
+  version = "0.60.4";
 
   linuxSource.url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
-  linuxSource.sha256 = "0hfrww1r4s2rga8wzwhcfk60jy4b4xwglgflbc5jbxk3jalvk73x";
+  linuxSource.sha256 = "02vbghvi2sbh943rslgm712x9zccvpjab3jvr5b1bw4bq5fzppgq";
 
   darwinSource.url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-mac-x64-${version}.zip";
-  darwinSource.sha256 = "0scwq4fmllhjmcj0621rlaaniib3nabfwjmsxdfc5hfnlhjzq7qs";
+  darwinSource.sha256 = "0z6dk16xdzkiyxrm1yh3iz5351c8sdzvk8v5l3jdqy7davxw9f86";
 
   meta = metaCommon // {
     mainProgram = "trilium";

--- a/pkgs/applications/office/trilium/server.nix
+++ b/pkgs/applications/office/trilium/server.nix
@@ -3,8 +3,8 @@
 
 let
   serverSource.url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-server-${version}.tar.xz";
-  serverSource.sha256 = "1ys9vnxrxhy52accqxkmvf63kqwaf3ba6ysk3a8wfn2rwxa766g8";
-  version = "0.59.4";
+  serverSource.sha256 = "16xlbhjsd0xqaph14wk05qri256d7jga7fz0fwl4rw0li8r9qyd7";
+  version = "0.60.3";
 in stdenv.mkDerivation rec {
   pname = "trilium-server";
   inherit version;

--- a/pkgs/applications/office/trilium/server.nix
+++ b/pkgs/applications/office/trilium/server.nix
@@ -3,8 +3,8 @@
 
 let
   serverSource.url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-server-${version}.tar.xz";
-  serverSource.sha256 = "16xlbhjsd0xqaph14wk05qri256d7jga7fz0fwl4rw0li8r9qyd7";
-  version = "0.60.3";
+  serverSource.sha256 = "16xyxpxqvzhdq63wc2nzmfabpasypxwm474jf15y3q8kdrca9myv";
+  version = "0.60.4";
 in stdenv.mkDerivation rec {
   pname = "trilium-server";
   inherit version;


### PR DESCRIPTION
## Description of changes

The upcoming 0.61 release will require that users upgrade to 0.60 first: https://github.com/zadam/trilium/releases/tag/v0.61.6-beta

Since [0.60](https://github.com/zadam/trilium/releases/tag/v0.60.3) is only a bugfix release, it is safe to backport.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Did not add a release notes entry since the change is minor
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md): cherry-pick done with `-x`