### PR TITLE
terminal-typeracer: 2.0.8 -> 2.1.3

### DIFF
--- a/pkgs/applications/misc/terminal-typeracer/default.nix
+++ b/pkgs/applications/misc/terminal-typeracer/default.nix
@@ -1,7 +1,9 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitLab
 , rustPlatform
 , pkg-config
+, libgit2
 , openssl
 , sqlite
 , libiconv
@@ -10,19 +12,23 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "terminal-typeracer";
-  version = "2.0.8";
+  version = "2.1.3";
 
   src = fetchFromGitLab {
     owner = "ttyperacer";
     repo = pname;
     rev = "v${version}";
-    sha256 = "Fb2MCQaQaJseXa8Csesz1s5Yel4wcSMxfMeKSW7rlU4=";
+    hash = "sha256-S3OW6KihRd6ReTWUXRb1OWC7+YoxehjFRBxcnJVgImU=";
   };
 
-  cargoSha256 = "sha256-SAVDSUm2jpDwTfwo4L6MVUKzBxZvCfjn4UNIGUJziSY=";
+  cargoHash = "sha256-OwbFIbKB/arj+3gq2tfEq8yTKSUPBQNYJNzrWvDv4A4=";
 
-  buildInputs = [ openssl sqlite ] ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
   nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libgit2 openssl sqlite ] ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  OPENSSL_NO_VENDOR = 1;
+  LIBGIT2_NO_VENDOR = 1;
 
   meta = with lib; {
     description = "An open source terminal based version of Typeracer written in rust";


### PR DESCRIPTION
## Description of changes

Changelog:
https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.0.9
https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.0.10
https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.0.12
https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.0.13
https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.1.0
https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.1.1
https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.1.2
https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.1.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
