### PR TITLE
xorg: add meta.mainProgram to various utilities

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -18,6 +18,10 @@ let
     (stdenv.hostPlatform != stdenv.buildPlatform)
     "--enable-malloc0returnsnull";
 
+  addMainProgram = pkg: { mainProgram ? pkg.pname }: pkg.overrideAttrs (attrs: {
+    meta = attrs.meta // { inherit mainProgram; };
+  });
+
   brokenOnDarwin = pkg: pkg.overrideAttrs (attrs: {
     meta = attrs.meta // { broken = isDarwin; };
   });
@@ -42,12 +46,18 @@ self: super:
       postInstallHooks+=(wrapWithXFileSearchPath)
   '')) {};
 
+  appres = addMainProgram super.appres { };
+
   bdftopcf = super.bdftopcf.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [ xorg.xorgproto ];
+    meta = attrs.meta // { mainProgram = "bdftopcf"; };
   });
+
+  bitmap = addMainProgram super.bitmap { };
 
   editres = super.editres.overrideAttrs (attrs: {
     hardeningDisable = [ "format" ];
+    meta = attrs.meta // { mainProgram = "editres"; };
   });
 
   fontmiscmisc = super.fontmiscmisc.overrideAttrs (attrs: {
@@ -60,8 +70,15 @@ self: super:
   });
 
   fonttosfnt = super.fonttosfnt.overrideAttrs (attrs: {
-    meta = attrs.meta // { license = lib.licenses.mit; };
+    meta = attrs.meta // {
+      license = lib.licenses.mit;
+      mainProgram = "fonttosfnt";
+    };
   });
+
+  gccmakedep = addMainProgram super.gccmakedep { };
+  iceauth = addMainProgram super.iceauth { };
+  ico = addMainProgram super.ico { };
 
   imake = super.imake.overrideAttrs (attrs: {
     inherit (xorg) xorgcffiles;
@@ -75,6 +92,8 @@ self: super:
     configureFlags = attrs.configureFlags or [] ++ [ "ac_cv_path_RAWCPP=${stdenv.cc.targetPrefix}cpp" ];
 
     inherit tradcpp;
+
+    meta = attrs.meta // { mainProgram = "imake"; };
   });
 
   mkfontdir = xorg.mkfontscale;
@@ -115,6 +134,8 @@ self: super:
       platforms = lib.platforms.unix ++ lib.platforms.windows;
     };
   });
+
+  libxcvt = addMainProgram super.libxcvt { mainProgram = "cvt"; };
 
   libX11 = super.libX11.overrideAttrs (attrs: {
     outputs = [ "out" "dev" "man" ];
@@ -193,6 +214,9 @@ self: super:
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
   });
+
+  listres = addMainProgram super.listres { };
+
   xdpyinfo = super.xdpyinfo.overrideAttrs (attrs: {
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
@@ -213,6 +237,7 @@ self: super:
     ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
       # checking for /dev/urandom... configure: error: cannot check for file existence when cross compiling
       [ "ac_cv_file__dev_urandom=true" "ac_cv_file__dev_random=true" ];
+    meta = attrs.meta // { mainProgram = "xdm"; };
   });
 
   # Propagate some build inputs because of header file dependencies.
@@ -237,6 +262,7 @@ self: super:
     configureFlags = [ "--disable-selective-werror" ];
 
     buildInputs = attrs.buildInputs ++ [libiconv];
+    meta = attrs.meta // { mainProgram = "luit"; };
   });
 
   libICE = super.libICE.overrideAttrs (attrs: {
@@ -359,6 +385,7 @@ self: super:
     outputs = [ "bin" "dev" "out" ]; # tiny man in $bin
     patchPhase = "sed -i '/USE_GETTEXT_TRUE/d' sxpm/Makefile.in cxpm/Makefile.in";
     XPM_PATH_COMPRESS = lib.makeBinPath [ ncompress ];
+    meta = attrs.meta // { mainProgram = "sxpm"; };
   });
 
   libXpresent = super.libXpresent.overrideAttrs (attrs: {
@@ -402,15 +429,27 @@ self: super:
         ln -sfn ${xorg.xkeyboardconfig}/etc/X11 $out/share/X11
         ln -sfn ${xorg.xkeyboardconfig}/share/man/man7/xkeyboard-config.7.gz $out/share/man/man7
       '';
+    meta = attrs.meta // { mainProgram = "setxkbmap"; };
   });
+
+  makedepend = addMainProgram super.makedepend { };
+  mkfontscale = addMainProgram super.mkfontscale { };
+  oclock = addMainProgram super.oclock { };
+  smproxy = addMainProgram super.smproxy { };
+  transset = addMainProgram super.transset { };
 
   utilmacros = super.utilmacros.overrideAttrs (attrs: { # not needed for releases, we propagate the needed tools
     propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ automake autoconf libtool ];
   });
 
+  viewres = addMainProgram super.viewres { };
+
   x11perf = super.x11perf.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [ freetype fontconfig ];
+    meta = attrs.meta // { mainProgram = "x11perf"; };
   });
+
+  xcalc = addMainProgram super.xcalc { };
 
   xcbutil = super.xcbutil.overrideAttrs (attrs: {
     outputs = [ "out" "dev" ];
@@ -579,14 +618,20 @@ self: super:
 
   xdriinfo = super.xdriinfo.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [libGL];
+    meta = attrs.meta // { mainProgram = "xdriinfo"; };
   });
+
+  xev = addMainProgram super.xev { };
+  xeyes = addMainProgram super.xeyes { };
 
   xvinfo = super.xvinfo.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [xorg.libXext];
+    meta = attrs.meta // { mainProgram = "xvinfo"; };
   });
 
   xkbcomp = super.xkbcomp.overrideAttrs (attrs: {
     configureFlags = [ "--with-xkb-config-root=${xorg.xkeyboardconfig}/share/X11/xkb" ];
+    meta = attrs.meta // { mainProgram = "xkbcomp"; };
   });
 
   xkeyboardconfig = super.xkeyboardconfig.overrideAttrs (attrs: {
@@ -670,7 +715,10 @@ self: super:
     });
 
   xlsfonts = super.xlsfonts.overrideAttrs (attrs: {
-    meta = attrs.meta // { license = lib.licenses.mit; };
+    meta = attrs.meta // {
+      license = lib.licenses.mit;
+      mainProgram = "xlsfonts";
+    };
   });
 
   xorgproto = super.xorgproto.overrideAttrs (attrs: {
@@ -704,6 +752,7 @@ self: super:
                 sed -i -e "s|#include <drm_fourcc.h>|#include <libdrm/drm_fourcc.h>|" $i
               done
             '';
+            meta = attrs_passed.meta // { mainProgram = "X"; };
           }
         else throw "unsupported xorg abiCompat ${abiCompat} for ${attrs_passed.name}";
 
@@ -870,11 +919,12 @@ self: super:
         --replace '_X_NORETURN' '__attribute__((noreturn))' \
         --replace 'n_dirs--;' ""
     '';
-    meta.mainProgram = "lndir";
+    meta = attrs.meta // { mainProgram = "lndir"; };
   });
 
   twm = super.twm.overrideAttrs (attrs: {
     nativeBuildInputs = attrs.nativeBuildInputs ++ [bison flex];
+    meta = attrs.meta // { mainProgram = "twm"; };
   });
 
   xauth = super.xauth.overrideAttrs (attrs: {
@@ -884,7 +934,15 @@ self: super:
     + lib.optionalString stdenv.hostPlatform.isStatic ''
       export NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK -lxcb -lXau -lXdmcp"
     '';
+    meta = attrs.meta // { mainProgram = "xauth"; };
   });
+
+  xbacklight = addMainProgram super.xbacklight { };
+  xclock = addMainProgram super.xclock { };
+  xcmsdb = addMainProgram super.xcmsdb { };
+  xcompmgr = addMainProgram super.xcompmgr { };
+  xconsole = addMainProgram super.xconsole { };
+  xcursorgen = addMainProgram super.xcursorgen { };
 
   xcursorthemes = super.xcursorthemes.overrideAttrs (attrs: {
     nativeBuildInputs = attrs.nativeBuildInputs ++ [ xorg.xcursorgen ];
@@ -915,6 +973,7 @@ self: super:
         --replace $out/etc/X11/xinit/xserverrc /etc/X11/xinit/xserverrc \
         --replace $out/etc/X11/xinit/xinitrc /etc/X11/xinit/xinitrc
     '';
+    meta = attrs.meta // { mainProgram = "xinit"; };
   });
 
   xf86videointel = super.xf86videointel.overrideAttrs (attrs: {
@@ -971,6 +1030,25 @@ self: super:
     ];
   });
 
+  xfd = addMainProgram super.xfd { };
+  xfontsel = addMainProgram super.xfontsel { };
+  xfs = addMainProgram super.xfs { };
+  xfsinfo = addMainProgram super.xfsinfo { };
+  xgamma = addMainProgram super.xgamma { };
+  xgc = addMainProgram super.xgc { };
+  xhost = addMainProgram super.xhost { };
+  xinput = addMainProgram super.xinput { };
+  xkbevd = addMainProgram super.xkbevd { };
+  xkbprint = addMainProgram super.xkbprint { };
+  xkill = addMainProgram super.xkill { };
+  xload = addMainProgram super.xload { };
+  xlsatoms = addMainProgram super.xlsatoms { };
+  xlsclients = addMainProgram super.xlsclients { };
+  xmag = addMainProgram super.xmag { };
+  xmessage = addMainProgram super.xmessage { };
+  xmodmap = addMainProgram super.xmodmap { };
+  xmore = addMainProgram super.xmore { };
+
   xorgcffiles = super.xorgcffiles.overrideAttrs (attrs: {
     postInstall = lib.optionalString stdenv.isDarwin ''
       substituteInPlace $out/lib/X11/config/darwin.cf --replace "/usr/bin/" ""
@@ -983,12 +1061,17 @@ self: super:
     postInstall = "mkdir $out/bin";
   });
 
+  xpr = addMainProgram super.xpr { };
+  xprop = addMainProgram super.xprop { };
+
   xrdb = super.xrdb.overrideAttrs (attrs: {
     configureFlags = [ "--with-cpp=${mcpp}/bin/mcpp" ];
+    meta = attrs.meta // { mainProgram = "xrdb"; };
   });
 
   sessreg = super.sessreg.overrideAttrs (attrs: {
     preBuild = "sed -i 's|gcc -E|gcc -E -P|' man/Makefile";
+    meta = attrs.meta // { mainProgram = "sessreg"; };
   });
 
   xrandr = super.xrandr.overrideAttrs (attrs: {
@@ -1000,11 +1083,14 @@ self: super:
     };
   });
 
-  xset = super.xset.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      mainProgram = "xset";
-    };
-  });
+  xrefresh = addMainProgram super.xrefresh { };
+  xset = addMainProgram super.xset { };
+  xsetroot = addMainProgram super.xsetroot { };
+  xsm = addMainProgram super.xsm { };
+  xstdcmap = addMainProgram super.xstdcmap { };
+  xwd = addMainProgram super.xwd { };
+  xwininfo = addMainProgram super.xwininfo { };
+  xwud = addMainProgram super.xwud { };
 
   # convert Type1 vector fonts to OpenType fonts
   fontbitstreamtype1 = super.fontbitstreamtype1.overrideAttrs (attrs: {


### PR DESCRIPTION
## Description of changes

Adds `meta.mainProgram` so that `lib.getExe` can be used with the various tools under `pkgs.xorg`. See #246386 for details.

Closes #249169

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
