### PR TITLE
python310Packages.pytorch-pfn-extras: fix build error

### DIFF
--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ numpy packaging torch typing-extensions ];
 
-  nativeCheckInputs = [ onnx pytestCheckHook torchvision ];
+  nativeCheckInputs = [ pytestCheckHook torchvision ];
 
   # ignore all pytest warnings
   preCheck = ''
@@ -41,6 +41,15 @@ buildPythonPackage rec {
     "tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py"
     "tests/pytorch_pfn_extras_tests/onnx_tests/test_torchvision.py"
     "tests/pytorch_pfn_extras_tests/onnx_tests/utils.py"
+
+    # exclude all other onnx tests since the build currently fails with
+    # a mismatched version.
+    # See https://github.com/NixOS/nixpkgs/issues/252741
+    "tests/pytorch_pfn_extras_tests/onnx_tests/test_annotate.py"
+    "tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py"
+    "tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py"
+    "tests/pytorch_pfn_extras_tests/onnx_tests/test_load_model.py"
+    "tests/pytorch_pfn_extras_tests/runtime_tests/test_jit_runtime.py"
 
     # RuntimeError: No Op registered for Gradient with domain_version of 9
     "tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py"


### PR DESCRIPTION
Due to mismatched dependency on the onnx version.  See https://github.com/NixOS/nixpkgs/issues/252741

## Description of changes

The package fails to build currently because there is an issue with to mismatched versions on onnx.  This pull request removes onnx and associated tests from the package for the time being.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
