### PR TITLE
buildFHSEnv: disable security features by default

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -17,12 +17,12 @@
 , meta ? {}
 , passthru ? {}
 , extraBwrapArgs ? []
-, unshareUser ? true
-, unshareIpc ? true
-, unsharePid ? true
+, unshareUser ? false
+, unshareIpc ? false
+, unsharePid ? false
 , unshareNet ? false
-, unshareUts ? true
-, unshareCgroup ? true
+, unshareUts ? false
+, unshareCgroup ? false
 , dieWithParent ? true
 , ...
 } @ args:


### PR DESCRIPTION
## Description of changes

The implicit contract of `buildFHSUserEnv` was that it allows to run software built for a typical GNU/Linux distribution (not NixOS) without patching it (`patchelf`, `autoPatchelfHook`, etc.). Note that this does not inherently imply running untrusted programs.

buildFHSUserEnv was implemented by using chroot and assembling a standard-compliant FHS environment in the new root. As expected, this did not provide any kind of isolation between the system and the programs.

However, when it was later reimplemented using bubblewrap (PR #225748), which *is* a security tool, several isolation features involving detaches Linux namespaces were turned on by default. This decision has introduced a number of breakages that are very difficult to debug and trace back to this change.
For example: `unshareIPC` breaks software audio mixing in programs using ALSA (dmix) and `unsharePID` breaks gdb,

Since:

  1. the security features were enable without any clear threat model;
  2. `buildFHSEnvBubblewrap` is supposed to be a drop-in replacement of `buildFHSEnvChrootenv` (see the release notes for NixOS 23.05);
  3. the change is breaking in several common cases (security does not come for free);
  4. the contract was not changed, or at least communicated in a clear way to the users;

all security features should be turned off by default.

P.S. It would be useful to create a variant of buildFHSEnv that does provide some isolation. This could unshare some namespaces and mount only limited parts of the filesystem.
Note that buildFHSEnv mounts every directory in / under the new root, so again, very little is gained by unsharing alone.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
