### PR TITLE
r2modman: fixes

### DIFF
--- a/pkgs/games/r2modman/default.nix
+++ b/pkgs/games/r2modman/default.nix
@@ -28,6 +28,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-CXitb/b2tvTfrkFrFv4KP4WdmMg+1sDtC/s2u5ezDfI=";
   };
 
+  patches = [
+    # Make it possible to launch Steam games from r2modman.
+    ./steam-launch-fix.patch
+  ];
+
   nativeBuildInputs = [
     yarn
     fixup_yarn_lock

--- a/pkgs/games/r2modman/steam-launch-fix.patch
+++ b/pkgs/games/r2modman/steam-launch-fix.patch
@@ -1,0 +1,21 @@
+diff --git a/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts b/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
+index ddee0e9..fc9ffca 100644
+--- a/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
++++ b/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
+@@ -61,15 +61,9 @@ export default class SteamGameRunner_Linux extends GameRunnerProvider {
+     async start(game: Game, args: string): Promise<void | R2Error> {
+ 
+         const settings = await ManagerSettings.getSingleton(game);
+-        const steamDir = await GameDirectoryResolverProvider.instance.getSteamDirectory();
+-        if(steamDir instanceof R2Error) {
+-            return steamDir;
+-        }
+-
+-        LoggerProvider.instance.Log(LogSeverity.INFO, `Steam directory is: ${steamDir}`);
+ 
+         try {
+-            const cmd = `"${steamDir}/steam.sh" -applaunch ${game.activePlatform.storeIdentifier} ${args} ${settings.getContext().gameSpecific.launchParameters}`;
++            const cmd = `steam -applaunch ${game.activePlatform.storeIdentifier} ${args} ${settings.getContext().gameSpecific.launchParameters}`;
+             LoggerProvider.instance.Log(LogSeverity.INFO, `Running command: ${cmd}`);
+             await exec(cmd);
+         } catch(err) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38427,7 +38427,10 @@ with pkgs;
 
   r2mod_cli = callPackage ../games/r2mod_cli { };
 
-  r2modman = callPackage ../games/r2modman { };
+  r2modman = callPackage ../games/r2modman {
+    # Electron 26 has regressions making applications unusable.
+    electron = electron_25;
+  };
 
   racer = callPackage ../games/racer { };
 


### PR DESCRIPTION
## Description of changes
Fix #240369 and #254624

For the patch to fix launching Steam, I have opted not to make Steam a dependency of the `r2modman` package, because Steam isn't going to work properly if has not been installed and set up by the user, so making it a dependency will not help anything.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
