### PR TITLE
gcc12, gcc13: always mangle __FILE__ into invalid store path

### DIFF
--- a/pkgs/development/compilers/gcc/patches/12/mangle-NIX_STORE-in-__FILE__.patch
+++ b/pkgs/development/compilers/gcc/patches/12/mangle-NIX_STORE-in-__FILE__.patch
@@ -1,0 +1,85 @@
+From b10785c1be469319a09b10bc69db21159b0599ee Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <siarheit@google.com>
+Date: Fri, 22 Sep 2023 22:41:49 +0100
+Subject: [PATCH] gcc/file-prefix-map.cc: always mangle __FILE__ into invalid
+ store path
+
+Without the change `__FILE__` used in static inline functions in headers
+embed paths to header files into executable images. For local headers
+it's not a problem, but for headers in `/nix/store` this causes `-dev`
+inputs to be retained in runtime closure.
+
+Typical examples are `nix` -> `nlohmann_json` and `pipewire` ->
+`lttng-ust.dev`.
+
+Ideally we would like to use `-fmacro-prefix-map=` feature of `gcc` as:
+
+  -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/eeee.eee-nlohmann-json-ver
+  -fmacro-prefix-map=/nix/...
+
+In practice it quickly exhausts argument lengtth limit due to `gcc`
+deficiency: https://gcc.gnu.org/PR111527
+
+Until it;s fixed let's hardcode header mangling if $NIX_STORE variable
+is present in the environment.
+
+Tested as:
+
+    $ printf "# 0 \"/nix/store/01234567890123456789012345678901-pppppp-vvvvvvv\" \nconst char * f(void) { return __FILE__; }" | NIX_STORE=/nix/store ./gcc/xgcc -Bgcc -x c - -S -o -
+    ...
+    .string "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-pppppp-vvvvvvv"
+    ...
+
+Mangled successfully.
+--- a/gcc/file-prefix-map.cc
++++ b/gcc/file-prefix-map.cc
+@@ -60,6 +60,9 @@ add_prefix_map (file_prefix_map *&maps, const char *arg, const char *opt)
+   maps = map;
+ }
+ 
++/* Forward declaration for a $NIX_STORE remap hack below. */
++static file_prefix_map *macro_prefix_maps; /* -fmacro-prefix-map  */
++
+ /* Perform user-specified mapping of filename prefixes.  Return the
+    GC-allocated new name corresponding to FILENAME or FILENAME if no
+    remapping was performed.  */
+@@ -76,7 +79,30 @@ remap_filename (file_prefix_map *maps, const char *filename)
+     if (filename_ncmp (filename, map->old_prefix, map->old_len) == 0)
+       break;
+   if (!map)
+-    return filename;
++    {
++      if (maps == macro_prefix_maps)
++	{
++	  /* Remap all fo $NIX_STORE/.{32} paths to
++	  * equivalent $NIX_STORE/e{32}.
++	  *
++	  * That way we avoid argument parameters explosion
++	  * and still avoid embedding headers into runtime closure:
++	  *   https://gcc.gnu.org/PR111527
++	  */
++	  char * nix_store = getenv("NIX_STORE");
++	  size_t nix_store_len = nix_store ? strlen(nix_store) : 0;
++	  const char * name = filename;
++	  size_t name_len = strlen(name);
++	  if (nix_store && name_len >= nix_store_len + 1 + 32 && memcmp(name, nix_store, nix_store_len) == 0)
++	    {
++	       s = (char *) ggc_alloc_atomic (name_len + 1);
++	       memcpy(s, name, name_len + 1);
++	       memset(s + nix_store_len + 1, 'e', 32);
++	       return s;
++	    }
++	}
++      return filename;
++    }
+   name = filename + map->old_len;
+   name_len = strlen (name) + 1;
+ 
+@@ -90,7 +116,6 @@ remap_filename (file_prefix_map *maps, const char *filename)
+    ignore it in DW_AT_producer (dwarf2out.cc).  */
+ 
+ /* Linked lists of file_prefix_map structures.  */
+-static file_prefix_map *macro_prefix_maps; /* -fmacro-prefix-map  */
+ static file_prefix_map *debug_prefix_maps; /* -fdebug-prefix-map  */
+ static file_prefix_map *profile_prefix_maps; /* -fprofile-prefix-map  */
+ 

--- a/pkgs/development/compilers/gcc/patches/13/mangle-NIX_STORE-in-__FILE__.patch
+++ b/pkgs/development/compilers/gcc/patches/13/mangle-NIX_STORE-in-__FILE__.patch
@@ -1,0 +1,84 @@
+From b10785c1be469319a09b10bc69db21159b0599ee Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <siarheit@google.com>
+Date: Fri, 22 Sep 2023 22:41:49 +0100
+Subject: [PATCH] gcc/file-prefix-map.cc: always mangle __FILE__ into invalid
+ store path
+
+Without the change `__FILE__` used in static inline functions in headers
+embed paths to header files into executable images. For local headers
+it's not a problem, but for headers in `/nix/store` this causes `-dev`
+inputs to be retained in runtime closure.
+
+Typical examples are `nix` -> `nlohmann_json` and `pipewire` ->
+`lttng-ust.dev`.
+
+Ideally we would like to use `-fmacro-prefix-map=` feature of `gcc` as:
+
+  -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/eeee.eee-nlohmann-json-ver
+  -fmacro-prefix-map=/nix/...
+
+In practice it quickly exhausts argument lengtth limit due to `gcc`
+deficiency: https://gcc.gnu.org/PR111527
+
+Until it;s fixed let's hardcode header mangling if $NIX_STORE variable
+is present in the environment.
+
+Tested as:
+
+    $ printf "# 0 \"/nix/store/01234567890123456789012345678901-pppppp-vvvvvvv\" \nconst char * f(void) { return __FILE__; }" | NIX_STORE=/nix/store ./gcc/xgcc -Bgcc -x c - -S -o -
+    ...
+    .string "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-pppppp-vvvvvvv"
+    ...
+
+Mangled successfully.
+--- a/gcc/file-prefix-map.cc
++++ b/gcc/file-prefix-map.cc
+@@ -69,6 +69,9 @@ add_prefix_map (file_prefix_map *&maps, const char *arg, const char *opt)
+   maps = map;
+ }
+ 
++/* Forward declaration for a $NIX_STORE remap hack below. */
++static file_prefix_map *macro_prefix_maps; /* -fmacro-prefix-map  */
++
+ /* Perform user-specified mapping of filename prefixes.  Return the
+    GC-allocated new name corresponding to FILENAME or FILENAME if no
+    remapping was performed.  */
+@@ -102,6 +105,29 @@ remap_filename (file_prefix_map *maps, const char *filename)
+       break;
+   if (!map)
+     {
++      if (maps == macro_prefix_maps)
++	{
++	  /* Remap all fo $NIX_STORE/.{32} paths to
++	   * equivalent $NIX_STORE/e{32}.
++	   *
++	   * That way we avoid argument parameters explosion
++	   * and still avoid embedding headers into runtime closure:
++	   *   https://gcc.gnu.org/PR111527
++	   */
++	   char * nix_store = getenv("NIX_STORE");
++	   size_t nix_store_len = nix_store ? strlen(nix_store) : 0;
++	   const char * name = realname ? realname : filename;
++	   size_t name_len = strlen(name);
++	   if (nix_store && name_len >= nix_store_len + 1 + 32 && memcmp(name, nix_store, nix_store_len) == 0)
++	     {
++		s = (char *) ggc_alloc_atomic (name_len + 1);
++		memcpy(s, name, name_len + 1);
++		memset(s + nix_store_len + 1, 'e', 32);
++		if (realname != filename)
++		  free (const_cast <char *> (realname));
++		return s;
++	     }
++	}
+       if (realname != filename)
+ 	free (const_cast <char *> (realname));
+       return filename;
+@@ -124,7 +150,6 @@ remap_filename (file_prefix_map *maps, const char *filename)
+    ignore it in DW_AT_producer (gen_command_line_string in opts.cc).  */
+ 
+ /* Linked lists of file_prefix_map structures.  */
+-static file_prefix_map *macro_prefix_maps; /* -fmacro-prefix-map  */
+ static file_prefix_map *debug_prefix_maps; /* -fdebug-prefix-map  */
+ static file_prefix_map *profile_prefix_maps; /* -fprofile-prefix-map  */
+ 
+

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -63,8 +63,8 @@ in
 ++ optionals (noSysDirs) (
   [(if atLeast12 then ./gcc-12-no-sys-dirs.patch else ./no-sys-dirs.patch)] ++
   ({
-    "13" = [ ./13/no-sys-dirs-riscv.patch ];
-    "12" = [ ./no-sys-dirs-riscv.patch ];
+    "13" = [ ./13/no-sys-dirs-riscv.patch ./13/mangle-NIX_STORE-in-__FILE__.patch ];
+    "12" = [ ./no-sys-dirs-riscv.patch ./12/mangle-NIX_STORE-in-__FILE__.patch ];
     "11" = [ ./no-sys-dirs-riscv.patch ];
     "10" = [ ./no-sys-dirs-riscv.patch ];
     "9"  = [ ./no-sys-dirs-riscv-gcc9.patch ];


### PR DESCRIPTION
Before the change macros like assert() embedded paths to source file into an executable binary. Examples are nlohmann_json embedding into nix:

    $ nix shell nixpkgs#nix nixpkgs#binutils-unwrapped nixpkgs#which
    $ strings $(which nix) | fgrep nlohmann_json
    /nix/store/5xih6daf5g3hpa0wc5vs2cgrhakn4s0j-nlohmann_json-3.11.2/include/nlohmann/json.hpp
    /nix/store/5xih6daf5g3hpa0wc5vs2cgrhakn4s0j-nlohmann_json-3.11.2/include/nlohmann/detail/output/serializer.hpp
    /nix/store/5xih6daf5g3hpa0wc5vs2cgrhakn4s0j-nlohmann_json-3.11.2/include/nlohmann/detail/conversions/to_chars.hpp
    /nix/store/5xih6daf5g3hpa0wc5vs2cgrhakn4s0j-nlohmann_json-3.11.2/include/nlohmann/detail/input/lexer.hpp
    /nix/store/5xih6daf5g3hpa0wc5vs2cgrhakn4s0j-nlohmann_json-3.11.2/include/nlohmann/detail/iterators/iter_impl.hpp
    /nix/store/5xih6daf5g3hpa0wc5vs2cgrhakn4s0j-nlohmann_json-3.11.2/include/nlohmann/detail/input/json_sax.hpp
    /nix/store/5xih6daf5g3hpa0wc5vs2cgrhakn4s0j-nlohmann_json-3.11.2/include/nlohmann/detail/iterators/iteration_proxy.hpp
    /nix/store/5xih6daf5g3hpa0wc5vs2cgrhakn4s0j-nlohmann_json-3.11.2/include/nlohmann/detail/input/parser.hpp

Sometimes these dependencies are not too large: nlohmann_json is "just" 1MB of headers code.

But sometimes the `-dev` outputs contain python scripts and other build-only dependencies. The example is `lttng-ust`.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
