### PR TITLE
fetchDebianPatch: do not assume `.patch` extension (v2)

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -86,7 +86,7 @@ Most other fetchers return a directory rather than a single file.
 ## `fetchDebianPatch` {#fetchdebianpatch}
 
 A wrapper around `fetchpatch`, which takes:
-- `patch` and `hash`: the patch's filename without the `.patch` suffix,
+- `patch` and `hash`: the patch's filename,
   and its hash after normalization by `fetchpatch` ;
 - `pname`: the Debian source package's name ;
 - `version`: the upstream version number ;
@@ -110,7 +110,7 @@ buildPythonPackage rec {
     (fetchDebianPatch {
       inherit pname version;
       debianRevision = "5";
-      name = "Add-quotes-to-SOAPAction-header-in-SoapClient";
+      name = "Add-quotes-to-SOAPAction-header-in-SoapClient.patch";
       hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0=";
     })
   ];

--- a/pkgs/build-support/fetchdebianpatch/default.nix
+++ b/pkgs/build-support/fetchdebianpatch/default.nix
@@ -1,8 +1,8 @@
 { lib, fetchpatch }:
 
 lib.makeOverridable (
-  { pname, version, debianRevision ? null, patch, hash,
-    area ? "main", name ? "${patch}.patch" }:
+  { pname, version, debianRevision ? null, area ? "main",
+    patch, name ? patch, hash }:
   let
     inherit (lib.strings) hasPrefix substring;
     prefix =
@@ -14,6 +14,6 @@ lib.makeOverridable (
     inherit name hash;
     url =
       "https://sources.debian.org/data/${area}/${prefix}/"
-      + "${pname}/${versionString}/debian/patches/${patch}.patch";
+      + "${pname}/${versionString}/debian/patches/${patch}";
   }
 )

--- a/pkgs/development/python-modules/pysimplesoap/default.nix
+++ b/pkgs/development/python-modules/pysimplesoap/default.nix
@@ -28,17 +28,17 @@ buildPythonPackage rec {
     debianRevision = "5";
   } // args)) [
     # Merged upstream: f5f96210e1483f81cb5c582a6619e3ec4b473027
-    { patch = "Add-quotes-to-SOAPAction-header-in-SoapClient";
+    { patch = "Add-quotes-to-SOAPAction-header-in-SoapClient.patch";
       hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0="; }
     # Merged upstream: ad03a21cafab982eed321553c4bfcda1755182eb
-    { patch = "fix-httplib2-version-check";
+    { patch = "fix-httplib2-version-check.patch";
       hash = "sha256-zUeF3v0N/eMyRVRH3tQLfuUfMKOD/B/aqEwFh/7HxH4="; }
-    { patch = "reorder-type-check-to-avoid-a-TypeError";
+    { patch = "reorder-type-check-to-avoid-a-TypeError.patch";
       hash = "sha256-2p5Cqvh0SPfJ8B38wb/xq7jWGYgpI9pavA6qkMUb6hA="; }
     # Merged upstream: 033e5899e131a2c1bdf7db5852f816f42aac9227
-    { patch = "Support-integer-values-in-maxOccurs-attribute";
+    { patch = "Support-integer-values-in-maxOccurs-attribute.patch";
       hash = "sha256-IZ0DP7io+ihcnB5547cR53FAdnpRLR6z4J5KsNrkfaI="; }
-    { patch = "PR204";
+    { patch = "PR204.patch";
       hash = "sha256-JlxeTnKDFxvEMFBthZsaYRbNOoBvLJhBnXCRoiL/nVw="; }
   ] ++ [ ./stringIO.patch ];
 

--- a/pkgs/tools/typesetting/pdfchain/default.nix
+++ b/pkgs/tools/typesetting/pdfchain/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch
+{ lib, stdenv, fetchurl, fetchDebianPatch
 , autoconf, gtkmm3, glib, pdftk, pkg-config, wrapGAppsHook
 }:
 
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-Hu4Pk9voyc75+f5OwKEOCkXKjN5nzWzv+izmyEN1Lz0=";
+    hash = "sha256-Hu4Pk9voyc75+f5OwKEOCkXKjN5nzWzv+izmyEN1Lz0=";
   };
 
   nativeBuildInputs = [
@@ -20,23 +20,24 @@ stdenv.mkDerivation rec {
   ];
 
   patches = let
-    fetchDebianPatch = {name, sha256}: fetchpatch {
-      url = "https://salsa.debian.org/debian/pdfchain/raw/2d29107756a3194fb522bdea8e9b9e393b15a8f3/debian/patches/${name}";
-      inherit name sha256;
-    };
+    fetchDebianPatch' = args: fetchDebianPatch ({
+      inherit pname;
+      version = "1:0.4.4.2";
+      debianRevision = "2";
+    } // args);
   in
   [
-    (fetchDebianPatch {
-      name = "fix_crash_on_startup";
-      sha256 = "sha256-1UyMHHGrmUIFhY53ILdMMsyocSIbcV6CKQ7sLVNhNQw=";
+    (fetchDebianPatch' {
+      patch = "fix_crash_on_startup";
+      hash = "sha256-1UyMHHGrmUIFhY53ILdMMsyocSIbcV6CKQ7sLVNhNQw=";
     })
-    (fetchDebianPatch {
-      name = "fix_desktop_file";
-      sha256 = "sha256-L6lhUs7GqVN1XOQO6bbz6BT29n4upsJtlHCAIGzk1Bw=";
+    (fetchDebianPatch' {
+      patch = "fix_desktop_file";
+      hash = "sha256-L6lhUs7GqVN1XOQO6bbz6BT29n4upsJtlHCAIGzk1Bw=";
     })
-    (fetchDebianPatch {
-      name = "fix_spelling";
-      sha256 = "sha256-sOUUslPfcOo2K3zuaLcux+CNdgfWM0phsfe6g4GUFes=";
+    (fetchDebianPatch' {
+      patch = "fix_spelling";
+      hash = "sha256-sOUUslPfcOo2K3zuaLcux+CNdgfWM0phsfe6g4GUFes=";
     })
   ];
 
@@ -51,6 +52,6 @@ stdenv.mkDerivation rec {
     homepage = "https://pdfchain.sourceforge.io";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ hqurve ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

- Changed `fetchDebianPatch` to expect the `patch`'s full filename (incl. extension)
- Consequently updated documentation and `pysimplesoap` derivation.
- Use `fetchDebianPatch` in `pdfchain`

This is another take on #253661, including the requested changes and necessary fixup.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
