### PR TITLE
envoy: fix another hash invalidator in fetcher

### DIFF
--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -80,8 +80,8 @@ buildBazelPackage rec {
 
   fetchAttrs = {
     sha256 = {
-      x86_64-linux = "sha256-+8MnbcFUyAE2122VA5olWAW8ZgjGweumRI62bxi9KOI=";
-      aarch64-linux = "sha256-4PH8rgsHxEwtx8RQGjLbAxHpLfWVqRLOvSX9sqQoy4Y=";
+      x86_64-linux = "sha256-MvY4cLdLOeb7+Zt7Oz7Kzz1+dsUceemP/V02egvHg+M=";
+      aarch64-linux = "sha256-U5mnAq8RHDygxiYeNc0HDeOgoaGyrd0MPjHKdyUkM0A=";
     }.${stdenv.system} or (throw "unsupported system ${stdenv.system}");
     dontUseCmakeConfigure = true;
     dontUseGnConfigure = true;
@@ -97,7 +97,7 @@ buildBazelPackage rec {
         -e 's,${stdenv.shellPackage},__NIXSHELL__,' \
         $bazelOut/external/com_github_luajit_luajit/build.py \
         $bazelOut/external/local_config_sh/BUILD \
-        $bazelOut/external/base_pip3/BUILD.bazel
+        $bazelOut/external/*_pip3/BUILD.bazel
 
       rm -r $bazelOut/external/go_sdk
       rm -r $bazelOut/external/local_jdk
@@ -133,7 +133,7 @@ buildBazelPackage rec {
         -e 's,__NIXSHELL__,${stdenv.shellPackage},' \
         $bazelOut/external/com_github_luajit_luajit/build.py \
         $bazelOut/external/local_config_sh/BUILD \
-        $bazelOut/external/base_pip3/BUILD.bazel
+        $bazelOut/external/*_pip3/BUILD.bazel
     '';
     installPhase = ''
       install -Dm0755 bazel-bin/source/exe/envoy-static $out/bin/envoy


### PR DESCRIPTION
## Description of changes

This all seems very fragile, but here's another fix.

``` diff
diff -r ccy/external/dev_pip3/BUILD.bazel p0v/external/dev_pip3/BUILD.bazel
7c7
< # /nix/store/lx8vhp4fxclp494svlfis3sb2g8z4l9h-python3-3.10.12/bin/python3 -m python.pip_install.tools.lock_file_generator.lock_file_generator --requirements_lock /build/source/tools/dev/requirements.txt --r
equirements_lock_label @//tools/dev:requirements.txt --quiet True --timeout 600 --annotations /build/output/external/dev_pip3/annotations.json --bzlmod false --python_interpreter python3 --repo dev_pip3 --rep
o-prefix dev_pip3_ --isolated --extra_pip_args {"arg":["--require-hashes"]} --pip_data_exclude {"arg":[]} --environment {"arg":{}}
\ No newline at end of file
---
> # /nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12/bin/python3 -m python.pip_install.tools.lock_file_generator.lock_file_generator --requirements_lock /build/source/tools/dev/requirements.txt --r
equirements_lock_label @//tools/dev:requirements.txt --quiet True --timeout 600 --annotations /build/output/external/dev_pip3/annotations.json --bzlmod false --python_interpreter python3 --repo dev_pip3 --rep
o-prefix dev_pip3_ --isolated --extra_pip_args {"arg":["--require-hashes"]} --pip_data_exclude {"arg":[]} --environment {"arg":{}}
\ No newline at end of file

diff -r ccy/external/fuzzing_pip3/BUILD.bazel p0v/external/fuzzing_pip3/BUILD.bazel
7c7
< # /nix/store/lx8vhp4fxclp494svlfis3sb2g8z4l9h-python3-3.10.12/bin/python3 -m python.pip_install.tools.lock_file_generator.lock_file_generator --requirements_lock /build/output/external/rules_fuzzing/fuzzing
/requirements.txt --requirements_lock_label @rules_fuzzing//fuzzing:requirements.txt --quiet True --timeout 600 --annotations /build/output/external/fuzzing_pip3/annotations.json --bzlmod false --python_inter
preter python3 --repo fuzzing_pip3 --repo-prefix fuzzing_pip3_ --isolated --extra_pip_args {"arg":["--require-hashes"]} --pip_data_exclude {"arg":[]} --environment {"arg":{}}
\ No newline at end of file
---
> # /nix/store/vagb0sjv83ybi435i6iiv10hjrdghph9-python3-3.10.12/bin/python3 -m python.pip_install.tools.lock_file_generator.lock_file_generator --requirements_lock /build/output/external/rules_fuzzing/fuzzing
/requirements.txt --requirements_lock_label @rules_fuzzing//fuzzing:requirements.txt --quiet True --timeout 600 --annotations /build/output/external/fuzzing_pip3/annotations.json --bzlmod false --python_inter
preter python3 --repo fuzzing_pip3 --repo-prefix fuzzing_pip3_ --isolated --extra_pip_args {"arg":["--require-hashes"]} --pip_data_exclude {"arg":[]} --environment {"arg":{}}
\ No newline at end of file
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
