### PR TITLE
ocaml-ng.ocamlPackages_5_1.ocaml: 5.1.0-rc3 → 5.1.0

### DIFF
--- a/pkgs/development/compilers/ocaml/5.1.nix
+++ b/pkgs/development/compilers/ocaml/5.1.nix
@@ -1,9 +1,6 @@
 import ./generic.nix {
   major_version = "5";
   minor_version = "1";
-  patch_version = "0-rc3";
-  src = fetchTarball {
-    url = "https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.0~rc3.tar.xz";
-    sha256 = "sha256:0cbvdcsq1qh70mm116dcgk6y7d4g4nrypzq20k7i6ww7am1563d3";
-  };
+  patch_version = "0";
+  sha256 = "sha256-bOjbOTqvwmTlr3McaPvrIJIKtq6E1b+TURllt0IzUas=";
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1935,7 +1935,7 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_5_1 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.1.nix { });
 
-  ocamlPackages_latest = ocamlPackages_5_0;
+  ocamlPackages_latest = ocamlPackages_5_1;
 
   ocamlPackages = ocamlPackages_4_14;
 


### PR DESCRIPTION
## Description of changes

https://discuss.ocaml.org/t/ocaml-5-1-0-released/13021

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
