### PR TITLE
mir: 2.14.1 -> 2.15.0

### DIFF
--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -6,8 +6,6 @@
 , cmake
 , pkg-config
 , python3
-, doxygen
-, libxslt
 , boost
 , egl-wayland
 , freetype
@@ -40,13 +38,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mir";
-  version = "2.14.1";
+  version = "2.15.0";
 
   src = fetchFromGitHub {
     owner = "MirServer";
     repo = "mir";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-IEGeZVNxwzHn5GASCyjNuQsnCzzfQBHdC33MWVMeZws=";
+    hash = "sha256-c1+gxzLEtNCjR/mx76O5QElQ8+AO4WsfcG7Wy1+nC6E=";
   };
 
   postPatch = ''
@@ -73,21 +71,13 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/platform/graphics/CMakeLists.txt \
       --replace "/usr/include/drm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h" \
       --replace "/usr/include/libdrm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h"
-
-    # Fix date in generated docs not honouring SOURCE_DATE_EPOCH
-    # Install docs to correct dir
-    substituteInPlace cmake/Doxygen.cmake \
-      --replace '"date"' '"date" "--date=@'"$SOURCE_DATE_EPOCH"'"' \
-      --replace "\''${CMAKE_INSTALL_PREFIX}/share/doc/mir-doc" "\''${CMAKE_INSTALL_DOCDIR}"
   '';
 
   strictDeps = true;
 
   nativeBuildInputs = [
     cmake
-    doxygen
     glib # gdbus-codegen
-    libxslt
     lttng-ust # lttng-gen-tp
     pkg-config
     (python3.withPackages (ps: with ps; [
@@ -137,9 +127,8 @@ stdenv.mkDerivation (finalAttrs: {
     wlcs
   ];
 
-  buildFlags = [ "all" "doc" ];
-
   cmakeFlags = [
+    "-DBUILD_DOXYGEN=OFF"
     "-DMIR_PLATFORM='gbm-kms;x11;eglstream-kms;wayland'"
     "-DMIR_ENABLE_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
     # BadBufferTest.test_truncated_shm_file *doesn't* throw an error as the test expected, mark as such
@@ -160,7 +149,7 @@ stdenv.mkDerivation (finalAttrs: {
     export XDG_RUNTIME_DIR=/tmp
   '';
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "dev" ];
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , gitUpdater
 , testers
 , cmake
@@ -46,6 +47,16 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-c1+gxzLEtNCjR/mx76O5QElQ8+AO4WsfcG7Wy1+nC6E=";
   };
+
+  patches = [
+    # Fix gbm-kms tests
+    # Remove when version > 2.15.0
+    (fetchpatch {
+      name = "0001-mir-Fix-the-signature-of-drmModeCrtcSetGamma.patch";
+      url = "https://github.com/MirServer/mir/commit/98250e9c32c5b9b940da2fb0a32d8139bbc68157.patch";
+      hash = "sha256-tTtOHGNue5rsppOIQSfkOH5sVfFSn/KPGHmubNlRtLI=";
+    })
+  ];
 
   postPatch = ''
     # Fix scripts that get run in tests


### PR DESCRIPTION
## Description of changes

https://github.com/MirServer/mir/releases/tag/v2.15.0

Building the documentation has been dropped from this package, as mentioned [here](https://github.com/NixOS/nixpkgs/pull/245854#issuecomment-1697875267):

- Upstream migrated from custom Doxygen management to a Sphinx-based doc building process
  - It's possible to patch out some things we don't want or bypass it for the most part with `python3Packages.sphinxHook`, but we're missing some sphinx-related packages for this to work: https://github.com/MirServer/mir/blob/v2.15.0/doc/sphinx/.sphinx/requirements.txt
- Upstream themselves dropped the packaged version of the docs:
  ![image](https://github.com/NixOS/nixpkgs/assets/23431373/890043e9-7309-4591-94a1-675e4bf80d97)


I would still prefer to get these built again at some point, but this'll have to do for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
