### PR TITLE
python310Packages.anyio: disable timing sensitive test

### DIFF
--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -84,6 +84,10 @@ buildPythonPackage rec {
     "test_exception_group_children"
     "test_exception_group_host"
     "test_exception_group_filtering"
+    # timing sensitive
+    # assert threading.active_count() == initial_count + 1
+    # assert 4 == (4 + 1)
+    "test_run_sync_from_thread_pooling"
   ] ++ lib.optionals stdenv.isDarwin [
     # PermissionError: [Errno 1] Operation not permitted: '/dev/console'
     "test_is_block_device"


### PR DESCRIPTION
## Description of changes

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.2.1, pluggy-1.0.0
rootdir: /build/source, configfile: pyproject.toml, testpaths: tests
plugins: anyio-3.6.2, hypothesis-6.68.2, mock-3.10.0, xdist-3.2.1
gw0 [917] / gw1 [917] / gw2 [917] / gw3 [917] / gw4 [917] / gw5 [917] / gw6 [917] / gw7 [917] / gw8 [917] / gw9 [917] / gw10 [917] / gw11 [917] / gw12 [917] / gw13 [917] / gw14 [917] / gw15 [917] / gw16 [917] / gw17 [917] / gw18 [917] / gw19 [917]m
.s...................................................................... [  7%]
..........s.......................................ss.................... [ 15%]
...........................s............................................ [ 23%]
........................................................................ [ 31%]
........................................................................ [ 39%]
.............F.......................................................... [ 46%]
........................................................................ [ 54%]
........................................................................ [ 62%]
......................................................................... [ 70%]
........................................................................ [ 78%]
........................................................................ [ 86%]
......................................................................... [ 94%]
...................................................                      [100%]
=================================== FAILURES ===================================
___________ TestRunAsyncFromThread.test_run_sync_from_thread_pooling ___________
[gw6] linux -- Python 3.10.12 /nix/store/bc45k1n0pkrdkr3xa6w84w1xhkl1kkyp-python3-3.10.12/bin/python3.10
tests/test_from_thread.py:81: in test_run_sync_from_thread_pooling
    run(main, backend="asyncio")
/nix/store/2lhv2r45jcjni9dsqjrs0ld69ghb5x00-python3.10-anyio-3.6.2/lib/python3.10/site-packages/anyio/_core/_eventloop.py:70: in run
    return asynclib.run(func, *args, **backend_options)
/nix/store/2lhv2r45jcjni9dsqjrs0ld69ghb5x00-python3.10-anyio-3.6.2/lib/python3.10/site-packages/anyio/_backends/_asyncio.py:292: in run
    return native_run(wrapper(), debug=debug)
/nix/store/bc45k1n0pkrdkr3xa6w84w1xhkl1kkyp-python3-3.10.12/lib/python3.10/asyncio/runners.py:44: in run
    return loop.run_until_complete(main)
uvloop/loop.pyx:1517: in uvloop.loop.Loop.run_until_complete
    ???
/nix/store/2lhv2r45jcjni9dsqjrs0ld69ghb5x00-python3.10-anyio-3.6.2/lib/python3.10/site-packages/anyio/_backends/_asyncio.py:287: in wrapper
    return await func(*args)
tests/test_from_thread.py:77: in main
    assert threading.active_count() == initial_count + 1
E   assert 4 == (4 + 1)
E    +  where 4 = <function active_count at 0x7ffff7471240>()
E    +    where <function active_count at 0x7ffff7471240> = threading.active_count
=========================== short test summary info ============================
SKIPPED [1] tests/test_fileio.py:124: Drive only makes sense on Windows
SKIPPED [1] tests/test_fileio.py:166: Only makes sense on Windows
SKIPPED [3] tests/test_fileio.py:340: os.lchmod() is not available
================== 1 failed, 911 passed, 5 skipped in 22.05s ===================
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
