### PR TITLE
yosys: 0.32 -> 0.33

### DIFF
--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -71,13 +71,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname   = "yosys";
-  version = "0.32";
+  version = "0.33";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo  = "yosys";
     rev   = "${pname}-${version}";
-    hash  = "sha256-ER61pIvXNjV74A9LwxeXDXoQFkVgqjdI9KiYQyOobk8=";
+    hash  = "sha256-3MsWF161pqqeAbmeTlkQY6UpU4pq1WT0XXK9yciwt0M=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/yosys/fix-clang-build.patch
+++ b/pkgs/development/compilers/yosys/fix-clang-build.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index 86abc6958..a72f7b792 100644
+index fa95b7b70..4d15ed721 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -187,7 +192,7 @@ endif
+@@ -215,7 +215,7 @@ ABC_ARCHFLAGS += "-DABC_NO_RLIMIT"
  endif
  
  ifeq ($(CONFIG),clang)
@@ -10,4 +10,26 @@ index 86abc6958..a72f7b792 100644
 +CXX = clang++
  LD = clang++
  CXXFLAGS += -std=$(CXXSTD) -Os
- ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
+ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -Wno-c++11-narrowing $(ABC_ARCHFLAGS)"
+diff --git a/tests/fmt/run-test.sh b/tests/fmt/run-test.sh
+index 914a72347..bc0b129d2 100644
+--- a/tests/fmt/run-test.sh
++++ b/tests/fmt/run-test.sh
+@@ -51,7 +51,7 @@ test_cxxrtl () {
+ 	local subtest=$1; shift
+ 
+ 	../../yosys -p "read_verilog ${subtest}.v; proc; clean; write_cxxrtl -print-output std::cerr yosys-${subtest}.cc"
+-	${CC:-gcc} -std=c++11 -o yosys-${subtest} -I../.. ${subtest}_tb.cc -lstdc++
++	${CXX:-gcc} -std=c++11 -o yosys-${subtest} -I../.. ${subtest}_tb.cc -lstdc++
+ 	./yosys-${subtest} 2>yosys-${subtest}.log
+ 	iverilog -o iverilog-${subtest} ${subtest}.v ${subtest}_tb.v
+ 	./iverilog-${subtest} |grep -v '\$finish called' >iverilog-${subtest}.log
+@@ -69,7 +69,7 @@ diff iverilog-always_full.log iverilog-always_full-1.log
+ 
+ ../../yosys -p "read_verilog display_lm.v" >yosys-display_lm.log
+ ../../yosys -p "read_verilog display_lm.v; write_cxxrtl yosys-display_lm.cc"
+-${CC:-gcc} -std=c++11 -o yosys-display_lm_cc -I../.. display_lm_tb.cc -lstdc++
++${CXX:-gcc} -std=c++11 -o yosys-display_lm_cc -I../.. display_lm_tb.cc -lstdc++
+ ./yosys-display_lm_cc >yosys-display_lm_cc.log
+ for log in yosys-display_lm.log yosys-display_lm_cc.log; do
+ 	grep "^%l: \\\\bot\$" "$log"


### PR DESCRIPTION
## Description of changes
https://github.com/YosysHQ/yosys/releases/tag/yosys-0.33

A patch needed to be adapted to fix this error on macOS:
```
+ clang -std=c++11 -o yosys-always_full -I../.. always_full_tb.cc -lstdc++
In file included from always_full_tb.cc:1:
In file included from ./yosys-always_full.cc:1:
../../backends/cxxrtl/cxxrtl.h:29:10: fatal error: 'cstddef' file not found
#include <cstddef>
      ^~~~~~~~~
1 error generated.
make: *** [Makefile:885: test] Error 1
```

`openroad` also fails to build without this PR.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).