### PR TITLE
schismtracker: 20220506 -> 20230906

### DIFF
--- a/pkgs/applications/audio/schismtracker/default.nix
+++ b/pkgs/applications/audio/schismtracker/default.nix
@@ -4,18 +4,20 @@
 , autoreconfHook
 , alsa-lib
 , python3
-, SDL
+, SDL2
+, libXext
+, Cocoa
 }:
 
 stdenv.mkDerivation rec {
   pname = "schismtracker";
-  version = "20220506";
+  version = "20230906";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-fK0FBn9e7l1Y/A7taFlaoas6ZPREFhEmskVBqjda6q0=";
+    sha256 = "sha256-eW1sqfcAR3lutSyQKj7j1elkFTa8jfZqgrJYYAzMlzo=";
   };
 
   configureFlags = [ "--enable-dependency-tracking" ]
@@ -23,9 +25,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook python3 ];
 
-  buildInputs = [ SDL ] ++ lib.optional stdenv.isLinux alsa-lib;
+  buildInputs = [ SDL2 ]
+    ++ lib.optionals stdenv.isLinux [ alsa-lib libXext ]
+    ++ lib.optionals stdenv.isDarwin [ Cocoa ];
 
   enableParallelBuilding = true;
+
+  # Our Darwin SDL2 doesn't have a SDL2main to link against
+  preConfigure = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace configure.ac \
+      --replace '-lSDL2main' '-lSDL2'
+  '';
 
   meta = with lib; {
     description = "Music tracker application, free reimplementation of Impulse Tracker";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30726,7 +30726,9 @@ with pkgs;
 
   ptcollab = libsForQt5.callPackage ../applications/audio/ptcollab { };
 
-  schismtracker = callPackage ../applications/audio/schismtracker { };
+  schismtracker = callPackage ../applications/audio/schismtracker {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   jnetmap = callPackage ../applications/networking/jnetmap { };
 


### PR DESCRIPTION
## Description of changes

Since the last version bump, schismtracker has migrated from SDL1 to SDL2. This is a change that improves audio options, video output quality, and allows mouse/keyboard capture under wayland. There's also various other fixes and improvements listed under https://github.com/schismtracker/schismtracker/releases , and an out-of-bounds memory access was fixed in some common rendering code that isn't mentioned in the release notes.

~~I don't have any macOS hardware to test darwin on, but schismtracker has working macOS CI, so I'm reasonably confident it'll work there too.~~ lol, lmao. were it so easy

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
