### PR TITLE
stage-2: don't write to /dev/kmsg if booting in container

### DIFF
--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -54,7 +54,7 @@ if [ ! -e /proc/1 ]; then
 fi
 
 
-if [ "${IN_NIXOS_SYSTEMD_STAGE1:-}" = true ]; then
+if [ "${IN_NIXOS_SYSTEMD_STAGE1:-}" = true ] || [ ! -c /dev/kmsg ] ; then
     echo "booting system configuration ${systemConfig}"
 else
     echo "booting system configuration $systemConfig" > /dev/kmsg


### PR DESCRIPTION
## Description of changes

Affecting lxc / podman / docker / nixos containers, `/dev/kmsg` is not available, it gets mistakenly created which brakes `dmesg` and most likely some other things.

## Steps to reproduce on LXD

Setup lxd, use provided flake.nix to generate the image and import it into lxd daemon.

<details>
  <summary>flake.nix</summary>
   
```
{
  description = "lxd bootstrap";

  inputs = {
    nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
  };

  outputs = { self, nixpkgs }:
    let
      LXDBootstrap = nixpkgs.lib.nixosSystem {
        system = "x86_64-linux";
        modules = [
          "${nixpkgs}/nixos/maintainers/scripts/lxd/lxd-container-image.nix"
        ];
      };
    in
    {
      tarball = LXDBootstrap.config.system.build.tarball;
      metadata = LXDBootstrap.config.system.build.metadata;
    };
}
```
</details>

```
lxc image import --alias nixos $(nix build --print-out-paths .\#metadata)/tarball/nixos-system-x86_64-linux.tar.xz $(nix build --print-out-paths .\#tarball)/tarball/nixos-system-x86_64-linux.tar.xz
```
* launch t1 nixos container

```
$ lxc launch nixos t1 -c security.nesting=true
Creating t1
Starting t1
```

* run `dmesg` 

```
$ lxc exec t1 /run/current-system/sw/bin/bash
[root@nixos:~]# dmesg


[root@nixos:~]#
```
Which gives empty output

Let's try running it with `strace`:

```
[root@nixos:~]# strace dmesg
...
openat(AT_FDCWD, "/dev/kmsg", O_RDONLY|O_NONBLOCK) = 3
...
```

Now it gets weird:
```
[root@nixos:~]# ls -la /dev/kmsg
-rw-r--r-- 1 root root 143 Sep 11 07:29 /dev/kmsg

[root@nixos:~]# cat /dev/kmsg
<46>systemd-journald[175]: Collecting audit messages is disabled.
<46>systemd-journald[175]: Received client request to flush runtime journal.
```
There is some garbage piling up inside which brakes `dmesg`. If this file is removed `dmesg` will start working normally.

For the reference I've checked the ubuntu image, there is no `/dev/kmesg` device available in lxd containers.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
