### PR TITLE
Revert "[Backport release-23.05] linux: fix hash for 6.5.2"

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-6.5.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.5.nix
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-    hash = "sha256-ICfhQFfVaK093BANrfTIhTpJsDEnBHimHYj2ARVyZQ8=";
+    hash = "sha256-I3Zd1EQlRizZKtvuUmcGCP1/P9GDqDslunp7SIPQRRs=";
   };
 } // (args.argsOverride or { }))


### PR DESCRIPTION
Reverts NixOS/nixpkgs#254413

This shouldn't have been merged before #254360