### PR TITLE
systemd-lib: add name to X-{Reloads,Restart}-Triggers to easily ident…

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -274,7 +274,7 @@ in rec {
       });
     in "${out}/bin/${scriptName}";
 
-  unitConfig = { config, options, ... }: {
+  unitConfig = { config, name, options, ... }: {
     config = {
       unitConfig =
         optionalAttrs (config.requires != [])
@@ -294,9 +294,9 @@ in rec {
         // optionalAttrs (config.requisite != [])
           { Requisite = toString config.requisite; }
         // optionalAttrs (config ? restartTriggers && config.restartTriggers != [])
-          { X-Restart-Triggers = "${pkgs.writeText "X-Restart-Triggers" (toString config.restartTriggers)}"; }
+          { X-Restart-Triggers = "${pkgs.writeText "X-Restart-Triggers-${name}" (toString config.restartTriggers)}"; }
         // optionalAttrs (config ? reloadTriggers && config.reloadTriggers != [])
-          { X-Reload-Triggers = "${pkgs.writeText "X-Reload-Triggers" (toString config.reloadTriggers)}"; }
+          { X-Reload-Triggers = "${pkgs.writeText "X-Reload-Triggers-${name}" (toString config.reloadTriggers)}"; }
         // optionalAttrs (config.description != "") {
           Description = config.description; }
         // optionalAttrs (config.documentation != []) {


### PR DESCRIPTION
…ify to which service/unit/... they belong

## Description of changes

In the theme of other recent PRs of mine.

```
command nix store diff-closures /nix/var/nix/profiles/system-25-link/ /nix/var/nix/profiles/system-26-link/
X-Restart-Triggers-nix: ∅ → ε
X-Restart-Triggers-systemd: ∅ → ε
X-Restart-Triggers-systemd-journald-: ∅ → ε
```

```
- /nix/var/nix/profiles/system-25-link/:{out}
+ /nix/var/nix/profiles/system-26-link/:{out}
  • The input derivation named `system-units` differs
    - /nix/store/dfk3kiwab0wvwjhnaj6nrlcjwnri6aya-system-units.drv:{out}
    + /nix/store/skh2q0fxcxrgpn0g89lg13jfi32qi3pa-system-units.drv:{out}
    • The input derivation named `unit-dbus.service` differs
      - /nix/store/ybrx9pb6pbzagzdagmmdada5l1801d6p-unit-dbus.service.drv:{out}
      + /nix/store/6kv70a3yikn20p7c364wf3wrjl4qp57q-unit-dbus.service.drv:{out}
      • The set of input derivation names do not match:
          - X-Restart-Triggers
          + X-Restart-Triggers-dbus
      • The environments do not match:
          text=''
          [Unit]
          ←X-Restart-Triggers=/nix/store/nyh3xac2in6hdvkzh15whn970jdh6gf2-X-Restart-Triggers←→X-Restart-Triggers=/nix/store/xpc6hdq553f5dqv2jvs8dchf1qqzl3ik-X-Restart-Triggers-dbus→
          
          [Service]
          Environment="LD_LIBRARY_PATH=/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/lib"
          Environment="LOCALE_ARCHIVE=/nix/store/zsil0154b9rvk6az7h9v0rgm4n4kh34i-glibc-locales-2.37-8/lib/locale/locale-archive"
          Environment="PATH=/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/bin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/bin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/bin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/bin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/bin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/sbin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/sbin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/sbin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/sbin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/sbin"
          Environment="TZDIR=/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c/share/zoneinfo"
          
          X-ReloadIfChanged=true
          
          
          
      ''
    • The input derivation named `unit-nix-daemon.service` differs
      - /nix/store/8m0l3b6jhi75b3wb6vlv10incgd6ywvm-unit-nix-daemon.service.drv:{out}
      + /nix/store/za6zwksjj9ixqhxjwalirj23gp0xzlxs-unit-nix-daemon.service.drv:{out}
      • The set of input derivation names do not match:
          - X-Restart-Triggers
          + X-Restart-Triggers-nix-daemon
      • The environments do not match:
          text=''
          [Unit]
          RequiresMountsFor=/nix/store
          ←X-Restart-Triggers=/nix/store/r6s8c5p1y30myf24q41vhca89h5gv0bb-X-Restart-Triggers←→X-Restart-Triggers=/nix/store/2xc3ib19h0wp7ff6w95cxg3iidsgdj5n-X-Restart-Triggers-nix-daemon→
          
          [Service]
          Environment="CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
          Environment="LOCALE_ARCHIVE=/nix/store/zsil0154b9rvk6az7h9v0rgm4n4kh34i-glibc-locales-2.37-8/lib/locale/locale-archive"
          Environment="PATH=/nix/store/dhjlj0bdw4jb76w2ym156l3jlp7l2yzv-nix-2.17.0/bin:/nix/store/dxi5zrshcibajlvldgvffaqpg417cjqs-util-linux-2.39.1-bin/bin:/nix/store/14pg65nv4v68fw6n2xsmfmqg8zqda4fj-openssh-9.4p1/bin:/nix/store/mbvy50fhspgwanw0fpns41afchll75br-gzip-1.12/bin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/bin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/bin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/bin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/bin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/bin:/nix/store/dhjlj0bdw4jb76w2ym156l3jlp7l2yzv-nix-2.17.0/sbin:/nix/store/dxi5zrshcibajlvldgvffaqpg417cjqs-util-linux-2.39.1-bin/sbin:/nix/store/14pg65nv4v68fw6n2xsmfmqg8zqda4fj-openssh-9.4p1/sbin:/nix/store/mbvy50fhspgwanw0fpns41afchll75br-gzip-1.12/sbin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/sbin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/sbin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/sbin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/sbin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/sbin"
          Environment="TZDIR=/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c/share/zoneinfo"
          
          
          X-StopIfChanged=false
          CPUSchedulingPolicy=other
          IOSchedulingClass=best-effort
          IOSchedulingPriority=4
          KillMode=control-group
          LimitNOFILE=1048576
          Restart=on-failure
          
      ''
    • The input derivation named `unit-sshd.service` differs
      - /nix/store/xm6pdlnm9lfddbvk0gv5k1kjjgfv8qd5-unit-sshd.service.drv:{out}
      + /nix/store/ffq29lm558s40xx250nimz7iy9mdvlz7-unit-sshd.service.drv:{out}
      • The set of input derivation names do not match:
          - X-Restart-Triggers
          + X-Restart-Triggers-sshd
      • The environments do not match:
          text=''
          [Unit]
          After=network.target
          Description=SSH Daemon
          ←X-Restart-Triggers=/nix/store/v3fz3brajqfnay59q5qw9p629x587bhf-X-Restart-Triggers←→X-Restart-Triggers=/nix/store/hjkz918v03w6cyj1wkpghlpsxkjdxjdn-X-Restart-Triggers-sshd→
          
          [Service]
          Environment="LD_LIBRARY_PATH=/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/lib"
          Environment="LOCALE_ARCHIVE=/nix/store/zsil0154b9rvk6az7h9v0rgm4n4kh34i-glibc-locales-2.37-8/lib/locale/locale-archive"
          Environment="PATH=/nix/store/14pg65nv4v68fw6n2xsmfmqg8zqda4fj-openssh-9.4p1/bin:/nix/store/3cg1n66ln0l5frnk4lydjajrbf9pavv9-gawk-5.2.2/bin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/bin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/bin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/bin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/bin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/bin:/nix/store/14pg65nv4v68fw6n2xsmfmqg8zqda4fj-openssh-9.4p1/sbin:/nix/store/3cg1n66ln0l5frnk4lydjajrbf9pavv9-gawk-5.2.2/sbin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/sbin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/sbin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/sbin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/sbin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/sbin"
          Environment="TZDIR=/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c/share/zoneinfo"
          
          
          X-StopIfChanged=false
          ExecStart=/nix/store/14pg65nv4v68fw6n2xsmfmqg8zqda4fj-openssh-9.4p1/bin/sshd -D -f /etc/ssh/sshd_config
          ExecStartPre=/nix/store/wxmg47l2ll0pfpllfxs7f0w0r9fqx1lp-unit-script-sshd-pre-start/bin/sshd-pre-start
          KillMode=process
          Restart=always
          Type=simple
          
      ''
    • The input derivation named `unit-systemd-journald-.service` differs
      - /nix/store/92x8hx4yppm75x1n4v5b4nx8fbzbg6wk-unit-systemd-journald-.service.drv:{out}
      + /nix/store/rddjhynblxaiwx0x6n41dm9qvpc4zqjc-unit-systemd-journald-.service.drv:{out}
      • The set of input derivation names do not match:
          - X-Restart-Triggers
          + X-Restart-Triggers-systemd-journald-
      • The environments do not match:
          text=''
          [Unit]
          ←X-Restart-Triggers=/nix/store/msa5hfff04frvc52qhdj8wd21qll6np3-X-Restart-Triggers←→X-Restart-Triggers=/nix/store/yrzsdr1lw81fj7ghdx43yr160ih5dzr2-X-Restart-Triggers-systemd-journald-→
          
          [Service]
          Environment="LOCALE_ARCHIVE=/nix/store/zsil0154b9rvk6az7h9v0rgm4n4kh34i-glibc-locales-2.37-8/lib/locale/locale-archive"
          Environment="PATH=/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/bin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/bin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/bin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/bin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/bin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/sbin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/sbin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/sbin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/sbin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/sbin"
          Environment="TZDIR=/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c/share/zoneinfo"
          
          
          X-StopIfChanged=false
          
      ''
    • The input derivation named `unit-systemd-journald.service` differs
      - /nix/store/4sxw5jylqfy8y98jig5yxny62fpk1maf-unit-systemd-journald.service.drv:{out}
      + /nix/store/yzplw2slld7336q1v6984rlrhi2gwf42-unit-systemd-journald.service.drv:{out}
      • The set of input derivation names do not match:
          - X-Restart-Triggers
          + X-Restart-Triggers-systemd-journald
      • The environments do not match:
          text=''
          [Unit]
          ←X-Restart-Triggers=/nix/store/msa5hfff04frvc52qhdj8wd21qll6np3-X-Restart-Triggers←→X-Restart-Triggers=/nix/store/jm9fwjgywc22nfnsf0l6fykm8k4q3qay-X-Restart-Triggers-systemd-journald→
          
          [Service]
          Environment="LOCALE_ARCHIVE=/nix/store/zsil0154b9rvk6az7h9v0rgm4n4kh34i-glibc-locales-2.37-8/lib/locale/locale-archive"
          Environment="PATH=/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/bin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/bin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/bin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/bin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/bin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/sbin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/sbin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/sbin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/sbin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/sbin"
          Environment="TZDIR=/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c/share/zoneinfo"
          
          
          X-StopIfChanged=false
          
      ''
    • The input derivation named `unit-systemd-resolved.service` differs
      - /nix/store/l2ddv9q1gblxd1hs445i1w9ln158iy57-unit-systemd-resolved.service.drv:{out}
      + /nix/store/7zbiqapnxmlwnnv7v1ss995wfwzkndsl-unit-systemd-resolved.service.drv:{out}
      • The set of input derivation names do not match:
          - X-Restart-Triggers
          + X-Restart-Triggers-systemd-resolved
      • The environments do not match:
          text=''
          [Unit]
          ←X-Restart-Triggers=/nix/store/c6nhdgczvmdnm1089sqmnjsj4wa4gwlf-X-Restart-Triggers←→X-Restart-Triggers=/nix/store/ravjzdhq1jk1x6bn81waq3k4b269v028-X-Restart-Triggers-systemd-resolved→
          
          [Service]
          Environment="LOCALE_ARCHIVE=/nix/store/zsil0154b9rvk6az7h9v0rgm4n4kh34i-glibc-locales-2.37-8/lib/locale/locale-archive"
          Environment="PATH=/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/bin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/bin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/bin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/bin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/bin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/sbin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/sbin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/sbin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/sbin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/sbin"
          Environment="TZDIR=/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c/share/zoneinfo"
          
          
          X-StopIfChanged=false
          
      ''
    • The input derivation named `unit-systemd-sysctl.service` differs
      - /nix/store/76ir8jhav9njzzh3x6068xmh4aihb31h-unit-systemd-sysctl.service.drv:{out}
      + /nix/store/na9spx1zqqawrf9sqy1k4abgz5xr7wb4-unit-systemd-sysctl.service.drv:{out}
      • The set of input derivation names do not match:
          - X-Restart-Triggers
          + X-Restart-Triggers-systemd-sysctl
      • The environments do not match:
          text=''
          [Unit]
          ←X-Restart-Triggers=/nix/store/f39yxvvdp2advbpm6imca4sx2d5wdkx5-X-Restart-Triggers←→X-Restart-Triggers=/nix/store/nh80zrv3l1lc8k4wpvrgyjp24sjyq1hl-X-Restart-Triggers-systemd-sysctl→
          
          [Service]
          Environment="LOCALE_ARCHIVE=/nix/store/zsil0154b9rvk6az7h9v0rgm4n4kh34i-glibc-locales-2.37-8/lib/locale/locale-archive"
          Environment="PATH=/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/bin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/bin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/bin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/bin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/bin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/sbin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/sbin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/sbin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/sbin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/sbin"
          Environment="TZDIR=/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c/share/zoneinfo"
          
          X-RestartIfChanged=false
          
          
          
      ''
    • The input derivation named `unit-systemd-timesyncd.service` differs
      - /nix/store/k96l6b4jp7wgrv742x1qlifk8p3vzrwx-unit-systemd-timesyncd.service.drv:{out}
      + /nix/store/azgnlrm6fwx0x8y47k7mrrlxpb2ih616-unit-systemd-timesyncd.service.drv:{out}
      • The set of input derivation names do not match:
          - X-Restart-Triggers
          + X-Restart-Triggers-systemd-timesyncd
      • The environments do not match:
          text=''
          [Unit]
          ConditionVirtualization=
          ←X-Restart-Triggers=/nix/store/aca9bagw3zsns7rkkfym6l4gqqhg900z-X-Restart-Triggers←→X-Restart-Triggers=/nix/store/4kbc4bj5pb0kvv06k7qfrimz3l4n0vn3-X-Restart-Triggers-systemd-timesyncd→
          
          [Service]
          Environment="LOCALE_ARCHIVE=/nix/store/zsil0154b9rvk6az7h9v0rgm4n4kh34i-glibc-locales-2.37-8/lib/locale/locale-archive"
          Environment="PATH=/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/bin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/bin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/bin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/bin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/bin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/sbin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/sbin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/sbin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/sbin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/sbin"
          Environment="TZDIR=/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c/share/zoneinfo"
          
          
          
          
      ''
    • Skipping environment comparison
  • The input derivation named `user-units` differs
    - /nix/store/hj555gy5x67y8ag7m9rhdxibx1fqw5c1-user-units.drv:{out}
    + /nix/store/xv7fc98c9zjzmjw1r2k0w2176wrgjgll-user-units.drv:{out}
    • The input derivation named `unit-dbus.service` differs
      - /nix/store/2b5y6fh3wxb78lp03362b66lpmpslp7g-unit-dbus.service.drv:{out}
      + /nix/store/yshwjs4r5sdl17xvzqnbgh8zhq8pmk04-unit-dbus.service.drv:{out}
      • The set of input derivation names do not match:
          - X-Restart-Triggers
          + X-Restart-Triggers-dbus
      • The environments do not match:
          text=''
          [Unit]
          ←X-Restart-Triggers=/nix/store/nyh3xac2in6hdvkzh15whn970jdh6gf2-X-Restart-Triggers←→X-Restart-Triggers=/nix/store/xpc6hdq553f5dqv2jvs8dchf1qqzl3ik-X-Restart-Triggers-dbus→
          
          [Service]
          Environment="LOCALE_ARCHIVE=/nix/store/zsil0154b9rvk6az7h9v0rgm4n4kh34i-glibc-locales-2.37-8/lib/locale/locale-archive"
          Environment="PATH=/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/bin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/bin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/bin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/bin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/bin:/nix/store/zr0fzzkknaycqj8ij13gk6bhq8lnwxl1-coreutils-9.3/sbin:/nix/store/dybcqb2k9b7qm3f29vm9n3jagxvmmcmr-findutils-4.9.0/sbin:/nix/store/d2kvfr3r06rf5zdzsw7ayzj8lkpxh2lx-gnugrep-3.11/sbin:/nix/store/q8afk7kyb85c0n2h3v0mphnjmdqyj49q-gnused-4.9/sbin:/nix/store/lfs1ix4r0hi6is4k1kh06g7nq33kisx6-systemd-253.6/sbin"
          Environment="TZDIR=/nix/store/xrpbs72b5yqq45b6l5vq6sib6396655a-tzdata-2023c/share/zoneinfo"
          
          X-ReloadIfChanged=true
          
          
          
      ''
    • Skipping environment comparison
  • Skipping environment comparison
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
