### PR TITLE
neochat: add missing runtime dependencies

### DIFF
--- a/pkgs/applications/kde/neochat.nix
+++ b/pkgs/applications/kde/neochat.nix
@@ -15,6 +15,7 @@
 , kirigami2
 , kitemmodels
 , knotifications
+, kquickcharts
 , kquickimageedit
 , libpulseaudio
 , libquotient
@@ -24,6 +25,7 @@
 , qqc2-desktop-style
 , qtgraphicaleffects
 , qtkeychain
+, qtlocation
 , qtmultimedia
 , qtquickcontrols2
 , sonnet
@@ -49,6 +51,7 @@ mkDerivation {
     kirigami2
     kitemmodels
     knotifications
+    kquickcharts
     kquickimageedit
     libpulseaudio
     libquotient
@@ -57,6 +60,7 @@ mkDerivation {
     qcoro
     qtgraphicaleffects
     qtkeychain
+    qtlocation
     qtmultimedia
     qtquickcontrols2
     qqc2-desktop-style


### PR DESCRIPTION
## Description of changes

Without these, it fails to launch, e.g.:

> QQmlApplicationEngine failed to load component
> qrc:/main.qml:20:5: Type RoomList.Page unavailable
> qrc:/RoomList/Page.qml:87:20: Type ExploreComponent unavailable
> qrc:/RoomList/ExploreComponent.qml: Type org.kde.neochat/OsmLocationPlugin unavailable
> qrc:/OsmLocationPlugin.qml:7:1: module "QtLocation" is not installed

Fixes: e50edcb50693 ("kde/gear: 23.04.3 -> 23.08.0")

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
