### PR TITLE
Use rcodesign verification on Xcode

### DIFF
--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -3,7 +3,7 @@
 let requireXcode = version: sha256:
   let
     xip = "Xcode_" + version +  ".xip";
-    # TODO(alexfmpe): Find out how to validate the .xip signature in Linux
+
     unxip = if stdenv.buildPlatform.isDarwin
             then ''
               open -W ${xip}
@@ -14,7 +14,9 @@ let requireXcode = version: sha256:
               rm -rf ${xip}
               pbzx -n Content | cpio -i
               rm Content Metadata
+              rcodesign verify Xcode.app/Contents/MacOS/Xcode
             '';
+
     app = requireFile rec {
       name     = "Xcode.app";
       url      = "https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_${version}/${xip}";
@@ -83,4 +85,3 @@ in lib.makeExtensible (self: {
   xcode_15_1 = requireXcode "15.1" "sha256-0djqoSamU87rCpjo50Un3cFg9wKf+pSczRko6uumGM0=";
   xcode = self."xcode_${lib.replaceStrings ["."] ["_"] (if (stdenv.targetPlatform ? xcodeVer) then stdenv.targetPlatform.xcodeVer else "12.3")}";
 })
-


### PR DESCRIPTION
## Description of changes

This is currently very much a best-effort thing on linux, but beforehand we did no effort and gave no warning to the user, so it seems like an improvement on both counts.

```
$ rcodesign verify Xcode.app/Contents/MacOS/Xcode 
no problems detected!
(we do not verify everything so please do not assume that the signature meets Apple standards)
```

Verifying the `.app` or the binary seems to be the same (which is good because `rcodesign` complains it can't verify a directory). The order seems to vary across invocations even for the same path, so I added a `sort`.

```shell
$ codesign -v --verbose=6 Xcode.app 2>&1 | sort > dir
$ codesign -v --verbose=6 Xcode.app/Contents/MacOS/Xcode 2>&1 | sort > bin
$ diff dir bin
557,558c557,558
< Xcode.app: satisfies its Designated Requirement
< Xcode.app: valid on disk
---
> Xcode.app/Contents/MacOS/Xcode: satisfies its Designated Requirement
> Xcode.app/Contents/MacOS/Xcode: valid on disk
```

I thought the `.wip` was the signed thing but apparently not
```
$ codesign -v Xcode14.wip:
Xcode14.wip: code object is not signed at all
```
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
