### PR TITLE
doc: minimal documentation of supported platforms

### DIFF
--- a/doc/using-nixpkgs.md
+++ b/doc/using-nixpkgs.md
@@ -1,6 +1,7 @@
 # Using Nixpkgs {#part-using}
 
 ```{=include=} chapters
+using/platform-support.chapter.md
 using/configuration.chapter.md
 using/overlays.chapter.md
 using/overrides.chapter.md

--- a/doc/using/platform-support.chapter.md
+++ b/doc/using/platform-support.chapter.md
@@ -1,0 +1,18 @@
+# Platform Support {#chap-platform-support}
+
+Packages receive varying degrees of support, both in terms of maintainer attention and available computation resources for continuous integration (CI).
+
+Below is the list of the best supported platforms:
+
+- `x86_64-linux`: Highest level of support.
+- `aarch64-linux`: Well supported, with most packages building successfully in CI.
+- `aarch64-darwin`: Receives better support than `x86_64-darwin`.
+- `x86_64-darwin`: Receives some support.
+
+There are many other platforms with varying levels of support.
+The provisional platform list in [Appendix A] of [RFC046], while not up to date, can be used as guidance.
+
+A more formal definition of the platform support tiers is provided in [RFC046], but has not been fully implemented yet.
+
+[RFC046]: https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md
+[Appendix A]: https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#appendix-a-non-normative-description-of-platforms-in-november-2019


### PR DESCRIPTION

This commit adds minimal documentation of the supported platforms.

More exhaustive documentation would require producing a list of platforms for each of the 7 tiers. This was attempted in #245368, but it quickly became clear that that would be a long-term effort.
    
In the meantime, this commit adds the most important information to the manual.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
