### PR TITLE
cloudcompare: add draco io plugin

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -5,6 +5,7 @@
 , cmake
 , boost
 , cgal_5
+, draco
 , eigen
 , flann
 , gdal
@@ -42,6 +43,7 @@ mkDerivation rec {
   buildInputs = [
     boost
     cgal_5
+    draco
     flann
     gdal
     gmp
@@ -68,6 +70,8 @@ mkDerivation rec {
     "-DPLUGIN_IO_QADDITIONAL=ON"
     "-DPLUGIN_IO_QCORE=ON"
     "-DPLUGIN_IO_QCSV_MATRIX=ON"
+    "-DPLUGIN_IO_QCSV_MATRIX=ON"
+    "-DPLUGIN_IO_QDRACO=ON"
     "-DPLUGIN_IO_QE57=ON"
     "-DPLUGIN_IO_QFBX=OFF" # Autodesk FBX SDK is gratis+proprietary; not packaged in nixpkgs
     "-DPLUGIN_IO_QPDAL=ON" # required for .las/.laz support


### PR DESCRIPTION
I’ve tried to add the draco IO plugin to cloudcompare

However, I have a problem : the package compiles (on x86_64-linux), but the plugin isn’t working : a symbol is missing 
```
[21:30:38] 	libQDRACO_IO_PLUGIN.so does not seem to be a valid plugin	(Cannot load library /nix/store/xmws7gw0q0px85fd9ha6fkf9lg97r1v5-cloudcompare-2.12.4/lib/cloudcompare/plugins/libQDRACO_IO_PLUGIN.so: (/nix/store/xmws7gw0q0px85fd9ha6fkf9lg97r1v5-cloudcompare-2.12.4/lib/cloudcompare/plugins/libQDRACO_IO_PLUGIN.so: undefined symbol: _ZTVN5draco4MeshE))
```

## Description of changes

cmake flags for draco compilation and dependency to the draco library have been added.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
