### PR TITLE
python3.pkgs.xdot: 1.2 -> 1.3

### DIFF
--- a/pkgs/development/python-modules/xdot/default.nix
+++ b/pkgs/development/python-modules/xdot/default.nix
@@ -1,31 +1,57 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k, python, xvfb-run
-, wrapGAppsHook, gobject-introspection, pygobject3, graphviz, gtk3, numpy }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, xvfb-run
+, wrapGAppsHook
+, gobject-introspection
+, pygobject3
+, graphviz
+, gtk3
+, numpy
+}:
 
 buildPythonPackage rec {
   pname = "xdot";
-  version = "1.2";
+  version = "1.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "3df91e6c671869bd2a6b2a8883fa3476dbe2ba763bd2a7646cf848a9eba71b70";
+  src = fetchFromGitHub {
+    owner = "jrfonseca";
+    repo = "xdot.py";
+    rev = version;
+    hash = "sha256-0UfvN7z7ThlFu825h03Z5Wur9zbiUpvD5cb5gcIhQQI=";
   };
 
-  disabled = !isPy3k;
-  nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
-  propagatedBuildInputs = [ pygobject3 graphviz gtk3 numpy ];
-  nativeCheckInputs = [ xvfb-run ];
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+  ];
+  propagatedBuildInputs = [
+    pygobject3
+    graphviz
+    gtk3
+    numpy
+  ];
+  nativeCheckInputs = [
+    xvfb-run
+  ];
 
-  postInstall = ''
-    wrapProgram "$out/bin/xdot" --prefix PATH : "${lib.makeBinPath [ graphviz ]}"
+  dontWrapGApps = true;
+  # Arguments to be passed to `makeWrapper`, only used by buildPython*
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    makeWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ graphviz ]})
   '';
 
   checkPhase = ''
-    xvfb-run -s '-screen 0 800x600x24' ${python.interpreter} nix_run_setup test
+    runHook preCheck
+
+    xvfb-run -s '-screen 0 800x600x24' ${python.interpreter} test.py
+
+    runHook postCheck
   '';
 
-  # https://github.com/NixOS/nixpkgs/pull/107872#issuecomment-752175866
-  # cannot import name '_gi' from partially initialized module 'gi' (most likely due to a circular import)
-  doCheck = false;
+  doCheck = true;
 
   meta = with lib; {
     description = "An interactive viewer for graphs written in Graphviz's dot";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
