### PR TITLE
abaddon: 0.1.10 -> 0.1.11

### DIFF
--- a/pkgs/applications/networking/instant-messengers/abaddon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/abaddon/default.nix
@@ -9,20 +9,24 @@
 , curl
 , gtkmm3
 , libhandy
+, libopus
 , libsecret
+, libsodium
 , nlohmann_json
+, pcre2
+, spdlog
 , sqlite
 }:
 
 stdenv.mkDerivation rec {
   pname = "abaddon";
-  version = "0.1.10";
+  version = "0.1.11";
 
   src = fetchFromGitHub {
     owner = "uowuo";
     repo = "abaddon";
     rev = "v${version}";
-    hash = "sha256-84DrPx0e3pZjg87dHZO4y/z7KfIYNyAibE7/J7oYwXA=";
+    hash = "sha256-KrBZESYab7QFwUfpTl40cgKn/if31oqA9oCe0PwoYbs=";
     fetchSubmodules = true;
   };
 
@@ -37,8 +41,12 @@ stdenv.mkDerivation rec {
     curl
     gtkmm3
     libhandy
+    libopus
     libsecret
+    libsodium
     nlohmann_json
+    pcre2
+    spdlog
     sqlite
   ];
 


### PR DESCRIPTION
## Description of changes

Update abaddon. Closes #251028.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


