### PR TITLE
python3Packages.gradio: 3.20.1 -> 3.43.1

### DIFF
--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -1,0 +1,109 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pythonRelaxDepsHook
+# pyproject
+, hatchling
+, hatch-requirements-txt
+, hatch-fancy-pypi-readme
+# runtime
+, setuptools
+, fsspec
+, httpx
+, huggingface-hub
+, packaging
+, requests
+, typing-extensions
+, websockets
+# checkInputs
+, pytestCheckHook
+, pytest-asyncio
+, pydub
+, gradio
+}:
+
+let
+
+  # Cyclic dependencies are fun!
+  # This is gradio without gradio-client, only needed for checkPhase
+  gradio' = (gradio.override (old: {
+    gradio-client = null;
+  })).overridePythonAttrs (old: {
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ pythonRelaxDepsHook ];
+    pythonRemoveDeps = (old.pythonRemoveDeps or []) ++ [ "gradio_client" ];
+    doInstallCheck = false;
+    doCheck = false;
+    pythonImportsCheck = null;
+  });
+
+in
+
+buildPythonPackage rec {
+  pname = "gradio_client";
+  version = "0.5.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  # no tests on pypi
+  src = fetchFromGitHub {
+    owner = "gradio-app";
+    repo = "gradio";
+    #rev = "refs/tags/v${gradio.version}";
+    rev = "ba4c6d9e65138c97062d1757d2a588c4fc449daa"; # v3.43.1 is not tagged...
+    sparseCheckout = [ "client/python" ];
+    hash = "sha256-savka4opyZKSWPeBqc2LZqvwVXLYIZz5dS1OWJSwvHo=";
+  };
+  prePatch = ''
+    cd client/python
+  '';
+
+  nativeBuildInputs = [
+    hatchling
+    hatch-requirements-txt
+    hatch-fancy-pypi-readme
+  ];
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+    fsspec
+    httpx
+    huggingface-hub
+    packaging
+    requests
+    typing-extensions
+    websockets
+  ];
+
+  nativeCheckInputs =[
+    pytestCheckHook
+    pytest-asyncio
+    pydub
+    gradio'
+  ];
+  disallowedReferences = [
+    gradio' # ensuring we don't propagate this intermediate build
+  ];
+
+  # Add a pytest hook skipping tests that access network, marking them as "Expected fail" (xfail).
+  preCheck = ''
+    export HOME=$TMPDIR
+    cat ${./conftest-skip-network-errors.py} >> test/conftest.py
+  '';
+
+  pytestFlagsArray = [
+    "test/"
+    #"-m" "not flaky" # doesn't work, even when advertised
+    #"-x" "-W" "ignore" # uncomment for debugging help
+  ];
+
+  pythonImportsCheck = [ "gradio_client" ];
+
+  meta = with lib; {
+    homepage = "https://www.gradio.app/";
+    description = "Lightweight library to use any Gradio app as an API";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4579,6 +4579,8 @@ self: super: with self; {
 
   gradio = callPackage ../development/python-modules/gradio { };
 
+  gradio-client = callPackage ../development/python-modules/gradio/client.nix { };
+
   grammalecte = callPackage ../development/python-modules/grammalecte { };
 
   grandalf = callPackage ../development/python-modules/grandalf { };


### PR DESCRIPTION
## Description of changes

Cyclic dependencies are fun, and the gradio devs sure can't tag their releases nor provide all needed test artifacts. But thankfully they've reduced the size of their testing closure tremendously. 

Superseeds #254011

~~This does not build in its current state, but sure am i getting close!~~
I was hit by [this issue](https://discourse.nixos.org/t/overriding-docheck-doesnt-work-with-python-package/14674). TIL about `overridePythonAttrs`.

Tests for `gradio-clients`:
![image](https://github.com/NixOS/nixpkgs/assets/140964/90a9ca81-491f-4a86-97e7-e70dc072801b)

Tests for `gradio`:
![image](https://github.com/NixOS/nixpkgs/assets/140964/20242500-ec9f-4cf4-a445-1c5af105ecae)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
