### PR TITLE
Set `passthru.updateScript` for nicoo's packages

### DIFF
--- a/pkgs/development/python-modules/debianbts/default.nix
+++ b/pkgs/development/python-modules/debianbts/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, nix-update-script
 , pysimplesoap
 , pytest , pytest-xdist
 , pythonOlder
@@ -13,6 +14,7 @@ buildPythonPackage rec {
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
+  passthru.updateScript = nix-update-script { };
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pysimplesoap/default.nix
+++ b/pkgs/development/python-modules/pysimplesoap/default.nix
@@ -3,12 +3,15 @@
 , fetchPypi
 , buildPythonPackage
 , m2crypto
+, nix-update-script
 }:
 
 buildPythonPackage rec {
   pname = "pysimplesoap";
   # Unfortunately, the latest stable release is broken on Python 3.
   version = "1.16.2";
+
+  passthru.updateScript = nix-update-script { };
 
   src = fetchPypi {
     pname = "PySimpleSOAP";

--- a/pkgs/development/python-modules/pysimplesoap/default.nix
+++ b/pkgs/development/python-modules/pysimplesoap/default.nix
@@ -8,7 +8,6 @@
 
 buildPythonPackage rec {
   pname = "pysimplesoap";
-  # Unfortunately, the latest stable release is broken on Python 3.
   version = "1.16.2";
 
   passthru.updateScript = nix-update-script { };
@@ -23,6 +22,7 @@ buildPythonPackage rec {
     m2crypto
   ];
 
+  # Patches necessary for Python 3 compatibility plus bugfixes
   patches = map (args: fetchDebianPatch ({
     inherit pname version;
     debianRevision = "5";

--- a/pkgs/tools/security/sudo-rs/default.nix
+++ b/pkgs/tools/security/sudo-rs/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , fetchpatch
 , installShellFiles
+, nix-update-script
 , pam
 , pandoc
 , rustPlatform
@@ -71,6 +72,8 @@ rustPlatform.buildRustPackage rec {
     "env::tests::test_environment_variable_filtering"
     "su::context::tests::invalid_shell"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A memory safe implementation of sudo and su.";


### PR DESCRIPTION
## Description of changes

- Set `passthru.updateScript` on `pythonPackages.{debianbts, pysimplesoap}` and `sudo-rs`
- Clarified some comment in `pysimplesoap`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
