### PR TITLE
maintainers/scripts/remove-old-aliases: Drop `pkgs.` prefix

### DIFF
--- a/maintainers/scripts/remove-old-aliases.py
+++ b/maintainers/scripts/remove-old-aliases.py
@@ -102,12 +102,13 @@ def convert_to_throw(date_older_list: list[str]) -> list[tuple[str, str]]:
 
         alias = before_equal
         alias_unquoted = before_equal.strip('"')
-        after_equal_list = [x.strip(";:") for x in after_equal.split()]
+        replacement = next(x.strip(";:") for x in after_equal.split())
+        replacement = replacement.removeprefix("pkgs.")
 
         converted = (
-            f"{indent}{alias} = throw \"'{alias_unquoted}' has been renamed to/replaced by"
-            f" '{after_equal_list.pop(0)}'\";"
-            f' # Converted to throw {datetime.today().strftime("%Y-%m-%d")}'
+            f"{indent}{alias} = throw \"'{alias_unquoted}' has been"
+            f" renamed to/replaced by '{replacement}'\";"
+            f" # Converted to throw {datetime.today().strftime('%Y-%m-%d')}"
         )
         converted_list.append((line, converted))
 


### PR DESCRIPTION
## Description of changes

Changed the `remove-old-aliases.py` maintainer script, to remove the (extraneous) `pkgs.`
prefix from aliases where it was present in the alias' definition.

This addresses cases such as [this](https://github.com/NixOS/nixpkgs/pull/254418#discussion_r1322076574).


## Things done

- [x] Tested basic functionality by running the script, checked it fixed the issue I encountered.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Ran the `mypy` typechecker on it
