### PR TITLE
ruby-modules: Allow the user to specify files the Gemfile depends on

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -23,6 +23,7 @@
 , nativeBuildInputs ? []
 , buildInputs ? []
 , extraConfigPaths ? []
+, gemfileExtraFiles ? []
 , ...
 }@args:
 
@@ -85,6 +86,7 @@ let
     ${maybeCopyAll mainGemName}
     cp ${gemFiles.gemfile} $out/Gemfile || ls -l $out/Gemfile
     cp ${gemFiles.lockfile} $out/Gemfile.lock || ls -l $out/Gemfile.lock
+    cp ${builtins.concatStringsSep " " gemfileExtraFiles} $out
 
     ${lib.concatMapStringsSep "\n" (path: "cp -r ${path} $out/") extraConfigPaths}
   '';


### PR DESCRIPTION
## Description of changes

Some Gemfiles depend on the presence of other files. ej. Depends on .ruby-version to be in the same directory to be able to specify the version from its contents. This is going to be more common now that bundler supports doing so using keyword argument, ie. `ruby file: '.ruby-version'`.

For those scenarios, allow bundlerEnv to take a list as an extra argument, gemfileExtraFiles, to specify a list of files to copy alongside the Gemfile, lockfile and gemset file. That way when the Gemfile is evaluated it will find the file it expects. If the file is not found the ruby version is unset and when bundler tries to validate the ruby version [0] it fails the check and the process aborts. This happens when trying to run a 'binstubed' executable that is bundled with a gem such as rackup.

Closes #181693

[0]: https://github.com/rubygems/rubygems/blob/4bbefa9c4db32ef857d92af5ee5e8f98813cfc5e/bundler/lib/bundler/definition.rb#L429

Note sure if it helps but I've setup this repository to reproduce the issue and test fix https://github.com/PuercoPop/nixpkgs-181693

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
