### PR TITLE
Revert "Revert "Merge pull request #253760 from chivay/bootstrap-scrt""

### DIFF
--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -78,7 +78,8 @@ in with pkgs; rec {
         cp -d ${libc.out}/lib/libutil*.so* $out/lib
         cp -d ${libc.out}/lib/libnss*.so* $out/lib
         cp -d ${libc.out}/lib/libresolv*.so* $out/lib
-        cp -d ${libc.out}/lib/crt?.o $out/lib
+        # Copy all runtime files to enable non-PIE, PIE, static PIE and profile-generated builds
+        cp -d ${libc.out}/lib/*.o $out/lib
 
         # Hacky compat with our current unpack-bootstrap-tools.sh
         ln -s librt.so "$out"/lib/librt-dummy.so


### PR DESCRIPTION
Reverts NixOS/nixpkgs#254073

If we revert the revert then hydra will build the bootstrap files for us and the hashes can be verified if one builds the packages locally too.