### PR TITLE
aflplusplus: 4.06c -> 4.08c

### DIFF
--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -19,13 +19,13 @@ let
   libtokencap = callPackage ./libtokencap.nix { inherit aflplusplus; };
   aflplusplus = stdenvNoCC.mkDerivation rec {
     pname = "aflplusplus";
-    version = "4.06c";
+    version = "4.08c";
 
     src = fetchFromGitHub {
       owner = "AFLplusplus";
       repo = "AFLplusplus";
-      rev = version;
-      sha256 = "sha256-Gb1nYDBnwLS+m8e1UD0WLIrnp8KRgliGQVvQD22JXrQ=";
+      rev = "v${version}";
+      sha256 = "sha256-r1elJlvGuVrMFLECYCfMsZVEJcCPYRdkljMbF4uRHQY=";
     };
     enableParallelBuilding = true;
 

--- a/pkgs/tools/security/aflplusplus/qemu.nix
+++ b/pkgs/tools/security/aflplusplus/qemu.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "AFLplusplus";
     repo = "qemuafl";
-    rev = "0569eff8a12dec73642b96757f6b5b51a618a03a";
-    sha256 = "sha256-nYWHyRfOH2p9znRxjxsiyw11uZuMBiuJfEc7FHM5X7M=";
+    rev = "a1321713c7502c152dd7527555e0f8a800d55225";
+    sha256 = "sha256-HLlOHqT2vrHjHyu4n83IzVzKv9ErinephLLev1E10nM=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Description of changes

Changelogs:

- https://github.com/AFLplusplus/AFLplusplus/releases/tag/v4.08c
- https://github.com/AFLplusplus/AFLplusplus/releases/tag/4.07c (skipped)

Commits aflplusplus-qemu sub-component (doesn't do releases):

- https://github.com/AFLplusplus/qemuafl/commit/a8582925c5ecc8a58e96f36bddc724aa177926ed
- https://github.com/AFLplusplus/qemuafl/commit/b0abbe2e74ed74ff6ff25b5ea3110d27ba978001

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux (not supported by package)
  - [ ] x86_64-darwin (not supported by package)
  - [ ] aarch64-darwin (not supported by package)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Partially: I tested the core binaries (afl-fuzz + the compiler wrappers). This package has a lot of executables and I don't even know how to use half of them. I at least validated that they all start and print help.
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

