### PR TITLE
nixos/systemd: ensure PATH is not clobbered for dropin service units

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -317,16 +317,19 @@ in rec {
     config.environment.PATH = mkIf (config.path != []) "${makeBinPath config.path}:${makeSearchPathOutput "bin" "sbin" config.path}";
   };
 
-  stage2ServiceConfig = {
+  stage2ServiceConfig = { config, ... }: {
     imports = [ serviceConfig ];
-    # Default path for systemd services. Should be quite minimal.
-    config.path = mkAfter [
-      pkgs.coreutils
-      pkgs.findutils
-      pkgs.gnugrep
-      pkgs.gnused
-      systemd
-    ];
+    # Default path for regular systemd services. Should be quite minimal.
+    # Ensure we don't clobber PATH for dropin service units
+    config = mkIf (config.overrideStrategy != "asDropin") {
+      path = mkAfter [
+        pkgs.coreutils
+        pkgs.findutils
+        pkgs.gnugrep
+        pkgs.gnused
+        systemd
+      ];
+    };
   };
 
   stage1ServiceConfig = serviceConfig;

--- a/nixos/tests/systemd-as-dropin.nix
+++ b/nixos/tests/systemd-as-dropin.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+{
+  name = "systemd-as-dropin";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ aanderse ];
+  };
+
+  nodes.machine = { pkgs, lib, ... }: lib.mkMerge [
+    {
+      systemd.services."foo@" = {
+        path = [ pkgs.hello ];
+        serviceConfig.Type = "oneshot";
+        scriptArgs = "%i";
+        script = ''
+          hello -g "Hello, $1!"
+        '';
+      };
+    }
+
+    {
+      systemd.services."foo@bar" = {
+        overrideStrategy = "asDropin";
+      };
+    }
+  ];
+
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # Ensure PATH is not clobbered for dropin service units
+    machine.succeed("systemctl start foo@bar.service")
+    machine.succeed("systemctl show foo@bar.service | grep Environment | grep ${pkgs.hello}")
+  '';
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

resolves https://github.com/NixOS/nixpkgs/issues/219013 by making our `systemd` module respect and follow upstream behavior

worth noting is that the following scenario will now be problematic:

```
{ config, pkgs, lib, ... }:
{
  # pkgs.foo includes etc/systemd/system/foo@.service which has Environment=PATH=/nix/store/....-hello/bin in it
  systemd.packages = [ pkgs.foo ];

  # foo@bar.service could fail now because hello won't be in PATH anymore
  systemd.services."foo@bar".overrideStrategy = "asDropin";
}
```

This is resolved by explicitly declaring the dependency via `systemd.services."foo@bar".path = [ pkgs.hello ];`, analogous to what you would have to do if you were on any non NixOS-systemd-based distro.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
