### PR TITLE
webrtc-audio-processing: Fetch patch for big-endian support, enable parallel building

### DIFF
--- a/pkgs/development/libraries/webrtc-audio-processing/0.3.nix
+++ b/pkgs/development/libraries/webrtc-audio-processing/0.3.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     substituteInPlace webrtc/base/checks.cc --replace 'defined(__UCLIBC__)' 1
   '';
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     homepage = "https://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing";
     description = "A more Linux packaging friendly copy of the AudioProcessing module from the WebRTC project";

--- a/pkgs/development/libraries/webrtc-audio-processing/0.3.nix
+++ b/pkgs/development/libraries/webrtc-audio-processing/0.3.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, darwin }:
+{ lib, stdenv, fetchurl, fetchpatch, darwin }:
 
 stdenv.mkDerivation rec {
   pname = "webrtc-audio-processing";
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
   patches = [
     ./enable-riscv.patch
     ./enable-powerpc.patch
+    # big-endian support, from https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/127
+    (fetchpatch {
+      name = "0001-webrtc-audio-processing-big-endian.patch";
+      url = "https://gitlab.freedesktop.org/pulseaudio/pulseaudio/uploads/2994c0512aaa76ebf41ce11c7b9ba23e/webrtc-audio-processing-0.2-big-endian.patch";
+      hash = "sha256-zVAj9H8SJureQd0t5O5v1je4ia8/gHJOXYxuEBEB6gg=";
+    })
   ];
 
   buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ ApplicationServices ]);


### PR DESCRIPTION
## Description of changes

Related to #253715, but I see no reason for this to depend on any changes from it.

From https://bugs.freedesktop.org/show_bug.cgi?id=95738, was migrated to https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/127.

Fixes building for i.e. `powerpc64-linux`, natively & `pkgsCross.ppc64`.

`enableParallelBuilding` is unrelated to the main goal, but it'll cause rebuilds anyway so might as well include it. Building with 40 cores multiple times worked fine for me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] powerpc64-linux
  - [x] x86_64-linux -> powerpc64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
