### PR TITLE
ocaml-ng.ocamlPackages_5_1.ocaml: init at 5.1.0-rc3

### DIFF
--- a/pkgs/development/compilers/ocaml/5.1.nix
+++ b/pkgs/development/compilers/ocaml/5.1.nix
@@ -1,0 +1,9 @@
+import ./generic.nix {
+  major_version = "5";
+  minor_version = "1";
+  patch_version = "0-rc3";
+  src = fetchTarball {
+    url = "https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.0~rc3.tar.xz";
+    sha256 = "sha256:0cbvdcsq1qh70mm116dcgk6y7d4g4nrypzq20k7i6ww7am1563d3";
+  };
+}

--- a/pkgs/development/ocaml-modules/awa/default.nix
+++ b/pkgs/development/ocaml-modules/awa/default.nix
@@ -1,5 +1,5 @@
 { lib, buildDunePackage, fetchurl
-, ppx_sexp_conv, ppx_cstruct
+, ppx_sexp_conv
 , mirage-crypto, mirage-crypto-ec, mirage-crypto-rng, mirage-crypto-pk
 , x509, cstruct, cstruct-unix, cstruct-sexp, sexplib, eqaf
 , rresult, mtime, logs, fmt, cmdliner, base64
@@ -23,8 +23,6 @@ buildDunePackage rec {
     logs base64 zarith
     ppx_sexp_conv eqaf
   ];
-
-  buildInputs = [ ppx_cstruct ];
 
   doCheck = true;
   checkInputs = [ cstruct-unix cmdliner fmt ];

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -35,6 +35,7 @@ let param =
   "4.13" = v6_6;
   "4.14" = v6_6;
   "5.0" = v6_6;
+  "5.1" = v6_6;
 }.${ocaml.meta.branch};
 in
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1927,6 +1927,8 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_5_0 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.0.nix { });
 
+  ocamlPackages_5_1 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.1.nix { });
+
   ocamlPackages_latest = ocamlPackages_5_0;
 
   ocamlPackages = ocamlPackages_4_14;


### PR DESCRIPTION
## Description of changes

https://discuss.ocaml.org/t/third-and-hopefully-last-release-candidate-for-ocaml-5-1-0/12975

A few libraries still fail to build (`mdx`, `apron`, etc.)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
