### PR TITLE
Revert "treewide: change wafConfigureFlags to configureFlags"

### DIFF
--- a/pkgs/applications/audio/ardour/6.nix
+++ b/pkgs/applications/audio/ardour/6.nix
@@ -129,7 +129,7 @@ stdenv.mkDerivation rec {
     vamp-plugin-sdk
   ] ++ lib.optionals videoSupport [ harvid xjadeo ];
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--cxx11"
     "--docs"
     "--freedesktop"

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -150,7 +150,7 @@ stdenv.mkDerivation rec {
     vamp-plugin-sdk
   ] ++ lib.optionals videoSupport [ harvid xjadeo ];
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--cxx11"
     "--docs"
     "--freedesktop"

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
     zita-resampler
   ];
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--no-font-cache-update"
     "--shared-lib"
     "--no-desktop-update"

--- a/pkgs/applications/office/semantik/default.nix
+++ b/pkgs/applications/office/semantik/default.nix
@@ -85,7 +85,7 @@ mkDerivation rec {
     kdelibs4support
   ];
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--qtlibs=${lib.getLib qtbase}/lib"
   ];
 

--- a/pkgs/development/libraries/audio/lvtk/default.nix
+++ b/pkgs/development/libraries/audio/lvtk/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     sed -e '/print/d' -i wscript
   '';
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--boost-includes=${boost.dev}/include"
     "--boost-libs=${boost.out}/lib"
   ];

--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
   wafPath = "buildtools/bin/waf";
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
     "--without-ldb-lmdb"

--- a/pkgs/development/libraries/ndn-cxx/default.nix
+++ b/pkgs/development/libraries/ndn-cxx/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost179 openssl sqlite ];
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--with-openssl=${openssl.dev}"
     "--boost-includes=${boost179.dev}/include"
     "--boost-libs=${boost179.out}/lib"

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   wafPath = "buildtools/bin/waf";
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--enable-talloc-compat1"
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"

--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   wafPath = "buildtools/bin/waf";
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
   ];

--- a/pkgs/development/libraries/tevent/default.nix
+++ b/pkgs/development/libraries/tevent/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
 
   wafPath = "buildtools/bin/waf";
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
   ];

--- a/pkgs/development/tools/build-managers/waf/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/waf/setup-hook.sh
@@ -18,7 +18,7 @@ wafConfigurePhase() {
 
     local flagsArray=(
         $prefixFlag
-        $configureFlags "${configureFlagsArray[@]}"
+        $wafConfigureFlags "${wafConfigureFlagsArray[@]}"
         ${configureTargets:-configure}
     )
 

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -51,8 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   dontAddWafCrossFlags = true;
-
-  configureFlags = [
+  wafConfigureFlags = [
     "--classic"
     "--autostart=${if (optDbus != null) then "dbus" else "classic"}"
   ] ++ lib.optional (optDbus != null) "--dbus"

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config sphinx waf.hook ];
   buildInputs = [ libpcap ndn-cxx openssl websocketpp ] ++ lib.optional withSystemd systemd;
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--boost-includes=${boost179.dev}/include"
     "--boost-libs=${boost179.out}/lib"
     "--with-tests"

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
     export PYTHONHASHSEED=1
   '';
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--with-static-modules=NONE"
     "--with-shared-modules=ALL"
     "--enable-fhs"

--- a/pkgs/tools/networking/ndn-tools/default.nix
+++ b/pkgs/tools/networking/ndn-tools/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config sphinx waf.hook ];
   buildInputs = [ libpcap ndn-cxx openssl ];
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--boost-includes=${boost.dev}/include"
     "--boost-libs=${boost.out}/lib"
     "--with-tests"

--- a/pkgs/tools/networking/saldl/default.nix
+++ b/pkgs/tools/networking/saldl/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ curl libevent ];
 
-  configureFlags = [ "--saldl-version ${version}" "--no-werror" ];
+  wafConfigureFlags = [ "--saldl-version ${version}" "--no-werror" ];
 
   outputs = [ "out" "man" ];
 


### PR DESCRIPTION
This reverts commit 9f52275e52509dc667e6b42514ce1531416254a5.

Caused breakage on staging-next (2023-09-07) due to the following error:

```
waf: error: no such option: --sbindir
```

Reverted on staging after the cut, refer to https://github.com/NixOS/nixpkgs/pull/252874

https://github.com/NixOS/nixpkgs/pull/253854

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
