### PR TITLE
xgboost: 1.7.6 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -45,14 +45,14 @@ stdenv.mkDerivation rec {
   #   in \
   #   rWrapper.override{ packages = [ xgb ]; }"
   pname = lib.optionalString rLibrary "r-" + pnameBase;
-  version = "1.7.6";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "dmlc";
     repo = pnameBase;
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-i7smd56rLbNY0qXysq818VYWYbjrnFbyIjQkIgf9aOs=";
+    hash = "sha256-HKITioCvBZHZWKFWwe9KbrFP+Nbz8adbZJvQiqApjUQ=";
   };
 
   nativeBuildInputs = [ cmake ]
@@ -144,6 +144,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/dmlc/xgboost";
     license = licenses.asl20;
     platforms = platforms.unix;
+    broken = stdenv.isDarwin;
     maintainers = with maintainers; [ abbradar nviets ];
   };
 }

--- a/pkgs/development/python-modules/xgboost/default.nix
+++ b/pkgs/development/python-modules/xgboost/default.nix
@@ -4,17 +4,19 @@
 , cmake
 , numpy
 , scipy
+, hatchling
 , stdenv
 , xgboost
 }:
 
 buildPythonPackage {
   pname = "xgboost";
+  format = "pyproject";
   inherit (xgboost) version src meta;
 
   disabled = pythonOlder "3.8";
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake hatchling ];
   buildInputs = [ xgboost ];
   propagatedBuildInputs = [ numpy scipy ];
 


### PR DESCRIPTION
## Description of changes

Updating xgboost to 2.0.0.

## Things done

Built library with and without GPU support and tested basic functionality.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin