### PR TITLE
cargo-rdme: init at 1.4.2

### DIFF
--- a/pkgs/by-name/ca/cargo-rdme/package.nix
+++ b/pkgs/by-name/ca/cargo-rdme/package.nix
@@ -1,0 +1,25 @@
+{ lib, rustPlatform, fetchCrate, stdenv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-rdme";
+  version = "1.4.2";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-ZveL/6iWxnEz13iHdTjDA4JT29CbvWjrIvblI65XuMM=";
+  };
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    Security
+  ];
+
+  cargoHash = "sha256-8srwz5p9NY+ymDpqSvG68oIHibSurdtrjBkG6TrZO70=";
+
+  meta = with lib; {
+    description = "Cargo command to create the README.md from your crate's documentation";
+    homepage = "https://github.com/orium/cargo-rdme";
+    changelog = "https://github.com/orium/cargo-rdme/blob/v${version}/release-notes.md";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ GoldsteinE ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17319,6 +17319,9 @@ with pkgs;
   cargo-raze = callPackage ../development/tools/rust/cargo-raze {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-rdme = callPackage ../by-name/ca/cargo-rdme/package.nix {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-readme = callPackage ../development/tools/rust/cargo-readme { };
   cargo-risczero = callPackage ../development/tools/rust/cargo-risczero { };
   cargo-run-bin = callPackage ../development/tools/rust/cargo-run-bin {};


### PR DESCRIPTION
## Description of changes

A new package, cargo-rdme. It generates `README.md` from the crate documentation. It’s more feature-full than already packaged `cargo-readme` (e.g. it has a `--check` option, allows inserting custom text above and below crate docs etc).

## Things done

- Built on platform(s)
  - [x] x86_64-linux (by me + in ofborg)
  - [x] aarch64-linux (in ofborg)
  - [x] x86_64-darwin (in ofborg)
  - [x] aarch64-darwin (in ofborg)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
