### PR TITLE
bumblebee-status: init at 2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1651,6 +1651,12 @@
     github = "auchter";
     githubId = 1190483;
   };
+  augustebaum = {
+    email = "auguste.apple@gmail.com";
+    github = "augustebaum";
+    githubId = 52001167;
+    name = "Auguste Baum";
+  };
   auntie = {
     email = "auntieNeo@gmail.com";
     github = "auntieNeo";

--- a/pkgs/applications/window-managers/i3/bumblebee-status/default.nix
+++ b/pkgs/applications/window-managers/i3/bumblebee-status/default.nix
@@ -1,0 +1,67 @@
+{ pkgs
+, lib
+, glibcLocales
+, python
+, fetchFromGitHub
+  # Usage: bumblebee-status.override { plugins = p: [p.arandr p.bluetooth2]; };
+, plugins ? p: [ ]
+}:
+let
+  version = "2.2.0";
+
+  # { <name> = { name = "..."; propagatedBuildInputs = [ ... ]; buildInputs = [ ... ]; } }
+  allPlugins =
+    lib.mapAttrs
+      (name: value: value // { inherit name; })
+      (import ./plugins.nix { inherit pkgs python; });
+
+  # [ { name = "..."; propagatedBuildInputs = [ ... ]; buildInputs = [ ... ]; } ]
+  selectedPlugins = plugins allPlugins;
+in
+python.pkgs.buildPythonPackage {
+  pname = "bumblebee-status";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "tobi-wan-kenobi";
+    repo = "bumblebee-status";
+    rev = "v${version}";
+    hash = "sha256-+RCg2XZv0AJnexi7vnQhEXB1qSoKBN1yKWm3etdys1s=";
+  };
+
+  buildInputs = lib.concatMap (p: p.buildInputs or [ ]) selectedPlugins;
+  propagatedBuildInputs = lib.concatMap (p: p.propagatedBuildInputs or [ ]) selectedPlugins;
+
+  checkInputs = with python.pkgs; [ freezegun netifaces psutil pytest pytest-mock requests ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    # Fixes `locale.Error: unsupported locale setting` in some tests.
+    export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive";
+
+    # FIXME: We skip the `dunst` module tests, some of which fail with
+    # `RuntimeError: killall -s SIGUSR2 dunst not found`.
+    # This is not solved by adding `pkgs.killall` to `checkInputs`.
+    ${python.interpreter} -m pytest -k 'not test_dunst.py'
+
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    # Remove binary cache files
+    find $out -name "__pycache__" -type d | xargs rm -rv
+
+    # Make themes available for bumblebee-status to detect them
+    cp -r ./themes $out/${python.sitePackages}
+  '';
+
+  meta = with lib; {
+    description = "A modular, theme-able status line generator for the i3 window manager";
+    homepage = "https://github.com/tobi-wan-kenobi/bumblebee-status";
+    mainProgram = "bumblebee-status";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ augustebaum ];
+  };
+}

--- a/pkgs/applications/window-managers/i3/bumblebee-status/plugins.nix
+++ b/pkgs/applications/window-managers/i3/bumblebee-status/plugins.nix
@@ -1,0 +1,162 @@
+{ pkgs
+, python
+, ...
+}:
+# propagatedBuildInputs are for Python libraries and executables
+# buildInputs are for libraries
+let
+  py = python.pkgs;
+in
+{
+  amixer.propagatedBuildInputs = [ pkgs.alsa-utils ];
+  # aptitude is unpackaged
+  # apt.propagatedBuildInputs = [aptitude];
+  arandr.propagatedBuildInputs = [ py.tkinter pkgs.arandr pkgs.xorg.xrandr ];
+  # checkupdates is unpackaged
+  # arch-update.propagatedBuildInputs = [checkupdates];
+  # checkupdates is unpackaged
+  # arch_update.propagatedBuildInputs = [checkupdates];
+  # yay is unpackaged
+  # aur-update.propagatedBuildInputs = [yay];
+  battery = { };
+  battery-upower = { };
+  battery_upower = { };
+  bluetooth.propagatedBuildInputs = [ pkgs.bluez pkgs.blueman pkgs.dbus ];
+  bluetooth2.propagatedBuildInputs = [ pkgs.bluez pkgs.blueman pkgs.dbus py.dbus-python ];
+  blugon.propagatedBuildInputs = [ pkgs.blugon ];
+  # If you do not allow this plugin to query the system's ACPI, i.e. the plugin option `use_acpi` is set to `False`, then you need at least one of [ brightnessctl light xbacklight ]
+  brightness.propagatedBuildInputs = [ ];
+  caffeine.propagatedBuildInputs = [ pkgs.xdg-utils pkgs.xdotool pkgs.xorg.xprop pkgs.libnotify ];
+  cmus.propagatedBuildInputs = [ pkgs.cmus ];
+  cpu.propagatedBuildInputs = [ py.psutil pkgs.gnome.gnome-system-monitor ];
+  cpu2.propagatedBuildInputs = [ py.psutil pkgs.lm_sensors ];
+  cpu3.propagatedBuildInputs = [ py.psutil pkgs.lm_sensors ];
+  currency.propagatedBuildInputs = [ py.requests ];
+  date = { };
+  datetime = { };
+  datetimetz.propagatedBuildInputs = [ py.tzlocal py.pytz ];
+  datetz = { };
+  deadbeef.propagatedBuildInputs = [ pkgs.deadbeef ];
+  debug = { };
+  deezer.propagatedBuildInputs = [ py.dbus-python ];
+  disk = { };
+  # dnf is unpackaged
+  # dnf.propagatedBuildInputs = [dnf];
+  docker_ps.propagatedBuildInputs = [ py.docker ];
+  dunst.propagatedBuildInputs = [ pkgs.dunst ];
+  dunstctl.propagatedBuildInputs = [ pkgs.dunst ];
+  # emerge is unpackaged
+  # emerge_status.propagatedBuildInputs = [emerge];
+  error = { };
+  gcalendar.propagatedBuildInputs = [
+    py.google-api-python-client
+    py.google-auth-httplib2
+    py.google-auth-oauthlib
+  ];
+  getcrypto.propagatedBuildInputs = [ py.requests ];
+  git.propagatedBuildInputs = [ pkgs.xcwd pkgs.pygit2 ];
+  github.propagatedBuildInputs = [ py.requests ];
+  gitlab.propagatedBuildInputs = [ py.requests ];
+  # gpmdp-remote is unpackaged
+  # gpmdp.propagatedBuildInputs = [gpmdp-remote];
+  hddtemp = { };
+  hostname = { };
+  http_status = { };
+  indicator.propagatedBuildInputs = [ pkgs.xorg.xset ];
+  kernel = { };
+  keys = { };
+  # python3Packages.xkbgroup is unpackaged
+  layout = {
+    buildInputs = [ pkgs.xorg.libX11 ];
+    # propagatedBuildInputs = [py.xkbgroup];
+  };
+  # python3Packages.xkbgroup is unpackaged
+  layout-xkb = {
+    buildInputs = [ pkgs.xorg.libX11 ];
+    # propagatedBuildInputs = [py.xkbgroup];
+  };
+  layout-xkbswitch.propagatedBuildInputs = [ pkgs.xkb-switch ];
+  # python3Packages.xkbgroup is unpackaged
+  # NOTE: Yes, there is also a plugin named `layout-xkb` with a dash.
+  layout_xkb = {
+    buildInputs = [ pkgs.xorg.libX11 ];
+    # propagatedBuildInputs = [python3Packages.xkbgroup];
+  };
+  # NOTE: Yes, there is also a plugin named `layout-xkbswitch` with a dash.
+  layout_xkbswitch.propagatedBuildInputs = [ pkgs.xkb-switch ];
+  libvirtvms.propagatedBuildInputs = [ py.libvirt ];
+  load.propagatedBuildInputs = [ pkgs.gnome.gnome-system-monitor ];
+  memory.propagatedBuildInputs = [ pkgs.gnome.gnome-system-monitor ];
+  messagereceiver = { };
+  mocp.propagatedBuildInputs = [ pkgs.moc ];
+  mpd.propagatedBuildInputs = [ pkgs.mpc-cli ];
+  network.propagatedBuildInputs = [ py.netifaces pkgs.iw ];
+  network_traffic.propagatedBuildInputs = [ py.netifaces ];
+  nic.propagatedBuildInputs = [ py.netifaces pkgs.iw ];
+  notmuch_count.propagatedBuildInputs = [ pkgs.notmuch ];
+  # nvidian-smi is unpackaged
+  # nvidiagpu.propagatedBuildInputs = [nvidia-smi];
+  octoprint.propagatedBuildInputs = [ py.tkinter ];
+  # optimus-manager is unpackaged
+  # optman.propagatedBuildInputs = [optimus-manager];
+  pacman.propagatedBuildInputs = [ pkgs.fakeroot pkgs.pacman ];
+  pamixer.propagatedBuildInputs = [ pkgs.pamixer ];
+  persian_date.propagatedBuildInputs = [ py.jdatetime ];
+  pihole = { };
+  ping.propagatedBuildInputs = [ pkgs.iputils ];
+  pipewire.buildInputs = [ pkgs.wireplumber ];
+  playerctl.propagatedBuildInputs = [ pkgs.playerctl ];
+  pomodoro = { };
+  # emerge is unpackaged
+  # portage_status.propagatedBuildInputs = [emerge];
+  # prime-select is unpackaged
+  # prime.propagatedBuildInputs = [prime-select];
+  progress.propagatedBuildInputs = [ pkgs.progress ];
+  publicip.propagatedBuildInputs = [ py.netifaces ];
+  # Deprecated in favor of pulsectl
+  # pulseaudio = {};
+  pulsectl.propagatedBuildInputs = [ pkgs.pulsectl ];
+  redshift.propagatedBuildInputs = [ pkgs.redshift ];
+  # rofication is unpackaged
+  # rofication.propagatedBuildInputs = [rofication];
+  rotation.propagatedBuildInputs = [ pkgs.xorg.xrandr ];
+  rss = { };
+  sensors.propagatedBuildInputs = [ pkgs.lm_sensors ];
+  sensors2.propagatedBuildInputs = [ pkgs.lm_sensors ];
+  shell = { };
+  shortcut = { };
+  smartstatus.propagatedBuildInputs = [ pkgs.smartmontools ];
+  solaar.propagatedBuildInputs = [ pkgs.solaar ];
+  spaceapi.propagatedBuildInputs = [ py.requests ];
+  spacer = { };
+  speedtest.propagatedBuildInputs = [ py.speedtest-cli ];
+  spotify.propagatedBuildInputs = [ py.dbus-python ];
+  stock = { };
+  # suntime is not packaged yet
+  # sun.propagatedBuildInputs = [ py.requests python-dateutil suntime ];
+  system.propagatedBuildInputs = [ py.tkinter ];
+  taskwarrior.propagatedBuildInputs = [ py.taskw ];
+  test = { };
+  thunderbird = { };
+  time = { };
+  timetz = { };
+  title.propagatedBuildInputs = [ py.i3ipc ];
+  todo = { };
+  todo_org = { };
+  todoist.propagatedBuildInputs = [ py.requests ];
+  traffic = { };
+  # Needs `systemctl`
+  twmn.propagatedBuildInputs = [ ];
+  uptime = { };
+  usage.propagatedBuildInputs = [ py.sqlite pkgs.activitywatch ];
+  vault.propagatedBuildInputs = [ pkgs.pass ];
+  vpn.propagatedBuildInputs = [ py.tkinter pkgs.networkmanager ];
+  wakatime.propagatedBuildInputs = [ py.requests ];
+  watson.propagatedBuildInputs = [ pkgs.watson ];
+  weather.propagatedBuildInputs = [ py.requests ];
+  xkcd = { };
+  # i3 is optional
+  xrandr.propagatedBuildInputs = [ pkgs.xorg.xrandr ];
+  yubikey.propagatedBuildInputs = [ pkgs.yubico ];
+  zpool = { };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31042,6 +31042,10 @@ with pkgs;
 
   boops = callPackage ../applications/audio/boops { };
 
+  bumblebee-status = callPackage ../applications/window-managers/i3/bumblebee-status {
+    python = python3;
+  };
+
   cgif = callPackage ../tools/graphics/cgif { };
 
   ChowCentaur  = callPackage ../applications/audio/ChowCentaur { };


### PR DESCRIPTION
## Description of changes

This creates a package for `bumblebee-status`, a status program for use with the i3 window manager (or similar).

Because the `bumblebee-status` includes a large number of plugins within its source code (see [here](https://bumblebee-status.readthedocs.io/en/main/modules.html) for the docs and [here](https://github.com/tobi-wan-kenobi/bumblebee-status/tree/main/bumblebee_status/modules) for the source code), each with its own set of dependencies, the package can be overriden in the form of the argument `withPlugins`, which is the list of plugins to get the dependencies for. By default the list is empty (i.e. no extra dependencies are installed, although the program still has access to the plugins).

Hence this PR includes two packages: `bumblebee-status`, and `bumblebee-status-full` for which all plugin dependencies are added as `propagatedBuildInputs`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
