### PR TITLE
pkgs/top-level: use lib.systems.equals for crossSystem

### DIFF
--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -94,6 +94,8 @@ with pkgs;
 
   config = callPackage ./config.nix { };
 
+  top-level = callPackage ./top-level { };
+
   haskell = callPackage ./haskell { };
 
   hooks = callPackage ./hooks { };

--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -1,0 +1,47 @@
+{ lib, pkgs, ... }:
+let
+  nixpkgsFun = import ../../top-level;
+in
+lib.recurseIntoAttrs {
+  platformEquality =
+    let
+      configsLocal = [
+        # crossSystem is implicitly set to localSystem.
+        {
+          localSystem = { system = "x86_64-linux"; };
+        }
+        {
+          localSystem = { system = "aarch64-linux"; };
+          crossSystem = null;
+        }
+        # Both systems explicitly set to the same string.
+        {
+          localSystem = { system = "x86_64-linux"; };
+          crossSystem = { system = "x86_64-linux"; };
+        }
+        # Vendor and ABI inferred from system double.
+        {
+          localSystem = { system = "aarch64-linux"; };
+          crossSystem = { config = "aarch64-unknown-linux-gnu"; };
+        }
+      ];
+      configsCross = [
+        # GNU is inferred from double, but config explicitly requests musl.
+        {
+          localSystem = { system = "aarch64-linux"; };
+          crossSystem = { config = "aarch64-unknown-linux-musl"; };
+        }
+        # Cross-compile from AArch64 to x86-64.
+        {
+          localSystem = { system = "aarch64-linux"; };
+          crossSystem = { system = "x86_64-unknown-linux-gnu"; };
+        }
+      ];
+
+      pkgsLocal = map nixpkgsFun configsLocal;
+      pkgsCross = map nixpkgsFun configsCross;
+    in
+    assert lib.all (p: p.buildPlatform == p.hostPlatform) pkgsLocal;
+    assert lib.all (p: p.buildPlatform != p.hostPlatform) pkgsCross;
+    pkgs.emptyFile;
+}

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -61,10 +61,22 @@ in let
   localSystem = lib.systems.elaborate args.localSystem;
 
   # Condition preserves sharing which in turn affects equality.
+  #
+  # See `lib.systems.equals` documentation for more details.
+  #
+  # Note that it is generally not possible to compare systems as given in
+  # parameters, e.g. if systems are initialized as
+  #
+  #   localSystem = { system = "x86_64-linux"; };
+  #   crossSystem = { config = "x86_64-unknown-linux-gnu"; };
+  #
+  # Both systems are semantically equivalent as the same vendor and ABI are
+  # inferred from the system double in `localSystem`.
   crossSystem =
-    if crossSystem0 == null || crossSystem0 == args.localSystem
+    let system = lib.systems.elaborate crossSystem0; in
+    if crossSystem0 == null || lib.systems.equals system localSystem
     then localSystem
-    else lib.systems.elaborate crossSystem0;
+    else system;
 
   # Allow both:
   # { /* the config */ } and


### PR DESCRIPTION
## Description of changes

Fixes otherwise equivalent systems being treated as different by packages that compare `stdenv.*Platform`s using `==` operator.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
