### PR TITLE
nftables: add option to disable interactive

### DIFF
--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -1,9 +1,10 @@
 { lib, stdenv, fetchurl, pkg-config, bison, flex
 , asciidoc, libxslt, findXMLCatalogs, docbook_xml_dtd_45, docbook_xsl
 , libmnl, libnftnl, libpcap
-, gmp, jansson, libedit
+, gmp, jansson
 , autoreconfHook
 , withDebugSymbols ? false
+, withCli ? true, libedit
 , withPython ? false, python3
 , withXtables ? true, iptables
 , nixosTests
@@ -26,8 +27,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libmnl libnftnl libpcap
-    gmp jansson libedit
-  ] ++ lib.optional withXtables iptables
+    gmp jansson
+  ] ++ lib.optional withCli libedit
+    ++ lib.optional withXtables iptables
     ++ lib.optionals withPython [
       python3
       python3.pkgs.setuptools
@@ -35,7 +37,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-json"
-    "--with-cli=editline"
+    (lib.withFeatureAs withCli "cli" "editline")
   ] ++ lib.optional (!withDebugSymbols) "--disable-debug"
     ++ lib.optional (!withPython) "--disable-python"
     ++ lib.optional withPython "--enable-python"


### PR DESCRIPTION
## Description of changes

I think "CLI" is a very strange name for this, but that's what upstream calls it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
