### PR TITLE
minimal-bootstrap.musl: init at 1.2.4

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -144,6 +144,11 @@ lib.makeScope
     mes = lib.recurseIntoAttrs (callPackage ./mes { });
     mes-libc = callPackage ./mes/libc.nix { };
 
+    musl = callPackage ./musl {
+      gcc = gcc46;
+      gawk = gawk-mes;
+    };
+
     stage0-posix = callPackage ./stage0-posix { };
 
     inherit (self.stage0-posix) kaem m2libc mescc-tools mescc-tools-extra;
@@ -180,6 +185,7 @@ lib.makeScope
       echo ${gzip.tests.get-version}
       echo ${heirloom.tests.get-version}
       echo ${mes.compiler.tests.get-version}
+      echo ${musl.tests.hello-world}
       echo ${tinycc-mes.compiler.tests.chain}
       echo ${xz.tests.get-version}
       mkdir ''${out}

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/default.nix
@@ -1,0 +1,87 @@
+{ lib
+, buildPlatform
+, hostPlatform
+, fetchurl
+, bash
+, gcc
+, binutils
+, gnumake
+, gnugrep
+, gnused
+, gawk
+, gnutar
+, gzip
+}:
+let
+  pname = "musl";
+  version = "1.2.4";
+
+  src = fetchurl {
+    url = "https://musl.libc.org/releases/musl-${version}.tar.gz";
+    hash = "sha256-ejXq4z1TcqfA2hGI3nmHJvaIJVE7euPr6XqqpSEU8Dk=";
+  };
+in
+bash.runCommand "${pname}-${version}" {
+  inherit pname version;
+
+  nativeBuildInputs = [
+    gcc
+    binutils
+    gnumake
+    gnused
+    gnugrep
+    gawk
+    gnutar
+    gzip
+  ];
+
+  passthru.tests.hello-world = result:
+    bash.runCommand "${pname}-simple-program-${version}" {
+        nativeBuildInputs = [ gcc binutils ];
+      } ''
+        cat <<EOF >> test.c
+        #include <stdio.h>
+        int main() {
+          printf("Hello World!\n");
+          return 0;
+        }
+        EOF
+        gcc -static -B${result}/lib -I${result}/include -o test test.c
+        ./test
+        mkdir $out
+      '';
+
+  meta = with lib; {
+    description = "An efficient, small, quality libc implementation";
+    homepage = "https://musl.libc.org";
+    license = licenses.mit;
+    maintainers = teams.minimal-bootstrap.members;
+    platforms = platforms.unix;
+  };
+} ''
+  # Unpack
+  tar xzf ${src}
+  cd musl-${version}
+
+  # Patch
+  # https://github.com/ZilchOS/bootstrap-from-tcc/blob/2e0c68c36b3437386f786d619bc9a16177f2e149/using-nix/2a3-intermediate-musl.nix
+  sed -i 's|/bin/sh|${bash}/bin/bash|' \
+    tools/*.sh
+  # patch popen/system to search in PATH instead of hardcoding /bin/sh
+  sed -i 's|posix_spawn(&pid, "/bin/sh",|posix_spawnp(\&pid, "sh",|' \
+    src/stdio/popen.c src/process/system.c
+  sed -i 's|execl("/bin/sh", "sh", "-c",|execlp("sh", "-c",|'\
+    src/misc/wordexp.c
+
+  # Configure
+  bash ./configure \
+    --prefix=$out \
+    --build=${buildPlatform.config} \
+    --host=${hostPlatform.config}
+
+  # Build
+  make
+
+  # Install
+  make install
+''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've spent probably a week of work trying to get glibc 2.16 to build and have ended up unsuccessful due to the age and complexity of the build system. After finally giving up and trying musl the build pretty much worked instantly >.>. I think it might be necessary to give up on a glibc bootstrap and switch. Future work can go back and replace glibc 2.2 with an older version of musl and remove some of the hacks that it caused.

Related #227914

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
