### PR TITLE
nixos/docker: Add module for network

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -534,6 +534,11 @@
     githubId = 19290901;
     name = "Andrew Brooks";
   };
+  agentx3 = {
+    githubId = 104329992;
+    github ="agentx3";
+    name = "agentx3";
+  };
   aherrmann = {
     email = "andreash87@gmx.ch";
     github = "aherrmann";

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -509,6 +509,8 @@ The module update takes care of the new config syntax and the data itself (user 
 
 - `services.bitcoind` now properly respects the `enable` option.
 
+- Docker networks can now be declared under `virtualisation.docker.networks`
+
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 
 - The use of `sourceRoot = "source";`, `sourceRoot = "source/subdir";`, and similar lines in package derivations using the default `unpackPhase` is deprecated as it requires `unpackPhase` to always produce a directory named "source". Use `sourceRoot = src.name`, `sourceRoot = "${src.name}/subdir";`, or `setSourceRoot = "sourceRoot=$(echo */subdir)";` or similar instead.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1505,6 +1505,7 @@
   ./virtualisation/cri-o.nix
   ./virtualisation/docker-rootless.nix
   ./virtualisation/docker.nix
+  ./virtualisation/docker-network.nix
   ./virtualisation/ecs-agent.nix
   ./virtualisation/hyperv-guest.nix
   ./virtualisation/incus.nix

--- a/nixos/modules/virtualisation/docker-network.nix
+++ b/nixos/modules/virtualisation/docker-network.nix
@@ -1,0 +1,315 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  # Used to identify networks created via nix config
+  nixLabel = "NIX_CREATED_BY";
+  nixLabelValue = "nix";
+
+  networkType = types.submodule ({ ... }: with types; {
+    options = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = lib.mdDoc ''
+          Whether to enable the docker network
+        '';
+      };
+      attachable = mkOption {
+        type = bool;
+        default = false;
+        description = lib.mdDoc ''
+          Enable manual container attachment
+        '';
+      };
+      aux-address = mkOption {
+        type = attrsOf str;
+        default = { };
+        example = {
+          router = "192.168.0.1";
+        };
+        description = lib.mdDoc ''
+          Auxiliary IPv4 or IPv6 addresses used by Network driver
+        '';
+      };
+      config-from = mkOption {
+        type = nullOr str;
+        default = null;
+        example = "myExistingConfigOnlyNetwork";
+        description = lib.mdDoc ''
+          The network from which to copy the configuration
+        '';
+      };
+      config-only = mkOption {
+        type = bool;
+        default = false;
+        description = lib.mdDoc ''
+          Create a configuration only network
+        '';
+      };
+      driver = mkOption {
+        type = str;
+        default = "bridge";
+        description = lib.mdDoc ''
+          Driver to manage the Network
+        '';
+      };
+      gateway = mkOption {
+        type = listOf str;
+        default = [ ];
+        description = lib.mdDoc ''
+          IPv4 or IPv6 Gateway for the master subnet
+        '';
+      };
+      ingress = mkOption {
+        type = bool;
+        default = false;
+        description = lib.mdDoc ''
+          Create swarm routing-mesh network
+        '';
+      };
+      internal = mkOption {
+        type = bool;
+        default = false;
+        description = lib.mdDoc ''
+          Restrict external access to the network
+        '';
+      };
+      ip-range = mkOption {
+        type = listOf str;
+        default = [ ];
+        example = [ "127.0.0.128/25" ];
+        description = lib.mdDoc ''
+          Allocate container ip from a sub-range
+        '';
+      };
+      ipam-driver = mkOption {
+        type = str;
+        default = "default";
+        example = "default";
+        description = lib.mdDoc ''
+          IP Address Management Driver
+        '';
+      };
+      ipam-opt = mkOption {
+        type = attrsOf str;
+        default = { };
+        example = {
+          foo = "bar";
+        };
+        description = lib.mdDoc ''
+          Set IPAM driver specific options
+        '';
+      };
+      ipv6 = mkOption {
+        type = bool;
+        default = false;
+        description = lib.mdDoc ''
+          Enable IPv6 networking
+        '';
+      };
+      label = mkOption {
+        type = attrsOf str;
+        default = { "${nixLabel}" = nixLabelValue; };
+        example = {
+          foo = "bar";
+        };
+        description = lib.mdDoc ''
+          Set metadata on a network. NixOS will label this network with "${nixLabel}"="${nixLabelValue}"
+        '';
+      };
+      opt = mkOption {
+        type = attrsOf str;
+        default = { };
+        example = {
+          "com.docker.network.bridge.enable_icc" = "true";
+        };
+        description = lib.mdDoc ''
+          Set driver specific options
+        '';
+      };
+      scope = mkOption {
+        type = nullOr (enum [ "local" "swarm" "global" "host" ]);
+        default = null;
+        example = "local";
+        description = lib.mdDoc ''
+          Control the network's scope
+        '';
+      };
+      subnet = mkOption {
+        type = listOf str;
+        default = [ ];
+        example = [ "127.0.0.1" ];
+        description = lib.mdDoc ''
+          Subnets in CIDR format that represents a network segment
+        '';
+      };
+
+    };
+  });
+  dockerCfg = config.virtualisation.docker;
+  cfg = dockerCfg.networks;
+
+
+  fillNetworkName = network:
+    mapAttrs'
+      (n: v:
+        nameValuePair (n) (recursiveUpdate v { name = n; label.${nixLabel} = nixLabelValue; }))
+      network;
+
+
+  configOnlyNetworks = fillNetworkName (filterAttrs (n: v: v.config-only) cfg);
+  normalNetworks = fillNetworkName (filterAttrs (n: v: !v.config-only) cfg);
+
+  mkStringArg = n: v: [ "--${n}" v ];
+  mkStringArgs = n: vs: concatMap (mkStringArg n) vs;
+  mkKeyValueArgs = optName: optSet: mapAttrsToList (key: value: [ "--${optName}" "${key}=${value}" ]) optSet;
+  mkBoolArg = n: v: if v then [ "--${n}" ] else [ ];
+
+  mkNetworkArgs = n: v:
+    if isString v then mkStringArg n v
+    else if isList v then mkStringArgs n v
+    else if isAttrs v then mkKeyValueArgs n v
+    else if isBool v then mkBoolArg n v
+    else if isNull v then [ ]
+    else throw "Unexpected type for network option ${n}: ${typeOf v}";
+
+  filteredAttrs = [ "name" "enable" ]; # Attributes that are used by Nix and not docker
+  optionFilter = n: v: ! (elem n filteredAttrs);
+  filterNetwork = network: filterAttrs optionFilter network;
+
+  networkArgsList = network: flatten (mapAttrsToList mkNetworkArgs (filterNetwork network));
+
+
+  mkNetworkService = network:
+    let
+      serviceName = n: "docker-network-${n}";
+      networkArgs = escapeShellArgs (networkArgsList network);
+
+    in
+    if !network.enable then null else {
+      name = serviceName network.name;
+      value =
+        let
+          docker = "${dockerCfg.package}/bin/docker";
+          mkConditionalService = net: cond:
+            if cond
+            then "${serviceName net}.service"
+            else null;
+          relationalServicesFor = categoryFn: networks: remove null (mapAttrsToList (n: v: categoryFn n v) (networks));
+        in
+        {
+          description = "Service to create ${network.name} as a docker network.";
+          wantedBy = [ "multi-user.target" ];
+
+          after =
+            let
+              mkAfterServices = net: v: mkConditionalService net (v.enable && v.name == network.config-from);
+              afterServices = relationalServicesFor mkAfterServices configOnlyNetworks;
+            in
+            [ "network.target" "docker.service" ] ++ optionals (network.config-from != null) afterServices;
+
+          requiredBy =
+            let
+              mkRequiredBy = net: v: mkConditionalService net (v.enable && v.config-from == network.name);
+              requiredByServices = relationalServicesFor mkRequiredBy normalNetworks;
+            in
+            mkIf network.config-only requiredByServices;
+          requires = [ "docker.service" ];
+
+          serviceConfig = {
+            RemainAfterExit = true;
+            Type = "oneshot";
+          };
+
+          script = ''
+            function isManagedByNix() {
+              local LABEL
+              LABEL=$(${docker} network inspect ${network.name} --format '{{ index .Labels "${nixLabel}" }}');
+              if [ "$LABEL" = "${nixLabelValue}" ]; then
+                return 0;
+              else
+                return 1;
+              fi
+            }
+            check=$( ${docker} network ls | grep -w "${network.name}" || true )
+            if [ -z "$check" ]; then
+              ${docker} network create ${network.name} ${networkArgs} || {
+                echo "Failed to create network ${network.name}"
+                exit 10
+              }
+            else
+                if isManagedByNix; then
+                  REMOVAL_STATUS=$(${docker} network rm ${network.name} 2>&1 || true)
+                  if [ "$REMOVAL_STATUS" = "${network.name}" ]; then
+                      ${docker} network create ${network.name} ${networkArgs} || {
+                          printf "Failed to create network ${network.name}"
+                          exit 10
+                      }
+                  else
+                    printf "Network '%s' already exists. An attempt was made to change the configuration of the network, but it has failed due to the following error: \n%s" "${network.name}" "$REMOVAL_STATUS"
+                    exit 12
+                  fi
+                else
+                  printf "Network '%s' already exists. Please remove it manually if you want NixOS to manage it." "${network.name}"
+                  exit 13
+                fi
+            fi
+          '';
+          preStop = ''
+            REMOVAL_STATUS=$(${docker} network rm ${network.name} 2>&1 || true )
+            if [ "$REMOVAL_STATUS" != '${network.name}' ]; then
+              printf " An attempt was made to remove '%s', but failed due to the following error: \n%s\n." "${network.name}" "$REMOVAL_STATUS"
+              exit 15
+            fi
+          '';
+        };
+    };
+  mkNetworkServiceList = networks:
+    listToAttrs (remove null (map mkNetworkService (attrValues (fillNetworkName networks))));
+  normalNetworkServices = mkNetworkServiceList normalNetworks;
+  configOnlyNetworkServices = mkNetworkServiceList configOnlyNetworks;
+
+in
+{
+  options.virtualisation.docker.networks = mkOption {
+    default = { };
+    type = types.attrsOf networkType;
+    example = {
+      "my-network" = {
+        enable = true;
+        driver = "bridge";
+        label = {
+          foo = "bar";
+        };
+      };
+    };
+    description = lib.mdDoc ''
+      An attribute set of docker networks and their configurations. See https://docs.docker.com/engine/reference/commandline/network_create/ for more info on the options.
+    '';
+  };
+
+  config = (mkIf dockerCfg.enable {
+    assertions =
+      let
+        conflictingConfigOptionsCheck = network: {
+          assertion = !(network.config-only && network.config-from != null);
+          message = "Network ${network.name} cannot have both config-only and config-from set";
+        };
+        configFromExistsCheck = network: {
+          assertion = !(network.config-from != null && !(cfg.${network.config-from}.enable or false));
+          message = "Network ${network.name} cannot have config-from set to ${network.config-from} as it does not exist";
+        };
+        allAssertions = concatMap (f: map f (mapAttrsToList (n: v: v) (fillNetworkName cfg))) [
+          conflictingConfigOptionsCheck
+          configFromExistsCheck
+        ];
+      in
+      allAssertions;
+
+    systemd.services = mkMerge [
+      (mkOrder 1100 normalNetworkServices)
+      (mkOrder 1000 configOnlyNetworkServices)
+    ];
+  });
+}
+

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -239,6 +239,7 @@ in {
   doas = handleTest ./doas.nix {};
   docker = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker.nix {};
   docker-rootless = handleTestOn ["aarch64-linux" "x86_64-linux"] ./docker-rootless.nix {};
+  docker-network = handleTestOn [ "x86_64-linux" ] ./docker-network.nix { };
   docker-registry = handleTest ./docker-registry.nix {};
   docker-tools = handleTestOn ["x86_64-linux"] ./docker-tools.nix {};
   docker-tools-cross = handleTestOn ["x86_64-linux" "aarch64-linux"] ./docker-tools-cross.nix {};

--- a/nixos/tests/docker-network.nix
+++ b/nixos/tests/docker-network.nix
@@ -1,0 +1,37 @@
+# This test runs docker and checks if simple container starts
+
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "docker-network";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ agentx3 ];
+  };
+
+  nodes = {
+    docker_network =
+      { pkgs, ... }:
+      {
+        virtualisation.docker.enable = true;
+        virtualisation.docker.autoPrune.enable = true;
+        virtualisation.docker.package = pkgs.docker;
+        virtualisation.docker.networks = {
+          "fooNetwork" = {
+            enable = true;
+            driver = "bridge";
+            label = {
+              foo = "bar";
+            };
+            subnet = [ "172.30.0.0/24" ];
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    docker_network.start()
+    docker_network.wait_for_unit("docker-network-fooNetwork.service")
+
+    docker_network.succeed("${pkgs.docker}/bin/docker network ls | grep fooNetwork")
+    docker_network.succeed("${pkgs.docker}/bin/docker network inspect fooNetwork | ${pkgs.jq}/bin/jq '.[0].Driver' | grep bridge")
+    docker_network.succeed('[ $(${pkgs.docker}/bin/docker network inspect fooNetwork | ${pkgs.jq}/bin/jq -r \'.[0].IPAM.Config[0].Subnet\') = "172.30.0.0/24" ]')
+  '';
+})


### PR DESCRIPTION
## Description of changes

This module supports declaratively creating docker networks and supports
all the standard arguments that the CLI tool accepts. It uses systemd to
do this. Networks are also removed upon systemd service stop.

For the test I just ran the docker test, as well as wrote an addition docker-network.nix test.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
