### PR TITLE
makeBinaryWrapper: protect wildcards in flags

### DIFF
--- a/pkgs/build-support/setup-hooks/make-binary-wrapper/make-binary-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper/make-binary-wrapper.sh
@@ -193,8 +193,23 @@ makeCWrapper() {
 
 addFlags() {
     local n flag before after var
+
+    # Disable file globbing, since bash will otherwise try to find
+    # filenames matching the the value to be prefixed/suffixed if
+    # it contains characters considered wildcards, such as `?` and
+    # `*`. We want the value as is, except we also want to split
+    # it on on the separator; hence we can't quote it.
+    local reenableGlob=0
+    if [[ ! -o noglob ]]; then
+        reenableGlob=1
+    fi
+    set -o noglob
     # shellcheck disable=SC2086
     before=($1) after=($2)
+    if (( reenableGlob )); then
+        set +o noglob
+    fi
+
     var="argv_tmp"
     printf '%s\n' "char **$var = calloc(${#before[@]} + argc + ${#after[@]} + 1, sizeof(*$var));"
     printf '%s\n' "assert($var != NULL);"

--- a/pkgs/test/make-binary-wrapper/add-flags.c
+++ b/pkgs/test/make-binary-wrapper/add-flags.c
@@ -3,19 +3,21 @@
 #include <assert.h>
 
 int main(int argc, char **argv) {
-    char **argv_tmp = calloc(4 + argc + 2 + 1, sizeof(*argv_tmp));
+    char **argv_tmp = calloc(6 + argc + 2 + 1, sizeof(*argv_tmp));
     assert(argv_tmp != NULL);
     argv_tmp[0] = argv[0];
     argv_tmp[1] = "-x";
     argv_tmp[2] = "-y";
     argv_tmp[3] = "-z";
     argv_tmp[4] = "-abc";
+    argv_tmp[5] = "-g";
+    argv_tmp[6] = "*.txt";
     for (int i = 1; i < argc; ++i) {
-        argv_tmp[4 + i] = argv[i];
+        argv_tmp[6 + i] = argv[i];
     }
-    argv_tmp[4 + argc + 0] = "-foo";
-    argv_tmp[4 + argc + 1] = "-bar";
-    argv_tmp[4 + argc + 2] = NULL;
+    argv_tmp[6 + argc + 0] = "-foo";
+    argv_tmp[6 + argc + 1] = "-bar";
+    argv_tmp[6 + argc + 2] = NULL;
     argv = argv_tmp;
 
     argv[0] = "/send/me/flags";

--- a/pkgs/test/make-binary-wrapper/add-flags.cmdline
+++ b/pkgs/test/make-binary-wrapper/add-flags.cmdline
@@ -1,3 +1,4 @@
     --append-flags "-foo -bar" \
     --add-flags "-x -y -z" \
-    --add-flags -abc
+    --add-flags -abc \
+    --add-flags "-g *.txt"

--- a/pkgs/test/make-binary-wrapper/add-flags.env
+++ b/pkgs/test/make-binary-wrapper/add-flags.env
@@ -4,5 +4,7 @@ SUBST_ARGV0
 -y
 -z
 -abc
+-g
+*.txt
 -foo
 -bar


### PR DESCRIPTION
## Description of changes

The split-on-spaces behavior of `--add-flags` and `--append-flags` was also causing wildcards to be interpreted when the wrapper was built. This is a quick fix to prevent that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
