### PR TITLE
srb2: 2.2.11 -> 2.2.13

### DIFF
--- a/pkgs/games/srb2/cmake.patch
+++ b/pkgs/games/srb2/cmake.patch
@@ -1,19 +1,61 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 915912af5..f5c2cf9cc 100644
+index 80a3bdcd6..380a1573a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -91,11 +91,6 @@ if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL Windows)
+@@ -61,7 +61,7 @@ option(
+ 	"Link dependencies using CMake's find_package and do not use internal builds"
+ 	${SRB2_CONFIG_SYSTEM_LIBRARIES_DEFAULT}
+ )
+-option(SRB2_CONFIG_ENABLE_TESTS "Build the test suite" ON)
++option(SRB2_CONFIG_ENABLE_TESTS "Build the test suite" OFF)
+ # This option isn't recommended for distribution builds and probably won't work (yet).
+ cmake_dependent_option(
+ 	SRB2_CONFIG_SHARED_INTERNAL_LIBRARIES
+@@ -80,25 +80,6 @@ option(SRB2_CONFIG_ZDEBUG "Compile with ZDEBUG defined." OFF)
+ option(SRB2_CONFIG_PROFILEMODE "Compile for profiling (GCC only)." OFF)
+ set(SRB2_CONFIG_ASSET_DIRECTORY "" CACHE PATH "Path to directory that contains all asset files for the installer. If set, assets will be part of installation and cpack.")
+ 
+-if(SRB2_CONFIG_ENABLE_TESTS)
+-	# https://github.com/catchorg/Catch2
+-	CPMAddPackage(
+-		NAME Catch2
+-		VERSION 3.4.0
+-		GITHUB_REPOSITORY catchorg/Catch2
+-		OPTIONS
+-			"CATCH_INSTALL_DOCS OFF"
+-	)
+-	list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/extras")
+-	include(CTest)
+-	include(Catch)
+-	add_executable(srb2tests)
+-	# To add tests, use target_sources to add individual test files to the target in subdirs.
+-	target_link_libraries(srb2tests PRIVATE Catch2::Catch2 Catch2::Catch2WithMain)
+-	target_compile_features(srb2tests PRIVATE c_std_11 cxx_std_17)
+-	catch_discover_tests(srb2tests)
+-endif()
+-
+ # Enable CCache
+ # (Set USE_CCACHE=ON to use, CCACHE_OPTIONS for options)
+ if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL Windows)
+@@ -113,12 +94,6 @@ if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL Windows)
+ 			message(WARNING "USE_CCACHE was set but ccache is not found (set CCACHE_TOOL_PATH)")
  		endif()
  	endif()
- else()
+-else()
 -	CPMAddPackage(
 -		NAME Ccache.cmake
 -		GITHUB_REPOSITORY TheLartians/Ccache.cmake
 -		VERSION 1.2
 -	)
  endif()
-
+ 
  # Dependencies
---
-2.40.1
-
+@@ -179,7 +154,7 @@ include(GitUtilities)
+ if("${SRB2_SDL2_EXE_NAME}" STREQUAL "")
+ 	# cause a reconfigure if the branch changes
+ 	get_git_dir(SRB2_GIT_DIR)
+-	configure_file("${SRB2_GIT_DIR}/HEAD" HEAD COPYONLY)
++	#configure_file("${SRB2_GIT_DIR}/HEAD" HEAD COPYONLY)
+ 
+ 	git_current_branch(SRB2_GIT_REVISION)
+ 

--- a/pkgs/games/srb2/default.nix
+++ b/pkgs/games/srb2/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "srb2";
-  version = "2.2.11";
+  version = "2.2.13";
 
   src = fetchFromGitHub {
     owner = "STJr";
     repo = "SRB2";
     rev = "SRB2_release_${finalAttrs.version}";
-    hash = "sha256-tyiXivJWjNnL+4YynUV6k6iaMs8o9HkHrp+qFj2+qvQ=";
+    hash = "sha256-OSkkjCz7ZW5+0vh6l7+TpnHLzXmd/5QvTidRQSHJYX8=";
   };
 
   nativeBuildInputs = [
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     src = fetchurl {
       url = "https://github.com/STJr/SRB2/releases/download/SRB2_release_${finalAttrs.version}/SRB2-v${lib.replaceStrings ["."] [""] finalAttrs.version}-Full.zip";
-      hash = "sha256-KsJIkCczD/HyIwEy5dI3zsHbWFCMBaCoCHizfupFoWM=";
+      hash = "sha256-g7kaNRE1tjcF5J2v+kTnrDzz4zs5f1b/NH67ce2ifUo=";
     };
 
     sourceRoot = ".";
@@ -77,8 +77,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # Fix unknown command "CPMAddPackage" by not using Ccache.cmake
+    # Make the build work without internet connectivity
+    # See: https://build.opensuse.org/request/show/1109889
     ./cmake.patch
+    ./thirdparty.patch
   ];
 
   desktopItems = [
@@ -111,5 +113,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ zeratax donovanglover ];
+    mainProgram = "srb2";
   };
 })

--- a/pkgs/games/srb2/thirdparty.patch
+++ b/pkgs/games/srb2/thirdparty.patch
@@ -1,0 +1,12 @@
+diff --git a/thirdparty/CMakeLists.txt b/thirdparty/CMakeLists.txt
+index f33b3bf3f..1214f179c 100644
+--- a/thirdparty/CMakeLists.txt
++++ b/thirdparty/CMakeLists.txt
+@@ -16,6 +16,5 @@ if(NOT "${SRB2_CONFIG_SYSTEM_LIBRARIES}")
+ 	include("cpm-png.cmake")
+ 	include("cpm-curl.cmake")
+ 	include("cpm-openmpt.cmake")
++	include("cpm-libgme.cmake")
+ endif()
+-
+-include("cpm-libgme.cmake")


### PR DESCRIPTION
Fixes #254167

## Description of changes

- https://github.com/STJr/SRB2/releases/tag/SRB2_release_2.2.13
- https://github.com/STJr/SRB2/releases/tag/SRB2_release_2.2.12

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
