### PR TITLE
treewide: don't use python3Minimal where it is not required

### DIFF
--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -120,7 +120,7 @@ in rec {
     { meta.description = "List of NixOS options in JSON format";
       nativeBuildInputs = [
         pkgs.brotli
-        pkgs.python3Minimal
+        pkgs.python3
       ];
       options = builtins.toFile "options.json"
         (builtins.unsafeDiscardStringContext (builtins.toJSON optionsNix));

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -510,14 +510,8 @@ let
             ntp
             perlPackages.ListCompare
             perlPackages.XMLLibXML
-            python3Minimal
             # make-options-doc/default.nix
-            (let
-                self = (pkgs.python3Minimal.override {
-                  inherit self;
-                  includeSiteCustomize = true;
-                });
-              in self.withPackages (p: [ p.mistune ]))
+            python3.withPackages (p: [ p.mistune ])
             shared-mime-info
             sudo
             texinfo

--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -95,7 +95,7 @@ in {
           ntp
           perlPackages.ListCompare
           perlPackages.XMLLibXML
-          python3Minimal
+          python3
           shared-mime-info
           stdenv
           sudo

--- a/pkgs/tools/nix/nixos-render-docs/default.nix
+++ b/pkgs/tools/nix/nixos-render-docs/default.nix
@@ -1,18 +1,11 @@
 { lib
 , stdenv
 , python3
-, python3Minimal
 , runCommand
 }:
 
 let
-  # python3Minimal can't be overridden with packages on Darwin, due to a missing framework.
-  # Instead of modifying stdenv, we take the easy way out, since most people on Darwin will
-  # just be hacking on the Nixpkgs manual (which also uses make-options-doc).
-  python = ((if stdenv.isDarwin then python3 else python3Minimal).override {
-    self = python;
-    includeSiteCustomize = true;
-  }).override {
+  python = python3.override {
     packageOverrides = final: prev: {
       markdown-it-py = prev.markdown-it-py.overridePythonAttrs (_: {
         doCheck = false;


### PR DESCRIPTION
Building a python environment with python3Minimal requires hydra to bootstrap pip and build all packages used in the environment which would otherwise not be built. This reduces cache re-use and duplicates things.

Also common dependencies normally included in python itself are not properly checked and can cause hard to debug errors because everyone just assumes those modules are there.

## Description of changes

nix-diff rebuilding my system with this minus the kernel change (took to long to build). I cut some unrelated changes to keep the text shorter. Also keep in mind that things are probably repeated.


```
- /nix/var/nix/profiles/system-118-link/:{out}
+ /nix/var/nix/profiles/system-119-link/:{out}
• The input derivation named `etc` differs
  - /nix/store/r8icf17zvrmz82c1f8g53dbf2hfryhsc-etc.drv:{out}
  + /nix/store/4ws40cp4j0s71nlzzy3007fmi5srk1g1-etc.drv:{out}
  • The input derivation named `dbus-1` differs
    - /nix/store/hlhawviasgg7jgsm0p58y4vj41dy06xl-dbus-1.drv:{out}
    + /nix/store/5wqh1wzr63lc57506m50vmlpk37am3ga-dbus-1.drv:{out}
    • The input derivation named `system-path` differs
      - /nix/store/znincwzzgzqy2isiq4yhd0d89ncva8dw-system-path.drv:{out}
      + /nix/store/hycm5q4vpvbw5zsydjzwk8p7hb3prxq2-system-path.drv:{out}
      • The input derivation named `nixos-configuration-reference-manpage` differs
        - /nix/store/5rqd3kc2krnv0jmk63xllih5d0frwppr-nixos-configuration-reference-manpage.drv:{out}
        + /nix/store/lzq8jdwl794rzzljcd20ky8zahzj669v-nixos-configuration-reference-manpage.drv:{out}
        • The input derivation named `nixos-render-docs-0.0` differs
          - /nix/store/hhwf7nhqgcx0yfbsw7a0ql0dz1v0nfx8-nixos-render-docs-0.0.drv:{out}
          + /nix/store/6ac9wbsv567q38d01y1wlhaiqjcg1bxb-nixos-render-docs-0.0.drv:{out}
          • The set of input derivation names do not match:
              - python3-minimal-3.10.12
              + python3-3.10.12
          • The input derivation named `pypa-build-hook.sh` differs
            - /nix/store/fp2wp32hj9h98xywk2glakc6wch7dxdr-pypa-build-hook.sh.drv:{out}
            + /nix/store/vjggrvqhccvda48qi4pnri5wfrm339sa-pypa-build-hook.sh.drv:{out}
            • The input derivation named `python3.10-build-0.10.0` differs
              - /nix/store/37z9b2z7nbnnya2a737dzk4n32z6kwcs-python3.10-build-0.10.0.drv:{out}
              + /nix/store/1sp7m3mx2mslppbv70q8w300wizs1bm5-python3.10-build-0.10.0.drv:{out}
              • The set of input derivation names do not match:
                  - python3-minimal-3.10.12
                  + python3-3.10.12
              • The input derivation named `pypa-build-hook.sh` differs
                - /nix/store/b3jhfjk0xd4rhq5h1j3dbgi77k239n6m-pypa-build-hook.sh.drv:{out}
                + /nix/store/lyc2cjf3l62w79yf0rskw4yjj56vhwxy-pypa-build-hook.sh.drv:{out}
                • The input derivation named `python3.10-bootstrap-build-0.10.0` differs
                  - /nix/store/92a9kzfd9mc5llg443h6wccd8jim6rmx-python3.10-bootstrap-build-0.10.0.drv:{out}
                  + /nix/store/bd88v4xij2alhakvwsff7y373w54xc15-python3.10-bootstrap-build-0.10.0.drv:{out}
                  • The set of input derivation names do not match:
                      - python3-minimal-3.10.12
                      + python3-3.10.12
                  • The input derivation named `python3.10-bootstrap-flit-core-3.9.0` differs
                    - /nix/store/igd8gn4p6n08kr90idv7f8w8hpsiwk7q-python3.10-bootstrap-flit-core-3.9.0.drv:{out}
                    + /nix/store/6niysn6ki033pd95776q33jybq6r2chw-python3.10-bootstrap-flit-core-3.9.0.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The environments do not match:
                        buildPhase=''
                        runHook preBuild
                        
                        ←/nix/store/k3qjsxiywav062br47kfw8p1bmxcq1z0-python3-minimal-3.10.12/bin/python3.10←→/nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12/bin/python3.10→ -m flit_core.wheel
                        
                        runHook postBuild
                    ''
                        installPhase=''
                        runHook preInstall
                        
                        ←/nix/store/k3qjsxiywav062br47kfw8p1bmxcq1z0-python3-minimal-3.10.12/bin/python3.10←→/nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12/bin/python3.10→ bootstrap_install.py dist/flit_core-*.whl \
                          --install-root "$out" --installdir "/lib/python3.10/site-packages"
                        
                        runHook postInstall
                    ''
                  • The input derivation named `python3.10-bootstrap-installer-0.7.0` differs
                    - /nix/store/l5b2vl5r6bwz3m15d2fqvgl3b9m3pnxz-python3.10-bootstrap-installer-0.7.0.drv:{out}
                    + /nix/store/s99qjkl67pgiqvjd50l24y8vljjsxn5w-python3.10-bootstrap-installer-0.7.0.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `python3.10-bootstrap-flit-core-3.9.0` differs
                      • These two derivations have already been compared
                    • Skipping environment comparison
                  • The input derivation named `python3.10-bootstrap-packaging-23.1` differs
                    - /nix/store/gs04l9hrw8sw57acrc2y08kczskwlymm-python3.10-bootstrap-packaging-23.1.drv:{out}
                    + /nix/store/c5cxv3jy3ijvpnh6ch236hvwc8bswl6c-python3.10-bootstrap-packaging-23.1.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `python3.10-bootstrap-flit-core-3.9.0` differs
                      • These two derivations have already been compared
                    • The input derivation named `python3.10-bootstrap-installer-0.7.0` differs
                      • These two derivations have already been compared
                    • Skipping environment comparison
                  • The input derivation named `python3.10-bootstrap-pyproject-hooks-1.0.0` differs
                    - /nix/store/hjxa8cfrciq51rvh2ljidiz6873zk8bv-python3.10-bootstrap-pyproject-hooks-1.0.0.drv:{out}
                    + /nix/store/wjaz1x6743hxblmxzr12rmzdyi2mls7g-python3.10-bootstrap-pyproject-hooks-1.0.0.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `python3.10-bootstrap-flit-core-3.9.0` differs
                      • These two derivations have already been compared
                    • The input derivation named `python3.10-bootstrap-installer-0.7.0` differs
                      • These two derivations have already been compared
                    • Skipping environment comparison
                  • The input derivation named `python3.10-bootstrap-tomli-2.0.1` differs
                    - /nix/store/57hyq1p5pqymmxxx0cbv3783hcmpqa7r-python3.10-bootstrap-tomli-2.0.1.drv:{out}
                    + /nix/store/bjkj16c4m3badyi23mqs8cnjvcdrl25k-python3.10-bootstrap-tomli-2.0.1.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `python3.10-bootstrap-flit-core-3.9.0` differs
                      • These two derivations have already been compared
                    • The input derivation named `python3.10-bootstrap-installer-0.7.0` differs
                      • These two derivations have already been compared
                    • Skipping environment comparison
                  • Skipping environment comparison
                • Skipping environment comparison
              • The input derivation named `pypa-install-hook` differs
                - /nix/store/jzarbxc4p6janqbgksrv0d3yrk0fc5pn-pypa-install-hook.drv:{out}
                + /nix/store/dd4c0nwpsis7kryfqy10rl5gx4fmdn0b-pypa-install-hook.drv:{out}
                • The set of input derivation names do not match:
                    - python3-minimal-3.10.12
                    + python3-3.10.12
                • The input derivation named `python3.10-installer-0.7.0` differs
                  - /nix/store/gg4zxirhi1wbymzjwd15fhwpacszwyq7-python3.10-installer-0.7.0.drv:{out}
                  + /nix/store/d0mdhjbbxbaxncg2z9sgjwcbf1a824d7-python3.10-installer-0.7.0.drv:{out}
                  • The set of input derivation names do not match:
                      - python3-minimal-3.10.12
                      + python3-3.10.12
                  • The input derivation named `pypa-build-hook.sh` differs
                    • These two derivations have already been compared
                  • The input derivation named `pypa-install-hook` differs
                    - /nix/store/r41g99mf19wd8wrzl83659hd67kfzx59-pypa-install-hook.drv:{out}
                    + /nix/store/4c74vai43jxfj3m7qqb5l1c79vqzx5n8-pypa-install-hook.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `python3.10-bootstrap-installer-0.7.0` differs
                      • These two derivations have already been compared
                    • Skipping environment comparison
                  • The input derivation named `python-imports-check-hook.sh` differs
                    - /nix/store/db9w3siidg79r49dxjx5av98ar0gr5x8-python-imports-check-hook.sh.drv:{out}
                    + /nix/store/ww5n5y3csy1z0maapmw21wng5n13iik0-python-imports-check-hook.sh.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The environments do not match:
                        pythonCheckInterpreter=''
                        ←/nix/store/k3qjsxiywav062br47kfw8p1bmxcq1z0-python3-minimal-3.10.12/bin/python3.10←→/nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12/bin/python3.10→
                    ''
                  • The input derivation named `python3.10-flit-core-3.9.0` differs
                    - /nix/store/d967pzpimc0a9qq7pmh8jih47mb6cgbw-python3.10-flit-core-3.9.0.drv:{out}
                    + /nix/store/3cbcmj480ql9c3nppi20nq8ac57vf70z-python3.10-flit-core-3.9.0.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `pypa-build-hook.sh` differs
                      • These two derivations have already been compared
                    • The input derivation named `pypa-install-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `python-imports-check-hook.sh` differs
                      • These two derivations have already been compared
                    • The input derivation named `wrap-python-hook` differs
                      - /nix/store/f8h1m3wqzdhfalx255pskjgghv466p6f-wrap-python-hook.drv:{out}
                      + /nix/store/nk8wwckdwfll0bifdwjc7h1vvkabi6rx-wrap-python-hook.drv:{out}
                      • The set of input derivation names do not match:
                          - python3-minimal-3.10.12
                          + python3-3.10.12
                      • The environments do not match:
                          executable=''
                          ←/nix/store/k3qjsxiywav062br47kfw8p1bmxcq1z0-python3-minimal-3.10.12/bin/python3.10←→/nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12/bin/python3.10→
                      ''
                          python=''
                          ←/nix/store/k3qjsxiywav062br47kfw8p1bmxcq1z0-python3-minimal-3.10.12←→/nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12→
                      ''
                          pythonHost=''
                          ←/nix/store/k3qjsxiywav062br47kfw8p1bmxcq1z0-python3-minimal-3.10.12←→/nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12→
                      ''
                    • Skipping environment comparison
                  • The input derivation named `wrap-python-hook` differs
                    • These two derivations have already been compared
                  • Skipping environment comparison
                • Skipping environment comparison
              • The input derivation named `python-imports-check-hook.sh` differs
                • These two derivations have already been compared
              • The input derivation named `python3.10-flit-core-3.9.0` differs
                • These two derivations have already been compared
              • The input derivation named `python3.10-packaging-23.1` differs
                - /nix/store/8fbr9mjz4584wa4jhdrcbi91j6449hs1-python3.10-packaging-23.1.drv:{out}
                + /nix/store/pz08nv29zyxbgf1hh1fw3ps33i6wlcmh-python3.10-packaging-23.1.drv:{out}
                • The set of input derivation names do not match:
                    - python3-minimal-3.10.12
                    + python3-3.10.12
                • The input derivation named `pypa-build-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `pypa-install-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-imports-check-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `python3.10-flit-core-3.9.0` differs
                  • These two derivations have already been compared
                • The input derivation named `wrap-python-hook` differs
                  • These two derivations have already been compared
                • Skipping environment comparison
              • The input derivation named `python3.10-pyproject-hooks-1.0.0` differs
                - /nix/store/m1i2maj5vr7yc770af8m448c9yiw0063-python3.10-pyproject-hooks-1.0.0.drv:{out}
                + /nix/store/9658zb5xvzrb97ng74y7r5wj1bpvrfb9-python3.10-pyproject-hooks-1.0.0.drv:{out}
                • The set of input derivation names do not match:
                    - python3-minimal-3.10.12
                    + python3-3.10.12
                • The input derivation named `pypa-build-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `pypa-install-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-imports-check-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `python3.10-flit-core-3.9.0` differs
                  • These two derivations have already been compared
                • The input derivation named `python3.10-tomli-2.0.1` differs
                  - /nix/store/g2xcaily89xk9xf58p33ykbd27sbld9i-python3.10-tomli-2.0.1.drv:{out}
                  + /nix/store/8fyp2k08kbp075b32nyf4gbm1yb8ya4c-python3.10-tomli-2.0.1.drv:{out}
                  • The set of input derivation names do not match:
                      - python3-minimal-3.10.12
                      + python3-3.10.12
                  • The input derivation named `pypa-build-hook.sh` differs
                    • These two derivations have already been compared
                  • The input derivation named `pypa-install-hook` differs
                    • These two derivations have already been compared
                  • The input derivation named `python-imports-check-hook.sh` differs
                    • These two derivations have already been compared
                  • The input derivation named `python3.10-flit-core-3.9.0` differs
                    • These two derivations have already been compared
                  • The input derivation named `unittest-check-hook` differs
                    - /nix/store/7nlgdcfzk0pm5cqc9qmg5jfs59fv0ssa-unittest-check-hook.drv:{out}
                    + /nix/store/hbi96bjvm6g88gcwfg03bv5jqx9gvg6y-unittest-check-hook.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The environments do not match:
                        pythonCheckInterpreter=''
                        ←/nix/store/k3qjsxiywav062br47kfw8p1bmxcq1z0-python3-minimal-3.10.12/bin/python3.10←→/nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12/bin/python3.10→
                    ''
                  • The input derivation named `wrap-python-hook` differs
                    • These two derivations have already been compared
                  • Skipping environment comparison
                • The input derivation named `wrap-python-hook` differs
                  • These two derivations have already been compared
                • Skipping environment comparison
              • The input derivation named `python3.10-tomli-2.0.1` differs
                • These two derivations have already been compared
              • The input derivation named `wrap-python-hook` differs
                • These two derivations have already been compared
              • Skipping environment comparison
            • The input derivation named `python3.10-wheel-0.41.1` differs
              - /nix/store/005ck2whfq8ijpy31c4327frqx29q25l-python3.10-wheel-0.41.1.drv:{out}
              + /nix/store/4r30sg439f5551vp44z5yidn1cnfz82a-python3.10-wheel-0.41.1.drv:{out}
              • The set of input derivation names do not match:
                  - python3-minimal-3.10.12
                  + python3-3.10.12
              • The input derivation named `pypa-build-hook.sh` differs
                • These two derivations have already been compared
              • The input derivation named `pypa-install-hook` differs
                • These two derivations have already been compared
              • The input derivation named `python-imports-check-hook.sh` differs
                • These two derivations have already been compared
              • The input derivation named `python3.10-flit-core-3.9.0` differs
                • These two derivations have already been compared
              • The input derivation named `wrap-python-hook` differs
                • These two derivations have already been compared
              • Skipping environment comparison
            • Skipping environment comparison
          • The input derivation named `pypa-install-hook` differs
            • These two derivations have already been compared
          • The input derivation named `pytest-check-hook` differs
            - /nix/store/7dpv65998j9543s7c1fjd10h25ki2fi9-pytest-check-hook.drv:{out}
            + /nix/store/7jxd2q46rvsl3j88abafn7zsdv0npszv-pytest-check-hook.drv:{out}
            • The set of input derivation names do not match:
                - python3-minimal-3.10.12
                + python3-3.10.12
            • The input derivation named `python3.10-pytest-7.4.0` differs
              - /nix/store/gqqh80q7ryg43if99p8qd5rxjln1ya15-python3.10-pytest-7.4.0.drv:{out}
              + /nix/store/a36wrcpwswh4j8512bzvwd7sscvdmx8r-python3.10-pytest-7.4.0.drv:{out}
              • The set of input derivation names do not match:
                  - python3-minimal-3.10.12
                  + python3-3.10.12
              • The input derivation named `pypa-build-hook.sh` differs
                • These two derivations have already been compared
              • The input derivation named `pypa-install-hook` differs
                • These two derivations have already been compared
              • The input derivation named `python-catch-conflicts-hook` differs
                - /nix/store/iglnrm3g50g118wcb7vd7viwb3hd9k1z-python-catch-conflicts-hook.drv:{out}
                + /nix/store/727h0f21knw6qh57cz98vfk49mgw83rd-python-catch-conflicts-hook.drv:{out}
                • The set of input derivation names do not match:
                    - python3-minimal-3.10.12
                    + python3-3.10.12
                • The input derivation named `python3.10-setuptools-68.0.0` differs
                  - /nix/store/r4b56mr6a07fc5ci58i8cql9wx0x70dz-python3.10-setuptools-68.0.0.drv:{out}
                  + /nix/store/7gr5nsknkc6wmz2zng9y902azlhdqqsl-python3.10-setuptools-68.0.0.drv:{out}
                  • The set of input derivation names do not match:
                      - python3-minimal-3.10.12
                      + python3-3.10.12
                  • The input derivation named `pypa-build-hook.sh` differs
                    • These two derivations have already been compared
                  • The input derivation named `pypa-install-hook` differs
                    • These two derivations have already been compared
                  • The input derivation named `python-imports-check-hook.sh` differs
                    • These two derivations have already been compared
                  • The input derivation named `python3.10-wheel-0.41.1` differs
                    • These two derivations have already been compared
                  • The input derivation named `wrap-python-hook` differs
                    • These two derivations have already been compared
                  • Skipping environment comparison
                • Skipping environment comparison
              • The input derivation named `python-imports-check-hook.sh` differs
                • These two derivations have already been compared
              • The input derivation named `python3.10-attrs-23.1.0` differs
                - /nix/store/pzq9c2zk5ida8a3313m2q11dd2zdq0wa-python3.10-attrs-23.1.0.drv:{out}
                + /nix/store/mb6mnr8dblqgwjy689dk2bh3wrlyd7f1-python3.10-attrs-23.1.0.drv:{out}
                • The set of input derivation names do not match:
                    - python3-minimal-3.10.12
                    + python3-3.10.12
                • The input derivation named `pypa-build-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `pypa-install-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-catch-conflicts-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-imports-check-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `python3.10-hatchling-1.18.0` differs
                  - /nix/store/r9sbn8hks86ffl8j6ja7998wvsmb8h37-python3.10-hatchling-1.18.0.drv:{out}
                  + /nix/store/40dl82qz2ai4shnldxyysfpv9c4fp15d-python3.10-hatchling-1.18.0.drv:{out}
                  • The set of input derivation names do not match:
                      - python3-minimal-3.10.12
                      + python3-3.10.12
                  • The input derivation named `pypa-build-hook.sh` differs
                    • These two derivations have already been compared
                  • The input derivation named `pypa-install-hook` differs
                    • These two derivations have already been compared
                  • The input derivation named `python-catch-conflicts-hook` differs
                    • These two derivations have already been compared
                  • The input derivation named `python-imports-check-hook.sh` differs
                    • These two derivations have already been compared
                  • The input derivation named `python3.10-editables-0.3` differs
                    - /nix/store/b1h0v910pqds69fnax65bm67rnkbjrjy-python3.10-editables-0.3.drv:{out}
                    + /nix/store/czmq4lp6q202p0i2nmf4zdarjg1dry8b-python3.10-editables-0.3.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `pypa-install-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `python-catch-conflicts-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `python-imports-check-hook.sh` differs
                      • These two derivations have already been compared
                    • The input derivation named `setuptools-setup-hook` differs
                      - /nix/store/d2bnmzb9fvr2x1bvpklws2s1l9058b05-setuptools-setup-hook.drv:{out}
                      + /nix/store/kmga1w3i0w5kskrmfncjmfh8jl3jdy94-setuptools-setup-hook.drv:{out}
                      • The set of input derivation names do not match:
                          - python3-minimal-3.10.12
                          + python3-3.10.12
                      • The input derivation named `python3.10-setuptools-68.0.0` differs
                        • These two derivations have already been compared
                      • The input derivation named `python3.10-wheel-0.41.1` differs
                        • These two derivations have already been compared
                      • Skipping environment comparison
                    • The input derivation named `wrap-python-hook` differs
                      • These two derivations have already been compared
                    • Skipping environment comparison
                  • The input derivation named `python3.10-packaging-23.1` differs
                    • These two derivations have already been compared
                  • The input derivation named `python3.10-pathspec-0.11.0` differs
                    - /nix/store/9d5c9hawf7nar4q9y8apvkqjxanp2liw-python3.10-pathspec-0.11.0.drv:{out}
                    + /nix/store/h5rcx2p8i8fnxmk5rq4dilf522gdrkxd-python3.10-pathspec-0.11.0.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `pypa-build-hook.sh` differs
                      • These two derivations have already been compared
                    • The input derivation named `pypa-install-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `python-catch-conflicts-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `python-imports-check-hook.sh` differs
                      • These two derivations have already been compared
                    • The input derivation named `python3.10-flit-core-3.9.0` differs
                      • These two derivations have already been compared
                    • The input derivation named `unittest-check-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `wrap-python-hook` differs
                      • These two derivations have already been compared
                    • Skipping environment comparison
                  • The input derivation named `python3.10-pluggy-1.2.0` differs
                    - /nix/store/knw5y02fr4gy2658nhg94gy9fsi2f5gh-python3.10-pluggy-1.2.0.drv:{out}
                    + /nix/store/nj4myh59r316kq7v40mi1g8aq21q7y6m-python3.10-pluggy-1.2.0.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `pypa-build-hook.sh` differs
                      • These two derivations have already been compared
                    • The input derivation named `pypa-install-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `python-catch-conflicts-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `python-imports-check-hook.sh` differs
                      • These two derivations have already been compared
                    • The input derivation named `python3.10-setuptools-scm-7.1.0` differs
                      - /nix/store/3vvpvhdzwdq4zk10y8wshybdkfjqg18z-python3.10-setuptools-scm-7.1.0.drv:{out}
                      + /nix/store/psw0hsm1s9k3j43xlj8lg807p1n5dj25-python3.10-setuptools-scm-7.1.0.drv:{out}
                      • The set of input derivation names do not match:
                          - python3-minimal-3.10.12
                          + python3-3.10.12
                      • The input derivation named `pypa-build-hook.sh` differs
                        • These two derivations have already been compared
                      • The input derivation named `pypa-install-hook` differs
                        • These two derivations have already been compared
                      • The input derivation named `python-catch-conflicts-hook` differs
                        • These two derivations have already been compared
                      • The input derivation named `python-imports-check-hook.sh` differs
                        • These two derivations have already been compared
                      • The input derivation named `python3.10-packaging-23.1` differs
                        • These two derivations have already been compared
                      • The input derivation named `python3.10-setuptools-68.0.0` differs
                        • These two derivations have already been compared
                      • The input derivation named `python3.10-tomli-2.0.1` differs
                        • These two derivations have already been compared
                      • The input derivation named `python3.10-typing-extensions-4.7.1` differs
                        - /nix/store/4mwkkpdwgkj4dlbxmax96zdg2fdnd29l-python3.10-typing-extensions-4.7.1.drv:{out}
                        + /nix/store/q2zvi73lhjw41q0h5md0481b5nr3rgqk-python3.10-typing-extensions-4.7.1.drv:{out}
                        • The set of input derivation names do not match:
                            - python3-minimal-3.10.12
                            + python3-3.10.12
                        • The input derivation named `pypa-build-hook.sh` differs
                          • These two derivations have already been compared
                        • The input derivation named `pypa-install-hook` differs
                          • These two derivations have already been compared
                        • The input derivation named `python-catch-conflicts-hook` differs
                          • These two derivations have already been compared
                        • The input derivation named `python-imports-check-hook.sh` differs
                          • These two derivations have already been compared
                        • The input derivation named `python3.10-flit-core-3.9.0` differs
                          • These two derivations have already been compared
                        • The input derivation named `wrap-python-hook` differs
                          • These two derivations have already been compared
                        • Skipping environment comparison
                      • The input derivation named `wrap-python-hook` differs
                        • These two derivations have already been compared
                      • Skipping environment comparison
                    • The input derivation named `wrap-python-hook` differs
                      • These two derivations have already been compared
                    • Skipping environment comparison
                  • The input derivation named `python3.10-tomli-2.0.1` differs
                    • These two derivations have already been compared
                  • The input derivation named `python3.10-trove-classifiers-2023.7.6` differs
                    - /nix/store/43kcvx8phnjyjfg6396xpnysi1qff9m0-python3.10-trove-classifiers-2023.7.6.drv:{out}
                    + /nix/store/kjk7k7wkzi218vrqi16vflr2j9y4qwcn-python3.10-trove-classifiers-2023.7.6.drv:{out}
                    • The set of input derivation names do not match:
                        - python3-minimal-3.10.12
                        + python3-3.10.12
                    • The input derivation named `pypa-install-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `python-catch-conflicts-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `python-imports-check-hook.sh` differs
                      • These two derivations have already been compared
                    • The input derivation named `python3.10-calver-2022.06.26` differs
                      - /nix/store/ygg3lb9fqzac49j0p0gxy74vs6gy3d6h-python3.10-calver-2022.06.26.drv:{out}
                      + /nix/store/9kybxqpwzprnkw94hdziqdxp8b1dpb9z-python3.10-calver-2022.06.26.drv:{out}
                      • The set of input derivation names do not match:
                          - python3-minimal-3.10.12
                          + python3-3.10.12
                      • The input derivation named `pypa-install-hook` differs
                        • These two derivations have already been compared
                      • The input derivation named `python-catch-conflicts-hook` differs
                        • These two derivations have already been compared
                      • The input derivation named `python-imports-check-hook.sh` differs
                        • These two derivations have already been compared
                      • The input derivation named `setuptools-setup-hook` differs
                        • These two derivations have already been compared
                      • The input derivation named `wrap-python-hook` differs
                        • These two derivations have already been compared
                      • Skipping environment comparison
                    • The input derivation named `setuptools-setup-hook` differs
                      • These two derivations have already been compared
                    • The input derivation named `wrap-python-hook` differs
                      • These two derivations have already been compared
                    • Skipping environment comparison
                  • The input derivation named `wrap-python-hook` differs
                    • These two derivations have already been compared
                  • Skipping environment comparison
                • The input derivation named `wrap-python-hook` differs
                  • These two derivations have already been compared
                • Skipping environment comparison
              • The input derivation named `python3.10-exceptiongroup-1.1.2` differs
                - /nix/store/7jdkmnngsxyssa1zrz80h16gpcqn62f7-python3.10-exceptiongroup-1.1.2.drv:{out}
                + /nix/store/z168gm43577rkp4nnn563fhbnhjzc9sc-python3.10-exceptiongroup-1.1.2.drv:{out}
                • The set of input derivation names do not match:
                    - python3-minimal-3.10.12
                    + python3-3.10.12
                • The input derivation named `pypa-build-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `pypa-install-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-catch-conflicts-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-imports-check-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `python3.10-flit-scm-1.7.0` differs
                  - /nix/store/kqx018g1n2v0b559nlw150zlfj8kkp5f-python3.10-flit-scm-1.7.0.drv:{out}
                  + /nix/store/7dilcfxsxakyczckvl1hgbf3vwbhcdll-python3.10-flit-scm-1.7.0.drv:{out}
                  • The set of input derivation names do not match:
                      - python3-minimal-3.10.12
                      + python3-3.10.12
                  • The input derivation named `pypa-build-hook.sh` differs
                    • These two derivations have already been compared
                  • The input derivation named `pypa-install-hook` differs
                    • These two derivations have already been compared
                  • The input derivation named `python-catch-conflicts-hook` differs
                    • These two derivations have already been compared
                  • The input derivation named `python-imports-check-hook.sh` differs
                    • These two derivations have already been compared
                  • The input derivation named `python3.10-flit-core-3.9.0` differs
                    • These two derivations have already been compared
                  • The input derivation named `python3.10-setuptools-scm-7.1.0` differs
                    • These two derivations have already been compared
                  • The input derivation named `python3.10-tomli-2.0.1` differs
                    • These two derivations have already been compared
                  • The input derivation named `wrap-python-hook` differs
                    • These two derivations have already been compared
                  • Skipping environment comparison
                • The input derivation named `wrap-python-hook` differs
                  • These two derivations have already been compared
                • Skipping environment comparison
              • The input derivation named `python3.10-iniconfig-2.0.0` differs
                - /nix/store/f86l5ll6qd9krlmizy4dcydkhy5d0s8d-python3.10-iniconfig-2.0.0.drv:{out}
                + /nix/store/p7q720nxbn54nr60fqamqw1pya61ifmz-python3.10-iniconfig-2.0.0.drv:{out}
                • The set of input derivation names do not match:
                    - python3-minimal-3.10.12
                    + python3-3.10.12
                • The input derivation named `pypa-build-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `pypa-install-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-catch-conflicts-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-imports-check-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `python3.10-hatchling-1.18.0` differs
                  • These two derivations have already been compared
                • The input derivation named `wrap-python-hook` differs
                  • These two derivations have already been compared
                • Skipping environment comparison
              • The input derivation named `python3.10-packaging-23.1` differs
                • These two derivations have already been compared
              • The input derivation named `python3.10-pluggy-1.2.0` differs
                • These two derivations have already been compared
              • The input derivation named `python3.10-py-1.11.0` differs
                - /nix/store/3jzggyydrr9idw03v6zvi6d13dccim2p-python3.10-py-1.11.0.drv:{out}
                + /nix/store/q7046326xjccv4z65cgbcc5nahbdr44y-python3.10-py-1.11.0.drv:{out}
                • The set of input derivation names do not match:
                    - python3-minimal-3.10.12
                    + python3-3.10.12
                • The input derivation named `pypa-install-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-catch-conflicts-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `python-imports-check-hook.sh` differs
                  • These two derivations have already been compared
                • The input derivation named `python3.10-setuptools-scm-7.1.0` differs
                  • These two derivations have already been compared
                • The input derivation named `setuptools-setup-hook` differs
                  • These two derivations have already been compared
                • The input derivation named `wrap-python-hook` differs
                  • These two derivations have already been compared
                • Skipping environment comparison
              • The input derivation named `python3.10-setuptools-scm-7.1.0` differs
                • These two derivations have already been compared
              • The input derivation named `python3.10-tomli-2.0.1` differs
                • These two derivations have already been compared
              • The input derivation named `wrap-python-hook` differs
                • These two derivations have already been compared
              • Skipping environment comparison
            • Skipping environment comparison
          • The input derivation named `python-catch-conflicts-hook` differs
            • These two derivations have already been compared
          • The input derivation named `python-imports-check-hook.sh` differs
            • These two derivations have already been compared
          • The input derivation named `python3.10-markdown-it-py-2.2.0` differs
            - /nix/store/2cspqsh0xfnw3x2hrk914v9n2v7gjs6n-python3.10-markdown-it-py-2.2.0.drv:{out}
            + /nix/store/jgmfy8qbim2gi14f6j2dagablfvxk9b1-python3.10-markdown-it-py-2.2.0.drv:{out}
            • The set of input derivation names do not match:
                - python3-minimal-3.10.12
                + python3-3.10.12
            • The input derivation named `pypa-build-hook.sh` differs
              • These two derivations have already been compared
            • The input derivation named `pypa-install-hook` differs
              • These two derivations have already been compared
            • The input derivation named `python-catch-conflicts-hook` differs
              • These two derivations have already been compared
            • The input derivation named `python-imports-check-hook.sh` differs
              • These two derivations have already been compared
            • The input derivation named `python-relax-deps-hook` differs
              - /nix/store/3vrm41jziqpsbrrkaxavf3k1jj7cpjx8-python-relax-deps-hook.drv:{out}
              + /nix/store/zs8jl9b2vy5laargbbxa9dli1kif5lq9-python-relax-deps-hook.drv:{out}
              • The set of input derivation names do not match:
                  - python3-minimal-3.10.12
                  + python3-3.10.12
              • The input derivation named `python3.10-wheel-0.41.1` differs
                • These two derivations have already been compared
              • Skipping environment comparison
            • The input derivation named `python3.10-flit-core-3.9.0` differs
              • These two derivations have already been compared
            • The input derivation named `python3.10-mdurl-0.1.2` differs
              - /nix/store/j1n9r4jcpj23401997qcq4q94lkbygfy-python3.10-mdurl-0.1.2.drv:{out}
              + /nix/store/ldfia51g0x781i7g7pj1wfrzqjalafch-python3.10-mdurl-0.1.2.drv:{out}
              • The set of input derivation names do not match:
                  - python3-minimal-3.10.12
                  + python3-3.10.12
              • The input derivation named `pypa-build-hook.sh` differs
                • These two derivations have already been compared
              • The input derivation named `pypa-install-hook` differs
                • These two derivations have already been compared
              • The input derivation named `pytest-check-hook` differs
                • These two derivations have already been compared
              • The input derivation named `python-catch-conflicts-hook` differs
                • These two derivations have already been compared
              • The input derivation named `python-imports-check-hook.sh` differs
                • These two derivations have already been compared
              • The input derivation named `python3.10-flit-core-3.9.0` differs
                • These two derivations have already been compared
              • The input derivation named `wrap-python-hook` differs
                • These two derivations have already been compared
              • Skipping environment comparison
            • The input derivation named `wrap-python-hook` differs
              • These two derivations have already been compared
            • Skipping environment comparison
          • The input derivation named `python3.10-mdit-py-plugins-0.3.5` differs
            - /nix/store/h3bpwgwk5s5dv77dzsaicpfxz9llpgzz-python3.10-mdit-py-plugins-0.3.5.drv:{out}
            + /nix/store/3527d1ni2qjpgg7kwdh39d8qbw6jwixd-python3.10-mdit-py-plugins-0.3.5.drv:{out}
            • The set of input derivation names do not match:
                - python3-minimal-3.10.12
                + python3-3.10.12
            • The input derivation named `pypa-build-hook.sh` differs
              • These two derivations have already been compared
            • The input derivation named `pypa-install-hook` differs
              • These two derivations have already been compared
            • The input derivation named `python-catch-conflicts-hook` differs
              • These two derivations have already been compared
            • The input derivation named `python-imports-check-hook.sh` differs
              • These two derivations have already been compared
            • The input derivation named `python3.10-flit-core-3.9.0` differs
              • These two derivations have already been compared
            • The input derivation named `python3.10-markdown-it-py-2.2.0` differs
              • These two derivations have already been compared
            • The input derivation named `wrap-python-hook` differs
              • These two derivations have already been compared
            • Skipping environment comparison
          • The input derivation named `python3.10-setuptools-68.0.0` differs
            • These two derivations have already been compared
          • The input derivation named `wrap-python-hook` differs
            • These two derivations have already been compared
          • Skipping environment comparison
        • The input derivation named `options.json` differs
          - /nix/store/d0zrc36slxj6n5ri0jpcndfp5vmaxdny-options.json.drv:{out}
          + /nix/store/d40hlqiaq9fzdhi0pldcwhz211lscahj-options.json.drv:{out}
          • The set of input derivation names do not match:
              - python3-minimal-3.10.12
              + python3-3.10.12
          • The input derivation named `lazy-options.json` differs
            - /nix/store/z78ij649p1qnz0yjk8pq1ynqw438by1y-lazy-options.json.drv:{out}
            + /nix/store/f3qa0hfjjcinhz07aszyrpxi45k6wa1s-lazy-options.json.drv:{out}
            • The input source named `nixos` differs
            • The environments do not match:
                nixosPath=''
                ←/nix/store/pr0d8vwbg9pdcip2mi0g6x18jiqqz160-nixos←→/nix/store/2j8s6wq53swdlq3jz7xynh77jm8cka93-nixos→
            ''
          • Skipping environment comparison
        • Skipping environment comparison
      • Skipping environment comparison
    • Skipping environment comparison
  • The input derivation named `etc-man_db.conf` differs
    - /nix/store/phfah3ncy0mxs7yhzhl6k3fsb9p250mj-etc-man_db.conf.drv:{out}
    + /nix/store/jvb75d4rhskmhpnyz21njkc9mv880n5i-etc-man_db.conf.drv:{out}
    • The input derivation named `man-cache` differs
      - /nix/store/4sy45k498qbzjhzhfw5zffwfknj6r47p-man-cache.drv:{out}
      + /nix/store/8slm5hh323rpf7dsigbsfa8vrbcrmiyh-man-cache.drv:{out}
      • The input derivation named `man-paths` differs
        - /nix/store/bnszs6air1n6s9rrqmg94jahsv6q2bxv-man-paths.drv:{out}
        + /nix/store/xly44jw9yh5zkpzwvmjyw1ar1x0kn2z6-man-paths.drv:{out}
        • The input derivation named `nixos-configuration-reference-manpage` differs
          • These two derivations have already been compared
        • Skipping environment comparison
      • Skipping environment comparison
    • Skipping environment comparison

........

• The input derivation named `system-path` differs
  • These two derivations have already been compared
• Skipping environment comparison
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
