### PR TITLE
python3.pkgs.pypaBuildHook: fix conflicts via propagated inputs

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -66,7 +66,19 @@ in {
   pypaBuildHook = callPackage ({ makePythonHook, build, wheel }:
     makePythonHook {
       name = "pypa-build-hook.sh";
-      propagatedBuildInputs = [ build wheel ];
+      propagatedBuildInputs = [ wheel ];
+      substitutions = {
+        inherit build;
+      };
+      # A test to ensure that this hook never propagates any of its dependencies
+      #   into the build environment.
+      # This prevents false positive alerts raised by catchConflictsHook.
+      # Such conflicts don't happen within the standard nixpkgs python package
+      #   set, but in downstream projects that build packages depending on other
+      #   versions of this hook's dependencies.
+      passthru.tests = import ./pypa-build-hook-tests.nix {
+        inherit pythonForBuild runCommand;
+      };
     } ./pypa-build-hook.sh) {
       inherit (pythonForBuild.pkgs) build;
     };

--- a/pkgs/development/interpreters/python/hooks/pypa-build-hook-test.nix
+++ b/pkgs/development/interpreters/python/hooks/pypa-build-hook-test.nix
@@ -1,0 +1,32 @@
+{ pythonForBuild, runCommand }: {
+  dont-propagate-conflicting-deps = let
+    # customize a package so that its store paths differs
+    mkConflict = pkg: pkg.overrideAttrs { some_modification = true; };
+    # minimal pyproject.toml for the example project
+    pyprojectToml = builtins.toFile "pyproject.toml" ''
+      [project]
+      name = "my-project"
+      version = "1.0.0"
+    '';
+    # the source of the example project
+    projectSource = runCommand "my-project-source" {} ''
+      mkdir -p $out/src
+      cp ${pyprojectToml} $out/pyproject.toml
+      touch $out/src/__init__.py
+    '';
+    in
+    # this build must never triger conflicts
+    pythonForBuild.pkgs.buildPythonPackage {
+      pname = "dont-propagate-conflicting-deps";
+      version = "0.0.0";
+      src = projectSource;
+      format = "pyproject";
+      propagatedBuildInputs = [
+        # At least one dependency of `build` should be included here to
+        # keep the test meaningful
+        (mkConflict pythonForBuild.pkgs.tomli)
+        # setuptools is also needed to build the example project
+        pythonForBuild.pkgs.setuptools
+      ];
+    };
+}

--- a/pkgs/development/interpreters/python/hooks/pypa-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pypa-build-hook.sh
@@ -6,7 +6,7 @@ pypaBuildPhase() {
     runHook preBuild
 
     echo "Creating a wheel..."
-    pyproject-build --no-isolation --outdir dist/ --wheel $pypaBuildFlags
+    @build@/bin/pyproject-build --no-isolation --outdir dist/ --wheel $pypaBuildFlags
     echo "Finished creating a wheel..."
 
     runHook postBuild


### PR DESCRIPTION
## Description of changes

This modifies the pypaBuildHook to not propagate its own python dependencies into the build environment. This prevents package conflicts in downstream projects whenever a package is built against other versions of the dependencies of the hook.

This problem was likely introduced by https://github.com/NixOS/nixpkgs/pull/248866

Done:
- modify pypa-build-hook.sh to call pyproject-build via an absolute path. This removes the need of putting the dependencies inside the hook's propagatedBuildInputs
- remove the hook's dependencies from propagatedBuildInputs
- add a passthru test to the hook testing for the fix

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
