### PR TITLE
openexr_3: 3.1.10 -> 3.2.0

### DIFF
--- a/pkgs/development/libraries/openexr/3.nix
+++ b/pkgs/development/libraries/openexr/3.nix
@@ -1,21 +1,21 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
-, zlib
 , cmake
 , imath
+, libdeflate
+, pkg-config
 }:
 
 stdenv.mkDerivation rec {
   pname = "openexr";
-  version = "3.1.10";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "AcademySoftwareFoundation";
     repo = "openexr";
     rev = "v${version}";
-    sha256 = "sha256-8oV7Himk9AS2e2Z3OREE7KQgFIUysXwATlUN51dDe5M=";
+    hash = "sha256-cV+qgx3WzdotypgpZhVFxzdKAU2rNVw0KWSdkeN0gLk=";
   };
 
   outputs = [ "bin" "dev" "out" "doc" ];
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = lib.optional stdenv.hostPlatform.isStatic "-DCMAKE_SKIP_RPATH=ON";
 
-  nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ imath zlib ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  propagatedBuildInputs = [ imath libdeflate ];
 
   # Without 'sse' enforcement tests fail on i686 as due to excessive precision as:
   #   error reading back channel B pixel 21,-76 got -nan expected -nan

--- a/pkgs/development/libraries/openexr/3.nix
+++ b/pkgs/development/libraries/openexr/3.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "doc" ];
 
+  patches =
+    # Disable broken test on musl libc
+    # https://github.com/AcademySoftwareFoundation/openexr/issues/1556
+    lib.optional stdenv.hostPlatform.isMusl ./disable-iex-test.patch
+  ;
+
   # tests are determined to use /var/tmp on unix
   postPatch = ''
     cat <(find . -name tmpDir.h) <(echo src/test/OpenEXRCoreTest/main.cpp) | while read -r f ; do

--- a/pkgs/development/libraries/openexr/disable-iex-test.patch
+++ b/pkgs/development/libraries/openexr/disable-iex-test.patch
@@ -1,0 +1,13 @@
+diff --git a/src/test/CMakeLists.txt b/src/test/CMakeLists.txt
+index 44d9185d..8ffcd2b2 100644
+--- a/src/test/CMakeLists.txt
++++ b/src/test/CMakeLists.txt
+@@ -4,7 +4,7 @@
+ # We require this to get object library link library support and
+ # combined python 2 + 3 support
+ 
+-add_subdirectory(IexTest)
++#add_subdirectory(IexTest)
+ add_subdirectory(OpenEXRCoreTest)
+ add_subdirectory(OpenEXRTest)
+ add_subdirectory(OpenEXRUtilTest)


### PR DESCRIPTION
## Description of changes

Primarily created this PR to get https://github.com/AcademySoftwareFoundation/openexr/pull/1507 in and hopefully fix simd compilation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
