### PR TITLE
mpfi: replace lost tarball by tagged commit on gitlab

### DIFF
--- a/pkgs/development/libraries/mpfi/default.nix
+++ b/pkgs/development/libraries/mpfi/default.nix
@@ -1,16 +1,20 @@
-{lib, stdenv, fetchurl, autoreconfHook, texinfo, mpfr}:
+{lib, stdenv, fetchFromGitLab, autoreconfHook, texinfo, mpfr}:
 stdenv.mkDerivation rec {
   pname = "mpfi";
   version = "1.5.4";
-  file_nr = "38111";
 
-  src = fetchurl {
-    # NOTE: the file_nr is whats important here. The actual package name (including the version)
-    # is ignored. To find out the correct file_nr, go to https://gforge.inria.fr/projects/mpfi/
-    # and click on Download in the section "Latest File Releases".
-    url = "https://gforge.inria.fr/frs/download.php/file/${file_nr}/mpfi-${version}.tgz";
-    sha256 = "sha256-Ozk4WV1yCvF5c96vcnz8DdQcixbCCtwQOpcPSkOuOlY=";
-  };
+  src = fetchFromGitLab {
+    domain = "gitlab.inria.fr";
+    owner = pname;
+    repo = pname;
+    rev = "${version}";
+    hash = "sha256-EZMJa6+HRsNyVWy+hZD/srm8Fj02VsHFXXA4WHcwNKM=";
+  } + "/${pname}";
+
+  postPatch = ''
+    # apparently, they tagged a version with a missing file
+    sed -i 's/ div_ext.c / /' src/Makefile.am
+  '';
 
   nativeBuildInputs = [ autoreconfHook texinfo ];
   buildInputs = [ mpfr ];


### PR DESCRIPTION
## Description of changes

Retrieved 1.5.4 version from gitlab since no tarball was available. Might fix https://github.com/NixOS/nixpkgs/issues/254809

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).