### PR TITLE
mtr-exporter: support specifying multiple jobs

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -224,6 +224,8 @@
 
 - `rome` was removed because it is no longer maintained and is succeeded by `biome`.
 
+- The `services.mtr-exporter.target` has been removed in favor of `services.mtr-exporter.jobs` which allows specifying multiple targets.
+
 ## Other Notable Changes {#sec-release-23.11-notable-changes}
 
 - The Cinnamon module now enables XDG desktop integration by default. If you are experiencing collisions related to xdg-desktop-portal-gtk you can safely remove `xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];` from your NixOS configuration.

--- a/nixos/modules/services/networking/mtr-exporter.nix
+++ b/nixos/modules/services/networking/mtr-exporter.nix
@@ -2,32 +2,26 @@
 
 let
   inherit (lib)
-    maintainers types mkEnableOption mkOption mkIf
-    literalExpression escapeShellArg escapeShellArgs;
+    maintainers types literalExpression
+    escapeShellArg escapeShellArgs
+    mkEnableOption mkOption mkRemovedOptionModule mkIf mdDoc
+    optionalString concatMapStrings concatStringsSep;
+
   cfg = config.services.mtr-exporter;
+
+  jobsConfig = pkgs.writeText "mtr-exporter.conf" (concatMapStrings (job: ''
+    ${job.name} -- ${job.schedule} -- ${concatStringsSep " " job.flags} ${job.address}
+  '') cfg.jobs);
 in {
+  imports = [
+    (mkRemovedOptionModule [ "services" "mtr-exporter" "target" ] "Use services.mtr-exporter.jobs instead.")
+    (mkRemovedOptionModule [ "services" "mtr-exporter" "mtrFlags" ] "Use services.mtr-exporter.jobs.<job>.flags instead.")
+  ];
+
   options = {
     services = {
       mtr-exporter = {
-        enable = mkEnableOption (lib.mdDoc "a Prometheus exporter for MTR");
-
-        target = mkOption {
-          type = types.str;
-          example = "example.org";
-          description = lib.mdDoc "Target to check using MTR.";
-        };
-
-        interval = mkOption {
-          type = types.int;
-          default = 60;
-          description = lib.mdDoc "Interval between MTR checks in seconds.";
-        };
-
-        port = mkOption {
-          type = types.port;
-          default = 8080;
-          description = lib.mdDoc "Listen port for MTR exporter.";
-        };
+        enable = mkEnableOption (mdDoc "a Prometheus exporter for MTR");
 
         address = mkOption {
           type = types.str;
@@ -35,30 +29,87 @@ in {
           description = lib.mdDoc "Listen address for MTR exporter.";
         };
 
-        mtrFlags = mkOption {
-          type = with types; listOf str;
+        port = mkOption {
+          type = types.port;
+          default = 8080;
+          description = mdDoc "Listen port for MTR exporter.";
+        };
+
+        extraFlags = mkOption {
+          type = types.listOf types.str;
           default = [];
-          example = ["-G1"];
-          description = lib.mdDoc "Additional flags to pass to MTR.";
+          example = ["-flag.deprecatedMetrics"];
+          description = mdDoc ''
+            Extra command line options to pass to MTR exporter.
+          '';
+        };
+
+        package = mkOption {
+          type = types.package;
+          default = pkgs.mtr-exporter;
+          defaultText = literalExpression "pkgs.mtr-exporter";
+          description = mdDoc "The MTR exporter package to use.";
+        };
+
+        mtrPackage = mkOption {
+          type = types.package;
+          default = pkgs.mtr;
+          defaultText = literalExpression "pkgs.mtr";
+          description = mdDoc "The MTR package to use.";
+        };
+
+        jobs = mkOption {
+          description = mdDoc "List of MTR jobs. Will be added to /etc/mtr-exporter.conf";
+          type = types.nonEmptyListOf (types.submodule {
+            options = {
+              name = mkOption {
+                type = types.str;
+                description = mdDoc "Name of ICMP pinging job.";
+              };
+
+              address = mkOption {
+                type = types.str;
+                example = "host.example.org:1234";
+                description = mdDoc "Target address for MTR client.";
+              };
+
+              schedule = mkOption {
+                type = types.str;
+                default = "@every 60s";
+                example = "@hourly";
+                description = mdDoc "Schedule of MTR checks. Also accepts Cron format.";
+              };
+
+              flags = mkOption {
+                type = with types; listOf str;
+                default = [];
+                example = ["-G1"];
+                description = mdDoc "Additional flags to pass to MTR.";
+              };
+            };
+          });
         };
       };
     };
   };
 
   config = mkIf cfg.enable {
+    environment.etc."mtr-exporter.conf" = {
+      source = jobsConfig;
+    };
+
     systemd.services.mtr-exporter = {
-      script = ''
-        exec ${pkgs.mtr-exporter}/bin/mtr-exporter \
-          -mtr ${pkgs.mtr}/bin/mtr \
-          -schedule '@every ${toString cfg.interval}s' \
-          -bind ${escapeShellArg cfg.address}:${toString cfg.port} \
-          -- \
-          ${escapeShellArgs (cfg.mtrFlags ++ [ cfg.target ])}
-      '';
       wantedBy = [ "multi-user.target" ];
       requires = [ "network.target" ];
       after = [ "network.target" ];
       serviceConfig = {
+        ExecStart = ''
+          ${cfg.package}/bin/mtr-exporter \
+            -mtr '${cfg.mtrPackage}/bin/mtr' \
+            -bind ${escapeShellArg "${cfg.address}:${toString cfg.port}"} \
+            -jobs '${jobsConfig}' \
+            ${escapeShellArgs cfg.extraFlags}
+        '';
         Restart = "on-failure";
         # Hardening
         CapabilityBoundingSet = [ "" ];


### PR DESCRIPTION
## Description of changes

This ability has been added in `0.3.0` release:
* https://github.com/mgumz/mtr-exporter/releases/tag/0.3.0
* https://github.com/NixOS/nixpkgs/pull/252667

To achieve this a config file is generated and symlinked at `/etc/mtr-exporter.conf`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).