### PR TITLE
bazecor: init at 1.3.6

### DIFF
--- a/pkgs/applications/misc/bazecor/10-dygma.rules
+++ b/pkgs/applications/misc/bazecor/10-dygma.rules
@@ -1,0 +1,4 @@
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2201", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2200", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="35ef", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idVendor}=="35ef", MODE="0666"

--- a/pkgs/applications/misc/bazecor/default.nix
+++ b/pkgs/applications/misc/bazecor/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, appimageTools
+, fetchurl
+}:
+
+appimageTools.wrapAppImage rec {
+  pname = "bazecor";
+  version = "1.3.6";
+
+  src = appimageTools.extract {
+    inherit pname version;
+    src = fetchurl {
+      url = "https://github.com/Dygmalab/Bazecor/releases/download/v.${version}/Bazecor-${version}-x64.AppImage";
+      hash = "sha256-Mz7T/AAlyfMzdfy/ZV4AEP3ClTolwr2pPzkSCPL66/w=";
+    };
+
+    # Workaround for https://github.com/Dygmalab/Bazecor/issues/370
+    postExtract = ''
+      substituteInPlace \
+        $out/usr/lib/bazecor/resources/app/.webpack/main/index.js \
+        --replace \
+          'checkUdev=()=>{try{if(c.default.existsSync(f))return c.default.readFileSync(f,"utf-8").trim()===l.trim()}catch(e){console.error(e)}return!1}' \
+          'checkUdev=()=>{return 1}'
+    '';
+  };
+
+  # also make sure to update the udev rules in ./10-dygma.rules; most recently
+  # taken from
+  # https://github.com/Dygmalab/Bazecor/blob/v1.3.6/src/main/utils/udev.ts#L6
+
+  extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [
+    p.glib
+  ];
+
+  # Also expose the udev rules here, so it can be used as:
+  #   services.udev.packages = [ pkgs.bazecor ];
+  # to allow non-root modifications to the keyboards.
+
+  extraInstallCommands = ''
+    mv $out/bin/bazecor-* $out/bin/bazecor
+
+    mkdir -p $out/lib/udev/rules.d
+    ln -s --target-directory=$out/lib/udev/rules.d ${./10-dygma.rules}
+  '';
+
+  meta = {
+    description = "Graphical configurator for Dygma Products";
+    homepage = "https://github.com/Dygmalab/Bazecor";
+    changelog = "https://github.com/Dygmalab/Bazecor/releases/tag/v${version}";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ amesgen ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "bazecor";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -342,6 +342,8 @@ with pkgs;
 
   bakelite = callPackage ../tools/backup/bakelite { };
 
+  bazecor = callPackage ../applications/misc/bazecor { };
+
   bearer = callPackage ../development/tools/bearer { };
 
   benthos = callPackage ../development/tools/benthos { };


### PR DESCRIPTION
## Description of changes

Adapted from the chrysalis derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

