### PR TITLE
python311Packages.sseclient-py: 1.7.2 -> 1.8.0 

### DIFF
--- a/pkgs/development/python-modules/sseclient-py/default.nix
+++ b/pkgs/development/python-modules/sseclient-py/default.nix
@@ -1,8 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, python
 , pythonOlder
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -16,13 +16,20 @@ buildPythonPackage rec {
     owner = "mpetazzoni";
     repo = "sseclient";
     rev = "sseclient-py-${version}";
-    sha256 = "sha256-rNiJqR7/e+Rhi6kVBY8gZJZczqSUsyszotXkb4OKfWk=";
+    hash = "sha256-rNiJqR7/e+Rhi6kVBY8gZJZczqSUsyszotXkb4OKfWk=";
   };
 
-  # based on tox.ini
-  checkPhase = ''
-    ${python.interpreter} tests/unittests.py
-  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "sseclient"
+  ];
+
+  pytestFlagsArray = [
+    "tests/unittests.py"
+  ];
 
   meta = with lib; {
     description = "Pure-Python Server Side Events (SSE) client";

--- a/pkgs/development/python-modules/sseclient-py/default.nix
+++ b/pkgs/development/python-modules/sseclient-py/default.nix
@@ -19,6 +19,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Pure-Python Server Side Events (SSE) client";
     homepage = "https://github.com/mpetazzoni/sseclient";
+    changelog = "https://github.com/mpetazzoni/sseclient/releases/tag/sseclient-py-${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ jamiemagee ];
   };

--- a/pkgs/development/python-modules/sseclient-py/default.nix
+++ b/pkgs/development/python-modules/sseclient-py/default.nix
@@ -1,8 +1,16 @@
-{ buildPythonPackage, fetchFromGitHub, lib, python }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "sseclient-py";
   version = "1.8.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "mpetazzoni";

--- a/pkgs/development/python-modules/sseclient-py/default.nix
+++ b/pkgs/development/python-modules/sseclient-py/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "sseclient-py";
-  version = "1.7.2";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "mpetazzoni";
     repo = "sseclient";
     rev = "sseclient-py-${version}";
-    sha256 = "096spyv50jir81xiwkg9l88ycp1897d3443r6gi1by8nkp4chvix";
+    sha256 = "sha256-rNiJqR7/e+Rhi6kVBY8gZJZczqSUsyszotXkb4OKfWk=";
   };
 
   # based on tox.ini


### PR DESCRIPTION
Diff: https://github.com/mpetazzoni/sseclient/compare/sseclient-py-1.7.2...sseclient-py-1.8.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
