### PR TITLE
python310Packages.abjad: init at 3.19

### DIFF
--- a/pkgs/development/python-modules/abjad/default.nix
+++ b/pkgs/development/python-modules/abjad/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ply
+, roman
+, uqbar
+, pythonOlder
+, pytestCheckHook
+, lilypond
+}:
+
+buildPythonPackage rec {
+  pname = "abjad";
+  version = "3.19";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-I9t3ORUKFFlMfXJsAzXhCzl1B4a9/ZNmvSX2/R44TPs=";
+  };
+
+  propagatedBuildInputs = [
+    ply
+    roman
+    uqbar
+  ];
+
+  buildInputs = [
+    lilypond
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace abjad/io.py \
+      --replace 'lilypond_path = self.get_lilypond_path()' \
+                'lilypond_path = "${lilypond}/bin/lilypond"'
+    # general invocations of binary for IO purposes
+
+    substituteInPlace abjad/configuration.py \
+      --replace '["lilypond"' '["${lilypond}/bin/lilypond"'
+    # get_lilypond_version_string
+  '';
+
+  pythonImportsCheck = [ "abjad" ];
+
+  meta = {
+    description = "GNU LilyPond wrapper for Python";
+    longDescription = ''
+      Abjad helps composers build up complex pieces of music notation in
+      iterative and incremental ways. Use Abjad to create a symbolic
+      representation of all the notes, rests, chords, tuplets, beams and slurs
+      in any score. Because Abjad extends the Python programming language, you
+      can use Abjad to make systematic changes to music as you work. Because
+      Abjad wraps the LilyPond music notation package, you can use Abjad to
+      control the typographic detail of symbols on the page.
+    '';
+    license = lib.licenses.mit;
+    homepage = "https://abjad.github.io/";
+    changelog = "https://abjad.github.io/appendices/changes.html";
+    maintainers = [ lib.maintainers.davisrichard437 ];
+  };
+}

--- a/pkgs/development/python-modules/uqbar/default.nix
+++ b/pkgs/development/python-modules/uqbar/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, unidecode
+, sphinx
+, pythonAtLeast
+, pythonOlder
+, pytestCheckHook
+, pytest-cov
+}:
+
+buildPythonPackage rec {
+  pname = "uqbar";
+  version = "0.7.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-cEhWXGtMSXVjT5QigDedjT/lwYQnVqPCE5vbctXWznk=";
+  };
+
+  propagatedBuildInputs = [
+    unidecode
+    sphinx
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov
+  ];
+
+  pytestFlagsArray = [
+    "tests/"
+    "-vv"
+    "-rf"
+    "--cov-branch"
+    "--cov-report=html"
+    "--cov-report=term"
+    "--doctest-modules"
+  ];
+
+  disabledTests = [
+    # UnboundLocalError: local variable 'output_path' referenced before
+    # assignment
+    "test_01"
+    # AssertionError: assert False
+    "test_sphinx_book_html_cached"
+    # FileNotFoundError: [Errno 2] No such file or directory: 'unflatten'
+    "test_sphinx_style_html"
+    # assert not ["\x1b[91mWARNING: dot command 'dot' cannot be run (needed for
+    # graphviz output), check the graphviz_dot setting\x1b[39;49;00m"]
+    "test_sphinx_style_latex"
+  ]
+  # assert not '\x1b[91m/build/uqbar-0.7.0/tests/fake_package/enums.py:docstring
+  ++ lib.optional (pythonAtLeast "3.11") "test_sphinx_style";
+
+  pythonImportsCheck = [ "uqbar" ];
+
+  meta = {
+    description = "Tools for creating Sphinx and Graphviz documentation";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/josiah-wolf-oberholtzer/uqbar";
+    changelog =
+      "https://github.com/josiah-wolf-oberholtzer/uqbar/releases/tag/v${version}";
+    maintainers = [ lib.maintainers.davisrichard437 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13440,6 +13440,8 @@ self: super: with self; {
 
   uptime-kuma-monitor = callPackage ../development/python-modules/uptime-kuma-monitor { };
 
+  uqbar = callPackage ../development/python-modules/uqbar { };
+
   uranium = callPackage ../development/python-modules/uranium { };
 
   uritemplate = callPackage ../development/python-modules/uritemplate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -30,6 +30,8 @@ self: super: with self; {
 
   aardwolf = callPackage ../development/python-modules/aardwolf { };
 
+  abjad = callPackage ../development/python-modules/abjad { };
+
   about-time = callPackage ../development/python-modules/about-time { };
 
   absl-py = callPackage ../development/python-modules/absl-py { };


### PR DESCRIPTION
## Description of changes

This pull request adds the python module [`abjad`](https://abjad.github.io/), as well as a dependency library, [`uqbar`](https://github.com/josiah-wolf-oberholtzer/uqbar/tree/main). Abjad is a library that wraps GNU Lilypond, a text-based music notation typesetting system, with ergonomic python bindings for the purposes of computer-assisted music composition and building up complex music incrementally.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
