### PR TITLE
nixos/binfmt: improve type annotations

### DIFF
--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -279,7 +279,7 @@ in {
           support your new systems.
           Warning: the builder can execute all emulated systems within the same build, which introduces impurities in the case of cross compilation.
         '';
-        type = types.listOf types.str;
+        type = types.listOf (types.enum (builtins.attrNames magics));
       };
     };
   };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Change `boot.binfmt.emulatedSystems`'s type from `list of str` to `list of enum`

Before
```
$ sudo nixos-rebuild test
warning: Git tree '/home/lc/ws/nixos' is dirty
building the system configuration...
warning: Git tree '/home/lc/ws/nixos' is dirty
trace: warning: lib.modules.defaultPriority is deprecated, please use lib.modules.defaultOverridePriority instead.
error:
… while calling the 'head' builtin

at /nix/store/rh9r2vzd2v4q5fz7dqp8vyp44dan6r7n-source/lib/attrsets.nix:820:11:

819|         || pred here (elemAt values 1) (head values) then
820|           head values
|           ^
821|         else

… while evaluating the attribute 'value'

at /nix/store/rh9r2vzd2v4q5fz7dqp8vyp44dan6r7n-source/lib/modules.nix:800:9:

799|     in warnDeprecation opt //
800|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
|         ^
801|         inherit (res.defsFinal') highestPrio;

(stack trace truncated; use '--show-trace' to show the full trace)

error: Cannot create binfmt registration for system abcde
```

After
```
$ sudo nixos-rebuild test --override-input nixpkgs ~/gh/nixpkgs                                                                                    1 ↵
warning: Git tree '/home/lc/ws/nixos' is dirty
warning: not writing modified lock file of flake 'git+file:///home/lc/ws/nixos':
• Updated input 'nixpkgs':
'github:NixOS/nixpkgs/0bffda19b8af722f8069d09d8b6a24594c80b352' (2023-09-06)
→ 'git+file:///home/lc/gh/nixpkgs?ref=refs/heads/feature-better-binfmt&rev=9c5afb2f9acdd7d9eb15b8fe1689cd91af05ed8c&shallow=1' (2023-09-08)
building the system configuration...
warning: Git tree '/home/lc/ws/nixos' is dirty
warning: not writing modified lock file of flake 'git+file:///home/lc/ws/nixos':
• Updated input 'nixpkgs':
'github:NixOS/nixpkgs/0bffda19b8af722f8069d09d8b6a24594c80b352' (2023-09-06)
→ 'git+file:///home/lc/gh/nixpkgs?ref=refs/heads/feature-better-binfmt&rev=9c5afb2f9acdd7d9eb15b8fe1689cd91af05ed8c&shallow=1' (2023-09-08)
error:
… while calling the 'head' builtin

at /nix/store/mx64vvhnh2h3xg49six8y6dy4ahinww3-source/lib/attrsets.nix:820:11:

819|         || pred here (elemAt values 1) (head values) then
820|           head values
|           ^
821|         else

… while evaluating the attribute 'value'

at /nix/store/mx64vvhnh2h3xg49six8y6dy4ahinww3-source/lib/modules.nix:800:9:

799|     in warnDeprecation opt //
800|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
|         ^
801|         inherit (res.defsFinal') highestPrio;

(stack trace truncated; use '--show-trace' to show the full trace)

error: A definition for option `boot.binfmt.emulatedSystems."[definition 1-entry 1]"' is not of type `one of "aarch64-linux", "aarch64_be-linux", "alpha-linux", "armv6l-linux", "armv7l-linux", "i386-linux", "i486-linux", "i586-linux", "i686-linux", "i686-windows", "loongarch64-linux", "mips-linux","mips64-linux", "mips64-linuxabin32", "mips64el-linux", "mips64el-linuxabin32", "mipsel-linux", "powerpc-linux", "powerpc64-linux", "powerpc64le-linux","riscv32-linux", "riscv64-linux", "sparc-linux", "sparc64-linux", "wasm32-wasi", "wasm64-wasi", "x86_64-linux", "x86_64-windows"'. Definition values:
- In `/nix/store/1j1k5ncdir8plwvmd5cv093jca09lpbb-source/profiles/home-pc/configuration.nix': "abcde"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
