### PR TITLE
nim2lsp: init at 0.4.4

### DIFF
--- a/pkgs/by-name/ni/nim2lsp/package.nix
+++ b/pkgs/by-name/ni/nim2lsp/package.nix
@@ -1,0 +1,34 @@
+{ lib, nim2Packages, fetchFromGitHub, srcOnly, nim }:
+
+nim2Packages.buildNimPackage rec {
+  pname = "nimlsp";
+  version = "0.4.4";
+  nimBinOnly = true;
+
+  src = fetchFromGitHub {
+    owner = "PMunch";
+    repo = "nimlsp";
+    rev = "v${version}";
+    sha256 = "sha256-Z67iKlL+dnRbxdFt/n/fsUcb2wpZwzPpL/G29jfCaMY=";
+  };
+
+  buildInputs = with nim2Packages; [ jsonschema asynctools ];
+
+  nimFlags = [
+    "--threads:on"
+    "-d:explicitSourcePath=${srcOnly nim2Packages.nim.passthru.nim}"
+    "-d:tempDir=/tmp"
+  ];
+
+  nimDefines = [ "nimcore" "nimsuggest" "debugCommunication" "debugLogging" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Language Server Protocol implementation for Nim";
+    homepage = "https://github.com/PMunch/nimlsp";
+    license = licenses.mit;
+    platforms = nim.meta.platforms;
+    maintainers = [ maintainers.marsam maintainers.marcusramberg ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
