### PR TITLE
dockerfile-language-server-nodejs: fix build

### DIFF
--- a/pkgs/development/tools/language-servers/dockerfile-language-server-nodejs/default.nix
+++ b/pkgs/development/tools/language-servers/dockerfile-language-server-nodejs/default.nix
@@ -14,6 +14,10 @@ buildNpmPackage rec {
     hash = "sha256-uwwwF1eMoSA2C5h56BBllTZW8zRHueNeVwhwtycrNfA=";
   };
 
+  preBuild = ''
+    npm run prepublishOnly
+  '';
+
   npmDepsHash = "sha256-lI+tkUBR0rmWcU57jU0y7XaMK3JADNU7fcbCxMmz/7s=";
 
   meta = {
@@ -22,6 +26,6 @@ buildNpmPackage rec {
     homepage = "https://github.com/rcjsuen/dockerfile-language-server-nodejs";
     license = lib.licenses.mit;
     mainProgram = "docker-langserver";
-    maintainers = with lib.maintainers; [ rvolosatovs ];
+    maintainers = with lib.maintainers; [ rvolosatovs net-mist ];
   };
 }


### PR DESCRIPTION
## Description of changes

When trying to use the dockerfile-language-server, it fails to start with message "Error: Cannot find module '../lib/server".

In package.json there is an additional step to generate this file : `"prepublishOnly": "tsc -p ./src"`.

I don't know a lot JS, so their might be a clever way to fix this issue, but adding `tsc -p ./src` to the build command solve it for me (tested with Helix editor)
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
