### PR TITLE
mpvScripts.mpv-slicing: init at 0-unstable-2017-11-25

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -75,6 +75,7 @@ let
     mpv-cheatsheet = callPackage ./mpv-cheatsheet.nix { };
     mpv-osc-modern = callPackage ./mpv-osc-modern.nix { };
     mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };
+    mpv-slicing = callPackage ./mpv-slicing.nix { };
     mpv-webm = callPackage ./mpv-webm.nix { };
     mpvacious = callPackage ./mpvacious.nix { };
     quack = callPackage ./quack.nix { };

--- a/pkgs/applications/video/mpv/scripts/mpv-slicing.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-slicing.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  ffmpeg,
+}:
+
+buildLua {
+  pname = "mpv-slicing";
+  version = "0-unstable-2017-11-25";
+
+  src = fetchFromGitHub {
+    owner = "Kagami";
+    repo = "mpv_slicing";
+    rev = "d09c11227704c8d5bdaa2c799ef64dce881c63a7";
+    hash = "sha256-MKoM0f74/XoctiHQVOB3LzFWtJXpsREfQh5icaebCJo=";
+  };
+
+  postPatch = ''
+    substituteInPlace slicing.lua \
+        --replace-fail ffmpeg ${lib.getExe ffmpeg}
+  '';
+
+  passthru.scriptName = "slicing.lua";
+
+  meta = {
+    description = "A lua script to cut fragments of the video in uncompressed RGB format";
+    homepage = "https://github.com/Kagami/mpv_slicing";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/254308

This PR adds 1 package: `mpvScripts.mpv-slicing`

It seemed to work with a random `.mp4` video.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
