### PR TITLE
Don't require ellipsis in NixOS module definitions.

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -13,6 +13,7 @@ let
     elem
     filter
     foldl'
+    functionArgs
     getAttrFromPath
     head
     id
@@ -510,7 +511,7 @@ let
       # context on the explicit arguments of "args" too. This update
       # operator is used to make the "args@{ ... }: with args.lib;" notation
       # works.
-    in f (args // extraArgs);
+    in f (builtins.intersectAttrs (functionArgs f) (args // extraArgs));
 
   /* Merge a list of modules.  This will recurse over the option
      declarations in all modules, combining them into a single set.

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -433,6 +433,9 @@ checkConfigError 'Could not load a value as a module, because it is of type "fla
 checkConfigOutput '^true$' "$@" config.enable ./declare-enable.nix ./define-enable-with-top-level-mkIf.nix
 checkConfigError 'Could not load a value as a module, because it is of type "configuration", in file .*/import-configuration.nix.*please only import the modules that make up the configuration.*' config ./import-configuration.nix
 
+checkConfigOutput '"foo"' config.foo ./no-ellipsis-module.nix
+checkConfigOutput '"foo"' config.foo ./module-with-at-pattern.nix
+
 # doRename works when `warnings` does not exist.
 checkConfigOutput '^1234$' config.c.d.e ./doRename-basic.nix
 # doRename adds a warning.

--- a/lib/tests/modules/module-with-at-pattern.nix
+++ b/lib/tests/modules/module-with-at-pattern.nix
@@ -1,0 +1,5 @@
+# this no longer works since functionArgs is blind to both `...` and `@`-patterns
+{ ... }@inputs: {
+  options.foo = inputs.lib.mkOption { type = inputs.lib.types.str; };
+  config.foo = "foo";
+}

--- a/lib/tests/modules/no-ellipsis-module.nix
+++ b/lib/tests/modules/no-ellipsis-module.nix
@@ -1,0 +1,5 @@
+# the module can now request only what it needs without a `...`.
+{ lib }: {
+  options.foo = lib.mkOption { type = lib.types.str; };
+  config.foo = "foo";
+}


### PR DESCRIPTION
## Description of changes

Having used `callPackage` a bit, it seems a bit odd and inconsistent that modules require `...` in their signatures as opposed to figuring out the signature and passing only what's requested, like `callPackage` does.

Now I don't know if there is an actual reason for why it is important for modules to require `...`, but I could not find any and upon a brief chat with @infinisil, it seemed like there might not be a reason. So if you know of a reason, please let me know.

Worth noting that, as currently implemented, it's is a breaking change, namely modules that use at-pattern arg capture don't work (`{ ... }@args`, args used to contain all available module args, but is now empty, see newly added failing test for details). I don't have any data on how common it is to write modules with at-pattern capturing, so would like to get some guidance on how important it is to preserve this behavior.

It's possible to make it a non-breaking change by detecting `...` and/or `@args` with something like [#8961](https://github.com/NixOS/nix/pull/8961), and passing all available arguments if detected. Similar prior art: #194992 [#7317](https://github.com/NixOS/nix/issues/7317).

Would like to get your thoughts on the idea to see if there are any strong objections to pursuing this further.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
