### PR TITLE
nodePackages.swagger: drop

### DIFF
--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -106,6 +106,7 @@ mapAliases {
   ssb-server = throw "ssb-server was removed because it was broken"; # added 2023-08-21
   stf = throw "stf was removed because it was broken"; # added 2023-08-21
   surge = pkgs.surge-cli; # Added 2023-09-08
+  swagger = throw "swagger was removed because it was broken and abandoned upstream"; # added 2023-09-09
   thelounge = pkgs.thelounge; # Added 2023-05-22
   three = throw "three was removed because it was no longer needed"; # Added 2023-09-08
   inherit (pkgs) titanium; # added 2023-08-17

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -242,7 +242,6 @@
 , "svelte-check"
 , "svelte-language-server"
 , "svgo"
-, "swagger"
 , "tailwindcss"
 , {"tedicross": "git+https://github.com/TediCross/TediCross.git#v0.8.7"}
 , "teck-programmer"


### PR DESCRIPTION
`swagger project create` fails with

    /nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/node_modules/js-yaml/lib/js-yaml/dumper.js:779
          throw new YAMLException('unacceptable kind of an object to dump ' + type);
          ^
    YAMLException: unacceptable kind of an object to dump [object Error]
        at writeNode (/nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/node_modules/js-yaml/lib/js-yaml/dumper.js:779:13)
        at writeBlockSequence (/nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/node_modules/js-yaml/lib/js-yaml/dumper.js:542:9)
        at writeNode (/nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/node_modules/js-yaml/lib/js-yaml/dumper.js:763:9)
        at dump (/nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/node_modules/js-yaml/lib/js-yaml/dumper.js:840:7)
        at Object.safeDump (/nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/node_modules/js-yaml/lib/js-yaml/dumper.js:846:10)
        at print (/nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/lib/util/cli.js:100:22)
        at printAndExit (/nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/lib/util/cli.js:85:5)
        at cb (/nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/lib/util/cli.js:155:5)
        at /nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/lib/commands/project/project.js:105:25
        at /nix/store/pg6q73qfnr9dfjywmifi9iwp626409l3-swagger-0.7.5/lib/node_modules/swagger/lib/commands/project/project.js:330:23 {
      reason: 'unacceptable kind of an object to dump [object Error]',
      mark: undefined
    }

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
