### PR TITLE
deconz: init at 2.23.00

### DIFF
--- a/pkgs/servers/deconz/default.nix
+++ b/pkgs/servers/deconz/default.nix
@@ -1,0 +1,83 @@
+{ stdenv
+, lib
+, fetchurl
+, wrapQtAppsHook
+, dpkg
+, autoPatchelfHook
+, qtserialport
+, qtwebsockets
+, openssl
+, libredirect
+, makeWrapper
+, gzip
+, gnutar
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deconz";
+  version = "2.23.00";
+
+  src = fetchurl {
+    url = "https://deconz.dresden-elektronik.de/ubuntu/beta/deconz-${version}-qt5.deb";
+    sha256 = "sha256-TMftm1fz8c8ndSyA3HUd7JWT0DINxvbdUSDrmVMwmws=";
+  };
+
+  devsrc = fetchurl {
+    url = "https://deconz.dresden-elektronik.de/ubuntu/beta/deconz-dev-${version}.deb";
+    sha256 = "sha256-uW5iF3rvFlowFhMBVDTOHkJ2K4LBgAxxC79tXpMhy5U=";
+  };
+
+  nativeBuildInputs = [ dpkg autoPatchelfHook makeWrapper wrapQtAppsHook ];
+
+  buildInputs = [ qtserialport qtwebsockets openssl ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg -x $src ./deconz-src
+    dpkg -x $devsrc ./deconz-devsrc
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -r deconz-src/* "$out"
+    cp -r deconz-devsrc/* "$out"
+
+    # Flatten /usr and manually merge lib/ and usr/lib/, since mv refuses to.
+    mv "$out/lib" "$out/orig_lib"
+    mv "$out/usr/"* "$out/"
+    mkdir -p "$out/lib/systemd/system/"
+    mv "$out/orig_lib/systemd/system/"* "$out/lib/systemd/system/"
+    rmdir "$out/orig_lib/systemd/system"
+    rmdir "$out/orig_lib/systemd"
+    rmdir "$out/orig_lib"
+    rmdir "$out/usr"
+
+    for f in "$out/lib/systemd/system/"*.service \
+             "$out/share/applications/"*.desktop; do
+        substituteInPlace "$f" \
+            --replace "/usr/" "$out/"
+    done
+
+    for p in "$out/bin/deCONZ" "$out/bin/GCFFlasher_internal.bin"; do
+        wrapProgram "$p" \
+            --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+            --set NIX_REDIRECTS "/usr/share=$out/share:/usr/bin=$out/bin" \
+            --prefix PATH : "${lib.makeBinPath [ gzip gnutar ]}"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Manage Zigbee network with ConBee, ConBee II or RaspBee hardware";
+    homepage = "https://www.dresden-elektronik.com/wireless/software/deconz.html";
+    license = licenses.unfree;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ bjornfor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26447,6 +26447,8 @@ with pkgs;
 
   dcnnt = python3Packages.callPackage ../servers/dcnnt { };
 
+  deconz = qt5.callPackage ../servers/deconz { };
+
   dendrite = callPackage ../servers/dendrite { };
 
   dex-oidc = callPackage ../servers/dex { };


### PR DESCRIPTION
## Description of changes

Add deCONZ, software for managing Zigbee devices.

https://www.dresden-elektronik.com/wireless/software/deconz.html

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
