### PR TITLE
kega-fusion: add missing libGL dependency

### DIFF
--- a/pkgs/applications/emulators/kega-fusion/default.nix
+++ b/pkgs/applications/emulators/kega-fusion/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, writeText, fetchurl, upx, libGLU, glib, gtk2, alsa-lib, libSM, libX11, gdk-pixbuf, pango, libXinerama, mpg123, runtimeShell }:
+{ stdenv, lib, writeText, fetchurl, upx, libGL, libGLU, glib, gtk2, alsa-lib, libSM, libX11, gdk-pixbuf, pango, libXinerama, mpg123, runtimeShell }:
 
 let
-  libPath = lib.makeLibraryPath [ stdenv.cc.cc libGLU glib gtk2 alsa-lib libSM libX11 gdk-pixbuf pango libXinerama ];
+  libPath = lib.makeLibraryPath [ stdenv.cc.cc libGL libGLU glib gtk2 alsa-lib libSM libX11 gdk-pixbuf pango libXinerama ];
 
 in stdenv.mkDerivation {
   pname = "kega-fusion";


### PR DESCRIPTION
## Description of changes

Adds libGL to the library path that's patched into the `Fusion` executable. Without this dependency, starting kega-fusion would fail with:

```
.../lib/kega-fusion/Fusion: error while loading shared libraries: libGL.so.1: cannot open shared object file: No such file or directory
```

Fixes #231028

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - ~~x86_64-darwin~~
  - ~~aarch64-darwin~~
- ~~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
- ~~Tested, as applicable:~~
  - ~~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
  - ~~and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~~
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - ~~(Module updates) Added a release notes entry if the change is significant~~
  - ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).