### PR TITLE
cudaPackages.cudnn: use libcublas split outputs

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -31,12 +31,6 @@ assert useCudatoolkitRunfile || (libcublas != null); let
   # versionTriple :: String
   # Version with three components: major.minor.patch
   versionTriple = majorMinorPatch version;
-
-  # cudatoolkit_root :: Derivation
-  cudatoolkit_root =
-    if useCudatoolkitRunfile
-    then cudatoolkit
-    else libcublas;
 in
   backendStdenv.mkDerivation {
     pname = "cudatoolkit-${cudaMajorVersion}-cudnn";
@@ -65,7 +59,10 @@ in
       stdenv.cc.cc.lib
 
       zlib
-      cudatoolkit_root
+    ] ++ lists.optionals useCudatoolkitRunfile [
+      cudatoolkit
+    ] ++ lists.optionals (!useCudatoolkitRunfile) [
+      libcublas.lib
     ];
 
     # We used to patch Runpath here, but now we use autoPatchelfHook


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Use the new split output to reduce the closure size.

We see a reduction of 1GB.

Before:

```console
$ nix build --impure github:NixOS/nixpkgs/3cba01e8ab6de58f0836218b3da0c5930adaed62#cudaPackages.cudnn -o before-253951
$ nix path-info -rSsh ./before-253951
/nix/store/gnzwqa9df994g01yw5x75qnbl1rhp9ds-libunistring-1.1                 	   1.8M	   1.8M
/nix/store/h3aw16j1c54jv8s39yvdhpfcx3538jwi-libidn2-2.3.4                    	 350.4K	   2.1M
/nix/store/kv0v4h5i911gj39m7n9q10k8r8gbn3sa-xgcc-12.3.0-libgcc               	 139.1K	 139.1K
/nix/store/905gkx2q1pswixwmi1qfhfl6mik3f22l-glibc-2.37-8                     	  28.8M	  31.1M
/nix/store/s2pgr9iqj60mfnmabixnqacxl4bzb408-gcc-12.3.0-libgcc                	 139.1K	 139.1K
/nix/store/gi26p79iq8jrw51irq5x82c2cqlgicxi-gcc-12.3.0-lib                   	   7.5M	  38.8M
/nix/store/m1rszkm1s0d5z12r3pyg1rp0rns5hdm9-zlib-1.2.13                      	 125.6K	  31.2M
/nix/store/j2lncpzja3acsgc34whxx8xq1rlm2dri-libcublas-11.11.3.6-dev          	 402.6K	 402.6K
/nix/store/p62rbw34am37v131md1b23djnc2zyhvv-libcublas-11.11.3.6-static       	   1.0G	   1.0G
/nix/store/qih1c2kfdc05h9cl7mw96v3gfggjfiv9-libcublas-11.11.3.6-lib          	 639.2M	 678.0M
/nix/store/xa6g53ka3hzb44z7x0xwi06v5dini711-libcublas-11.11.3.6              	 438.6K	   1.7G
/nix/store/07r299jpsmdp7lyr6ds4xfl7h6rpmmrd-cudatoolkit-11-cudnn-8.9.1-lib   	   1.1G	   2.8G
/nix/store/fawa1l0cb7flifdd8ks001089pqzhai8-cudatoolkit-11-cudnn-8.9.1-dev   	 401.7K	 401.7K
/nix/store/ym3c9qknj7740prgj44n8gy5w59a17l4-cudatoolkit-11-cudnn-8.9.1-static	   1.2G	   1.2G
/nix/store/qw3rpqlybkyy9gw70rglgynj5yh2h4ad-cudatoolkit-11-cudnn-8.9.1       	  43.4K	   4.0G
```

After:

```console
$ nix build --impure github:NixOS/nixpkgs/10bb3be659f65c84b5639e83a94f3415927850bc#cudaPackages.cudnn -o after-253951
$ nix path-info -rSsh ./after-253951
/nix/store/gnzwqa9df994g01yw5x75qnbl1rhp9ds-libunistring-1.1                 	   1.8M	   1.8M
/nix/store/h3aw16j1c54jv8s39yvdhpfcx3538jwi-libidn2-2.3.4                    	 350.4K	   2.1M
/nix/store/kv0v4h5i911gj39m7n9q10k8r8gbn3sa-xgcc-12.3.0-libgcc               	 139.1K	 139.1K
/nix/store/905gkx2q1pswixwmi1qfhfl6mik3f22l-glibc-2.37-8                     	  28.8M	  31.1M
/nix/store/s2pgr9iqj60mfnmabixnqacxl4bzb408-gcc-12.3.0-libgcc                	 139.1K	 139.1K
/nix/store/gi26p79iq8jrw51irq5x82c2cqlgicxi-gcc-12.3.0-lib                   	   7.5M	  38.8M
/nix/store/m1rszkm1s0d5z12r3pyg1rp0rns5hdm9-zlib-1.2.13                      	 125.6K	  31.2M
/nix/store/qih1c2kfdc05h9cl7mw96v3gfggjfiv9-libcublas-11.11.3.6-lib          	 639.2M	 678.0M
/nix/store/78v49jkm04djgmchdngfddkcxh8j7057-cudatoolkit-11-cudnn-8.9.1-lib   	   1.1G	   1.8G
/nix/store/m0fkv37g5phd10hmw5x7x165ci964glh-cudatoolkit-11-cudnn-8.9.1-dev   	 401.7K	 401.7K
/nix/store/zavw1pjiv9rr4jrzvih73wm5hi77a7yx-cudatoolkit-11-cudnn-8.9.1-static	   1.2G	   1.2G
/nix/store/j2xv7p60rvz95w0nplbm210r0x3gs2h4-cudatoolkit-11-cudnn-8.9.1       	  43.4K	   3.0G
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
