### PR TITLE
blisp: unstable-2023-06-03 -> 0.0.4

### DIFF
--- a/pkgs/development/embedded/blisp/default.nix
+++ b/pkgs/development/embedded/blisp/default.nix
@@ -5,18 +5,19 @@
 , cmake
 , libserialport
 , pkg-config
+, testers
 , IOKit
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "blisp";
-  version = "unstable-2023-06-03";
+  version = "0.0.4";
 
   src = fetchFromGitHub {
     owner = "pine64";
     repo = "blisp";
-    rev = "048a72408218788d519a87bcdfb23bcf9ed91a84";
-    hash = "sha256-hipJrr0D4uEN2hk8ooXeg0gv0X3w4U9ReXbC4oPEPwI=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-cN35VLbdQFA3KTZ8PxgpbsLGXqfFhw5eh3nEBRZqAm4=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -31,12 +32,16 @@ stdenv.mkDerivation {
     "-DBLISP_USE_SYSTEM_LIBRARIES=ON"
   ];
 
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    version = "v${finalAttrs.version}";
+  };
+
   meta = with lib; {
-    description = "ISP tool & library for Bouffalo Labs RISC-V Microcontrollers and SoCs";
+    description = "An In-System-Programming (ISP) tool & library for Bouffalo Labs RISC-V Microcontrollers and SoCs";
     license = licenses.mit;
+    mainProgram = "blisp";
     homepage = "https://github.com/pine64/blisp";
     maintainers = [ maintainers.fortuneteller2k ];
   };
-}
-# TODO: update when next stable release supports building without vendored
-# libraries
+})


### PR DESCRIPTION
- Slightly change the description to be...more descriptive.
- Add a passthru test.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
