### PR TITLE
nginxModules.zstd: fix build failing due to zstd deprecations

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -1,4 +1,5 @@
 { lib
+, applyPatches
 , config
 , fetchFromGitHub
 , fetchFromGitLab
@@ -1018,12 +1019,17 @@ let self = {
 
   zstd = {
     name = "zstd";
-    src = fetchFromGitHub {
-      name = "zstd";
-      owner = "tokers";
-      repo = "zstd-nginx-module";
-      rev = "25d88c262be47462cf90015ee7ebf6317b6848f9";
-      sha256 = "sha256-YRluKekhx1tb6e5IL1FPK05jPtzfQPaHI47cdada928=";
+    src = applyPatches {
+      src = fetchFromGitHub {
+        name = "zstd";
+        owner = "tokers";
+        repo = "zstd-nginx-module";
+        rev = "25d88c262be47462cf90015ee7ebf6317b6848f9";
+        sha256 = "sha256-YRluKekhx1tb6e5IL1FPK05jPtzfQPaHI47cdada928=";
+      };
+      patches = [
+        ./zstd-fix-deprecation.patch # https://github.com/tokers/zstd-nginx-module/pull/26
+      ];
     };
 
     inputs = [ zstd ];

--- a/pkgs/servers/http/nginx/zstd-fix-deprecation.patch
+++ b/pkgs/servers/http/nginx/zstd-fix-deprecation.patch
@@ -1,0 +1,39 @@
+From 61fe122c75d6720e9ea667ec7ec516b049aa091a Mon Sep 17 00:00:00 2001
+From: Andrew Marshall <andrew@johnandrewmarshall.com>
+Date: Thu, 7 Sep 2023 08:39:11 -0400
+Subject: [PATCH] bugfix: fix deprecation warning with zstd 1.5+
+
+See https://github.com/facebook/zstd/releases/tag/v1.5.0
+---
+ filter/ngx_http_zstd_filter_module.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/filter/ngx_http_zstd_filter_module.c b/filter/ngx_http_zstd_filter_module.c
+index d5784ba..a5e9d55 100644
+--- a/filter/ngx_http_zstd_filter_module.c
++++ b/filter/ngx_http_zstd_filter_module.c
+@@ -603,6 +603,16 @@ ngx_http_zstd_filter_create_cstream(ngx_http_request_t *r,
+     /* TODO use the advanced initialize functions */
+ 
+     if (zlcf->dict) {
++#if ZSTD_VERSION_MAJOR > 1 || (ZSTD_VERSION_MAJOR == 1 && ZSTD_VERSION_MINOR >= 5)
++        rc = ZSTD_CCtx_refCDict(cstream, zlcf->dict);
++        if (ZSTD_isError(rc)) {
++            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                          "ZSTD_CCtx_refCDict() failed: %s",
++                          ZSTD_getErrorName(rc));
++
++            goto failed;
++        }
++#else
+         rc = ZSTD_initCStream_usingCDict(cstream, zlcf->dict);
+         if (ZSTD_isError(rc)) {
+             ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+@@ -611,6 +621,7 @@ ngx_http_zstd_filter_create_cstream(ngx_http_request_t *r,
+ 
+             goto failed;
+         }
++#endif
+ 
+     } else {
+         rc = ZSTD_initCStream(cstream, zlcf->level);


### PR DESCRIPTION
## Description of changes


## Things done

`nix-build -A nginxStable` after applying below patch. Then running nginx and testing requests succeed when configured with zstd and use zstd.

<details>
<summary>patch for testing build</summary>

```diff
diff --git a/pkgs/top-level/all-packages.nix b/pkgs/top-level/all-packages.nix
index 887e05b63691..e8e9d63cedd7 100644
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26887,7 +26887,7 @@ with pkgs;
     withPerl = false;
     # We don't use `with` statement here on purpose!
     # See https://github.com/NixOS/nixpkgs/pull/10474#discussion_r42369334
-    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders ];
+    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders nginxModules.zstd ];
   };
 
   nginxMainline = callPackage ../servers/http/nginx/mainline.nix {
```

</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
