### PR TITLE
nixos/user-groups: fixup of 5666a378

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -239,12 +239,12 @@ foreach my $u (@{$spec->{users}}) {
         chmod oct($u->{homeMode}), $u->{home};
     }
 
-    if (defined $u->{passwordFile}) {
-        if (-e $u->{passwordFile}) {
-            $u->{hashedPassword} = read_file($u->{passwordFile});
+    if (defined $u->{hashedPasswordFile}) {
+        if (-e $u->{hashedPasswordFile}) {
+            $u->{hashedPassword} = read_file($u->{hashedPasswordFile});
             chomp $u->{hashedPassword};
         } else {
-            warn "warning: password file ‘$u->{passwordFile}’ does not exist\n";
+            warn "warning: password file ‘$u->{hashedPasswordFile}’ does not exist\n";
         }
     } elsif (defined $u->{password}) {
         $u->{hashedPassword} = hashPassword($u->{password});

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -264,7 +264,7 @@ let
       };
 
       passwordFile = mkOption {
-        type = with types; nullOr (passwdEntry str);
+        type = with types; nullOr str;
         default = null;
         visible = false;
         description = lib.mdDoc "Deprecated alias of hashedPasswordFile";

--- a/nixos/tests/shadow.nix
+++ b/nixos/tests/shadow.nix
@@ -32,7 +32,7 @@ in import ./make-test-python.nix ({ pkgs, ... }: {
       };
       users.berta = {
         isNormalUser = true;
-        hashedPassword = hashed_bcrypt;
+        hashedPasswordFile = (pkgs.writeText "hashed_bcrypt" hashed_bcrypt).outPath;
         shell = pkgs.bash;
       };
       users.yesim = {


### PR DESCRIPTION
## Description of changes

This should fix the problem introduced by #254080.

I tested with `nix build -f. nixosTests.shadow`, after applying this patch:
```patch
diff --git a/nixos/tests/shadow.nix b/nixos/tests/shadow.nix
index c9a04088e870..7dc5dacb255f 100644
--- a/nixos/tests/shadow.nix
+++ b/nixos/tests/shadow.nix
@@ -32,12 +32,12 @@ in import ./make-test-python.nix ({ pkgs, ... }: {
       };
       users.berta = {
         isNormalUser = true;
-        hashedPassword = hashed_bcrypt;
+        passwordFile = (pkgs.writeText "hashed_bcrypt" hashed_bcrypt).outPath;
         shell = pkgs.bash;
       };
       users.yesim = {
         isNormalUser = true;
-        hashedPassword = hashed_yeshash;
+        passwordFile = (pkgs.writeText "hashed_yeshash" hashed_yeshash).outPath;
         shell = pkgs.bash;
       };
       users.leo = {
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested with `nixosTests.shadow`, see above
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc: @dunxen @1sixth
