### PR TITLE
gnome-frog: 1.3.0 -> 1.4.2

### DIFF
--- a/pkgs/applications/misc/gnome-frog/default.nix
+++ b/pkgs/applications/misc/gnome-frog/default.nix
@@ -83,6 +83,7 @@ python3Packages.buildPythonApplication rec {
     description =
       "Intuitive text extraction tool (OCR) for GNOME desktop";
     license = licenses.mit;
+    mainProgram = "frog";
     maintainers = with maintainers; [ foo-dogsquared ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/gnome-frog/default.nix
+++ b/pkgs/applications/misc/gnome-frog/default.nix
@@ -11,6 +11,8 @@
 , desktop-file-utils
 , glib
 , gobject-introspection
+, blueprint-compiler
+, libxml2
 , libnotify
 , libadwaita
 , libportal
@@ -18,17 +20,18 @@
 , librsvg
 , tesseract5
 , zbar
+, gst_all_1
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "gnome-frog";
-  version = "1.3.0";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "TenderOwl";
     repo = "Frog";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-ErDHrdD9UZxOIGwgN5eakY6vhNvE6D9SoRYXZhzmYX4=";
+    sha256 = "sha256-w/ENUhJt7bYy5htBLolb/HysK8/scRaPQX5qEezQcXY=";
   };
 
   format = "other";
@@ -52,6 +55,8 @@ python3Packages.buildPythonApplication rec {
     glib
     wrapGAppsHook4
     gobject-introspection
+    blueprint-compiler
+    libxml2
   ];
 
   buildInputs = [
@@ -61,6 +66,7 @@ python3Packages.buildPythonApplication rec {
     libportal
     zbar
     tesseract5
+    gst_all_1.gstreamer
   ];
 
   propagatedBuildInputs = with python3Packages; [
@@ -68,6 +74,7 @@ python3Packages.buildPythonApplication rec {
     pillow
     pytesseract
     pyzbar
+    gtts
   ];
 
   # This is to prevent double-wrapping the package. We'll let


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
