### PR TITLE
fastcdr: init at 1.1.1

### DIFF
--- a/pkgs/development/libraries/fastcdr/0001-Do-not-require-wget-and-unzip.patch
+++ b/pkgs/development/libraries/fastcdr/0001-Do-not-require-wget-and-unzip.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+Date: Sat, 5 Jun 2021 14:50:26 +0200
+Subject: [PATCH] Do not require wget and unzip
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2261fe7..ce8edad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -243,21 +243,6 @@ if(BUILD_DOCUMENTATION)
+         set(DOXYFILE_MAKE make.bat)
+     endif()
+ 
+-    if(NOT CHECK_DOCUMENTATION)
+-        find_program(WGET_EXE wget)
+-        if(WGET_EXE)
+-            message(STATUS "Found WGet: ${WGET_EXE}")
+-        else()
+-            message(FATAL_ERROR "wget is needed to build the documentation. Please install it correctly")
+-        endif()
+-        find_program(UNZIP_EXE unzip)
+-        if(UNZIP_EXE)
+-            message(STATUS "Found Unzip: ${UNZIP_EXE}")
+-        else()
+-            message(FATAL_ERROR "unzip is needed to build the documentation. Please install it correctly")
+-        endif()
+-    endif()
+-
+     # Target to create documentation directories
+     add_custom_target(docdirs
+         COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/doc
+-- 
+2.40.1
+

--- a/pkgs/development/libraries/fastcdr/default.nix
+++ b/pkgs/development/libraries/fastcdr/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, gtest
+, withDocs ? true
+, doxygen
+, graphviz-nox
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fastcdr";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "eProsima";
+    repo = "Fast-CDR";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ZJQnm3JN56y2v/XIShfZxkEEu1AKMJxt8wpRqSn9HWk=";
+  };
+
+  patches = [
+    ./0001-Do-not-require-wget-and-unzip.patch
+  ];
+
+  cmakeFlags = lib.optional (stdenv.hostPlatform.isStatic) "-DBUILD_SHARED_LIBS=OFF"
+  # fastcdr doesn't respect BUILD_TESTING
+  ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "-DEPROSIMA_BUILD_TESTS=ON"
+  ++ lib.optional withDocs "-DBUILD_DOCUMENTATION=ON";
+
+  outputs = [ "out" ] ++ lib.optional withDocs "doc";
+
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optionals withDocs [
+    doxygen
+    graphviz-nox
+  ];
+
+  doCheck = true;
+
+  checkInputs = [ gtest ];
+
+  meta = with lib; {
+    homepage = "https://github.com/eProsima/Fast-CDR";
+    description = "Serialization library for OMG's Common Data Representation (CDR)";
+    longDescription = ''
+      A C++ library that provides two serialization mechanisms. One is the
+      standard CDR serialization mechanism, while the other is a faster
+      implementation that modifies the standard.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ panicgh ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21333,6 +21333,8 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
+  fastcdr = callPackage ../development/libraries/fastcdr { };
+
   fbthrift = callPackage ../development/libraries/fbthrift { };
 
   fb303 = callPackage ../development/libraries/fb303 { };


### PR DESCRIPTION
## Description of changes

https://github.com/eProsima/Fast-CDR/

eProsima Fast CDR is a C++ library that provides two serialization mechanisms. One is the standard CDR serialization mechanism, while the other is a faster implementation that modifies the standard.

This pkg in other distros: https://repology.org/project/fastcdr/versions

This package is a prerequesite should anyone later want to package [Fast-DDS](https://github.com/eProsima/Fast-DDS), a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group).

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
