### PR TITLE
python310Packages.natsort: disable timing sensitive test

### DIFF
--- a/pkgs/development/python-modules/natsort/default.nix
+++ b/pkgs/development/python-modules/natsort/default.nix
@@ -34,6 +34,12 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # timing sensitive test
+    # hypothesis.errors.DeadlineExceeded: Test took 524.23ms, which exceeds the deadline of 200.00ms
+    "test_string_component_transform_factory"
+  ];
+
   pythonImportsCheck = [
     "natsort"
   ];


### PR DESCRIPTION
## Description of changes

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.2.1, pluggy-1.0.0
rootdir: /build/natsort-8.3.1
plugins: hypothesis-6.68.2, mock-3.10.0
collected 333 items                                                            

tests/test_fake_fastnumbers.py ...............                           [  4%]
tests/test_final_data_transform_factory.py ........                      [  6%]
tests/test_input_string_transform_factory.py .................           [ 12%]
tests/test_main.py ......................                                [ 18%]
tests/test_natsort_key.py .....                                          [ 20%]
tests/test_natsort_keygen.py .....................                       [ 26%]
tests/test_natsorted.py ................................................ [ 40%]
...                                                                      [ 41%]
tests/test_natsorted_convenience.py .............                        [ 45%]
tests/test_ns_enum.py .......................................            [ 57%]
tests/test_os_sorted.py .....                                            [ 58%]
tests/test_parse_bytes_function.py ....                                  [ 60%]
tests/test_parse_number_function.py ...........                          [ 63%]
tests/test_parse_string_function.py ....                                 [ 64%]
tests/test_regex.py .................................................... [ 80%]
                                                                         [ 80%]
tests/test_string_component_transform_factory.py ...F.....               [ 82%]
tests/test_unicode_numbers.py ......                                     [ 84%]
tests/test_utils.py ...................................................  [100%]

=================================== FAILURES ===================================
_________ test_string_component_transform_factory[1025-example_func3] __________

self = <hypothesis.core.StateForActualGivenExecution object at 0x7fffe8b89090>
data = ConjectureData(INTERESTING, 48 bytes, frozen)

    def _execute_once_for_engine(self, data):
        """Wrapper around ``execute_once`` that intercepts test failure
        exceptions and single-test control exceptions, and turns them into
        appropriate method calls to `data` instead.
    
        This allows the engine to assume that any exception other than
        ``StopTest`` must be a fatal error, and should stop the entire engine.
        """
        try:
            trace = frozenset()
            if (
                self.failed_normally
                and not self.failed_due_to_deadline
                and Phase.shrink in self.settings.phases
                and Phase.explain in self.settings.phases
                and sys.gettrace() is None
                and not PYPY
            ):  # pragma: no cover
                # This is in fact covered by our *non-coverage* tests, but due to the
                # settrace() contention *not* by our coverage tests.  Ah well.
                tracer = Tracer()
                try:
                    sys.settrace(tracer.trace)
                    result = self.execute_once(data)
                    if data.status == Status.VALID:
                        self.explain_traces[None].add(frozenset(tracer.branches))
                finally:
                    sys.settrace(None)
                    trace = frozenset(tracer.branches)
            else:
>               result = self.execute_once(data)

/nix/store/3g4mp3dsz17z7dfiqhd5brmd8gnak6ns-python3.10-hypothesis-6.68.2/lib/python3.10/site-packages/hypothesis/core.py:878: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <hypothesis.core.StateForActualGivenExecution object at 0x7fffe8b89090>
data = ConjectureData(INTERESTING, 48 bytes, frozen), print_example = False
is_final = False, expected_failure = None

    def execute_once(
        self, data, print_example=False, is_final=False, expected_failure=None
    ):
        """Run the test function once, using ``data`` as input.
    
        If the test raises an exception, it will propagate through to the
        caller of this method. Depending on its type, this could represent
        an ordinary test failure, or a fatal error, or a control exception.
    
        If this method returns normally, the test might have passed, or
        it might have placed ``data`` in an unsuccessful state and then
        swallowed the corresponding control exception.
        """
    
        self.ever_executed = True
        data.is_find = self.is_find
    
        text_repr = None
        if self.settings.deadline is None:
            test = self.test
        else:
    
            @proxies(self.test)
            def test(*args, **kwargs):
                self.__test_runtime = None
                initial_draws = len(data.draw_times)
                start = time.perf_counter()
                result = self.test(*args, **kwargs)
                finish = time.perf_counter()
                internal_draw_time = sum(data.draw_times[initial_draws:])
                runtime = datetime.timedelta(
                    seconds=finish - start - internal_draw_time
                )
                self.__test_runtime = runtime
                current_deadline = self.settings.deadline
                if not is_final:
                    current_deadline = (current_deadline // 4) * 5
                if runtime >= current_deadline:
                    raise DeadlineExceeded(runtime, self.settings.deadline)
                return result
    
        def run(data):
            # Set up dynamic context needed by a single test run.
            with local_settings(self.settings):
                with deterministic_PRNG():
                    with BuildContext(data, is_final=is_final) as context:
                        # Generate all arguments to the test function.
                        args, kwargs = data.draw(self.search_strategy)
                        if expected_failure is not None:
                            nonlocal text_repr
                            text_repr = repr_call(test, args, kwargs)
    
                        if print_example or current_verbosity() >= Verbosity.verbose:
                            output = StringIO()
    
                            printer = RepresentationPrinter(output, context=context)
                            if print_example:
                                printer.text("Falsifying example:")
                            else:
                                printer.text("Trying example:")
    
                            if self.print_given_args:
                                printer.text(" ")
                                printer.repr_call(
                                    test.__name__,
                                    args,
                                    kwargs,
                                    force_split=True,
                                )
                            report(printer.getvalue())
                        return test(*args, **kwargs)
    
        # Run the test function once, via the executor hook.
        # In most cases this will delegate straight to `run(data)`.
>       result = self.test_runner(data, run)

/nix/store/3g4mp3dsz17z7dfiqhd5brmd8gnak6ns-python3.10-hypothesis-6.68.2/lib/python3.10/site-packages/hypothesis/core.py:817: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

data = ConjectureData(INTERESTING, 48 bytes, frozen)
function = <function StateForActualGivenExecution.execute_once.<locals>.run at 0x7fffe58e9630>

    def default_new_style_executor(data, function):
>       return function(data)

/nix/store/3g4mp3dsz17z7dfiqhd5brmd8gnak6ns-python3.10-hypothesis-6.68.2/lib/python3.10/site-packages/hypothesis/executors.py:47: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

data = ConjectureData(INTERESTING, 48 bytes, frozen)

    def run(data):
        # Set up dynamic context needed by a single test run.
        with local_settings(self.settings):
            with deterministic_PRNG():
                with BuildContext(data, is_final=is_final) as context:
                    # Generate all arguments to the test function.
                    args, kwargs = data.draw(self.search_strategy)
                    if expected_failure is not None:
                        nonlocal text_repr
                        text_repr = repr_call(test, args, kwargs)
    
                    if print_example or current_verbosity() >= Verbosity.verbose:
                        output = StringIO()
    
                        printer = RepresentationPrinter(output, context=context)
                        if print_example:
                            printer.text("Falsifying example:")
                        else:
                            printer.text("Trying example:")
    
                        if self.print_given_args:
                            printer.text(" ")
                            printer.repr_call(
                                test.__name__,
                                args,
                                kwargs,
                                force_split=True,
                            )
                        report(printer.getvalue())
>                   return test(*args, **kwargs)

/nix/store/3g4mp3dsz17z7dfiqhd5brmd8gnak6ns-python3.10-hypothesis-6.68.2/lib/python3.10/site-packages/hypothesis/core.py:813: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

x = '\U000449f2\U000e0d90?8𤥂', alg = 1025
example_func = functools.partial(<built-in function try_float>, map=True, nan=inf)

    @pytest.mark.parametrize(
>       "alg, example_func",
        [
            (ns.INT, partial(try_int, map=True)),
            (ns.DEFAULT, partial(try_int, map=True)),
            (ns.FLOAT, partial(try_float, map=True, nan=float("-inf"))),
            (ns.FLOAT | ns.NANLAST, partial(try_float, map=True, nan=float("+inf"))),
            (ns.GROUPLETTERS, partial(try_int, map=True, on_fail=groupletters)),
            (ns.LOCALE, partial(try_int, map=True, on_fail=lambda x: get_strxfrm()(x))),
            (
                ns.GROUPLETTERS | ns.LOCALE,
                partial(
                    try_int, map=True, on_fail=lambda x: get_strxfrm()(groupletters(x))
                ),
            ),
            (
                NS_DUMB | ns.LOCALE,
                partial(
                    try_int, map=True, on_fail=lambda x: get_strxfrm()(groupletters(x))
                ),
            ),
            (
                ns.GROUPLETTERS | ns.LOCALE | ns.FLOAT | ns.NANLAST,
                partial(
                    try_float,
                    map=True,
                    on_fail=lambda x: get_strxfrm()(groupletters(x)),
                    nan=float("+inf"),
                ),
            ),
        ],
    )

tests/test_string_component_transform_factory.py:50: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = ('\U000449f2\U000e0d90?8𤥂', 1025, functools.partial(<built-in function try_float>, map=True, nan=inf))
kwargs = {}, initial_draws = 1, start = 3093611.533120096, result = None
finish = 3093612.057349764, internal_draw_time = 0
runtime = datetime.timedelta(microseconds=524230)
current_deadline = datetime.timedelta(microseconds=250000)

    @proxies(self.test)
    def test(*args, **kwargs):
        self.__test_runtime = None
        initial_draws = len(data.draw_times)
        start = time.perf_counter()
        result = self.test(*args, **kwargs)
        finish = time.perf_counter()
        internal_draw_time = sum(data.draw_times[initial_draws:])
        runtime = datetime.timedelta(
            seconds=finish - start - internal_draw_time
        )
        self.__test_runtime = runtime
        current_deadline = self.settings.deadline
        if not is_final:
            current_deadline = (current_deadline // 4) * 5
        if runtime >= current_deadline:
>           raise DeadlineExceeded(runtime, self.settings.deadline)
E           hypothesis.errors.DeadlineExceeded: Test took 524.23ms, which exceeds the deadline of 200.00ms

/nix/store/3g4mp3dsz17z7dfiqhd5brmd8gnak6ns-python3.10-hypothesis-6.68.2/lib/python3.10/site-packages/hypothesis/core.py:781: DeadlineExceeded

The above exception was the direct cause of the following exception:

alg = 1025
example_func = functools.partial(<built-in function try_float>, map=True, nan=inf)

    @pytest.mark.parametrize(
>       "alg, example_func",
        [
            (ns.INT, partial(try_int, map=True)),
            (ns.DEFAULT, partial(try_int, map=True)),
            (ns.FLOAT, partial(try_float, map=True, nan=float("-inf"))),
            (ns.FLOAT | ns.NANLAST, partial(try_float, map=True, nan=float("+inf"))),
            (ns.GROUPLETTERS, partial(try_int, map=True, on_fail=groupletters)),
            (ns.LOCALE, partial(try_int, map=True, on_fail=lambda x: get_strxfrm()(x))),
            (
                ns.GROUPLETTERS | ns.LOCALE,
                partial(
                    try_int, map=True, on_fail=lambda x: get_strxfrm()(groupletters(x))
                ),
            ),
            (
                NS_DUMB | ns.LOCALE,
                partial(
                    try_int, map=True, on_fail=lambda x: get_strxfrm()(groupletters(x))
                ),
            ),
            (
                ns.GROUPLETTERS | ns.LOCALE | ns.FLOAT | ns.NANLAST,
                partial(
                    try_float,
                    map=True,
                    on_fail=lambda x: get_strxfrm()(groupletters(x)),
                    nan=float("+inf"),
                ),
            ),
        ],
    )

tests/test_string_component_transform_factory.py:50: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <hypothesis.core.StateForActualGivenExecution object at 0x7fffe8b89090>
data = ConjectureData(VALID, 48 bytes, frozen), print_example = True
is_final = True
expected_failure = (DeadlineExceeded('Test took 524.23ms, which exceeds the deadline of 200.00ms'), "args = ('\\U000449f2\\U000e0d90?8𤥂',...qhd5brmd8gnak6ns-python3.10-hypothesis-6.68.2/lib/python3.10/site-packages/hypothesis/core.py:781: DeadlineExceeded\n")

    def execute_once(
        self, data, print_example=False, is_final=False, expected_failure=None
    ):
        """Run the test function once, using ``data`` as input.
    
        If the test raises an exception, it will propagate through to the
        caller of this method. Depending on its type, this could represent
        an ordinary test failure, or a fatal error, or a control exception.
    
        If this method returns normally, the test might have passed, or
        it might have placed ``data`` in an unsuccessful state and then
        swallowed the corresponding control exception.
        """
    
        self.ever_executed = True
        data.is_find = self.is_find
    
        text_repr = None
        if self.settings.deadline is None:
            test = self.test
        else:
    
            @proxies(self.test)
            def test(*args, **kwargs):
                self.__test_runtime = None
                initial_draws = len(data.draw_times)
                start = time.perf_counter()
                result = self.test(*args, **kwargs)
                finish = time.perf_counter()
                internal_draw_time = sum(data.draw_times[initial_draws:])
                runtime = datetime.timedelta(
                    seconds=finish - start - internal_draw_time
                )
                self.__test_runtime = runtime
                current_deadline = self.settings.deadline
                if not is_final:
                    current_deadline = (current_deadline // 4) * 5
                if runtime >= current_deadline:
                    raise DeadlineExceeded(runtime, self.settings.deadline)
                return result
    
        def run(data):
            # Set up dynamic context needed by a single test run.
            with local_settings(self.settings):
                with deterministic_PRNG():
                    with BuildContext(data, is_final=is_final) as context:
                        # Generate all arguments to the test function.
                        args, kwargs = data.draw(self.search_strategy)
                        if expected_failure is not None:
                            nonlocal text_repr
                            text_repr = repr_call(test, args, kwargs)
    
                        if print_example or current_verbosity() >= Verbosity.verbose:
                            output = StringIO()
    
                            printer = RepresentationPrinter(output, context=context)
                            if print_example:
                                printer.text("Falsifying example:")
                            else:
                                printer.text("Trying example:")
    
                            if self.print_given_args:
                                printer.text(" ")
                                printer.repr_call(
                                    test.__name__,
                                    args,
                                    kwargs,
                                    force_split=True,
                                )
                            report(printer.getvalue())
                        return test(*args, **kwargs)
    
        # Run the test function once, via the executor hook.
        # In most cases this will delegate straight to `run(data)`.
        result = self.test_runner(data, run)
    
        # If a failure was expected, it should have been raised already, so
        # instead raise an appropriate diagnostic error.
        if expected_failure is not None:
            exception, traceback = expected_failure
            if (
                isinstance(exception, DeadlineExceeded)
                and self.__test_runtime is not None
            ):
                report(
                    "Unreliable test timings! On an initial run, this "
                    "test took %.2fms, which exceeded the deadline of "
                    "%.2fms, but on a subsequent run it took %.2f ms, "
                    "which did not. If you expect this sort of "
                    "variability in your test timings, consider turning "
                    "deadlines off for this test by setting deadline=None."
                    % (
                        exception.runtime.total_seconds() * 1000,
                        self.settings.deadline.total_seconds() * 1000,
                        self.__test_runtime.total_seconds() * 1000,
                    )
                )
            else:
                report("Failed to reproduce exception. Expected: \n" + traceback)
>           raise Flaky(
                f"Hypothesis {text_repr} produces unreliable results: "
                "Falsified on the first call but did not on a subsequent one"
            ) from exception
E           hypothesis.errors.Flaky: Hypothesis test_string_component_transform_factory(x='\U000449f2\U000e0d90?8𤥂', alg=1025, example_func=functools.partial(<built-in function try_float>, map=True, nan=inf)) produces unreliable results: Falsified on the first call but did not on a subsequent one
E           Falsifying example: test_string_component_transform_factory(
E               x='\U000449f2\U000e0d90?8𤥂',
E               alg=1025,
E               example_func=functools.partial(<built-in function try_float>, map=True, nan=inf),
E           )
E           Unreliable test timings! On an initial run, this test took 524.23ms, which exceeded the deadline of 200.00ms, but on a subsequent run it took 0.08 ms, which did not. If you expect this sort of variability in your test timings, consider turning deadlines off for this test by setting deadline=None.

/nix/store/3g4mp3dsz17z7dfiqhd5brmd8gnak6ns-python3.10-hypothesis-6.68.2/lib/python3.10/site-packages/hypothesis/core.py:842: Flaky
=========================== short test summary info ============================
FAILED tests/test_string_component_transform_factory.py::test_string_component_transform_factory[1025-example_func3] - hypothesis.errors.Flaky: Hypothesis test_string_component_transform_factory...
======================== 1 failed, 332 passed in 37.70s ========================
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
