### PR TITLE
python3Packages.pyopenssl: fix `postPatch`

### DIFF
--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     # remove cryptography pin
-    sed "/cryptography/ s/,<[0-9]*//g" setup.py
+    sed -i "/cryptography/ s/,<[0-9]*//g" setup.py
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
#### Copy of commit msg
Add `-i` so that `sed` writes its output to the file.
Previously, the `sed` command was a no-op.`

### Discussion
This patch is currently not needed because the `cryptography` version in
nixpkgs matches the requirements, but it might be useful in the future.

cc @SuperSandro2000