### PR TITLE
furnace: 0.6pre9 -> 0.6pre16

### DIFF
--- a/pkgs/applications/audio/furnace/default.nix
+++ b/pkgs/applications/audio/furnace/default.nix
@@ -18,18 +18,22 @@
 , libjack2
 , withGUI ? true
 , Cocoa
+, portaudio
+, alsa-lib
+# Use GLES instead of GL
+, withGLES ? stdenv.hostPlatform.isAarch
 }:
 
 stdenv.mkDerivation rec {
   pname = "furnace";
-  version = "0.6pre9";
+  version = "0.6pre16";
 
   src = fetchFromGitHub {
     owner = "tildearrow";
     repo = "furnace";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-i7/NN179Wyr1FqNlgryyFtishFr5EY1HI6BRQKby/6E=";
+    sha256 = "sha256-n66Bv8xB/0KMJYoMILxsaKoaX+E0OFGI3QGqhxKTFUQ=";
   };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
@@ -53,8 +57,12 @@ stdenv.mkDerivation rec {
     rtmidi
     SDL2
     zlib
+    portaudio
   ] ++ lib.optionals withJACK [
     libjack2
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # portaudio pkg-config is pulling this in as a link dependency, not set in propagatedBuildInputs
+    alsa-lib
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     Cocoa
   ];
@@ -67,7 +75,12 @@ stdenv.mkDerivation rec {
     "-DSYSTEM_RTMIDI=ON"
     "-DSYSTEM_SDL2=ON"
     "-DSYSTEM_ZLIB=ON"
+    "-DSYSTEM_PORTAUDIO=ON"
     "-DWITH_JACK=${if withJACK then "ON" else "OFF"}"
+    "-DWITH_PORTAUDIO=ON"
+    "-DWITH_RENDER_SDL=ON"
+    "-DWITH_RENDER_OPENGL=ON"
+    "-DUSE_GLES=${lib.boolToString withGLES}"
     "-DWARNINGS_ARE_ERRORS=ON"
   ];
 

--- a/pkgs/applications/audio/furnace/default.nix
+++ b/pkgs/applications/audio/furnace/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     repo = "furnace";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-n66Bv8xB/0KMJYoMILxsaKoaX+E0OFGI3QGqhxKTFUQ=";
+    hash = "sha256-n66Bv8xB/0KMJYoMILxsaKoaX+E0OFGI3QGqhxKTFUQ=";
   };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
## Description of changes

- Bump:
  - https://github.com/tildearrow/furnace/releases/tag/v0.6pre10
  - https://github.com/tildearrow/furnace/releases/tag/v0.6pre11
  - https://github.com/tildearrow/furnace/releases/tag/v0.6pre12
  - https://github.com/tildearrow/furnace/releases/tag/v0.6pre13
  - https://github.com/tildearrow/furnace/releases/tag/v0.6pre14
  - https://github.com/tildearrow/furnace/releases/tag/v0.6pre15
  - https://github.com/tildearrow/furnace/releases/tag/v0.6pre16
- Explicitly enable PortAudio audio output option, use system-installed one
- Explicitly enable SDL & OpenGL render options
  - Prefer GL or GLES based on hostPlatform

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
