### PR TITLE
mathmod: init at 11.1-unstable-2024-01-26

### DIFF
--- a/pkgs/applications/science/math/mathmod/default.nix
+++ b/pkgs/applications/science/math/mathmod/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, qmake
+}:
+
+mkDerivation {
+  pname = "mathmod";
+  version = "11.1-unstable-2024-01-26";
+
+  src = fetchFromGitHub {
+    owner = "parisolab";
+    repo = "mathmod";
+    rev = "24d03a04c17363520ae7cf077e72a7b8684eb6fd";
+    hash = "sha256-HiqHssPGqYEVZWchZRj4rFPc+xNVZk1ryl5qvFC2BmQ=";
+  };
+
+  patches = [ ./fix-paths.patch ];
+
+  postPatch = ''
+    substituteInPlace MathMod.pro --subst-var out
+  '';
+
+  nativeBuildInputs = [ qmake ];
+
+  meta = {
+    description = "A mathematical modelling software";
+    homepage = "https://github.com/parisolab/mathmod";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "MathMod";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/applications/science/math/mathmod/fix-paths.patch
+++ b/pkgs/applications/science/math/mathmod/fix-paths.patch
@@ -1,0 +1,14 @@
+diff --git a/MathMod.pro b/MathMod.pro
+index 2e2fbf1..bb8f8bd 100644
+--- a/MathMod.pro
++++ b/MathMod.pro
+@@ -63,7 +63,5 @@ OTHER_FILES     += \
+                 mathmodcollection.js \
+                 mathmodconfig.js
+ # install
+-target.path    = $TARGET
+-sources.files  = $$SOURCES $$HEADERS $$RESOURCES $$FORMS mathmod.pro
+-sources.path   = $TARGET
+-INSTALLS      += target sources
++target.path    = @out@/bin
++INSTALLS      += target

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38929,6 +38929,8 @@ with pkgs;
     version = "11";
   };
 
+  mathmod = libsForQt5.callPackage ../applications/science/math/mathmod { };
+
   metis = callPackage ../development/libraries/science/math/metis { };
 
   nauty = callPackage ../applications/science/math/nauty { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/72469

This PR adds 1 package: `mathmod`

It seems to run alright

I am not copying the `.js` files, so some configuration features might not work properly, but I haven't found those yet.

The original project file wanted to copy all source files into a directory, so I removed that in a patch. The patch also sets the correct directory for the binary.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
