### PR TITLE
gitlab: use custom git

### DIFF
--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -1,14 +1,16 @@
 { lib
 , fetchFromGitLab
-, fetchFromGitHub
 , buildGoModule
-, pkg-config
+
+, callPackage
 }:
 
 let
   version = "16.5.1";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
+
+  git = callPackage ./git.nix { };
 
   commonOpts = {
     inherit version;
@@ -26,8 +28,6 @@ let
     ldflags = [ "-X ${gitaly_package}/internal/version.version=${version}" "-X ${gitaly_package}/internal/version.moduleVersion=${version}" ];
 
     tags = [ "static" ];
-
-    nativeBuildInputs = [ pkg-config ];
 
     doCheck = false;
   };
@@ -47,6 +47,10 @@ buildGoModule ({
     mkdir -p _build/bin
     cp -r ${auxBins}/bin/* _build/bin
   '';
+
+  passthru = {
+    inherit git;
+  };
 
   outputs = [ "out" ];
 

--- a/pkgs/applications/version-management/gitlab/gitaly/git.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/git.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, gitaly
+, fetchFromGitLab
+, curl
+, pcre2
+, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "gitaly-git";
+  version = "2.42.0";
+
+  # `src` attribute for nix-update
+  src = fetchFromGitLab {
+    owner = "gitlab-org";
+    repo = "git";
+    rev = "v${version}";
+    hash = "sha256-/kqU37JHp4xXDPzFLCdt6+AO1zE9tCwwhOnmYFFRen8=";
+  };
+
+  # we actually use the gitaly build system
+  unpackPhase = ''
+    cp -r ${gitaly.src} source
+    chmod -R +w source
+
+    mkdir -p source/_build/deps
+
+    cp -r ${src} source/_build/deps/git-distribution
+    chmod -R +w source/_build/deps/git-distribution
+
+    # FIXME? maybe just patch the makefile?
+    echo -n 'v${version} DEVELOPER=1 DEVOPTS=no-error USE_LIBPCRE=YesPlease NO_PERL=YesPlease NO_EXPAT=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease NO_PYTHON=YesPlease' > source/_build/deps/git-distribution.version
+    echo -n 'v${version}' > source/_build/deps/git-distribution/version
+  '';
+  sourceRoot = "source";
+
+  buildFlags = [ "git" ];
+
+  buildInputs = [
+    curl
+    pcre2
+    zlib
+  ];
+
+  # The build phase already installs it all
+  GIT_PREFIX = placeholder "out";
+  dontInstall = true;
+
+  meta = {
+    homepage = "https://git-scm.com/";
+    description = "Distributed version control system - with Gitaly patches";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/applications/version-management/gitlab/update.py
+++ b/pkgs/applications/version-management/gitlab/update.py
@@ -236,8 +236,16 @@ def update_gitaly():
     logger.info("Updating gitaly")
     data = _get_data_json()
     gitaly_server_version = data['passthru']['GITALY_SERVER_VERSION']
+    repo = GitLabRepo(repo='gitaly')
+    gitaly_dir = pathlib.Path(__file__).parent / 'gitaly'
+
+    makefile = repo.get_file("Makefile", f"v{gitaly_server_version}")
+    makefile += "\nprint-%:;@echo $($*)\n"
+
+    git_version = subprocess.run(['make', '-f', '-', 'print-GIT_VERSION'], check=True, input=makefile, text=True, capture_output=True).stdout.strip()
 
     _call_nix_update("gitaly", gitaly_server_version)
+    _call_nix_update('gitaly.git', git_version)
 
 
 @cli.command("update-gitlab-pages")


### PR DESCRIPTION
## Description of changes
for improved compatibility

not super polished, but we've been running something similar for a long time, internally

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).