### PR TITLE
nixos/jupyterhub: add automatic migrations

### DIFF
--- a/nixos/modules/services/development/jupyterhub/default.nix
+++ b/nixos/modules/services/development/jupyterhub/default.nix
@@ -179,6 +179,11 @@ in {
         Directory for jupyterhub state (token + database)
       '';
     };
+
+    automaticMigrations = mkEnableOption
+      (lib.mdDoc "automatic migrations for database schema and data") // {
+        default = true;
+      };
   };
 
   config = mkMerge [
@@ -196,6 +201,12 @@ in {
           StateDirectory = cfg.stateDirectory;
           WorkingDirectory = "/var/lib/${cfg.stateDirectory}";
         };
+
+        preStart = lib.mkBefore (
+          lib.optionalString cfg.automaticMigrations ''
+            ${cfg.jupyterhubEnv}/bin/jupyterhub upgrade-db --config ${jupyterhubConfig}
+          ''
+        );
       };
     })
   ];


### PR DESCRIPTION
## Description of changes

Sometimes when JupyterHub is upgraded, migrations need to be run on the database:

https://jupyterhub.readthedocs.io/en/stable/howto/upgrading.html#upgrade-jupyterhub-database

Currently, JupyterHub service on NixOS, doesn't run these automatically, so after upgrading the service stops working with an error like this:

```
Sep 07 00:16:27 jupyter jupyterhub[2281780]: Found database schema version 4dc2d5a8c53c != 0eee8c825d24. Backup your database and run `jupyterhub upgrade-db` to upgrade to the latest schema.
Sep 07 00:16:27 jupyter systemd[1]: jupyterhub.service: Main process exited, code=exited, status=1/FAILURE
Sep 07 00:16:27 jupyter systemd[1]: jupyterhub.service: Failed with result 'exit-code'.
```

One would need to run the following command:

```
jupyterhub upgrade-db
```

But this is surprisingly tricky given all the nix-related properties regarding separate environments: One needs to figure out the path to the correct executable `jupyterhub` and its config file. One can read these from the output of `systemctl status jupyterhub` and then manually write something as follows:

```
/nix/store/.../bin/jupyterhub upgrade-db --config /nix/store/...-jupyterhub_config.py
```

And actually this didn't work for me. I had to even define `PYTHONPATH` because JupyterHub launches alembic as a subprocess and for some reason it doesn't find JupyterHub when trying to import it. So, I had to run:

```
PYTHONPATH=/nix/store/.../lib/python3.10/site-packages /nix/store/.../bin/jupyterhub upgrade-db --config /nix/store/...-jupyterhub_config.py
```

So, instead of letting JupyterHub service to fail unnoticeably after upgrades and requiring users to figure out these complex manual commands, NixOS could just run the migrations automatically.

This PR makes the JupyterHub service to run the database migrations automatically, but the user can opt-out.

An alternative would be to create wrapper for the `jupyterhub` executable which sets all the paths and configs correctly, and the user could just run something like `manage-jupyterhub upgrade-db`. Of course, these to solutions don't need to be mutually exclusive, but I decided to implement only the automatic migrations for now.

Things to do still:

- [ ] I'm worried the current implementation doesn't work without setting `PYTHONPATH`. I don't understand why it's needed though. To me it sounds like there's a bug in the wrapping of `jupyterhub` or `alembic` executables, but probably it's all good and I just don't know how to handle this. If setting `PYTHONPATH` is the correct solution, perhaps it should be done on the service environment level.
- [ ] I'd like to add NixOS tests about this feature.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
