### PR TITLE
noto-fonts-emoji: Package both color and monochrome variants

### DIFF
--- a/doc/builders/packages/ibus.section.md
+++ b/doc/builders/packages/ibus.section.md
@@ -29,12 +29,12 @@ _Note: each language passed to `langs` must be an attribute name in `pkgs.hunspe
 
 ## Built-in emoji picker {#sec-ibus-typing-booster-emoji-picker}
 
-The `ibus-engines.typing-booster` package contains a program named `emoji-picker`. To display all emojis correctly, a special font such as `noto-fonts-emoji` is needed:
+The `ibus-engines.typing-booster` package contains a program named `emoji-picker`. To display all emojis correctly, a special font such as `noto-fonts-color-emoji` is needed:
 
 On NixOS, it can be installed using the following expression:
 
 ```nix
 { pkgs, ... }: {
-  fonts.packages = with pkgs; [ noto-fonts-emoji ];
+  fonts.packages = with pkgs; [ noto-fonts-color-emoji ];
 }
 ```

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -193,6 +193,10 @@
 
 - The `hail` NixOS module was removed, as `hail` was unmaintained since 2017.
 
+- Package `noto-fonts-emoji` was renamed to `noto-fonts-color-emoji`;
+  see [#221181](https://github.com/NixOS/nixpkgs/issues/221181).
+
+
 ## Other Notable Changes {#sec-release-23.11-notable-changes}
 
 - The Cinnamon module now enables XDG desktop integration by default. If you are experiencing collisions related to xdg-desktop-portal-gtk you can safely remove `xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];` from your NixOS configuration.

--- a/nixos/modules/config/fonts/packages.nix
+++ b/nixos/modules/config/fonts/packages.nix
@@ -37,7 +37,7 @@ in
       gyre-fonts # TrueType substitutes for standard PostScript fonts
       liberation_ttf
       unifont
-      noto-fonts-emoji
+      noto-fonts-color-emoji
     ]);
   };
 }

--- a/nixos/tests/fontconfig-default-fonts.nix
+++ b/nixos/tests/fontconfig-default-fonts.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ lib, ... }:
   nodes.machine = { config, pkgs, ... }: {
     fonts.enableDefaultPackages = true; # Background fonts
     fonts.packages = with pkgs; [
-      noto-fonts-emoji
+      noto-fonts-color-emoji
       cantarell-fonts
       twitter-color-emoji
       source-code-pro

--- a/nixos/tests/noto-fonts.nix
+++ b/nixos/tests/noto-fonts.nix
@@ -11,7 +11,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
         noto-fonts
         noto-fonts-cjk-sans
         noto-fonts-cjk-serif
-        noto-fonts-emoji
+        noto-fonts-color-emoji
       ];
       fontconfig.defaultFonts = {
         serif = [ "Noto Serif" "Noto Serif CJK SC" ];

--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
@@ -8,7 +8,7 @@
 , libdeltachat
 , makeDesktopItem
 , makeWrapper
-, noto-fonts-emoji
+, noto-fonts-color-emoji
 , pkg-config
 , python3
 , roboto
@@ -85,7 +85,7 @@ buildNpmPackage rec {
     install -D build/icon.png \
       $out/share/icons/hicolor/scalable/apps/deltachat.png
 
-    ln -sf ${noto-fonts-emoji}/share/fonts/noto/NotoColorEmoji.ttf \
+    ln -sf ${noto-fonts-color-emoji}/share/fonts/noto/NotoColorEmoji.ttf \
       $out/lib/node_modules/deltachat-desktop/html-dist/fonts/noto/emoji
     for font in $out/lib/node_modules/deltachat-desktop/html-dist/fonts/Roboto-*.ttf; do
       ln -sf ${roboto}/share/fonts/truetype/$(basename $font) \

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -164,7 +164,7 @@ rec {
     sha256 = "sha256-y1103SS0qkZMhEL5+7kQZ+OBs5tRaqkqOcs4796Fzhg=";
   };
 
-  noto-fonts-emoji =
+  noto-fonts-color-emoji =
     let
       version = "2.038";
       emojiPythonEnv =
@@ -217,7 +217,7 @@ rec {
       '';
 
       meta = with lib; {
-        description = "Color and Black-and-White emoji fonts";
+        description = "Color emoji font";
         homepage = "https://github.com/googlefonts/noto-emoji";
         license = with licenses; [ ofl asl20 ];
         platforms = platforms.all;

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -229,6 +229,7 @@ rec {
     # Metadata fetched from
     #  https://www.googleapis.com/webfonts/v1/webfonts?key=${GOOGLE_FONTS_TOKEN}&family=Noto+Emoji
     let metadata = with builtins; head (fromJSON (readFile ./noto-emoji.json)).items;
+        urlHashes = with builtins; fromJSON (readFile ./noto-emoji.hashes.json);
 
     in
     stdenvNoCC.mkDerivation {
@@ -245,17 +246,10 @@ rec {
           "600"   = "SemiBold";
           "700"   = "Bold";
         };
-        fileHashes = {
-          "NotoEmoji-Bold.ttf"     = "ce426e27c6254eb515fb6f301c8aa7cb7c90be3bd9a843c6e165d899a2dc63c0";
-          "NotoEmoji-Light.ttf"    = "f67750a89273b02911e8a71844d556df05d6331707fb44331604107421bcbd2a";
-          "NotoEmoji-Medium.ttf"   = "c3317d90a34c7904d86764144f9a4881aba1976a8ca59da730b35378026eaad4";
-          "NotoEmoji-Regular.ttf"  = "01718b75679b75dc8985328c5bf0ffead5bc38371a5eb50cf7a9b684df706258";
-          "NotoEmoji-SemiBold.ttf" = "3487a513c5fe94ab47eb24f77853d957bcd8511dd8e469cda1b01b7fb01c911d";
-        };
       in lib.mapAttrsToList
-        (variant: url: fetchurl rec { name = "NotoEmoji-${weightNames.${variant}}.ttf";
-                                      sha256 = fileHashes.${name};
-                                      inherit url; } )
+        (variant: url: fetchurl { name = "NotoEmoji-${weightNames.${variant}}.ttf";
+                                  hash = urlHashes.${url};
+                                  inherit url; } )
         metadata.files;
 
       installPhase = ''

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -225,6 +225,56 @@ rec {
       };
     };
 
+  noto-fonts-monochrome-emoji =
+    # Metadata fetched from
+    #  https://www.googleapis.com/webfonts/v1/webfonts?key=${GOOGLE_FONTS_TOKEN}&family=Noto+Emoji
+    let metadata = with builtins; head (fromJSON (readFile ./noto-emoji.json)).items;
+
+    in
+    stdenvNoCC.mkDerivation {
+      pname = "noto-fonts-monochrome-emoji";
+      version = "${lib.removePrefix "v" metadata.version}.${metadata.lastModified}";
+      preferLocalBuild = true;
+
+      dontUnpack = true;
+      srcs = let
+        weightNames = {
+          "300"   = "Light";
+          regular = "Regular";
+          "500"   = "Medium";
+          "600"   = "SemiBold";
+          "700"   = "Bold";
+        };
+        fileHashes = {
+          "NotoEmoji-Bold.ttf"     = "ce426e27c6254eb515fb6f301c8aa7cb7c90be3bd9a843c6e165d899a2dc63c0";
+          "NotoEmoji-Light.ttf"    = "f67750a89273b02911e8a71844d556df05d6331707fb44331604107421bcbd2a";
+          "NotoEmoji-Medium.ttf"   = "c3317d90a34c7904d86764144f9a4881aba1976a8ca59da730b35378026eaad4";
+          "NotoEmoji-Regular.ttf"  = "01718b75679b75dc8985328c5bf0ffead5bc38371a5eb50cf7a9b684df706258";
+          "NotoEmoji-SemiBold.ttf" = "3487a513c5fe94ab47eb24f77853d957bcd8511dd8e469cda1b01b7fb01c911d";
+        };
+      in lib.mapAttrsToList
+        (variant: url: fetchurl rec { name = "NotoEmoji-${weightNames.${variant}}.ttf";
+                                      sha256 = fileHashes.${name};
+                                      inherit url; } )
+        metadata.files;
+
+      installPhase = ''
+        for src in $srcs; do
+          install -D $src $out/share/fonts/noto/$(stripHash $src)
+        done
+      '';
+
+      meta = with lib; {
+        description = "Monochrome emoji font";
+        homepage = "https://fonts.google.com/noto/specimen/Noto+Emoji";
+        license = [ licenses.ofl ];
+        maintainers = [ maintainers.nicoo ];
+
+        platforms = platforms.all;
+        sourceProvenance = [ sourceTypes.binaryBytecode ];
+      };
+    };
+
   noto-fonts-emoji-blob-bin =
     let
       pname = "noto-fonts-emoji-blob-bin";

--- a/pkgs/data/fonts/noto-fonts/noto-emoji.hashes.json
+++ b/pkgs/data/fonts/noto-fonts/noto-emoji.hashes.json
@@ -1,0 +1,7 @@
+{
+  "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob_10jwvS-FGJCMY.ttf": "sha256-9ndQqJJzsCkR6KcYRNVW3wXWMxcH+0QzFgQQdCG8vSo=",
+  "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0jwvS-FGJCMY.ttf": "sha256-AXGLdWebddyJhTKMW/D/6tW8ODcaXrUM96m2hN9wYlg=",
+  "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-Z0jwvS-FGJCMY.ttf": "sha256-wzF9kKNMeQTYZ2QUT5pIgauhl2qMpZ2nMLNTeAJuqtQ=",
+  "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob911TwvS-FGJCMY.ttf": "sha256-NIelE8X+lKtH6yT3eFPZV7zYUR3Y5GnNobAbf7AckR0=",
+  "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob9M1TwvS-FGJCMY.ttf": "sha256-zkJuJ8YlTrUV+28wHIqny3yQvjvZqEPG4WXYmaLcY8A="
+}

--- a/pkgs/data/fonts/noto-fonts/noto-emoji.json
+++ b/pkgs/data/fonts/noto-fonts/noto-emoji.json
@@ -1,0 +1,30 @@
+{
+  "kind": "webfonts#webfontList",
+  "items": [
+    {
+      "family": "Noto Emoji",
+      "variants": [
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700"
+      ],
+      "subsets": [
+        "emoji"
+      ],
+      "version": "v46",
+      "lastModified": "2023-09-07",
+      "files": {
+        "300": "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob_10jwvS-FGJCMY.ttf",
+        "regular": "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0jwvS-FGJCMY.ttf",
+        "500": "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-Z0jwvS-FGJCMY.ttf",
+        "600": "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob911TwvS-FGJCMY.ttf",
+        "700": "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob9M1TwvS-FGJCMY.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "http://fonts.gstatic.com/s/notoemoji/v46/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0gwuQeU.ttf"
+    }
+  ]
+}

--- a/pkgs/data/fonts/noto-fonts/noto-emoji.py
+++ b/pkgs/data/fonts/noto-fonts/noto-emoji.py
@@ -135,6 +135,15 @@ if __name__ == "__main__":
             case KeyError if exn.args[0] == environVar:
                 print(f"No '{environVar}' in the environment, "
                        "skipping metadata update")
+
+            case HTTPError if exn.getcode() == 403:
+                print("Got HTTP 403 (Forbidden)")
+                if apiToken != '':
+                    print("Your Google API key appears to be valid "
+                          "but does not grant access to the fonts API.")
+                    print("Aborting!")
+                    raise SystemExit(1)
+
             case HTTPError if exn.getcode() == 400:
                 # Printing the supposed token should be fine, as this is
                 #  what the API returns on invalid tokens.

--- a/pkgs/data/fonts/noto-fonts/noto-emoji.py
+++ b/pkgs/data/fonts/noto-fonts/noto-emoji.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i "python3 -I" -p python3
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable
+from urllib import request
+
+import json
+
+
+def getUrls(metadata) -> Iterable[str]:
+    '''Fetch all files' URLs from Google Fonts' metadata.
+
+    The metadata must obey the API v1 schema, and can be obtained from:
+      https://www.googleapis.com/webfonts/v1/webfonts?key=${GOOGLE_FONTS_TOKEN}&family=${FAMILY}
+    '''
+    return ( url for i in metadata['items'] for _, url in i['files'].items() )
+
+
+def hashUrl(url: str, *, hash: str = 'sha256'):
+    '''Compute the hash of the data from HTTP GETing a given `url`.
+
+    The `hash` must be an algorithm name `hashlib.new` accepts.
+    '''
+    import hashlib
+    with request.urlopen(url) as req:
+        return hashlib.new(hash, req.read())
+
+def sriEncode(h) -> str:
+    '''Encode a hash in the SRI format.
+
+    Takes a `hashlib` object, and produces a string that
+    nixpkgs' `fetchurl` accepts as `hash` parameter.
+    '''
+    from base64 import b64encode
+    return f"{h.name}-{b64encode(h.digest()).decode()}"
+
+def hashUrls(
+    urls: Iterable[str],
+    knownHashes: dict[str, str] = {},
+) -> dict[str, str]:
+    '''Generate a `dict` mapping URLs to SRI-encoded hashes.
+
+    The `knownHashes` optional parameter can be used to avoid
+    re-downloading files whose URL have not changed.
+    '''
+    return {
+        url: knownHashes.get(url) or sriEncode(hashUrl(url))
+        for url in urls
+    }
+
+
+@contextmanager
+def atomicFileUpdate(target: Path):
+    '''Atomically replace the contents of a file.
+
+    Yields an open file to write into; upon exiting the context,
+    the file is closed and (atomically) replaces the `target`.
+
+    Guarantees that the `target` was either successfully overwritten
+    with new content and no exception was raised, or the temporary
+    file was cleaned up.
+    '''
+    from tempfile import mkstemp
+    fd, _p = mkstemp(
+        dir = target.parent,
+        prefix = target.name,
+    )
+    tmpPath = Path(_p)
+
+    try:
+        with open(fd, 'w') as f:
+            yield f
+
+        tmpPath.replace(target)
+
+    except Exception:
+        tmpPath.unlink(missing_ok = True)
+        raise
+
+
+if __name__ == "__main__":
+    currentDir = Path(__file__).parent
+
+    with (currentDir / 'noto-emoji.json').open() as f:
+        metadata = json.load(f)
+
+    hashPath = currentDir / 'noto-emoji.hashes.json'
+    try:
+        with hashPath.open() as hashFile:
+            hashes = json.load(hashFile)
+    except FileNotFoundError:
+        hashes = {}
+
+    with atomicFileUpdate(hashPath) as hashFile:
+        json.dump(
+            hashUrls(getUrls(metadata), knownHashes = hashes),
+            hashFile,
+            indent = 2,
+        )
+        hashFile.write("\n")  # Pacify nixpkgs' dumb editor config check

--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -10,7 +10,7 @@
 , python3
 , which
 , zopfli
-, noto-fonts-emoji
+, noto-fonts-color-emoji
 }:
 
 let
@@ -33,15 +33,15 @@ stdenv.mkDerivation rec {
   inherit version;
 
   srcs = [
-    noto-fonts-emoji.src
+    noto-fonts-color-emoji.src
     twemojiSrc
   ];
 
-  sourceRoot = noto-fonts-emoji.src.name;
+  sourceRoot = noto-fonts-color-emoji.src.name;
 
   postUnpack = ''
     chmod -R +w ${twemojiSrc.name}
-    mv ${twemojiSrc.name} ${noto-fonts-emoji.src.name}
+    mv ${twemojiSrc.name} ${noto-fonts-color-emoji.src.name}
   '';
 
   nativeBuildInputs = [
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
       "s#http://scripts.sil.org/OFL#http://creativecommons.org/licenses/by/4.0/#"
     ];
   in ''
-    ${noto-fonts-emoji.postPatch}
+    ${noto-fonts-color-emoji.postPatch}
 
     sed '${templateSubstitutions}' NotoColorEmoji.tmpl.ttx.tmpl > TwitterColorEmoji.tmpl.ttx.tmpl
     pushd ${twemojiSrc.name}/assets/72x72/

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1227,6 +1227,7 @@ mapAliases ({
   nomad_1_3 = throw "nomad_1_3 has been removed because it's outdated. Use a a newer version instead"; # Added 2023-09-02
   nordic-polar = throw "nordic-polar was removed on 2021-05-27, now integrated in nordic"; # Added 2021-05-27
   noto-fonts-cjk = noto-fonts-cjk-sans; # Added 2021-12-16
+  noto-fonts-emoji = noto-fonts-color-emoji; # Added 2023-09-09
   noto-fonts-extra = noto-fonts; # Added 2023-04-08
   nottetris2 = throw "nottetris2 was removed because it is unmaintained by upstream and broken"; # Added 2022-01-15
   now-cli = throw "now-cli has been replaced with nodePackages.vercel"; # Added 2021-08-05

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29924,8 +29924,9 @@ with pkgs;
     noto-fonts-lgc-plus
     noto-fonts-cjk-sans
     noto-fonts-cjk-serif
-    noto-fonts-emoji
-    noto-fonts-emoji-blob-bin;
+    noto-fonts-color-emoji
+    noto-fonts-emoji-blob-bin
+    ;
 
   nuclear = callPackage ../applications/audio/nuclear { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29926,6 +29926,7 @@ with pkgs;
     noto-fonts-cjk-serif
     noto-fonts-color-emoji
     noto-fonts-emoji-blob-bin
+    noto-fonts-monochrome-emoji
     ;
 
   nuclear = callPackage ../applications/audio/nuclear { };


### PR DESCRIPTION

## Description of changes

- noto-fonts-emoji → noto-fonts-color-emoji
- noto-fonts-monochrome-emoji: init at v46.2023-09-07

Closes #221181.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
