### PR TITLE
jinja2-cli: init at 0.8.2

### DIFF
--- a/pkgs/by-name/ji/jinja2-cli/package.nix
+++ b/pkgs/by-name/ji/jinja2-cli/package.nix
@@ -1,0 +1,49 @@
+{ lib
+, python3
+, fetchFromGitHub
+, extras ? [ "hjson" "json5" "toml" "xml" "yaml" ]
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "jinja2-cli";
+  version = "0.8.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "mattrobenolt";
+    repo = "jinja2-cli";
+    rev = version;
+    hash = "sha256-67gYt0nZX+VTVaoSxVXGzbRiXD7EMsVBFWC8wHo+Vw0=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  nativeCheckInputs = [
+    python3.pkgs.pytestCheckHook
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    jinja2
+  ] ++ lib.attrVals extras passthru.optional-dependencies;
+
+  pythonImportsCheck = [ "jinja2cli" ];
+
+  passthru.optional-dependencies = with python3.pkgs; {
+    hjson = [ hjson ];
+    json5 = [ json5 ];
+    toml = [ toml ];
+    xml = [ xmltodict ];
+    yaml = [ pyyaml ];
+  };
+
+  meta = with lib; {
+    description = "CLI for Jinja2";
+    homepage = "https://github.com/mattrobenolt/jinja2-cli";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ figsoda ];
+    mainProgram = "jinja2";
+  };
+}


### PR DESCRIPTION
https://github.com/mattrobenolt/jinja2-cli

## Description of changes

closes #253866 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
