### PR TITLE
kicad-testing: init at 7.0-2024-01-07

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -43,6 +43,7 @@
 , valgrind
 
 , stable
+, testing
 , baseName
 , kicadSrc
 , kicadVersion
@@ -56,6 +57,8 @@
 
 assert lib.assertMsg (!(sanitizeAddress && sanitizeThreads))
   "'sanitizeAddress' and 'sanitizeThreads' are mutually exclusive, use one.";
+assert testing -> !stable
+  -> throw "testing implies stable and cannot be used with stable = false";
 
 let
   inherit (lib) optional optionals optionalString;
@@ -74,9 +77,9 @@ stdenv.mkDerivation rec {
   ];
 
   # tagged releases don't have "unknown"
-  # kicad nightlies use git describe --dirty
+  # kicad testing and nightlies use git describe --dirty
   # nix removes .git, so its approximated here
-  postPatch = lib.optionalString (!stable) ''
+  postPatch = lib.optionalString (!stable || testing) ''
     substituteInPlace cmake/KiCadVersion.cmake \
       --replace "unknown" "${builtins.substring 0 10 src.rev}"
 
@@ -92,7 +95,7 @@ stdenv.mkDerivation rec {
   ]
   ++ optionals (stable) [
     # https://gitlab.com/kicad/code/kicad/-/issues/12491
-    # should be resolved in the next release
+    # should be resolved in the next major? release
     "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_eeschema'"
   ]
   ++ optional (stable && !withNgspice) "-DKICAD_SPICE=OFF"

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -2,22 +2,26 @@
 , runCommand
 , newScope
 , fetchFromGitLab
-, gnome
-, dconf
-, wxGTK32
-, gtk3
 , makeWrapper
-, gsettings-desktop-schemas
-, hicolor-icon-theme
+, symlinkJoin
 , callPackage
 , callPackages
+
+, gnome
+, dconf
+, gtk3
+, wxGTK32
 , librsvg
 , cups
+, gsettings-desktop-schemas
+, hicolor-icon-theme
+
 , unzip
 , jq
 
 , pname ? "kicad"
 , stable ? true
+, testing ? false
 , withNgspice ? !stdenv.isDarwin
 , libngspice
 , withScripting ? true
@@ -29,7 +33,6 @@
 , with3d ? true
 , withI18n ? true
 , srcs ? { }
-, symlinkJoin
 }:
 
 # `addons`: https://dev-docs.kicad.org/en/addons/
@@ -75,7 +78,9 @@
 # }
 
 let
-  baseName = if (stable) then "kicad" else "kicad-unstable";
+  baseName = if (testing) then "kicad-testing"
+    else if (stable) then "kicad"
+    else "kicad-unstable";
   versionsImport = import ./versions.nix;
 
   # versions.nix does not provide us with version, src and rev. We
@@ -154,7 +159,7 @@ stdenv.mkDerivation rec {
   passthru.libraries = callPackages ./libraries.nix { inherit libSrc; };
   passthru.callPackage = newScope { inherit addonPath python3; };
   base = callPackage ./base.nix {
-    inherit stable baseName;
+    inherit stable testing baseName;
     inherit kicadSrc kicadVersion;
     inherit wxGTK python wxPython;
     inherit withNgspice withScripting withI18n;
@@ -272,7 +277,8 @@ stdenv.mkDerivation rec {
   meta = rec {
     description = (if (stable)
     then "Open Source Electronics Design Automation suite"
-    else "Open Source EDA suite, development build")
+    else if (testing) then "Open Source EDA suite, latest on stable branch"
+    else "Open Source EDA suite, latest on master branch")
     + (lib.optionalString (!with3d) ", without 3D models");
     homepage = "https://www.kicad.org/";
     longDescription = ''

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -267,12 +267,10 @@ stdenv.mkDerivation rec {
     ln -s ${base}/share/metainfo $out/share/metainfo
   '';
 
-  # can't run this for each pname
-  # stable and unstable are in the same versions.nix
-  # and kicad-small reuses stable
-  # with "all" it updates both, run it manually if you don't want that
-  # and can't git commit if this could be running in parallel with other scripts
-  passthru.updateScript = [ ./update.sh "all" ];
+  passthru.updateScript = {
+    command = [ ./update.sh "${pname}" ];
+    supportedFeatures = [ "commit" ];
+  };
 
   meta = rec {
     description = (if (stable)

--- a/pkgs/applications/science/electronics/kicad/update.sh
+++ b/pkgs/applications/science/electronics/kicad/update.sh
@@ -77,7 +77,11 @@ for arg in "$@" "${UPDATE_NIX_PNAME}"; do
 done
 
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-now=$(date --iso-8601 --utc)
+commit_date() {
+  gitlab_json="$(curl -s https://gitlab.com/api/v4/projects/kicad%2Fcode%2Fkicad/repository/commits/"$1")"
+  commit_created="$(jq .created_at --raw-output <<< "${gitlab_json}")"
+  date --date="${commit_created}" --iso-8601 --utc
+}
 
 file="${here}/versions.nix"
 # just in case this runs in parallel
@@ -137,6 +141,8 @@ for version in "${all_versions[@]}"; do
   if [[ (-n ${check_stable} && ${version} != "master" && ${version} != "testing") \
      || (-n ${check_testing} && ${version} == "testing") \
      || (-n ${check_unstable} && ${version} == "master" ) ]]; then
+
+    now=$(commit_date "${src_version}")
 
     if [[ ${version} == "master" ]]; then
       pname="kicad-unstable"

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -23,6 +23,28 @@
       };
     };
   };
+  "kicad-testing" = {
+    kicadVersion = {
+      version =			"7.0-2024-01-07";
+      src = {
+        rev =			"ace6439758f8d211001235f36f02a60488337e41";
+        sha256 =		"0z4p2srz9rld7mq6k2y5fipz8mgsdhh2506wam4388nklzzkrccr";
+      };
+    };
+    libVersion = {
+      version =			"7.0-2024-01-07";
+      libSources = {
+        symbols.rev =		"eedf6c9ddac2816023e817d4dc91032f9d7390b9";
+        symbols.sha256 =	"0nlgmxf9z1vf4g350dfkxql1dawgmw275wqxkgszsfxmhdfpmi9v";
+        templates.rev =		"9ce98cc45f3778e05c404edebf0f98de5c247ffe";
+        templates.sha256 =	"0mykfwwik7472i4r0isc5szj3dnmvd0538p0vlmzh4rcgj3pj3vm";
+        footprints.rev =	"7061fc9847ecc1b838e60dc6826db534028494f6";
+        footprints.sha256 =	"1az6fzh1lma71mj12bc4bblnmzjayrxhkb8w9rjvlhvvgv33cdmy";
+        packages3d.rev =	"d7345b34daaa23acf0d4506ed937fb424b5b18cd";
+        packages3d.sha256 =	"0xzyi4mgyifwc6dppdzh6jq294mkj0a71cwkqw2ymz1kfbksw626";
+      };
+    };
+  };
   "kicad-unstable" = {
     kicadVersion = {
       version =			"2023-08-15";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39733,6 +39733,14 @@ with pkgs;
   kicad = callPackage ../applications/science/electronics/kicad { };
   # this is the same but without the (sizable) 3D models library
   kicad-small = kicad.override { pname = "kicad-small"; with3d = false; };
+  # this is the stable branch at whatever point update.sh last updated versions.nix
+  kicad-testing = kicad.override { pname = "kicad-testing"; testing = true; };
+  # and a small version of that
+  kicad-testing-small = kicad.override {
+    pname = "kicad-testing-small";
+    testing = true;
+    with3d = false;
+  };
   # this is the master branch at whatever point update.sh last updated versions.nix
   kicad-unstable = kicad.override { pname = "kicad-unstable"; stable = false; };
   # and a small version of that


### PR DESCRIPTION
update update.sh to include it in versions.nix

fix the update.sh to allow r-ryantm's automatic updates

sort the package inputs a bit

## Description of changes

upstream has been encouraging the use of a testing package to test the changes on the stable branch
(that is, changes that have been backported to stable and will be in the next stable minor or patch release)

This adds such a package.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).