### PR TITLE
mpfi: switch source to INRIA GitLab

### DIFF
--- a/pkgs/development/libraries/mpfi/default.nix
+++ b/pkgs/development/libraries/mpfi/default.nix
@@ -1,23 +1,32 @@
-{lib, stdenv, fetchurl, autoreconfHook, texinfo, mpfr}:
+{lib, stdenv, fetchFromGitLab, autoreconfHook, texinfo, mpfr}:
 stdenv.mkDerivation rec {
   pname = "mpfi";
   version = "1.5.4";
-  file_nr = "38111";
 
-  src = fetchurl {
-    # NOTE: the file_nr is whats important here. The actual package name (including the version)
-    # is ignored. To find out the correct file_nr, go to https://gforge.inria.fr/projects/mpfi/
-    # and click on Download in the section "Latest File Releases".
-    url = "https://gforge.inria.fr/frs/download.php/file/${file_nr}/mpfi-${version}.tgz";
-    sha256 = "sha256-Ozk4WV1yCvF5c96vcnz8DdQcixbCCtwQOpcPSkOuOlY=";
+  src = fetchFromGitLab {
+    domain = "gitlab.inria.fr";
+    owner = "mpfi";
+    repo = "mpfi";
+
+    # Apparently there is an upstream off-by-one-commit error in tagging
+    # Conditional to allow auto-updaters to try new releases
+    # TODO: remove the conditional after an upstream update
+    # rev = version;
+    rev = if version == "1.5.4" then
+      "feab26bc54529417af983950ddbffb3a4c334d4f"
+    else version;
+
+    sha256 = "sha256-aj/QmJ38ifsW36JFQcbp55aIQRvOpiqLHwEh/aFXsgo=";
   };
+
+  sourceRoot = "source/mpfi";
 
   nativeBuildInputs = [ autoreconfHook texinfo ];
   buildInputs = [ mpfr ];
 
   meta = {
     description = "A multiple precision interval arithmetic library based on MPFR";
-    homepage = "https://gforge.inria.fr/projects/mpfi/";
+    homepage = "http://perso.ens-lyon.fr/nathalie.revol/software.html";
     license = lib.licenses.lgpl21Plus;
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
## Description of changes

Fixes #254809 — updates the source to the new INRIA GitLab
The revision used is the next one after the release tag, as the tagged revision misses one file.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Most rev-deps built