### PR TITLE
python3.pkgs.primer3: enable tests

### DIFF
--- a/pkgs/development/python-modules/primer3/default.nix
+++ b/pkgs/development/python-modules/primer3/default.nix
@@ -5,6 +5,7 @@
 , cython
 , gcc
 , click
+, pytestCheckHook
 , pythonOlder
 }:
 
@@ -28,10 +29,18 @@ buildPythonPackage rec {
     gcc
   ];
 
-  # pytestCheckHook leads to a circular import issue
   nativeCheckInputs = [
     click
+    pytestCheckHook
   ];
+  # We are not sure why exactly this is need. It seems `pytestCheckHook`
+  # doesn't find extension modules installed in $out/${python.sitePackages},
+  # and the tests rely upon them. This was initially reported upstream at
+  # https://github.com/libnano/primer3-py/issues/120 and we investigate this
+  # downstream at: https://github.com/NixOS/nixpkgs/issues/255262.
+  preCheck = ''
+    python setup.py build_ext --inplace
+  '';
 
   pythonImportsCheck = [
     "primer3"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
