### PR TITLE
ocamlPackages.ocaml-protoc: 2.0.2 → 2.4

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-protoc/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-protoc/default.nix
@@ -1,30 +1,19 @@
 { lib, fetchFromGitHub, buildDunePackage
+, pbrt
 , stdlib-shims
 }:
 
 buildDunePackage rec {
   pname = "ocaml-protoc";
-  version = "2.0.2";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.02";
-
-  src = fetchFromGitHub {
-    owner = "mransan";
-    repo = "ocaml-protoc";
-    rev = version;
-    sha256 = "1vlnjqqpypmjhlyrxfzla79y4ilmc9ggz311giy6vmh4cyzl29h3";
-  };
+  inherit (pbrt) version src;
 
   buildInputs = [ stdlib-shims ];
+  propagatedBuildInputs = [ pbrt ];
 
   doCheck = true;
 
-  meta = with lib; {
-    homepage = "https://github.com/mransan/ocaml-protoc";
+  meta = pbrt.meta // {
     description = "A Protobuf Compiler for OCaml";
-    license = licenses.mit;
-    maintainers = [ maintainers.vyorkin ];
   };
 }

--- a/pkgs/development/ocaml-modules/pbrt/default.nix
+++ b/pkgs/development/ocaml-modules/pbrt/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "pbrt";
+  version = "2.4";
+
+  minimalOCamlVersion = "4.03";
+
+  src = fetchFromGitHub {
+    owner = "mransan";
+    repo = "ocaml-protoc";
+    rev = "${version}.0";
+    hash = "sha256-EXugdcjALukSjB31zAVG9WiN6GMGXi2jlhHWaZ+p+uM=";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/mransan/ocaml-protoc";
+    description = "Runtime library for Protobuf tooling";
+    license = licenses.mit;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1396,6 +1396,8 @@ let
 
     pbkdf = callPackage ../development/ocaml-modules/pbkdf { };
 
+    pbrt = callPackage ../development/ocaml-modules/pbrt { };
+
     pcap-format = callPackage ../development/ocaml-modules/pcap-format { };
 
     pecu = callPackage ../development/ocaml-modules/pecu { };


### PR DESCRIPTION
## Description of changes

https://github.com/mransan/ocaml-protoc/blob/2.4.0/CHANGES.md

cc maintainer @vyorkin

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
