### PR TITLE
brotab: add missing python dependency `setuptools`

### DIFF
--- a/pkgs/tools/misc/brotab/default.nix
+++ b/pkgs/tools/misc/brotab/default.nix
@@ -25,6 +25,7 @@ python.pkgs.buildPythonApplication rec {
     flask
     psutil
     requests
+    setuptools
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Without this change, the following error occurs:

```bash
$ nix shell nixpkgs#brotab --command sh -c 'bt install'                                                                                         +1 10:06:10
Traceback (most recent call last):
  File "/nix/store/wb7qpzdnp3d54ybp3p6nyp3dpnk9cz0y-brotab-1.4.2/bin/.bt-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/wb7qpzdnp3d54ybp3p6nyp3dpnk9cz0y-brotab-1.4.2/lib/python3.10/site-packages/brotab/main.py", line 769, in main
    exit(run_commands(sys.argv[1:]))
  File "/nix/store/wb7qpzdnp3d54ybp3p6nyp3dpnk9cz0y-brotab-1.4.2/lib/python3.10/site-packages/brotab/main.py", line 762, in run_commands
    result = args.func(args)
  File "/nix/store/wb7qpzdnp3d54ybp3p6nyp3dpnk9cz0y-brotab-1.4.2/lib/python3.10/site-packages/brotab/main.py", line 388, in install_mediator
    from pkg_resources import resource_string
ModuleNotFoundError: No module named 'pkg_resources'
```