### PR TITLE
nyxt: 3.6.0 -> 3.7.0

### DIFF
--- a/pkgs/applications/networking/browsers/nyxt/default.nix
+++ b/pkgs/applications/networking/browsers/nyxt/default.nix
@@ -3,7 +3,7 @@
 , glib, gdk-pixbuf, cairo
 , mailcap, pango, gtk3
 , glib-networking, gsettings-desktop-schemas
-, xclip, notify-osd, enchant
+, xclip, wl-clipboard, notify-osd, enchant
 }:
 
 stdenv.mkDerivation rec {
@@ -41,9 +41,8 @@ stdenv.mkDerivation rec {
       cp -f $src/assets/nyxt_''${i}x''${i}.png "$out/share/icons/hicolor/''${i}x''${i}/apps/nyxt.png"
     done
 
-    # Need to suffix PATH with xclip to be able to copy/paste in Nyxt even if xclip/xsel/wl-clipboard are not in the user's PATH
     mkdir -p $out/bin && makeWrapper $src/bin/nyxt $out/bin/nyxt \
-      --suffix PATH : ${lib.makeBinPath [ xclip ]} \
+      --prefix PATH : ${lib.makeBinPath [ xclip wl-clipboard ]} \
       --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${GST_PLUGIN_SYSTEM_PATH_1_0}" \
       --argv0 nyxt "''${gappsWrapperArgs[@]}"
   '';

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -218,18 +218,6 @@ let
     };
   };
 
-  cl-webkit2_3_5_9 = build-asdf-system {
-    inherit (super.cl-webkit2) pname systems nativeLibs lispLibs;
-    version = "3.5.9";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "joachifm";
-      repo = "cl-webkit";
-      rev = "3.5.9";
-      sha256 = "sha256-YJo5ahL6+HLeJrxFBuZZjuK3OfA6DnAu82vvXMsNBgI=";
-    };
-  };
-
   prompter = build-asdf-system {
     pname = "prompter";
     version = "0.1.0";
@@ -258,12 +246,12 @@ let
 
   nasdf = build-asdf-system {
     pname = "nasdf";
-    version = "20230524-git";
+    version = "20230911-git";
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "ntemplate";
-      rev = "51a884f388ec526c32914093fcad6bb2434e3c14";
-      sha256 = "sha256-bjQPkiHAxhjsHCnWpCGMsmQlGDJFGtQEdevnhK2k+kY=";
+      rev = "ab7a018f3a67a999c72710644b10b4545130c139";
+      sha256 = "sha256-fXGh0h6CXLoBgK1jRxkSNyQVAY1gvi4iyHQBuzueR5Y=";
     };
   };
 
@@ -370,7 +358,7 @@ let
 
   nyxt-gtk = build-asdf-system {
     pname = "nyxt";
-    version = "3.6.0";
+    version = "3.7.0";
 
     lispLibs = (with super; [
       alexandria
@@ -410,7 +398,6 @@ let
       spinneret
       slynk
       trivia
-      trivial-clipboard
       trivial-features
       trivial-garbage
       trivial-package-local-nicknames
@@ -418,9 +405,31 @@ let
       unix-opts
       cluffer
       cl-cffi-gtk
-      cl-gobject-introspection
       quri
       sqlite
+      # TODO: Remove these overrides after quicklisp updates past the June 2023 release
+      (trivial-clipboard.overrideAttrs (final: prev: {
+        src = pkgs.fetchFromGitHub {
+          owner = "snmsts";
+          repo = "trivial-clipboard";
+          rev = "6ddf8d5dff8f5c2102af7cd1a1751cbe6408377b";
+          sha256 = "sha256-n15IuTkqAAh2c1OfNbZfCAQJbH//QXeH0Bl1/5OpFRM=";
+        };}))
+      (cl-gobject-introspection.overrideAttrs (final: prev: {
+        src = pkgs.fetchFromGitHub {
+          owner = "andy128k";
+          repo = "cl-gobject-introspection";
+          rev = "83beec4492948b52aae4d4152200de5d5c7ac3e9";
+          sha256 = "sha256-g/FwWE+Rzmzm5Y+irvd1AJodbp6kPHJIFOFDPhaRlXc=";
+        };}))
+      (cl-webkit2.overrideAttrs (final: prev: {
+        src = pkgs.fetchFromGitHub {
+          owner = "joachifm";
+          repo = "cl-webkit";
+          rev = "66fd0700111586425c9942da1694b856fb15cf41";
+          sha256 = "sha256-t/B9CvQTekEEsM/ZEp47Mn6NeZaTYFsTdRqclfX9BNg=";
+        };
+      }))
     ]) ++ (with self; [
       history-tree
       nhooks
@@ -432,7 +441,6 @@ let
       nsymbols
       nclasses
       nfiles
-      cl-webkit2_3_5_9
       swank
       cl-containers
     ]);
@@ -440,8 +448,8 @@ let
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nyxt";
-      rev = "3.6.0";
-      sha256 = "sha256-DaPEKdYf5R+RS7VQzbdLSqZvEQfxjeGEdX8rwmHRLrY=";
+      rev = "3.7.0";
+      sha256 = "sha256-viiyO4fX3uyGuvojQ1rYYKBldRdVNzeJX1KYlYwfWVU=";
     };
 
     nativeBuildInputs = [ pkgs.makeWrapper ];


### PR DESCRIPTION
## Description of changes
Release notes since 3.6.0:
https://nyxt.atlas.engineer/article/release-3.7.0.org https://nyxt.atlas.engineer/article/release-3.6.1.org

Updated nyxt to version 3.7.0.

I also updated the dependencies which were updated in the upstream submodules, I opted to use `overrideAttrs` rather than making new attributes which have specific versions, I'm not sure if this is better, I can go back to using versioned attributes if it's better.

I added `wl-clipboard` to the wrapper for `nyxt` since with the update to `trivial-clipboard` it now works on both wayland and X11 has long as you have the clipboard utilities in your path (`xclip`, `wl-clipboard`, etc.), where before you could only have either X11 or wayland copy/paste. See: https://github.com/snmsts/trivial-clipboard/issues/16
I don't have a wayland setup so I couldn't test if it works correctly there, if someone could test it that would be appreciated, I tested on X11 and copy/paste works correctly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->



