### PR TITLE
translatelocally: 2023-08-25 -> 2023-09-14, fix aarch64-linux build

### DIFF
--- a/pkgs/applications/misc/translatelocally/default.nix
+++ b/pkgs/applications/misc/translatelocally/default.nix
@@ -3,17 +3,17 @@
 }:
 
 let
-  rev = "f8a2dba0a63989c6b3a7be36f736ed478cad1dd2";
+  rev = "cda79ea026b40ad2b633f16493cdcf12d5220959";
 
 in stdenv.mkDerivation (finalAttrs: {
   pname = "translatelocally";
-  version = "unstable-2023-08-25";
+  version = "unstable-2023-09-14";
 
   src = fetchFromGitHub {
     owner = "XapaJIaMnu";
     repo = "translateLocally";
     inherit rev;
-    hash = "sha256-uUdDi0CwCR/FQjw5D2s088d/Tp7NQOI0ia30oOhlGoc=";
+    hash = "sha256-EHTPoXDYCSDNPWKzEarOYHGdOSiSnWqpa0kyT6jkNSI=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/misc/translatelocally/default.nix
+++ b/pkgs/applications/misc/translatelocally/default.nix
@@ -26,6 +26,11 @@ in stdenv.mkDerivation (finalAttrs: {
       3rd_party/bergamot-translator/3rd_party/marian-dev/src/common/git_revision.h
   '';
 
+  # https://github.com/XapaJIaMnu/translateLocally/blob/81ed8b9/.github/workflows/build.yml#L330
+  postConfigure = lib.optionalString stdenv.isAarch64 ''
+    bash /build/source/cmake/fix_ruy_build.sh /build/source /build/source/build
+  '';
+
   nativeBuildInputs = [
     cmake
     protobuf
@@ -55,8 +60,5 @@ in stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     maintainers = with maintainers; [ pacien ];
     platforms = platforms.linux;
-
-    # https://github.com/XapaJIaMnu/translateLocally/issues/150
-    broken = stdenv.isAarch64;
   };
 })


### PR DESCRIPTION

## Description of changes

This updates the package to the latest version,
and fixes build for aarch64.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

