### PR TITLE
nodejs: make buildNpmPackage git dep lockfile fixup fail gracefully when no lockfile exists and git deps forced

### DIFF
--- a/pkgs/development/web/nodejs/node-npm-build-npm-package-logic.patch
+++ b/pkgs/development/web/nodejs/node-npm-build-npm-package-logic.patch
@@ -49,7 +49,7 @@ index 1fa8b1f96..a026bb50d 100644
 +      if (process.env['NIX_NODEJS_BUILDNPMPACKAGE']) {
 +        const spawn = require('@npmcli/promise-spawn')
 +
-+        const npmWithNixFlags = (args, cmd) => spawn('bash', ['-c', 'npm ' + args + ` $npm${cmd}Flags "$\{npm${cmd}FlagsArray[@]}" $npmFlags "$\{npmFlagsArray[@]}"`], { cwd: dir, env: { ...process.env, _PACOTE_NO_PREPARE_: noPrepare.join('\n') } }, { message: `\`npm ${args}\` failed` })
++        const npmWithNixFlags = (args, cmd) => spawn('bash', ['-c', 'npm ' + args + ` $npm${cmd}Flags "$\{npm${cmd}FlagsArray[@]}" $npmFlags "$\{npmFlagsArray[@]}" || [ -n "$forceGitDeps" ]`], { cwd: dir, env: { ...process.env, _PACOTE_NO_PREPARE_: noPrepare.join('\n') } }, { message: `\`npm ${args}\` failed` })
 +        const patchShebangs = () => spawn('bash', ['-c', 'source $stdenv/setup; patchShebangs node_modules'], { cwd: dir })
 +
 +        // the DirFetcher will do its own preparation to run the prepare scripts
@@ -57,7 +57,7 @@ index 1fa8b1f96..a026bb50d 100644
 +        //
 +        // We ignore this.npmConfig to maintain an environment that's as close
 +        // to the rest of the build as possible.
-+        return spawn('bash', ['-c', '$prefetchNpmDeps --fixup-lockfile package-lock.json'], { cwd: dir })
++        return spawn('bash', ['-c', '$prefetchNpmDeps --fixup-lockfile package-lock.json || [ -n "$forceGitDeps" ]'], { cwd: dir })
 +        .then(() => npmWithNixFlags('ci --ignore-scripts', 'Install'))
 +        .then(patchShebangs)
 +        .then(() => npmWithNixFlags('rebuild', 'Rebuild'))


### PR DESCRIPTION
## Description of changes

Along with #243458 this fixes #245849

The basic premise is that a git dep with install scripts that doesn't actually have any dev dependencies does sorta work with `forceGitDeps = true`, but it does not right now due to our own logic not failing gracefully in that case

~~I found pruning also needs to be turned off for this case, but I wasn't exactly sure why pruning specifically was requiring the cache to be available~~ (edit: would be sorta fixed by #267314)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).