### PR TITLE
ocamlPackages.pp_loc: init at 2.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/pp_loc/default.nix
+++ b/pkgs/development/ocaml-modules/pp_loc/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchurl, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "pp_loc";
+  version = "2.1.0";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/Armael/pp_loc/releases/download/v${version}/pp_loc-${version}.tbz";
+    hash = "sha256-L3NlBdQx6BpP6FGtMQ/ynsTNIMj9N+8FDZ5vEFC6p8s=";
+  };
+
+  doCheck = true;
+
+  meta = {
+    description = "Quote and highlight input fragments at a given source location";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+    homepage = "https://armael.github.io/pp_loc/pp_loc/";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1438,6 +1438,8 @@ let
 
     pp = callPackage ../development/ocaml-modules/pp { };
 
+    pp_loc = callPackage ../development/ocaml-modules/pp_loc { };
+
     pprint = callPackage ../development/ocaml-modules/pprint { };
 
     ppx_bap = janeStreet_0_15.ppx_bap;


### PR DESCRIPTION
## Description of changes

> This library provides support to additionally quote and highlight the input fragment the input that corresponds to a location (or a set of locations).

https://github.com/Armael/pp_loc

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
