### PR TITLE
 python311Packages.checkdmarc: init at 4.8.0, python311Packages.pyleri: init at 1.4.2

### DIFF
--- a/pkgs/development/python-modules/checkdmarc/default.nix
+++ b/pkgs/development/python-modules/checkdmarc/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, buildPythonPackage
+, cryptography
+, dnspython
+, expiringdict
+, fetchFromGitHub
+, hatchling
+, publicsuffixlist
+, pyleri
+, iana-etc
+, pytestCheckHook
+, pythonOlder
+, requests
+, timeout-decorator
+}:
+
+buildPythonPackage rec {
+  pname = "checkdmarc";
+  version = "4.8.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "domainaware";
+    repo = "checkdmarc";
+    # https://github.com/domainaware/checkdmarc/issues/102
+    rev = "d0364ceef3cfd41052273913369e3831cb6fe4fd";
+    hash = "sha256-OSljewDeyJtoxkCQjPU9wIsNhhxumHmeu9GHvRD4DRY=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    cryptography
+    dnspython
+    expiringdict
+    publicsuffixlist
+    pyleri
+    requests
+    timeout-decorator
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "checkdmarc"
+  ];
+
+  pytestFlagsArray = [
+    "tests.py"
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "testDMARCPctLessThan100Warning"
+    "testSPFMissingARecord"
+    "testSPFMissingMXRecord"
+    "testSplitSPFRecord"
+    "testTooManySPFDNSLookups"
+    "testTooManySPFVoidDNSLookups"
+  ];
+
+  meta = with lib; {
+    description = "A parser for SPF and DMARC DNS records";
+    homepage = "https://github.com/domainaware/checkdmarc";
+    changelog = "https://github.com/domainaware/checkdmarc/blob/${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}
+

--- a/pkgs/development/python-modules/pyleri/default.nix
+++ b/pkgs/development/python-modules/pyleri/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyleri";
+  version = "1.4.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "cesbit";
+    repo = "pyleri";
+    rev = "refs/tags/${version}";
+    hash = "sha256-52Q2iTrXFNbDzXL0FM+Gypipvo5ciNqAtZa5sKOwQRc=";
+  };
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pyleri"
+  ];
+
+  meta = with lib; {
+    description = "Module to parse SiriDB";
+    homepage = "https://github.com/cesbit/pyleri";
+    changelog = "https://github.com/cesbit/pyleri/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9310,6 +9310,8 @@ self: super: with self; {
 
   pyld = callPackage ../development/python-modules/pyld { };
 
+  pyleri = callPackage ../development/python-modules/pyleri { };
+
   pylev = callPackage ../development/python-modules/pylev { };
 
   pylgnetcast = callPackage ../development/python-modules/pylgnetcast { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1889,6 +1889,8 @@ self: super: with self; {
 
   check-manifest = callPackage ../development/python-modules/check-manifest { };
 
+  checkdmarc = callPackage ../development/python-modules/checkdmarc { };
+
   cheetah3 = callPackage ../development/python-modules/cheetah3 { };
 
   cheroot = callPackage ../development/python-modules/cheroot { };


### PR DESCRIPTION
## Description of changes
A parser for SPF and DMARC DNS records

https://github.com/domainaware/checkdmarc

Related to #81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
