### PR TITLE
python310Packages.objax: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/development/python-modules/objax/default.nix
+++ b/pkgs/development/python-modules/objax/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchFromGitHub
+, fetchPypi
 , buildPythonPackage
 , jax
 , jaxlib
@@ -12,13 +12,19 @@
 
 buildPythonPackage rec {
   pname = "objax";
-  version = "1.6.0";
+  version = "1.7.0";
 
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "objax";
-    rev = "v${version}";
-    hash = "sha256-/6tZxVDe/3C53Re14odU9VA3mKvSj9X3/xt6bHFLHwQ=";
+  # The latest release (1.7.0) has not been tagged on GitHub. Thus, we fallback to fetchPypi.
+  # An issue has been opened upstream: https://github.com/google/objax/issues/263
+  # src = fetchFromGitHub {
+  #   owner = "google";
+  #   repo = "objax";
+  #   rev = "v${version}";
+  #   hash = "";
+  # };
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-92Z5RxYoWkMAqyF7H/MagPnC4pfXks5k9zmjvo+Z2Mc=";
   };
 
   # Avoid propagating the dependency on `jaxlib`, see


### PR DESCRIPTION
## Description of changes

Update `objax`.
I switched to using `fetchPypi` because the latest release is not present on the GitHub repo (no tag nor release).

cc @ndl 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
