### PR TITLE
picard: add dependencies of ReplayGain plugin

### DIFF
--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -11,6 +11,9 @@
   enablePlayback ? true,
   gst_all_1,
 
+  enableReplayGain ? false,
+  rsgain,
+
   writableTmpDirAsHomeHook,
 }:
 
@@ -110,6 +113,9 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   ''
   + lib.optionalString (pyqt5.multimediaEnabled) ''
     makeWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+  ''
+  + lib.optionalString enableReplayGain ''
+    makeWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ rsgain ]})
   '';
 
   meta = {


### PR DESCRIPTION
Depends on #220842

## Description of changes

Picard is bundled with an optional [ReplayGain plugin](https://picard.musicbrainz.org/plugins/) ([source](https://github.com/metabrainz/picard-plugins/tree/0ec78c25c8d6daee2858725d6619dc89283a099b/plugins/replaygain2))—

> <img src="https://github.com/NixOS/nixpkgs/assets/1844746/96853d16-3cf8-4ccc-ad6d-cf438f879712" width="660" alt="Plugins → Calculate ReplayGain" />

—which depends on [rsgain](https://github.com/complexlogic/rsgain). For simplicity I’ve just added that to `PATH` since patching looks nontrivial.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `git cherry-pick NixOS/pull/220842 && nixpkgs-review rev HEAD`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).