### PR TITLE
plotutils: fix build with clang 16

### DIFF
--- a/pkgs/tools/graphics/plotutils/c++17-register-usage-fix.patch
+++ b/pkgs/tools/graphics/plotutils/c++17-register-usage-fix.patch
@@ -1,0 +1,44 @@
+diff -ur a/pic2plot/gram.cc b/pic2plot/gram.cc
+--- a/pic2plot/gram.cc	2000-06-28 00:23:21.000000000 -0400
++++ b/pic2plot/gram.cc	2023-09-07 22:59:47.004460065 -0400
+@@ -1229,9 +1229,9 @@
+      char *from;
+      unsigned int count;
+ {
+-  register char *f = from;
+-  register char *t = to;
+-  register int i = count;
++  char *f = from;
++  char *t = to;
++  int i = count;
+
+   while (i-- > 0)
+     *t++ = *f++;
+@@ -1244,9 +1244,9 @@
+ static void
+ __yy_memcpy (char *to, char *from, unsigned int count)
+ {
+-  register char *t = to;
+-  register char *f = from;
+-  register int i = count;
++  char *t = to;
++  char *f = from;
++  int i = count;
+
+   while (i-- > 0)
+     *t++ = *f++;
+@@ -1289,10 +1289,10 @@
+ yyparse(YYPARSE_PARAM_ARG)
+      YYPARSE_PARAM_DECL
+ {
+-  register int yystate;
+-  register int yyn;
+-  register short *yyssp;
+-  register YYSTYPE *yyvsp;
++  int yystate;
++  int yyn;
++  short *yyssp;
++  YYSTYPE *yyvsp;
+   int yyerrstatus;	/*  number of tokens to shift before error messages enabled */
+   int yychar1 = 0;		/*  lookahead token as an internal (translated) token number */
+ 

--- a/pkgs/tools/graphics/plotutils/default.nix
+++ b/pkgs/tools/graphics/plotutils/default.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libpng ];
-  patches = map fetchurl (import ./debian-patches.nix);
+  patches = map fetchurl (import ./debian-patches.nix)
+    # `pic2plot/gram.cc` uses the register storage class specifier, which is not supported in C++17.
+    # This prevents clang 16 from building plotutils because it defaults to C++17.
+    ++ [ ./c++17-register-usage-fix.patch ];
 
   preBuild = ''
     # Fix parallel building.


### PR DESCRIPTION
## Description of changes

Clang defaults to C++, which disallows the register storage class specifier. This causes the build to fail. Remove the specifier to allow clang 16 to build plotutils.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
