### PR TITLE
obj2voxel: init at 1.3.4

### DIFF
--- a/pkgs/by-name/ob/obj2voxel/1.3.4-fix-type-mismatch.patch
+++ b/pkgs/by-name/ob/obj2voxel/1.3.4-fix-type-mismatch.patch
@@ -1,0 +1,13 @@
+diff -Naurd x/voxelio/src/stream.cpp y/voxelio/src/stream.cpp
+--- x/voxelio/src/stream.cpp	2023-09-11 07:50:51.522074934 +0000
++++ y/voxelio/src/stream.cpp	2023-09-11 08:02:19.105142327 +0000
+@@ -117,7 +117,8 @@
+         return;
+     }
+ 
+-    size_t overwriteLength = std::min(size() - pos, length);
++    size_t const remaining = size() - pos;
++    size_t overwriteLength = std::min(remaining, length);
+     size_t pushLength = length - overwriteLength;
+ 
+     auto overwriteTarget = static_cast<std::vector<u8> *>(sink)->begin() + static_cast<ptrdiff_t>(pos);

--- a/pkgs/by-name/ob/obj2voxel/package.nix
+++ b/pkgs/by-name/ob/obj2voxel/package.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "obj2voxel";
+  version = "1.3.4";
+
+  src = (
+    fetchFromGitHub {
+      owner = "Eisenwave";
+      repo = "obj2voxel";
+      rev = "v${finalAttrs.version}";
+      fetchSubmodules = true;
+      hash = "sha256-FkGQjYm15le1Na+2U1TgK4nNOZNs5bME5J87pjVFpDs=";
+    }
+  ).overrideAttrs (
+    # prompted by https://github.com/Eisenwave/obj2voxel/pull/9
+    _: {
+      GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+      GIT_CONFIG_VALUE_0 = "git@github.com:";
+      GIT_CONFIG_COUNT = 1;
+    }
+  );
+
+  patches = [
+    # pull missing definitions (https://github.com/Eisenwave/voxel-io/pull/3)
+    (
+      fetchpatch {
+        name = "add-std-includes.patch";
+        url = "https://github.com/Eisenwave/voxel-io/compare/d902568de2d4afda254e533a5ee9e4ad5fe7d2be...2f800f6aca8acd0cc18f9625b411c6dc2956f2ea.patch";
+        hash = "sha256-2JeFBx0Ds++BplWXuxOo4KOAW6gXCT/kFI74i0M0ROM=";
+        stripLen = 1;
+        extraPrefix = "voxelio/";
+      }
+    )
+    # fix build on aarch64-darwin (https://github.com/Eisenwave/voxel-io/pull/4)
+    (
+      fetchpatch {
+        name = "fix-aarch64-darwin-type-mismatch.patch";
+        url = "https://github.com/Eisenwave/voxel-io/compare/d902568de2d4afda254e533a5ee9e4ad5fe7d2be...669ac7e9c640fa92bc1989cc7811afbed9bbd8b8.patch";
+        hash = "sha256-AuvjpTGBLKN0f47IoxIDkV32g9A/4RbvGBo3ToGiH/w=";
+        stripLen = 1;
+        extraPrefix = "voxelio/";
+      }
+    )
+    # already fixed in upstream git head
+    ./1.3.4-fix-type-mismatch.patch
+  ];
+
+  postPatch = ''
+    echo 'install(TARGETS obj2voxel-cli DESTINATION ''${CMAKE_INSTALL_PREFIX}/bin)' >> CMakeLists.txt
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.targetPlatform.isStatic then "OFF" else "ON"}"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Convert OBJ and STL files to voxels, with support for textures";
+    mainProgram = "obj2voxel";
+    homepage = "https://github.com/Eisenwave/obj2voxel";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.gm6k ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Add package for `obj2voxel`. Fixes https://github.com/NixOS/nixpkgs/issues/254298.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

