### PR TITLE
orchard: init at 0.12.0

### DIFF
--- a/pkgs/by-name/or/orchard/package.nix
+++ b/pkgs/by-name/or/orchard/package.nix
@@ -1,0 +1,55 @@
+{ lib, fetchFromGitHub, buildGoModule, installShellFiles }:
+
+buildGoModule rec {
+  pname = "orchard";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "cirruslabs";
+    repo = pname;
+    rev = version;
+    hash = "sha256-+QNYlZ3/GiDtCySZPOlrDy03lkdGGvbFCWidQhbZJYQ=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  vendorHash = "sha256-BrzS+QtpGUHcYNNmSI6FlBtcYwNFri7R6nlVvFihdb4=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X github.com/cirruslabs/orchard/internal/version.Version=${version}"
+  ];
+
+  # ldflags based on metadata from git and source
+  preBuild = ''
+    ldflags+=" -X github.com/cirruslabs/orchard/internal/version.Commit=$(cat COMMIT)"
+  '';
+
+  subPackages = [ "cmd/orchard" ];
+
+  postInstall = ''
+    export HOME="$(mktemp -d)"
+    installShellCompletion --cmd orchard \
+      --bash <($out/bin/orchard completion bash) \
+      --zsh <($out/bin/orchard completion zsh) \
+      --fish <($out/bin/orchard completion fish)
+  '';
+
+  meta = with lib; {
+    mainProgram = "orchard";
+    description =
+      "Orchestrator for running Tart Virtual Machines on a cluster of Apple Silicon devices";
+    homepage = "https://github.com/cirruslabs/orchard";
+    license = licenses.fairsource09;
+    maintainers = with maintainers; [ techknowlogick ];
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/cirruslabs/orchard is an Orchestrator for running Tart Virtual Machines on a cluster of Apple Silicon devices.

tart is already packaged in nixpkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
