### PR TITLE
nixos/system-path: convert environment.systemPackages to an attrset

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -119,7 +119,7 @@ let
     inherit (self.derivations) lazyDerivation defaultOutput
       outputsFor setOutputsToInstall;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
-      appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio
+      appendToName mapDerivationAttrset setPrio setPrioRecursively lowPrio lowPrioSet hiPrio
       hiPrioSet getLicenseFromSpdxId getExe getExe';
     inherit (self.filesystem) pathType pathIsDirectory pathIsRegularFile
       packagesFromDirectoryRecursive;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -116,7 +116,8 @@ let
     inherit (self.customisation) overrideDerivation makeOverridable
       callPackageWith callPackagesWith extendDerivation hydraJob
       makeScope makeScopeWithSplicing makeScopeWithSplicing';
-    inherit (self.derivations) lazyDerivation;
+    inherit (self.derivations) lazyDerivation defaultOutput
+      outputsFor setOutputsToInstall;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio
       hiPrioSet getLicenseFromSpdxId getExe getExe';

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -54,6 +54,11 @@ rec {
   */
   setPrio = priority: addMetaAttrs { inherit priority; };
 
+  # Set the nix-env priority of a package recursively, including all its outputs
+  setPrioRecursively = priority: drv: setPrio priority drv // (lib.listToAttrs (
+    map (output: lib.nameValuePair output (setPrioRecursively priority drv.${output})) drv.outputs
+  ));
+
   /* Decrease the nix-env priority of the package, i.e., other
      versions/variants of the package will be preferred.
   */

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -502,6 +502,15 @@ rec {
           else res;
     };
 
+    packageByOutPath =
+      package // {
+        merge = loc: defs:
+          let res = mergeEqualOption loc defs;
+          in if builtins.isPath res || (builtins.isString res && ! builtins.hasContext res)
+            then toDerivation res
+            else res;
+      };
+
     shellPackage = package // {
       check = x: isDerivation x && hasAttr "shellPath" x;
     };

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -34,6 +34,23 @@ In addition to numerous new and upgraded packages, this release has the followin
   }
   ```
 
+- It is now possible to use attribute sets to add packages to `environment.systemPackages`.
+  The advantage of this compared to the existing list-based syntax is that it allows you to
+  use the module system to override existing packages (disable them, override them, change the outputs to be installed, etc).
+  This change is backwards compatible, but we might deprecate the list syntax in a future release.
+  With the new syntax, you can add a package like this:
+  ```
+  environment.systemPackages = {
+    inherit (pkgs) foo;
+  };
+  ```
+  To disable a package that was added elsewhere, you could do something like
+  ```
+  environment.systemPackages.foo.enable = false;
+  ```
+  (adding `lib.mkForce` to the assignment might be required, depending on the priority with which the attribute was previously assigned to).
+  Note that packages that are added through the legacy list syntax, cannot reliably be disabled or overridden.
+
 ## New Services {#sec-release-24.05-new-services}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -6,40 +6,120 @@
 with lib;
 
 let
+  # This type can accept three different types of expressions:
+  #   * A list of packages like `[ pkgs.foo pkgs.bar ]`
+  #   * An attribute set of packages like `{ inherit (pkgs) foo bar; }`
+  #   * A more structured attribute set of packages like `{ "foo".package = pkgs.foo.override { hasBar = false; }; }`
+  #
+  # The first two cases will be coerced into the third one, which allows the
+  # package to be disabled and its package and list of outputs to be overridden.
+  packagesType =
+    let
+      inherit (lib) types;
 
-  requiredPackages = map (pkg: setPrio ((pkg.meta.priority or 5) + 3) pkg)
-    [ pkgs.acl
-      pkgs.attr
-      pkgs.bashInteractive # bash with ncurses support
-      pkgs.bzip2
-      pkgs.coreutils-full
-      pkgs.cpio
-      pkgs.curl
-      pkgs.diffutils
-      pkgs.findutils
-      pkgs.gawk
-      pkgs.stdenv.cc.libc
-      pkgs.getent
-      pkgs.getconf
-      pkgs.gnugrep
-      pkgs.gnupatch
-      pkgs.gnused
-      pkgs.gnutar
-      pkgs.gzip
-      pkgs.xz
-      pkgs.less
-      pkgs.libcap
-      pkgs.ncurses
-      pkgs.netcat
-      config.programs.ssh.package
-      pkgs.mkpasswd
-      pkgs.procps
-      pkgs.su
-      pkgs.time
-      pkgs.util-linux
-      pkgs.which
-      pkgs.zstd
-    ];
+      outputsFor' = drv: lib.listToAttrs (
+        map (output: lib.nameValuePair output true) (lib.outputsFor drv)
+      );
+
+      drvToAttrs = drv: {
+        package = lib.defaultOutput drv;
+        outputs = outputsFor' drv;
+      };
+
+      pkgsToAttrs = list:
+        lib.mapAttrs
+          (name: values:
+            if length values == 0 then
+              abort "Something went terribly wrong"
+            else {
+              # If we get multiple values here, it means that we got the same
+              # derivation multiple times.
+              # This is usually because different outputs were selected.
+              # Therefore we add the derivation once and collect all the selected outputs.
+              package = defaultOutput (head values);
+              outputs = lib.foldl (acc: drv: acc // outputsFor' drv) {} values;
+            }
+          )
+          (lib.groupBy (drv: builtins.unsafeDiscardStringContext drv.drvPath) list);
+    in
+    types.coercedTo
+      (types.listOf types.package)
+      pkgsToAttrs
+      (types.attrsOf (types.coercedTo
+        types.package
+        drvToAttrs
+        (types.submodule ( { config, lib, ... }: {
+          options = {
+            enable = (lib.mkEnableOption "the package") // {
+              default = true;
+            };
+            package = lib.mkOption {
+              # We can get the same derivation here if it was added with different
+              # outputs selected. In that case we want to merge the values if the
+              # outpath is the same, and concat the lists of outputs.
+              type = types.packageByOutPath;
+              description = "The derivation that will be used for this package.";
+            };
+            outputs = lib.mkOption {
+              type = types.attrsOf types.bool;
+              description = "The outputs to install for this package.";
+              default = outputsFor' config.package;
+              defaultText = ''
+                If no outputs are explicitly specified, we add the default outputs of the package.
+              '';
+            };
+          };
+        }))
+      ));
+
+  # This function takes the attribute set from the packages type and converts it
+  # back into a list that can be given to something like pkgs.buildEnv.
+  packagesApplyFun = ps:
+    let
+      enabled = lib.filterAttrs (_: p: p.enable) ps;
+      setOutputs = p:
+        let
+          outputsToInstall = lib.mapAttrsToList lib.const (lib.filterAttrs (_: lib.id) p.outputs);
+        in
+        lib.setOutputsToInstall p.package outputsToInstall;
+    in
+    lib.mapAttrsToList (_: setOutputs) enabled;
+
+  requiredPackages = mapAttrs (name: pkg: setPrioRecursively ((pkg.meta.priority or 5) + 3) pkg)
+    {
+      inherit (pkgs)
+        acl
+        attr
+        bashInteractive # bash with ncurses support
+        bzip2
+        coreutils-full
+        cpio
+        curl
+        diffutils
+        findutils
+        gawk
+        getent
+        getconf
+        gnugrep
+        gnupatch
+        gnused
+        gnutar
+        gzip
+        xz
+        less
+        libcap
+        ncurses
+        netcat
+        mkpasswd
+        procps
+        su
+        time
+        util-linux
+        which
+        zstd;
+      inherit (pkgs.stdenv.cc) libc;
+      ssh = config.programs.ssh.package;
+    };
 
   defaultPackageNames =
     [ "perl"
@@ -47,9 +127,9 @@ let
       "strace"
     ];
   defaultPackages =
-    map
-      (n: let pkg = pkgs.${n}; in setPrio ((pkg.meta.priority or 5) + 3) pkg)
-      defaultPackageNames;
+    lib.listToAttrs (map
+      (n: let pkg = pkgs.${n}; in lib.nameValuePair n (setPrioRecursively ((pkg.meta.priority or 5) + 3) pkg))
+      defaultPackageNames);
   defaultPackagesText = "[ ${concatMapStringsSep " " (n: "pkgs.${n}") defaultPackageNames } ]";
 
 in
@@ -60,9 +140,10 @@ in
     environment = {
 
       systemPackages = mkOption {
-        type = types.listOf types.package;
-        default = [];
-        example = literalExpression "[ pkgs.firefox pkgs.thunderbird ]";
+        type = packagesType;
+        apply = packagesApplyFun;
+        default = {};
+        example = literalExpression "{ inherit (pkgs) firefox thunderbird; }";
         description = lib.mdDoc ''
           The set of packages that appear in
           /run/current-system/sw.  These packages are
@@ -71,11 +152,32 @@ in
           configuration.  (The latter is the main difference with
           installing them in the default profile,
           {file}`/nix/var/nix/profiles/default`.
+
+          This option accepts three different types of expressions:
+          - An attribute set of packages like `{ inherit (pkgs) foo bar; }`
+          - A more structured attribute set of packages like
+            ```
+            {
+              foo = {
+                package = pkgs.foo.override { hasBar = false; };
+                outputs = { out = true; lib = true; };
+              };
+            }
+            ```
+          - A list of packages like `[ pkgs.foo pkgs.bar ]` (this is deprecated)
+
+          The first and third of which will be converted into the second form.
+
+          The recommended syntax to add packages to this set, is to write
+          `{ inherit (pkgs) foo; }`.
+          To disable or override a package that was added elsewhere, you can do
+          `{ foo.enable = false; }` or `{ foo = pkgs.foo.override { ... }; }`.
         '';
       };
 
       defaultPackages = mkOption {
-        type = types.listOf types.package;
+        type = packagesType;
+        apply = packagesApplyFun;
         default = defaultPackages;
         defaultText = literalMD ''
           these packages, with their `meta.priority` numerically increased
@@ -83,7 +185,7 @@ in
 
               ${defaultPackagesText}
         '';
-        example = [];
+        example = {};
         description = lib.mdDoc ''
           Set of default packages that aren't strictly necessary
           for a running system, entries can be removed for a more
@@ -142,7 +244,10 @@ in
 
   config = {
 
-    environment.systemPackages = requiredPackages ++ config.environment.defaultPackages;
+    environment.systemPackages = lib.mkMerge [
+      requiredPackages
+      config.environment.defaultPackages
+    ];
 
     environment.pathsToLink =
       [ "/bin"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -825,6 +825,7 @@ in {
   syncthing-many-devices = handleTest ./syncthing-many-devices.nix {};
   syncthing-relay = handleTest ./syncthing-relay.nix {};
   sysinit-reactivation = runTest ./sysinit-reactivation.nix;
+  system-packages = runTest ./system-packages.nix;
   systemd = handleTest ./systemd.nix {};
   systemd-analyze = handleTest ./systemd-analyze.nix {};
   systemd-binfmt = handleTestOn ["x86_64-linux"] ./systemd-binfmt.nix {};

--- a/nixos/tests/system-packages.nix
+++ b/nixos/tests/system-packages.nix
@@ -55,7 +55,7 @@
           "gzip".enable = false;
 
           # Disable a non-default output of a package that was included elsewhere.
-          "multi".outputs.extra = lib.mkForce false;
+          "multi".outputs.extra.enable = lib.mkForce false;
 
           # Include a package using the attrset syntax.
           "fd".package = pkgs.fd;

--- a/nixos/tests/system-packages.nix
+++ b/nixos/tests/system-packages.nix
@@ -1,0 +1,84 @@
+{
+  name = "system-packages";
+
+  nodes.machine =
+    { pkgs, lib, ... }:
+    let
+      multiOutputDrv = pkgs.runCommand "multi"
+        {
+          outputs = [ "out" "extra" "foo" ];
+        } ''
+        mkdir -p "$out/bin"
+        cat <<EOF > $out/bin/multi-out
+        #!/usr/bin/env sh
+        echo "Called multi-out"
+        EOF
+        chmod a+x $out/bin/multi-out
+
+        mkdir -p "$extra/bin"
+        cat <<EOF > $extra/bin/multi-extra
+        #!/usr/bin/env sh
+        echo "Called multi-extra"
+        EOF
+        chmod a+x $extra/bin/multi-extra
+
+        mkdir -p "$foo/bin"
+        cat <<EOF > $foo/bin/multi-foo
+        #!/usr/bin/env sh
+        echo "Called multi-foo"
+        EOF
+        chmod a+x $foo/bin/multi-foo
+      '';
+    in
+    {
+      environment.systemPackages = lib.mkMerge [
+        [
+          pkgs.hello
+          multiOutputDrv
+          multiOutputDrv.foo
+        ]
+        [
+          pkgs.hello
+        ]
+        {
+          inherit (pkgs) neovim-unwrapped;
+          multi = multiOutputDrv.extra;
+        }
+        {
+          multi = multiOutputDrv.extra;
+        }
+        {
+          # Disable a package that was included elsewhere
+          "neovim-unwrapped".enable = false;
+
+          # Disable a package from
+          "gzip".enable = false;
+
+          # Disable a non-default output of a package that was included elsewhere.
+          "multi".outputs.extra = lib.mkForce false;
+
+          # Include a package using the attrset syntax.
+          "fd".package = pkgs.fd;
+        }
+      ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    machine.execute("ls -la /run/current-system/sw/bin/")
+
+    machine.succeed("which hello")
+    machine.fail("which nvim")
+    machine.succeed("which hello")
+    machine.succeed("which multi-out")
+    machine.fail("which multi-extra")
+    machine.succeed("which multi-foo")
+    machine.succeed("which fd")
+
+    machine.succeed("which bzip2")
+    machine.fail("which gzip")
+    machine.succeed("which xz")
+    machine.succeed("which curl")
+  '';
+}


### PR DESCRIPTION
## Description of changes

Lists are pretty bad for overriding, this PR proposes to use an attribute set for `environment.systemPackages` so that we can more easily disable packages or override the derivation for a package.

In order not to break the current API, we use the `coercedTo` type so that we can still accept a list of derivations and we convert this list into an attribute set. This should therefore be a non-breaking change.

We also allow for a shorthand syntax:
```nix
environment.systemPackages = {
  inherit (pkgs) acl;
};
```
Which gets coerced into
```nix
environment.systemPackages = {
  acl = {
    enable = true;
    package = pkgs.acl;
    outputs = {
      bin = true;
      man = true;
    };
  };
};
```
where the outputs were taken from `meta.outputsToInstall` and can be individually disabled (hence the attrset that maps every output to a boolean).

The nixos test gives a good overview of what the syntax would look like.

@roberth @infinisil @nikstur : I'd love to get your thoughts on this.