### PR TITLE
gpsprune: add media type associations

### DIFF
--- a/pkgs/applications/misc/gpsprune/default.nix
+++ b/pkgs/applications/misc/gpsprune/default.nix
@@ -17,12 +17,17 @@ stdenv.mkDerivation rec {
   desktopItems = [
     (makeDesktopItem {
       name = "gpsprune";
-      exec = "gpsprune";
+      exec = "gpsprune %F";
       icon = "gpsprune";
       desktopName = "GpsPrune";
       genericName = "GPS Data Editor";
       comment = meta.description;
       categories = [ "Education" "Geoscience" ];
+      mimeTypes = [
+        "application/gpx+xml"
+        "application/vnd.google-earth.kml+xml"
+        "application/vnd.google-earth.kmz"
+      ];
     })
   ];
 


### PR DESCRIPTION
## Description of changes

Associate GpsPrune with GPX, KML, and KMZ files:

> <img src="https://github.com/NixOS/nixpkgs/assets/1844746/30b7aa56-f215-4c63-886c-cfe13262508b" width="559" alt="Open With…" />

> <img src="https://github.com/NixOS/nixpkgs/assets/1844746/cdbe0470-d071-41f4-bc52-1778f54c07b2" width="393" alt="Recommended Apps: GpsPrune" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev gpsprune/media-type-associations`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
