### PR TITLE
lesspipe: validate and add script dependencies

### DIFF
--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -1,4 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, perl, procps, file, gnused, bash, binutils }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, perl
+, procps
+, bash
+
+# shell referenced dependencies
+, resholve
+, binutils-unwrapped
+, file
+, gnugrep
+, coreutils
+, gnused
+, gnutar
+, iconv
+, ncurses
+}:
 
 stdenv.mkDerivation rec {
   pname = "lesspipe";
@@ -28,9 +46,65 @@ stdenv.mkDerivation rec {
   installFlags = [ "DESTDIR=$(out)" ];
 
   postInstall = ''
-    for f in lesspipe.sh lesscomplete; do
-      wrapProgram "$out/bin/$f" --prefix-each PATH : "${lib.makeBinPath [ binutils file gnused procps ]}"
-    done
+    # resholve doesn't see strings in an array definition
+    substituteInPlace $out/bin/lesspipe.sh --replace 'nodash strings' "nodash ${binutils-unwrapped}/bin/strings"
+
+    ${resholve.phraseSolution "lesspipe.sh" {
+      scripts = [ "bin/lesspipe.sh" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = [
+        coreutils
+        file
+        gnugrep
+        gnused
+        gnutar
+        iconv
+        procps
+        ncurses
+      ];
+      keep = [ "$prog" "$c1" "$c2" "$c3" "$c4" "$c5" "$cmd" "$colorizer" "$HOME" ];
+      fake = {
+        # script guards usage behind has_cmd test function, it's safe to leave these external and optional
+        external = [
+          "cpio" "isoinfo" "cabextract" "bsdtar" "rpm2cpio" "bsdtar" "unzip" "ar" "unrar" "rar" "7zr" "7za" "isoinfo"
+          "gzip" "bzip2" "lzip" "lzma" "xz" "brotli" "compress" "zstd" "lz4"
+          "archive_color" "bat" "batcat" "pygmentize" "source-highlight" "vimcolor" "code2color"
+
+          "w3m" "lynx" "elinks" "html2text" "dtc" "pdftotext" "pdftohtml" "pdfinfo" "ps2ascii" "procyon" "ccze"
+          "mdcat" "pandoc" "docx2txt" "libreoffice" "pptx2md" "mdcat" "xlscat" "odt2txt" "wvText" "antiword" "catdoc"
+          "broken_catppt" "sxw2txt" "groff" "mandoc" "unrtf" "dvi2tty" "pod2text" "perldoc" "h5dump" "ncdump" "matdump"
+          "djvutxt" "openssl" "gpg" "plistutil" "plutil" "id3v2" "csvlook" "jq" "zlib-flate" "lessfilter"
+        ] ++ lib.optional stdenv.isDarwin [
+          # resholve only identifies this on darwin
+          # call site is gaurded by || so it's safe to leave dynamic
+          "locale"
+        ];
+        builtin = [ "setopt" ];
+      };
+      execer = [
+        "cannot:${iconv}/bin/iconv"
+      ];
+    }}
+    ${resholve.phraseSolution "lesscomplete" {
+      scripts = [ "bin/lesscomplete" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = [
+        coreutils
+        file
+        gnugrep
+        gnused
+        gnutar
+      ];
+      keep = [ "$prog" "$c1" "$c2" "$c3" "$c4" "$c5" "$cmd" ];
+      fake = {
+        # script guards usage behind has_cmd test function, it's safe to leave these external and optional
+        external = [
+          "cpio" "isoinfo" "cabextract" "bsdtar" "rpm2cpio" "bsdtar" "unzip" "ar" "unrar" "rar" "7zr" "7za" "isoinfo"
+          "gzip" "bzip2" "lzip" "lzma" "xz" "brotli" "compress" "zstd" "lz4"
+        ];
+        builtin = [ "setopt" ];
+      };
+    }}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Default `less` generates an warning looking for `strings` in nixos when opening certain files. This happens because less reads `LESSOPEN` environment variable and invokes `lesspipe` which expects [many things](https://github.com/wofr06/lesspipe#3-required-programs) to be available on the `PATH`. The less module defines a default value for the [LESSOPEN](https://github.com/NixOS/nixpkgs/blob/964006733a3380811d2e6c5870a8dc42f681429f/nixos/modules/programs/less.nix#L95) environment variable. The [environment.nix](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/environment.nix#L29) file enables the less module by default. `lesspipe` references `strings` [here](https://github.com/wofr06/lesspipe/blob/lesspipe/lesspipe.sh#L597).

Use resholve to wrap `lesspipe.sh` and `lesscomplete` mostly avoiding accident external references and replace reference to `strings` manually as it's inside an array. 

fixes #216087

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
