### PR TITLE
ocamlPackages.dolmen: 0.6 → 0.9

### DIFF
--- a/pkgs/development/ocaml-modules/dolmen/default.nix
+++ b/pkgs/development/ocaml-modules/dolmen/default.nix
@@ -1,24 +1,26 @@
 { lib, fetchurl, buildDunePackage
 , menhir, menhirLib
 , fmt
+, qcheck
 }:
 
 buildDunePackage rec {
   pname = "dolmen";
-  version = "0.6";
+  version = "0.9";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
-    url = "https://github.com/Gbury/dolmen/releases/download/v${version}/dolmen-v${version}.tbz";
-    sha256 = "133l23mwxa9xy340izvk4zp5jqjz2cwsm2innsgs2kg85pd39c41";
+    url = "https://github.com/Gbury/dolmen/releases/download/v${version}/dolmen-${version}.tbz";
+    hash = "sha256-AD21OFS6zDoz+lXtac95gXwQNppPfGvpRK8dzDZXigo=";
   };
 
   nativeBuildInputs = [ menhir ];
   propagatedBuildInputs = [ menhirLib fmt ];
 
-  # Testr are not compatible with menhir 20211128
-  doCheck = false;
+  doCheck = true;
+
+  checkInputs = [ qcheck ];
 
   meta = {
     description = "An OCaml library providing clean and flexible parsers for input languages";

--- a/pkgs/development/ocaml-modules/dolmen/loop.nix
+++ b/pkgs/development/ocaml-modules/dolmen/loop.nix
@@ -1,12 +1,13 @@
 { buildDunePackage, dolmen, dolmen_type
 , gen
+, pp_loc
 }:
 
 buildDunePackage {
   pname = "dolmen_loop";
   inherit (dolmen) src version;
 
-  propagatedBuildInputs = [ dolmen dolmen_type gen ];
+  propagatedBuildInputs = [ dolmen dolmen_type gen pp_loc ];
 
   meta = dolmen.meta // {
     description = "A tool library for automated deduction tools";

--- a/pkgs/development/ocaml-modules/dolmen/loop.nix
+++ b/pkgs/development/ocaml-modules/dolmen/loop.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage, dolmen, dolmen_type
+, gen
+}:
+
+buildDunePackage {
+  pname = "dolmen_loop";
+  inherit (dolmen) src version;
+
+  propagatedBuildInputs = [ dolmen dolmen_type gen ];
+
+  meta = dolmen.meta // {
+    description = "A tool library for automated deduction tools";
+  };
+}

--- a/pkgs/development/ocaml-modules/dolmen/type.nix
+++ b/pkgs/development/ocaml-modules/dolmen/type.nix
@@ -1,0 +1,15 @@
+{ buildDunePackage, dolmen
+, spelll
+, uutf
+}:
+
+buildDunePackage {
+  pname = "dolmen_type";
+  inherit (dolmen) src version;
+
+  propagatedBuildInputs = [ dolmen spelll uutf ];
+
+  meta = dolmen.meta // {
+    description = "A typechecker for automated deduction languages";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -337,6 +337,8 @@ let
 
     dolmen =  callPackage ../development/ocaml-modules/dolmen { };
 
+    dolmen_loop =  callPackage ../development/ocaml-modules/dolmen/loop.nix { };
+
     dolmen_type =  callPackage ../development/ocaml-modules/dolmen/type.nix { };
 
     dolog = callPackage ../development/ocaml-modules/dolog { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -337,6 +337,8 @@ let
 
     dolmen =  callPackage ../development/ocaml-modules/dolmen { };
 
+    dolmen_type =  callPackage ../development/ocaml-modules/dolmen/type.nix { };
+
     dolog = callPackage ../development/ocaml-modules/dolog { };
 
     domain-local-await = callPackage ../development/ocaml-modules/domain-local-await { };


### PR DESCRIPTION
## Description of changes

https://github.com/Gbury/dolmen/blob/v0.9/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
