### PR TITLE
foonathan-memory: init at 0.7-3

### DIFF
--- a/pkgs/by-name/fo/foonathan-memory/package.nix
+++ b/pkgs/by-name/fo/foonathan-memory/package.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, doctest
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "foonathan-memory";
+  version = "0.7-3";
+
+  src = fetchFromGitHub {
+    owner = "foonathan";
+    repo = "memory";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-nLBnxPbPKiLCFF2TJgD/eJKJJfzktVBW3SRW2m3WK/s=";
+  };
+
+  patches = [
+    # do not download doctest, use the system doctest instead
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/f/foonathan-memory/0.7.3-2/debian/patches/0001-Use-system-doctest.patch";
+      hash = "sha256-/MuDeeIh+7osz11VfsAsQzm9HMZuifff+MDU3bDDxRE=";
+    })
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "FOONATHAN_MEMORY_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = true;
+
+  checkInputs = [ doctest ];
+
+  # fix a circular dependency between "out" and "dev" outputs
+  postInstall = ''
+    mkdir -p $dev/lib
+    mv $out/lib/foonathan_memory $dev/lib/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/foonathan/memory";
+    changelog = "https://github.com/foonathan/memory/releases/tag/${finalAttrs.src.rev}";
+    description = "STL compatible C++ memory allocator library";
+
+    longDescription = ''
+      The C++ STL allocator model has various flaws. For example, they are
+      fixed to a certain type, because they are almost necessarily required to
+      be templates. So you can't easily share a single allocator for multiple
+      types. In addition, you can only get a copy from the containers and not
+      the original allocator object. At least with C++11 they are allowed to be
+      stateful and so can be made object not instance based. But still, the
+      model has many flaws. Over the course of the years many solutions have
+      been proposed, for example EASTL. This library is another. But instead of
+      trying to change the STL, it works with the current implementation.
+    '';
+
+    license = licenses.zlib;
+    maintainers = with maintainers; [ panicgh ];
+    platforms = with platforms; unix ++ windows;
+  };
+})


### PR DESCRIPTION
## Description of changes

https://github.com/foonathan/memory

STL compatible C++ memory allocator library.

This package in other distros: https://repology.org/project/foonathan-memory/versions

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).