### PR TITLE
android.env.buildGradleApp: Reinit

### DIFF
--- a/pkgs/development/mobile/androidenv/build-gradle-app.nix
+++ b/pkgs/development/mobile/androidenv/build-gradle-app.nix
@@ -1,0 +1,115 @@
+{ stdenv, lib, androidenv, jdk, gnumake, gawk, file
+, which, gradle, fetchurl, buildEnv, runCommand }:
+
+args@{ name, src, platformVersions ? [ "8" ]
+     , buildToolsVersions ? [ "30.0.2" ]
+     , useGoogleAPIs ? false, useGooglePlayServices ? false
+     , release ? false, keyStore ? null, keyAlias ? null
+     , keyStorePassword ? null, keyAliasPassword ? null
+     , useNDK ? false, buildInputs ? [], mavenDeps, gradleTask
+     , buildDirectory ? "./.", acceptAndroidSdkLicenses ? false }:
+
+assert release -> keyStore != null;
+assert release -> keyAlias != null;
+assert release -> keyStorePassword != null;
+assert release -> keyAliasPassword != null;
+assert acceptAndroidSdkLicenses;
+
+let
+  inherit (lib) optionalString optional;
+
+  m2install = { repo, version, artifactId, groupId
+              , jarSha256, pomSha256, aarSha256, suffix ? ""
+              , customJarUrl ? null, customJarSuffix ? null }:
+    let m2Name = "${artifactId}-${version}";
+        m2Path = "${builtins.replaceStrings ["."] ["/"] groupId}/${artifactId}/${version}";
+        jarFile = fetchurl {
+          url = if customJarUrl != null then customJarUrl else "${repo}${m2Path}/${m2Name}${suffix}.jar";
+          sha256 = jarSha256;
+        };
+    in runCommand m2Name {} (''
+         installPath="$out"/m2/'${m2Path}'
+         mkdir -p "$installPath"
+       '' + optionalString (jarSha256 != null) ''
+         install -D '${jarFile}' "$installPath"/'${m2Name}${suffix}.jar'
+         ${optionalString (customJarSuffix != null) ''
+           install -D '${jarFile}' "$installPath"/'${m2Name}${suffix}${customJarSuffix}.jar'
+         ''}
+       '' + optionalString (pomSha256 != null) ''
+         install -D ${fetchurl {
+                        url = "${repo}${m2Path}/${m2Name}${suffix}.pom";
+                        sha256 = pomSha256;
+                      }} "$installPath/${m2Name}${suffix}.pom"
+       '' + optionalString (aarSha256 != null) ''
+         install -D ${fetchurl {
+                        url = "${repo}${m2Path}/${m2Name}${suffix}.aar";
+                        sha256 = aarSha256;
+                      }} "$installPath/${m2Name}${suffix}.aar"
+       '');
+  androidsdkComposition = androidenv.composeAndroidPackages {
+    inherit platformVersions useGoogleAPIs buildToolsVersions;
+    includeNDK = true;
+    includeExtras = [ "extras;android;m2repository" ]
+      ++ optional useGooglePlayServices "extras;google;google_play_services";
+  };
+in
+stdenv.mkDerivation ({
+  inherit src;
+  name = builtins.replaceStrings [" "] [""] args.name;
+
+  ANDROID_HOME = "${androidsdkComposition.androidsdk}/libexec";
+  ANDROID_NDK_HOME = "${androidsdkComposition.ndk-bundle}/libexec/android-sdk/ndk-bundle";
+
+  buildInputs = [ jdk gradle ] ++ buildInputs ++ lib.optional useNDK [ androidsdkComposition.ndk-bundle gnumake gawk file which ];
+
+  DEPENDENCIES = buildEnv { name = "${name}-maven-deps";
+                            paths = map m2install mavenDeps;
+                          };
+
+  buildPhase = ''
+    ${optionalString release ''
+      # Provide key signing attributes
+      ( echo "RELEASE_STORE_FILE=${keyStore}"
+        echo "RELEASE_KEY_ALIAS=${keyAlias}"
+        echo "RELEASE_STORE_PASSWORD=${keyStorePassword}"
+        echo "RELEASE_KEY_PASSWORD=${keyAliasPassword}"
+      ) >> gradle.properties
+    ''}
+    ${optionalString (builtins.length buildToolsVersions > 0) ''
+      echo "android.aapt2FromMavenOverride=local_sdk/android-sdk/build-tools/${builtins.head buildToolsVersions}/aapt2" >> gradle.properties
+    ''}
+    buildDir=`pwd`
+    cp -rL $ANDROID_HOME $buildDir/local_sdk
+    chmod -R 755 local_sdk
+    export ANDROID_HOME=$buildDir/local_sdk/android-sdk
+    # Key files cannot be stored in the user's home directory. This
+    # overrides it.
+    export ANDROID_SDK_HOME=`pwd`
+
+    mkdir -p "$ANDROID_HOME/licenses"
+    echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+    echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+
+    export APP_HOME=`pwd`
+
+    mkdir -p .m2/repository
+    if [ -d "$DEPENDENCIES/m2" ] ; then
+      cp -RL "$DEPENDENCIES"/m2/* .m2/repository/
+    fi
+    chmod -R 755 .m2
+    mkdir -p .m2/repository/com/android/support
+    cp -RL local_sdk/android-sdk/extras/android/m2repository/com/android/support/* .m2/repository/com/android/support/
+    gradle ${gradleTask} --offline --no-daemon -g ./tmp -Dmaven.repo.local=$(pwd)/.m2/repository
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    ${if gradleTask == "bundleRelease"
+    then "cp -RL build/outputs/bundle/release/*.aab $out"
+    else "cp -RL build/outputs/apk/*/*.apk $out"}
+  '';
+
+  meta = {
+    license = lib.licenses.unfree;
+  };
+} // builtins.removeAttrs args ["name" "mavenDeps"])

--- a/pkgs/development/mobile/androidenv/build-gradle-app.nix
+++ b/pkgs/development/mobile/androidenv/build-gradle-app.nix
@@ -6,14 +6,13 @@ args@{ name, src, platformVersions ? [ "8" ]
      , useGoogleAPIs ? false, useGooglePlayServices ? false
      , release ? false, keyStore ? null, keyAlias ? null
      , keyStorePassword ? null, keyAliasPassword ? null
-     , useNDK ? false, buildInputs ? [], mavenDeps, gradleTask
-     , buildDirectory ? "./.", acceptAndroidSdkLicenses ? false }:
+     , useNDK ? false, nativeBuildInputs ? [], mavenDeps ? null, gradleTask
+     , buildDirectory ? "./." }:
 
 assert release -> keyStore != null;
 assert release -> keyAlias != null;
 assert release -> keyStorePassword != null;
 assert release -> keyAliasPassword != null;
-assert acceptAndroidSdkLicenses;
 
 let
   inherit (lib) optionalString optional;
@@ -60,11 +59,11 @@ stdenv.mkDerivation ({
   ANDROID_HOME = "${androidsdkComposition.androidsdk}/libexec";
   ANDROID_NDK_HOME = "${androidsdkComposition.ndk-bundle}/libexec/android-sdk/ndk-bundle";
 
-  buildInputs = [ jdk gradle ] ++ buildInputs ++ lib.optional useNDK [ androidsdkComposition.ndk-bundle gnumake gawk file which ];
+  nativeBuildInputs = [ jdk gradle ] ++ nativeBuildInputs ++ lib.optional useNDK [ androidsdkComposition.ndk-bundle gnumake gawk file which ];
 
-  DEPENDENCIES = buildEnv { name = "${name}-maven-deps";
+  DEPENDENCIES = if mavenDeps != null then buildEnv { name = "${name}-maven-deps";
                             paths = map m2install mavenDeps;
-                          };
+                          } else null;
 
   buildPhase = ''
     ${optionalString release ''

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -11,6 +11,8 @@ rec {
     inherit composeAndroidPackages;
   };
 
+  buildGradleApp = pkgs.callPackage ./build-gradle-app.nix { };
+
   emulateApp = pkgs.callPackage ./emulate-app.nix {
     inherit composeAndroidPackages;
   };


### PR DESCRIPTION
Was removed in a27aa247c0681252f923fc0f39059e01a303dece

it's PR 50596 had "Readd androidenv.buildGradleApp" in "Still to do:" in its description.

copied from https://github.com/reflex-frp/reflex-platform/blob/bb2e06f1a327b79e91a0607ad9412422b25b4a32/android/build-gradle-app.nix

Which is where the original buildGradleApp came from in PR 41855.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
