### PR TITLE
fetchDebianPatch: Add nicoo to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@
 /.github/workflows/check-by-name.nix @infinisil
 
 # Nixpkgs build-support
+/pkgs/build-support/fetchdebianpatch @nbraud
 /pkgs/build-support/writers @lassulus @Profpatsch
 
 # Nixpkgs make-disk-image


### PR DESCRIPTION
## Description of changes

Add myself to `CODEOWNERS` for `build-support/fetchdebianpatch`.

This is apparently the only way to document who maintains a fetcher, and given that I wrote it, I'm presumably “it.”
