### PR TITLE
treewide: fix pythonImportsCheck typos

### DIFF
--- a/pkgs/development/python-modules/cson/default.nix
+++ b/pkgs/development/python-modules/cson/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ speg ];
 
-  pythonImportChecks = [ "cson" ];
+  pythonImportsCheck = [ "cson" ];
 
   meta = with lib; {
     description = "A python parser for the Coffeescript Object Notation (CSON)";

--- a/pkgs/development/python-modules/django-admin-datta/default.nix
+++ b/pkgs/development/python-modules/django-admin-datta/default.nix
@@ -24,8 +24,8 @@ buildPythonPackage rec {
   # no tests
   doCheck = false;
 
-  pythonImportCheck = [
-    "admin-datta"
+  pythonImportsCheck = [
+    "admin_datta"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/opcua-widgets/default.nix
+++ b/pkgs/development/python-modules/opcua-widgets/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     asyncua
   ];
 
-  pythonImportChecks = [ "opcua-widgets" ];
+  pythonImportsCheck = [ "uawidgets" ];
 
   #This test is broken, when updating this package check if the test was fixed.
   doCheck = false;

--- a/pkgs/development/python-modules/python-ndn/default.nix
+++ b/pkgs/development/python-modules/python-ndn/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportChecks = [ "ndn" ];
+  pythonImportsCheck = [ "ndn" ];
 
   meta = with lib; {
     description = "An NDN client library with AsyncIO support";

--- a/pkgs/development/python-modules/speg/default.nix
+++ b/pkgs/development/python-modules/speg/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     extension = "zip";
   };
 
-  pythonImportChecks = [ "speg" ];
+  pythonImportsCheck = [ "speg" ];
 
   # checks fail for seemingly spurious reasons
   doCheck = false;


### PR DESCRIPTION
## Description of changes

A misstyped `ripgrep` led me to discover that I'm not the only one who misremembers the name of the `pythonImportsCheck` attribute.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
