### PR TITLE
nixos/nginx: add `application/javascript` to `compressMimeTypes`

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -35,6 +35,7 @@ let
   compressMimeTypes = [
     "application/atom+xml"
     "application/geo+json"
+    "application/javascript" # Deprecated by IETF RFC 9239, but still widely used
     "application/json"
     "application/ld+json"
     "application/manifest+json"


### PR DESCRIPTION
#### Copy of commit msg
Although deprecated, this MIME type is still used by various applications and web frameworks which are potentially proxied by nginx.

Examples:
- [Nginx itself](https://hg.nginx.org/nginx/file/tip/conf/mime.types) (thanks @xfix)
- Apps based on ASP.NET Core
- Apps based on http.server (Python)
- https://nixos.org and https://github.com serve all JS as `application/javascript`