### PR TITLE
lib/types: init taggedSubmodule

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -710,6 +710,23 @@ rec {
         in mergedOption.type;
     };
 
+    # A type that is one of several submodules, similiar to types.oneOf but is usable inside attrsOf or listOf
+    # submodules need an option with a type str which is used to find the corresponding type
+    taggedSubmodules =
+      { types
+      , specialArgs ? {}
+      }: mkOptionType rec {
+      name = "taggedSubmodules";
+      description = "one of ${concatStringsSep "," (attrNames types)}";
+      check = x: if x ? type then types.${x.type}.check x else throw "No type option set in:\n${lib.generators.toPretty {} x}";
+      merge = loc: foldl'
+        (res: def: types.${def.value.type}.merge loc [
+          (lib.recursiveUpdate { value._module.args = specialArgs; } def)
+        ])
+        { };
+      nestedTypes = types;
+    };
+
     submoduleWith =
       { modules
       , specialArgs ? {}

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -213,6 +213,57 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
     options. This is equivalent to
     `types.submoduleWith { modules = toList o; shorthandOnlyDefinesConfig = true; }`.
 
+`types.taggedSubmodules` { *`types`*, *`specialArgs`* ? {} }
+
+:   Like `types.oneOf`, but takes an attrsSet of submodule in types. Those need to have a type option
+    which is used to find the correct submodule.
+
+::: {#ex-tagged-submodules .example}
+### Tagged submodules
+```nix
+let
+  submoduleA = submodule {
+    options = {
+      type = mkOption {
+        type = str;
+      };
+      foo = mkOption {
+        type = int;
+      };
+    };
+  };
+  submoduleB = submodule {
+    options = {
+      type = mkOption {
+        type = str;
+      };
+      bar = mkOption {
+        type = int;
+      };
+    };
+  };
+in
+options.mod = mkOption {
+  type = attrsOf (taggedSubmodule {
+    types = {
+      a = submoduleA;
+      b = submoduleB;
+    };
+  });
+};
+config.mod = {
+  someA = {
+    type = "a";
+    foo = 123;
+  };
+  someB = {
+    type = "b";
+    foo = 456;
+  };
+};
+```
+:::
+
 `types.submoduleWith` { *`modules`*, *`specialArgs`* ? {}, *`shorthandOnlyDefinesConfig`* ? false }
 
 :   Like `types.submodule`, but more flexible and with better defaults.


### PR DESCRIPTION
## Description of changes

This adds a new type: taggedSubmodules, which is similiar to oneOf but can be used in an attrsOf to have different submodules for each attr. A type like this is used heavily by disko and I briefly talked with @roberth about it and he said upstreaming it should be fine.

I'm not set on naming yet and haven't tested this fully. Just want to gather some ideas how to build this ideally. Happy to hear what you think! :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
