### PR TITLE
emacs: use `llvmPackages_14` from `apple_sdk_11_0`

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -10,6 +10,7 @@ lib.makeScope pkgs.newScope (self:
       inherit stdenv;
 
       inherit (pkgs.darwin) sigtool;
+      inherit (pkgs.darwin.apple_sdk_11_0) llvmPackages_14;
       inherit (pkgs.darwin.apple_sdk_11_0.frameworks)
         Accelerate AppKit Carbon Cocoa GSS ImageCaptureCore ImageIO IOKit OSAKit
         Quartz QuartzCore UniformTypeIdentifiers WebKit;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Explicitly pull in `llvmPackages_14` from `apple_sdk_11_0` for Emacs. This should pull in the correct `Libsystem` headers and resolve the remaining compilation issues related to the new SDK.

Tested:
- `emacs28-macport.withPackages`
  - Under a `nix repl` (`nix repl --expr 'import ./.{system="x86_64-darwin";}'`), evaluate `:b emacs28-macport.pkgs.withPackages (epkgs: with epkgs.melpaStablePackages; [ magit ])`
  - `result/bin/emacs -nw --batch --eval '(print (progn (package-initialize) (magit-version)))'` yields `"3.3.0"`, indicating that Magit has been correctly installed
- `emacs28-macport`
  - Builds correctly under Rosetta x86_64, `result/Applications/Emacs.app` contains an `Info.plist`
  - App bundle opens correctly


I've only tested this under Rosetta on an ARM Mac, so I'd appreciate any testing from those on Intel Macs.

Resolves #253502.

CC @sixtysecrun, @knl, @AndersonTorres

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
