### PR TITLE
runelite: 2.5.0 -> 2.6.9, build jar from source

### DIFF
--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -1,27 +1,17 @@
-{ pkgs, lib, stdenv, makeDesktopItem, fetchurl, unzip, makeWrapper, xorg, jre, }:
+{ lib, stdenv, makeDesktopItem, fetchurl, makeWrapper, xorg, jre, }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "runelite";
-  version = "2.5.0";
+  version = "2.6.8";
 
   jar = fetchurl {
-    url = "https://github.com/runelite/launcher/releases/download/${version}/RuneLite.jar";
-    hash = "sha512-uEvlxXtnq7pgt8H5/hYIMu/kl32/dNojcHrPW6n2/RD/nzywreDw4kZ3G1kx0gGBY71x0RIEseEbm4BM+fhJlQ==";
+    url = "https://github.com/runelite/launcher/releases/download/${finalAttrs.version}/RuneLite.jar";
+    hash = "sha256-reqTRYXmpfxwo5MkxQFdifldFpTY0ascTPXA4mSvluM=";
   };
 
   icon = fetchurl {
-    url = "https://github.com/runelite/launcher/raw/${version}/appimage/runelite.png";
-    hash = "sha512-Yh8mpc6z9xd6ePe3f1f+KzrpE9r3fsdtQ0pfAvOhK/0hrCo/17eQA6v73yFXZcPQogVwm9CmJlrx4CkfzB25RQ==";
-  };
-
-  # The `.so` files provided by these two jars aren't detected by RuneLite for some reason, so we have to provide them manually
-  jogl = fetchurl {
-    url = "https://repo.runelite.net/net/runelite/jogl/jogl-all/2.4.0-rc-20200429/jogl-all-2.4.0-rc-20200429-natives-linux-amd64.jar";
-    hash = "sha512-OmJIbk5pKtvf1n1I5UHu6iaOKNrPgmaJTPhqC8yMjaRh/Hso1vV/+Eu+zKu7d5UiVggVUzJxqDKatmEnqFrzbg==";
-  };
-  gluegen = fetchurl {
-    url = "https://repo.runelite.net/net/runelite/gluegen/gluegen-rt/2.4.0-rc-20220318/gluegen-rt-2.4.0-rc-20220318-natives-linux-amd64.jar";
-    hash = "sha512-kF+RdDzYEhBuZOJ6ZwMhaEVcjYLxiwR8tYAm08FXDML45iP4HBEfmqHOLJpIakK06aQFj99/296vx810eDFX5A==";
+    url = "https://github.com/runelite/launcher/raw/${finalAttrs.version}/appimage/runelite.png";
+    hash = "sha256-gcts59jEuRVOmECrnSk40OYjTyJwSfAEys+Qck+VzBE=";
   };
   dontUnpack = true;
 
@@ -29,41 +19,35 @@ stdenv.mkDerivation rec {
     name = "RuneLite";
     type = "Application";
     exec = "runelite";
-    icon = icon;
+    icon = finalAttrs.icon;
     comment = "Open source Old School RuneScape client";
     desktopName = "RuneLite";
     genericName = "Oldschool Runescape";
     categories = [ "Game" ];
   };
 
-  nativeBuildInputs = [ makeWrapper unzip ];
+  nativeBuildInputs = [ makeWrapper ];
   installPhase = ''
     mkdir -p $out/share/runelite
     mkdir -p $out/share/applications
-    mkdir -p $out/natives
 
-    unzip ${jogl}    'natives/*' -d $out
-    unzip ${gluegen} 'natives/*' -d $out
+    ln -s ${finalAttrs.jar} $out/share/runelite/RuneLite.jar
+    ln -s ${finalAttrs.desktop}/share/applications/RuneLite.desktop $out/share/applications/RuneLite.desktop
 
-    ln -s ${jar} $out/share/runelite/RuneLite.jar
-    ln -s ${desktop}/share/applications/RuneLite.desktop $out/share/applications/RuneLite.desktop
-
-    # RuneLite looks for `.so` files in $PWD/natives, so ensure that we set the PWD to the right place
     makeWrapper ${jre}/bin/java $out/bin/runelite \
-      --chdir "$out" \
       --prefix LD_LIBRARY_PATH : "${xorg.libXxf86vm}/lib" \
       --add-flags "-jar $out/share/runelite/RuneLite.jar"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Open source Old School RuneScape client";
     homepage = "https://runelite.net/";
-    sourceProvenance = with sourceTypes; [
+    sourceProvenance = with lib.sourceTypes; [
       binaryBytecode
       binaryNativeCode
     ];
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ kmeakin ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ kmeakin ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -5,6 +5,7 @@
 , maven
 , jre
 , xorg
+, gitUpdater
 }:
 
 maven.buildMavenPackage rec {
@@ -44,6 +45,8 @@ maven.buildMavenPackage rec {
       --prefix LD_LIBRARY_PATH : "${xorg.libXxf86vm}/lib" \
       --add-flags "-jar $out/share/RuneLite.jar"
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Open source Old School RuneScape client";

--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -49,5 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ kmeakin ];
     platforms = [ "x86_64-linux" ];
+    mainProgram = "runelite";
   };
 })

--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -1,12 +1,20 @@
-{ lib, stdenv, makeDesktopItem, fetchurl, makeWrapper, xorg, jre, }:
+{ lib
+, stdenv
+, makeDesktopItem
+, fetchurl
+, makeWrapper
+, xorg
+, jre
+,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "runelite";
-  version = "2.6.8";
+  version = "2.6.9";
 
   jar = fetchurl {
     url = "https://github.com/runelite/launcher/releases/download/${finalAttrs.version}/RuneLite.jar";
-    hash = "sha256-reqTRYXmpfxwo5MkxQFdifldFpTY0ascTPXA4mSvluM=";
+    hash = "sha256-91iBBviXM3tJN/jRgcOzUuTAr9VrKnW55uYrNW7eB5Q=";
   };
 
   icon = fetchurl {


### PR DESCRIPTION
## Description of changes

changelog: https://github.com/runelite/launcher/compare/2.5.0...2.6.9

This is a somewhat large refactor to instead build the launcher jar itself
using maven instead of downloading one from the GitHub releases. I have
tested logging in and use of the GPU plugin (which should ensure that the
native libraries are functioning as intended) and have not seen any issues.

Of note however this just builds the launcher itself from source, the actual
game client is still downloaded. While possible to build the game client itself
from source, my understanding is that redistributing our own built variant is
not exactly encouraged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
