### PR TITLE
nixos/{auto-cpufreq, below}: Add `meta.maintainers`

### DIFF
--- a/nixos/modules/services/hardware/auto-cpufreq.nix
+++ b/nixos/modules/services/hardware/auto-cpufreq.nix
@@ -44,5 +44,8 @@ in {
   };
 
   # uses attributes of the linked package
-  meta.buildDocsInSandbox = false;
+  meta = {
+    buildDocsInSandbox = false;
+    maintainers = with lib.maintainers; [ nicoo ];
+  };
 }

--- a/nixos/modules/services/monitoring/below.nix
+++ b/nixos/modules/services/monitoring/below.nix
@@ -103,4 +103,6 @@ in {
       };
     };
   };
+
+  meta.maintainers = with lib.maintainers; [ nicoo ];
 }


### PR DESCRIPTION
## Description of changes

Filled in maintainership metadata for 2 modules.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
