### PR TITLE
beamerpresenter: 0.2.3 -> 0.2.4

### DIFF
--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -7,6 +7,7 @@
 , wrapQtAppsHook
 , gst_all_1
 , qtbase
+, qtsvg
 , qtmultimedia
 , qttools
 , qtwayland
@@ -27,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "beamerpresenter";
-  version = "0.2.3-1";
+  version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "stiglers-eponym";
     repo = "BeamerPresenter";
-    rev = "dd41a00b3c6c8b881fa62945165c965634df66f0";
-    sha256 = "11yj1zl8hdnqbynkbyzg8kwyx1jl8c87x8f8qyllpk0s6cg304d0";
+    rev = "v${version}";
+    sha256 = "1zypzmkiwc14b9224nr37y7wviasirmwhfmifb7q1b33877g41ji";
   };
 
   nativeBuildInputs = [
@@ -51,6 +52,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-good
     zlib
     qtbase
+    qtsvg
     qtmultimedia
     qttools
   ] ++ lib.optionals stdenv.isLinux [
@@ -70,10 +72,10 @@ stdenv.mkDerivation rec {
     "-DUSE_POPPLER=${if usePoppler then "ON" else "OFF"}"
     "-DUSE_MUPDF=${if useMupdf then "ON" else "OFF"}"
     "-DUSE_QTPDF=OFF"
-    "-DUSE_MUPDF_THIRD=ON"
+    "-DLINK_MUPDF_THIRD=ON"
     "-DUSE_EXTERNAL_RENDERER=${if useExternalRenderer then "ON" else "OFF"}"
-    "-DUSE_MUJS=OFF"
-    "-DUSE_GUMBO=ON"
+    "-DLINK_MUJS=OFF"
+    "-DLINK_GUMBO=ON"
     "-DUSE_TRANSLATIONS=ON"
     "-DQT_VERSION_MAJOR=${lib.versions.major qtbase.version}"
   ];

--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     owner = "stiglers-eponym";
     repo = "BeamerPresenter";
     rev = "v${version}";
-    sha256 = "1zypzmkiwc14b9224nr37y7wviasirmwhfmifb7q1b33877g41ji";
+    hash = "sha256-UQbyzkFjrIDPcrE6yGuOWsXNjz8jWyJEWiQwHmf91/8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
this should fix building with MuPDF 1.23

## Description of changes
Version update: 0.2.3 -> 0.2.4, see [CHANGELOG.md](https://github.com/stiglers-eponym/BeamerPresenter/blob/main/CHANGELOG.md)
Some changes:
* compatibility with MuPDF 1.23 and Qt 6.4 - 6.6 (beta)
* new dependency: qtsvg (not optional anymore)

## Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
