### PR TITLE
streamdeck-ui: 3.0.1 -> 3.1.0

### DIFF
--- a/pkgs/applications/misc/streamdeck-ui/default.nix
+++ b/pkgs/applications/misc/streamdeck-ui/default.nix
@@ -10,13 +10,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "streamdeck-ui";
-  version = "3.0.1";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     repo = "streamdeck-linux-gui";
     owner = "streamdeck-linux-gui";
     rev = "v${version}";
-    sha256 = "sha256-nLtWExxufxT5nRiEYLGNeMhFhvlGzYKA+crA74Yt4ck=";
+    sha256 = "sha256-AIE9j022L4WSlHBAu3TT5uE4Ilgk/jYSmU03K8Hs8xY=";
   };
 
   patches = [
@@ -87,14 +87,10 @@ python3Packages.buildPythonApplication rec {
   nativeCheckInputs = [
     xvfb-run
     python3Packages.pytest
-    python3Packages.hypothesis-auto
   ];
 
-  # Ignored tests are not in a running or passing state.
-  # Revisit these ignored tests on each update.
   checkPhase = ''
-    xvfb-run pytest tests \
-      --ignore=tests/test_api.py
+    xvfb-run pytest tests
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

- [Release notes](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/releases/tag/v3.1.0)
- [Diff](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/compare/v3.0.1..v3.1.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
