### PR TITLE
nixos/wrapper: add basename of the wrapped program to the wrappers name to easily identify it

### DIFF
--- a/nixos/modules/security/wrappers/wrapper.nix
+++ b/nixos/modules/security/wrappers/wrapper.nix
@@ -1,8 +1,8 @@
 { stdenv, unsecvars, linuxHeaders, sourceProg, debug ? false }:
 # For testing:
-# $ nix-build -E 'with import <nixpkgs> {}; pkgs.callPackage ./wrapper.nix { parentWrapperDir = "/run/wrappers"; debug = true; }'
+# $ nix-build -E 'with import <nixpkgs> {}; pkgs.callPackage ./wrapper.nix { sourceProg = "${pkgs.hello}/bin/hello"; debug = true; }'
 stdenv.mkDerivation {
-  name = "security-wrapper";
+  name = "security-wrapper-${baseNameOf sourceProg}";
   buildInputs = [ linuxHeaders ];
   dontUnpack = true;
   CFLAGS = [


### PR DESCRIPTION
## Description of changes

make commands like nix store diff-closure more useful. eg:

```
command nix store diff-closures /nix/var/nix/profiles/system-23-link/ /nix/var/nix/profiles/system-24-link/
security: ε → ∅, -349.0 KiB
security-wrapper: ∅ → ε, +265.9 KiB
security-wrapper-arp: ∅ → ε, +16.6 KiB
security-wrapper-dbus-daemon-launch: ∅ → ε, +16.6 KiB
security-wrapper-fusermount3: ∅ → ε, +16.6 KiB
security-wrapper-mtr: ∅ → ε, +16.6 KiB
security-wrapper-unix_chkpwd: ∅ → ε, +16.6 KiB
```
or nix-diff (not relevant parts cut)

```
- /nix/var/nix/profiles/system-23-link/:{out}
+ /nix/var/nix/profiles/system-24-link/:{out}
• The set of input derivation names do not match:
    - security-wrapper
    + security-wrapper-arp-scan
    + security-wrapper-chsh
    + security-wrapper-dbus-daemon-launch-helper
    + security-wrapper-fusermount
    + security-wrapper-fusermount3
    + security-wrapper-iotop
    + security-wrapper-mount
    + security-wrapper-mtr-packet
    + security-wrapper-newgidmap
    + security-wrapper-newgrp
    + security-wrapper-newuidmap
    + security-wrapper-passwd
    + security-wrapper-ping
    + security-wrapper-plocate
    + security-wrapper-sg
    + security-wrapper-su
    + security-wrapper-sudo
    + security-wrapper-sudoedit
    + security-wrapper-tcpdump
    + security-wrapper-umount
    + security-wrapper-unix_chkpwd
...
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
