### PR TITLE
headscale: fix reacting to SIGTERM

### DIFF
--- a/pkgs/servers/headscale/default.nix
+++ b/pkgs/servers/headscale/default.nix
@@ -21,6 +21,10 @@ buildGoModule rec {
   patches = [
     # backport of https://github.com/juanfont/headscale/pull/1697
     ./trim-oidc-secret-path.patch
+
+    # fix for headscale not reacting to SIGTERM
+    # see https://github.com/juanfont/headscale/pull/1480 and https://github.com/juanfont/headscale/issues/1461
+    ./sigterm-fix.patch
   ];
 
   ldflags = ["-s" "-w" "-X github.com/juanfont/headscale/cmd/headscale/cli.Version=v${version}"];

--- a/pkgs/servers/headscale/sigterm-fix.patch
+++ b/pkgs/servers/headscale/sigterm-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/hscontrol/app.go b/hscontrol/app.go
+index b8dceba..4bcf019 100644
+--- a/hscontrol/app.go
++++ b/hscontrol/app.go
+@@ -821,6 +821,7 @@ func (h *Headscale) Serve() error {
+
+ 				// And we're done:
+ 				cancel()
++ 				return
+ 			}
+ 		}
+ 	}


### PR DESCRIPTION
## Description of changes
The current version of headscale does not react to SIGTERMs and so it can only be terminated by a SIGKILL at the moment. This PR provides a patch to fix this.

The fix is taken from [here](https://github.com/juanfont/headscale/pull/1480). For more information about this, see the related issue [here](https://github.com/juanfont/headscale/issues/1461).

I use this fix for my headscale and it works like a charm for weeks now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
