### PR TITLE
audiobookshelf: fix reference to getopt in wrapper

### DIFF
--- a/pkgs/servers/audiobookshelf/default.nix
+++ b/pkgs/servers/audiobookshelf/default.nix
@@ -1,4 +1,17 @@
-{ lib, stdenv, pkgs, fetchFromGitHub, runCommand, buildNpmPackage, nodejs_18, tone, ffmpeg-full, util-linux, python3 }:
+{
+  lib,
+  stdenv,
+  pkgs,
+  fetchFromGitHub,
+  runCommand,
+  buildNpmPackage,
+  nodejs_18,
+  tone,
+  ffmpeg-full,
+  util-linux,
+  python3,
+  getopt
+}:
 
 let
   nodejs = nodejs_18;
@@ -28,7 +41,7 @@ let
   };
 
   wrapper = import ./wrapper.nix {
-    inherit stdenv ffmpeg-full tone pname nodejs;
+    inherit stdenv ffmpeg-full tone pname nodejs getopt;
   };
 
 in buildNpmPackage {

--- a/pkgs/servers/audiobookshelf/wrapper.nix
+++ b/pkgs/servers/audiobookshelf/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, ffmpeg-full, tone, pname, nodejs }: ''
+{ stdenv, ffmpeg-full, tone, pname, nodejs, getopt }: ''
     #!${stdenv.shell}
 
     port=8000
@@ -7,7 +7,7 @@
     metadata=$(pwd)/metadata
 
     LONGOPTS=host:,port:,config:,metadata:,help
-    args=$(getopt -l "$LONGOPTS" -o h -- "$@")
+    args=$(${getopt}/bin/getopt -l "$LONGOPTS" -o h -- "$@")
 
     eval set -- "$args"
 
@@ -44,7 +44,7 @@
           ;;
         --help|-h)
           echo "Usage: audiobookshelf [--host <host>] [--port <port>] [--metadata <dir>] [--config <dir>]"
-          shift
+          exit 0
           ;;
       esac
       shift


### PR DESCRIPTION
## Description of changes

The wrapper script for audiobookshelf references getopt on `PATH`. Add a dependency on getopt and adjust the wrapper to reference it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

