### PR TITLE
buildMavenPackage: add offline build feature flag

### DIFF
--- a/pkgs/development/tools/build-managers/apache-maven/build-package.nix
+++ b/pkgs/development/tools/build-managers/apache-maven/build-package.nix
@@ -40,7 +40,7 @@ let
         mvn dependency:get -Dartifact="$artifactId" -Dmaven.repo.local=$out/.m2
       done
     '' + lib.optionalString (!buildOffline) ''
-      mvn package -Dmaven.repo.local=$out/.m2 ${mvnDepsParameters}
+      mvn package -Dmaven.repo.local=$out/.m2 ${mvnParameters}
     '' + ''
       runHook postBuild
     '';

--- a/pkgs/development/tools/build-managers/apache-maven/build-package.nix
+++ b/pkgs/development/tools/build-managers/apache-maven/build-package.nix
@@ -12,7 +12,7 @@
 , mvnHash ? ""
 , mvnFetchExtraArgs ? { }
 , mvnDepsParameters ? ""
-, manualMvnArtifactIds ? [ ]
+, manualMvnArtifacts ? [ ]
 , mvnParameters ? ""
 , ...
 } @args:
@@ -36,7 +36,7 @@ let
 
         mvn dependency:go-offline -Dmaven.repo.local=$out/.m2 ${mvnDepsParameters}
 
-        for artifactId in ${builtins.toString manualMvnArtifactIds}
+        for artifactId in ${builtins.toString manualMvnArtifacts}
         do
           echo "downloading manual $artifactId"
           mvn dependency:get -Dartifact="$artifactId" -Dmaven.repo.local=$out/.m2


### PR DESCRIPTION
## Description of changes

The offline build flags does the following:

- Only downloads the maven dependencies in the fixed output derivation with the `mvn dependencies:go-offline` phase.
- Builds the package offline in the main derivation's build phase.

## Motivation

While trying to add the lemminx package, I encountered failing tests. Since the build is currently performed in the fixed output derivation, I always had to redownload all dependencies which took around 2min and made iterating more difficult.
Clearly separating the downloading of the dependencies and the build of the package solves that problem.

## Caveats

However, `mvn dependencies:go-offline` does unfortunately not capture all dependencies: For example, when I added the lemminx derivation, I encountered that the maven surefire plugin downloads so called dynamic dependencies when executing the tests which `mvn dependencies:go-offline` did not capture. As a result, I added a `manualMvnArtifacts` config option where you can add these dependencies.

See the lemminx package example for how it looks like: https://github.com/tricktron/nixpkgs/blob/de51d3734670e0682673376aee46db50703213a2/pkgs/development/tools/language-servers/lemminx/default.nix#L23-L30

Besides, some maven builds may only work with internet access and thus I hid all this functionality behind a feature flag called `buildOffline` so that new and current packages can opt in without breaking any existing packages.

Let me know what you think.

Pinging @wegank since you started the buildMavenPackage😃. 

## Next steps
- Review
- If accepted, add documentation

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
