### PR TITLE
mariadb_104: remove

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -6,7 +6,7 @@ let
     # Native buildInputs components
     , bison, boost, cmake, fixDarwinDylibNames, flex, makeWrapper, pkg-config
     # Common components
-    , curl, libiconv, ncurses, openssl, openssl_1_1, pcre, pcre2
+    , curl, libiconv, ncurses, openssl, pcre2
     , libkrb5, libaio, liburing, systemd
     , CoreServices, cctools, perl
     , jemalloc, less, libedit
@@ -44,14 +44,13 @@ let
 
       buildInputs = [
         libiconv ncurses zlib
+        pcre2
+        openssl
+        curl
       ] ++ lib.optionals stdenv.hostPlatform.isLinux ([ libkrb5 systemd ]
         ++ (if (lib.versionOlder version "10.6") then [ libaio ] else [ liburing ]))
         ++ lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices cctools perl libedit ]
-        ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ jemalloc ]
-        ++ (if (lib.versionOlder version "10.5") then [ pcre ] else [ pcre2 ])
-        ++ (if (lib.versionOlder version "10.5")
-            then [ openssl_1_1 (curl.override { openssl = openssl_1_1; }) ]
-            else [ openssl curl ]);
+        ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ jemalloc ];
 
       prePatch = ''
         sed -i 's,[^"]*/var/log,/var/log,g' storage/mroonga/vendor/groonga/CMakeLists.txt
@@ -244,13 +243,6 @@ let
 in
   self: {
     # see https://mariadb.org/about/#maintenance-policy for EOLs
-    mariadb_104 = self.callPackage generic {
-      # Supported until 2024-06-18
-      version = "10.4.31";
-      hash = "sha256-Uqv1Q0xqQuCgSKY6uZo4mPt/yhWA+t16Yb0OnOm4UFQ=";
-      inherit (self.darwin) cctools;
-      inherit (self.darwin.apple_sdk.frameworks) CoreServices;
-    };
     mariadb_105 = self.callPackage generic {
       # Supported until 2025-06-24
       version = "10.5.22";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1083,6 +1083,7 @@ mapAliases ({
   manul = throw "manul has been dropped due to the lack of maintenance from upstream since 2018"; # Added 2022-06-01
   manpages = throw "'manpages' has been renamed to/replaced by 'man-pages'"; # Converted to throw 2022-02-22
   marathon = throw "marathon has been removed from nixpkgs, as it's unmaintained"; # Added 2020-08-15
+  mariadb_104 = throw "mariadb_104 has been removed from nixpkgs, please switch to another version like mariadb_106"; # Added 2023-09-11
   mariadb_108 = throw "mariadb_108 has been removed from nixpkgs, please switch to another version like mariadb_1010"; # Added 2022-05-10
   mariadb_109 = throw "mariadb_109 has been removed from nixpkgs, please switch to another version like mariadb_1010"; # Added 2022-05-10
   mariadb-client = hiPrio mariadb.client; #added 2019.07.28

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27105,7 +27105,6 @@ with pkgs;
   mariadb-galera = callPackage ../servers/sql/mariadb/galera { };
 
   inherit (import ../servers/sql/mariadb pkgs)
-    mariadb_104
     mariadb_105
     mariadb_106
     mariadb_1010


### PR DESCRIPTION
## Description of changes
depends on openssl_1_1, which is EOL

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).