### PR TITLE
snazy: 0.51.3 -> 0.52.0

### DIFF
--- a/pkgs/development/tools/snazy/default.nix
+++ b/pkgs/development/tools/snazy/default.nix
@@ -1,32 +1,21 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
-, fetchpatch
 , installShellFiles
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "snazy";
-  version = "0.51.3";
+  version = "0.52.0";
 
   src = fetchFromGitHub {
     owner = "chmouel";
     repo = pname;
     rev = version;
-    hash = "sha256-YE11ypzOhRNjoi+X9Khp6qxqhD1f/hslr1t2cEeUTbs=";
+    hash = "sha256-ax16BO2I+LgaVilqrsVToulBRcyr0C/QUtrdn0nUfBU=";
   };
 
-  cargoHash = "sha256-8oT9tdGeU/1mtgf470Ps4EwQmWxPhxAzmA8D30UG60o=";
-
-  cargoPatches = [
-    # update Cargo.toml to fix the version
-    # https://github.com/chmouel/snazy/pull/217
-    (fetchpatch {
-      name = "update-version-in-cargo-toml.patch";
-      url = "https://github.com/chmouel/snazy/commit/199f560e12d07c07c240bc91e7f929831af2cc4d.patch";
-      hash = "sha256-X1oi4Mf1m/k/HYYJvqIrN14JJSEPUmWJt9PhzLiyYUs=";
-    })
-  ];
+  cargoHash = "sha256-go6y/NH3vFb8xtAGVpgy0GQfMfzXfn8hI+tJnUdCFAU=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Diff: https://github.com/chmouel/snazy/compare/0.51.3...0.52.0

Changelog: https://github.com/chmouel/snazy/releases/tag/0.52.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
