### PR TITLE
nixos-anywhere: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ni/nixos-anywhere/package.nix
+++ b/pkgs/by-name/ni/nixos-anywhere/package.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, fetchFromGitHub
+, openssh
+, gitMinimal
+, rsync
+, nix
+, coreutils
+, curl
+, gnugrep
+, gawk
+, findutils
+, gnused
+, lib
+, makeWrapper
+}:
+let
+  runtimeDeps = [
+    gitMinimal # for git flakes
+    rsync
+    nix
+    coreutils
+    curl # when uploading tarballs
+    gnugrep
+    gawk
+    findutils
+    gnused # needed by ssh-copy-id
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "nixos-anywhere";
+  version = "1.0.0";
+  src = fetchFromGitHub {
+    owner = "numtide";
+    repo = "nixos-anywhere";
+    rev = version;
+    hash = "sha256-zM+N7+XDR34DuTrVLJd7Ggq1JPlURddsqNOjXY/rcQM=";
+  };
+  nativeBuildInputs = [ makeWrapper ];
+  installPhase = ''
+    install -D -m 0755 src/nixos-anywhere.sh $out/bin/nixos-anywhere
+
+    # We prefer the system's openssh over our own, since it might come with features not present in ours:
+    # https://github.com/numtide/nixos-anywhere/issues/62
+    wrapProgram $out/bin/nixos-anywhere \
+      --prefix PATH : ${lib.makeBinPath runtimeDeps} --suffix PATH : ${lib.makeBinPath [ openssh ]}
+  '';
+
+  meta = with lib; {
+    description = "Install nixos everywhere via ssh";
+    homepage = "https://github.com/numtide/nixos-anywhere";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.mic92 maintainers.lassulus maintainers.phaer ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
