### PR TITLE
top-level: Add a warning on deprecated aliases

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -46,7 +46,7 @@ let
     else
       let trailer =
         with lib; optionalString (isDerivation v)
-          ", use `${v.pname}` instead";
+          ", use `${v.pname or v.name}` instead";
       in lib.warn "`pkgs.${n}` is deprecated${trailer}" v;
 
   mapAliases = aliases:

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -40,11 +40,21 @@ let
     then throw "Alias ${n} is still in all-packages.nix"
     else alias;
 
+  deprecationWarning = n: v:
+    if !(with builtins; tryEval (typeOf v)).success then
+      v  # Presumably a `throw`
+    else
+      let trailer =
+        with lib; optionalString (isDerivation v)
+          ", use `${v.pname}` instead";
+      in lib.warn "`pkgs.${n}` is deprecated${trailer}" v;
+
   mapAliases = aliases:
     lib.mapAttrs (n: alias:
-      removeDistribute
-        (removeRecurseForDerivations
-          (checkInPkgs n alias)))
+      deprecationWarning n
+        (removeDistribute
+          (removeRecurseForDerivations
+            (checkInPkgs n alias))))
       aliases;
 in
 


### PR DESCRIPTION
## Description of changes

- [x] Programatically apply `lib.warn` on all aliases in `top-level/aliases.nix`
- [x] Include the alias' target's `pname` in the warning message, if it's a derivation.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
