### PR TITLE
 segger-jlink: init at 794a, nrfconnect: init at 4.3.0, nrf-command-line-tools: init at 10.23.2

### DIFF
--- a/pkgs/by-name/nr/nrf-command-line-tools/package.nix
+++ b/pkgs/by-name/nr/nrf-command-line-tools/package.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, udev
+, libusb1
+, segger-jlink
+}:
+
+let
+  supported = {
+    x86_64-linux = {
+      name = "linux-amd64";
+      hash = "sha256-zL9tXl2HsO8JZXEGsjg4+lDJJz30StOMH96rU7neDsg=";
+    };
+    aarch64-linux = {
+      name = "linux-arm64";
+      hash = "sha256-ACy3rXsvBZNVXdVkpP2AqrsoqKPliw6m9UUWrFOCBzs=";
+    };
+    armv7l-linux = {
+      name = "linux-armhf";
+      hash = "sha256-nD1pHL/SQqC7OlxuovWwvtnXKMmhfx5qFaF4ti8gh8g=";
+    };
+  };
+
+  platform = supported.${stdenv.system} or (throw "unsupported platform ${stdenv.system}");
+
+  version = "10.23.2";
+
+  url = let
+    versionWithDashes = builtins.replaceStrings ["."] ["-"] version;
+  in "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-${lib.versions.major version}-x-x/${versionWithDashes}/nrf-command-line-tools-${version}_${platform.name}.tar.gz";
+
+in stdenv.mkDerivation {
+  pname = "nrf-command-line-tools";
+  inherit version;
+
+  src = fetchurl {
+    inherit url;
+    inherit (platform) hash;
+  };
+
+  runtimeDependencies = [
+    segger-jlink
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    udev
+    libusb1
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -rf ./python
+    mkdir -p $out
+    cp -r * $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Nordic Semiconductor nRF Command Line Tools";
+    homepage = "https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools";
+    license = licenses.unfree;
+    platforms = attrNames supported;
+    maintainers = with maintainers; [ stargate01 ];
+  };
+}

--- a/pkgs/by-name/nr/nrfconnect/package.nix
+++ b/pkgs/by-name/nr/nrfconnect/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, fetchurl
+, appimageTools
+}:
+
+let
+  pname = "nrfconnect";
+  version = "4.3.0";
+
+  src = fetchurl {
+    url = "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-connect-for-desktop/${lib.versions.major version}-${lib.versions.minor version}-${lib.versions.patch version}/nrfconnect-${version}-x86_64.appimage";
+    hash = "sha256-G8//dZqPxn6mR8Bjzf/bAn9Gv7t2AFWIF9twCGbqMd8=";
+    name = "${pname}-${version}.AppImage";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+
+in appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: with pkgs; [
+    segger-jlink
+  ];
+
+  extraInstallCommands = ''
+    mv $out/bin/nrfconnect-* $out/bin/nrfconnect
+    install -Dm444 ${appimageContents}/nrfconnect.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/usr/share/icons/hicolor/512x512/apps/nrfconnect.png \
+      -t $out/share/icons/hicolor/512x512/apps
+    substituteInPlace $out/share/applications/nrfconnect.desktop \
+      --replace 'Exec=AppRun' 'Exec=nrfconnect'
+  '';
+
+  meta = with lib; {
+    description = "Nordic Semiconductor nRF Connect for Desktop";
+    homepage = "https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-desktop";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ stargate01 ];
+    mainProgram = "nrfconnect";
+  };
+}

--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -1,0 +1,228 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, udev
+, config
+, acceptLicense ? config.segger-jlink.acceptLicense or false
+, fontconfig
+, xorg
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+let
+  supported = {
+    x86_64-linux = {
+      name = "x86_64";
+      hash = "sha256-WGEDvB6TJ8Y2Xl1VUB1JWVMK54OevvPoVGris3I27t4=";
+    };
+    i686-linux = {
+      name = "i386";
+      hash = "sha256-BOQ4yExDRGKuUvsPUUswElrps0SpXcDCHxy2tmGbV/I=";
+    };
+    aarch64-linux = {
+      name = "arm64";
+      hash = "sha256-ZWzaWCUgV4x5Fbz+jphj771kIyLyeoRZKjgf8rmbFxQ=";
+    };
+    armv7l-linux = {
+      name = "arm";
+      hash = "sha256-Qjb5P1XH/CoiLP9iqWyEX0YHUjDIuSdw5ej1bE61T48=";
+    };
+  };
+
+  platform = supported.${stdenv.system} or (throw "unsupported platform ${stdenv.system}");
+
+  version = "794a";
+
+  url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
+
+  src =
+    assert !acceptLicense -> throw ''
+      Use of the "SEGGER JLink Software and Documentation pack" requires the
+      acceptance of the following licenses:
+
+        - SEGGER Downloads Terms of Use [1]
+        - SEGGER Software Licensing [2]
+
+      You can express acceptance by setting acceptLicense to true in your
+      configuration. Note that this is not a free license so it requires allowing
+      unfree licenses as well.
+
+      configuration.nix:
+        nixpkgs.config.allowUnfree = true;
+        nixpkgs.config.segger-jlink.acceptLicense = true;
+
+      config.nix:
+        allowUnfree = true;
+        segger-jlink.acceptLicense = true;
+
+      [1]: ${url}
+      [2]: https://www.segger.com/purchase/licensing/
+    '';
+      fetchurl {
+        inherit url;
+        inherit (platform) hash;
+        curlOpts = "--data accept_license_agreement=accepted";
+      };
+
+  qt4-bundled = stdenv.mkDerivation {
+    pname = "segger-jlink-qt4";
+    inherit src version;
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+    ];
+
+    buildInputs = [
+      stdenv.cc.cc.lib
+      fontconfig
+      xorg.libXrandr
+      xorg.libXfixes
+      xorg.libXcursor
+      xorg.libSM
+      xorg.libICE
+      xorg.libX11
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      # Install libraries
+      mkdir -p $out/lib
+      mv libQt* $out/lib
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "Bundled QT4 libraries for the J-Link Software and Documentation pack";
+      homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
+      license = licenses.lgpl21;
+      maintainers = with maintainers; [ stargate01 ];
+      knownVulnerabilities = [
+        "This bundled version of Qt 4 has reached its end of life after 2015. See https://github.com/NixOS/nixpkgs/pull/174634"
+        "CVE-2023-43114"
+        "CVE-2023-38197"
+        "CVE-2023-37369"
+        "CVE-2023-34410"
+        "CVE-2023-32763"
+        "CVE-2023-32762"
+        "CVE-2023-32573"
+        "CVE-2022-25634"
+        "CVE-2020-17507"
+        "CVE-2020-0570"
+        "CVE-2018-21035"
+        "CVE-2018-19873"
+        "CVE-2018-19871"
+        "CVE-2018-19870"
+        "CVE-2018-19869"
+        "CVE-2015-1290"
+        "CVE-2014-0190"
+        "CVE-2013-0254"
+        "CVE-2012-6093"
+        "CVE-2012-5624"
+        "CVE-2009-2700"
+      ];
+    };
+  };
+
+in stdenv.mkDerivation {
+  pname = "segger-jlink";
+  inherit src version;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    qt4-bundled
+  ];
+
+  # Udev is loaded late at runtime
+  appendRunpaths = [
+    "${udev}/lib"
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  desktopItems = map (entry:
+    (makeDesktopItem {
+      name = entry;
+      exec = entry;
+      icon = "applications-utilities";
+      desktopName = entry;
+      genericName = "SEGGER ${entry}";
+      categories = [ "Development" ];
+      type = "Application";
+      terminal = false;
+      startupNotify = false;
+    })
+  ) [
+    "JFlash"
+    "JFlashLite"
+    "JFlashSPI"
+    "JLinkConfig"
+    "JLinkGDBServer"
+    "JLinkLicenseManager"
+    "JLinkRTTViewer"
+    "JLinkRegistration"
+    "JLinkRemoteServer"
+    "JLinkSWOViewer"
+    "JLinkUSBWebServer"
+    "JMem"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install binaries and runtime files into /opt/
+    mkdir -p $out/opt
+    mv J* ETC GDBServer Firmwares $out/opt
+
+    # Link executables into /bin/
+    mkdir -p $out/bin
+    for binr in $out/opt/*Exe; do
+      binrlink=''${binr#"$out/opt/"}
+      ln -s $binr $out/bin/$binrlink
+      # Create additional symlinks without "Exe" suffix
+      binrlink=''${binrlink/%Exe}
+      ln -s $binr $out/bin/$binrlink
+    done
+
+    # Copy special alias symlinks
+    for slink in $(find $out/opt/. -type l); do
+      cp -P -n $slink $out/bin || true
+      rm $slink
+    done
+
+    # Install libraries
+    install -Dm444 libjlinkarm.so* -t $out/lib
+    for libr in $out/lib/libjlinkarm.*; do
+      ln -s $libr $out/opt
+    done
+
+    # Install docs and examples
+    mkdir -p $out/share
+    mv Doc $out/share/docs
+    mv Samples $out/share/examples
+
+    # Install udev rules
+    install -Dm444 99-jlink.rules -t $out/lib/udev/rules.d/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "J-Link Software and Documentation pack";
+    homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
+    license = licenses.unfree;
+    platforms = attrNames supported;
+    maintainers = with maintainers; [ FlorianFranzen stargate01 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR re-adds some packages which were purged due to their usage of QT4 in #174634 : `segger-jlink`, and two packages which depend on it: `nrfconnect` and `nrf-command-line-tools`.

Unfortunately the SEGGER J-Link tools are only distributed in binary form and have a hard requirement on (the bundled) QT4. I have packaged the bundled QT4 libs as a secondary package to not pollute the global namespace.

Supersedes #252137, #244637, #263487

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
