### PR TITLE
phpactor: slight refactor

### DIFF
--- a/pkgs/development/tools/phpactor/default.nix
+++ b/pkgs/development/tools/phpactor/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchFromGitHub, php, phpPackages }:
+{ lib, stdenvNoCC, fetchFromGitHub, makeBinaryWrapper, php, phpPackages }:
 
 let
   version = "2023.06.17";
@@ -51,6 +51,10 @@ stdenvNoCC.mkDerivation {
   pname = "phpactor";
   inherit src version;
 
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
   buildInputs = [
     php
   ];
@@ -63,7 +67,8 @@ stdenvNoCC.mkDerivation {
     mkdir -p $out/share/php/phpactor $out/bin
     cp -r . $out/share/php/phpactor
     cp -r ${vendor}/vendor $out/share/php/phpactor
-    ln -s $out/share/php/phpactor/bin/phpactor $out/bin/phpactor
+    makeWrapper ${php}/bin/php "$out/bin/phpactor" \
+      --add-flags $out/share/php/phpactor/bin/phpactor
 
     runHook postInstall
   '';


### PR DESCRIPTION

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The current installPhase for [phpactor](https://github.com/phpactor/phpactor) creates a symlink to the phpactor executable. This is broken on MacOS as the PHP shebang points to a script instead of an actual binary.
(see https://stackoverflow.com/questions/67100831/macos-shebang-with-absolute-path-not-working)

Added `makeBinaryWrapper` to `nativeBuildInputs`, and updated `installPhase` to use `makeWrapper` instead of `ln -s`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
