### PR TITLE
python310Packages.dns-lexicon: init at 3.14.1 and add aviallon to maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1743,6 +1743,15 @@
     githubId = 1222;
     name = "Aaron VonderHaar";
   };
+  aviallon = {
+    email = "antoine-nixos@lesviallon.fr";
+    github = "aviallon";
+    githubId = 7479436;
+    name = "Antoine Viallon";
+    keys = [{
+      fingerprint = "4AC4 A28D 7208 FC6F 2B51  5EA9 D126 B13A B555 E16F";
+    }];
+  };
   avitex = {
     email = "theavitex@gmail.com";
     github = "avitex";

--- a/pkgs/development/python-modules/dns-lexicon/default.nix
+++ b/pkgs/development/python-modules/dns-lexicon/default.nix
@@ -1,0 +1,84 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, beautifulsoup4
+, cryptography
+, importlib-metadata
+, pyyaml
+, requests
+, tldextract
+, pytestCheckHook
+, pytest-vcr
+# Optional depedencies
+, boto3
+, localzone
+, softlayer
+, zeep
+, dnspython
+, oci
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "dns_lexicon";
+  version = "3.14.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "Analogj";
+    repo = "lexicon";
+    rev = "v${version}";
+    hash = "sha256-flK2G9mdUWMUACQPo6TqYZ388EacIqkq//tCzUS+Eo8=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-vcr
+  ] ++ passthru.optional-dependencies.full;
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    cryptography
+    importlib-metadata
+    pyyaml
+    requests
+    tldextract
+  ];
+
+  passthru.optional-dependencies = {
+    route53 = [ boto3 ];
+    localzone = [ localzone ];
+    softlayer = [ softlayer ];
+    ddns = [ dnspython ];
+    duckdns = [ dnspython ];
+    oci = [ oci ];
+    full = [ boto3 localzone softlayer zeep dnspython oci ];
+  };
+
+  pytestFlagsArray = [
+    "tests/"
+  ];
+
+  disabledTestPaths = [
+    # Needs network access
+    "tests/providers/test_auto.py"
+
+    # Needs network access (and an API token)
+    "tests/providers/test_namecheap.py"
+  ];
+
+  pythonImportsCheck = [
+    "lexicon"
+  ];
+
+  meta = with lib; {
+    description = "Manipulate DNS records on various DNS providers in a standardized way";
+    homepage = "https://github.com/AnalogJ/lexicon";
+    changelog = "https://github.com/AnalogJ/lexicon/blob/v${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ aviallon ];
+    license = with licenses; [ mit ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3124,6 +3124,8 @@ self: super: with self; {
 
   dnspython = callPackage ../development/python-modules/dnspython { };
 
+  dns-lexicon = callPackage ../development/python-modules/dns-lexicon { };
+
   doc8 = callPackage ../development/python-modules/doc8 { };
 
   docformatter = callPackage ../development/python-modules/docformatter { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Lexicon provides a way to manipulate DNS records on multiple DNS providers in a standardized way.
It is notably used by `certbot-dns-ovh` plugin, which I intend to submit afterwards.
You can find the homepage here: https://github.com/AnalogJ/lexicon

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
