### PR TITLE
nixos/security/pam: add authorizedKeysFiles option for pam_ssh_agent_auth

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -189,6 +189,20 @@
 
 - The `hail` NixOS module was removed, as `hail` was unmaintained since 2017.
 
+- The `security.pam.enableSSHAgentAuth` option has been renamed and defaults changed. **To prevent being locked out of your system, read the following carefully:**
+
+  The sshAgentAuth module no longer reads authorized keys files from the same locations as configured for openssh. The new default looks only in `/etc/ssh/authorized_keys.d/<username>` which is automatically populated by the `users.users.<username>.openssh.authorizedKeys.keys` option.
+
+  If you set public keys anywhere else (e.g. `~/.ssh/authorized_keys`) or you changed services.openssh.authorizedKeysFiles from its default, then you should do one of the following:
+
+    1. (Recommended) Configure your user's public keys declaratively with the `users.users.<username>.openssh.authorizedKeys.keys` option.
+
+    2. Configure `security.pam.sshAgentAuth.authorizedKeysFiles` with paths to your authorized keys. Read the option description carefully to prevent privilege escalation attacks.
+
+  If you already configure your public keys declaratively, you don't need to change them.
+
+  Once you have completed the above instructions, you can re-enable SSH agent auth by setting the `security.pam.sshAgentAuth.enable` option.
+
 ## Other Notable Changes {#sec-release-23.11-notable-changes}
 
 - The Cinnamon module now enables XDG desktop integration by default. If you are experiencing collisions related to xdg-desktop-portal-gtk you can safely remove `xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];` from your NixOS configuration.


### PR DESCRIPTION
## Description of changes

The current default allows privilege escalation because a process running as a user can add its own key to the user-writable `authorized_keys` file.

This adds an option to configure the authorized keys files for `pam_ssh_agent_auth` separately from `openssh`. The default is only the `/etc/ssh/authorized_keys.d/%u` path which is not user-writable.

Since existing users may rely on keys in user-writable files for access to their system, the option has been renamed so that users are prompted with upgrade instructions.

Fixes #31611
Supersedes #62317

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
