### PR TITLE
zephyr-sdk: init at 0.16.1

### DIFF
--- a/pkgs/by-name/ze/zephyr-sdk/package.nix
+++ b/pkgs/by-name/ze/zephyr-sdk/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchurl
+, python38
+, autoPatchelfHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zephyr-sdk";
+  version = "0.16.1";
+
+  src = let
+    inherit (finalAttrs) version;
+  in builtins.getAttr stdenv.hostPlatform.system {
+    "x86_64-linux" = fetchurl {
+      url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${version}/zephyr-sdk-${version}_linux-x86_64.tar.xz";
+      hash = "sha256-UTONUapM6iUWZBzg2dwLUbdjd58A3EVkorwN1xPfIsc=";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${version}/zephyr-sdk-${version}_linux-aarch64.tar.xz";
+      hash = "sha256-BiuytcR8pW3Sm3+S3X8Hpc4iulE3WdK2lgvGWFMesAw=";
+    };
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    stdenv.cc.cc
+    python38
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    cp -r . $out
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/zephyrproject-rtos/sdk-ng";
+    description = "Collection of compilers and tools for the Zephyr RTOS";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ mib ];
+    sourceProvenance = with sourceTypes; [
+      binaryFirmware
+      binaryNativeCode
+    ];
+  };
+})


### PR DESCRIPTION
Based on #141694

## Description of changes

Adds the zephyr-sdk package

## Things done

Should be the same as #141694 with the exception of this being a newer version. Nonetheless testing is probably a good idea. I don't have access to any zephyr compatible boards right now, so if anyone can test it would be greatly appreciated!

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
