### PR TITLE
syncall: init at 1.5.1

### DIFF
--- a/pkgs/by-name/sy/syncall/package.nix
+++ b/pkgs/by-name/sy/syncall/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "syncall";
+  version = "1.8.5";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "bergercookie";
+    repo = "syncall";
+    rev = "v${version}";
+    hash = "sha256-f9WVZ1gpVG0wvIqoAkeaYBE4QsGXSqrYS4KyHy6S+0Q=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+    --replace-fail 'loguru = "^0.5.3"' 'loguru = "^0.7"' \
+    --replace-fail 'PyYAML = "~5.3.1"' 'PyYAML = "^6.0"' \
+    --replace-fail 'bidict = "^0.21.2"' 'bidict = "^0.23"' \
+    --replace-fail 'typing = "^3.7.4"' '''
+  '';
+
+  nativeBuildInputs = [
+    python3.pkgs.poetry-core
+    python3.pkgs.poetry-dynamic-versioning
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    bidict
+    bubop
+    click
+    item-synchronizer
+    loguru
+    python-dateutil
+    pyyaml
+    rfc3339
+    typing
+
+    # asana optional-dep
+    asana
+    # caldav optional-dep
+    caldav
+    icalendar
+    # fs optional-dep
+    xattr
+    # gkeep optional-dep
+    # gkeepapi is unavailable in nixpkgs
+    # google optional-dep
+    google-api-python-client
+    google-auth-oauthlib
+    # notion optional-dep
+    # FIXME: notion-client -- broken, doesn't build.
+    # taskwarrior optional-dep
+    taskw-ng
+  ];
+
+  postInstall = ''
+    # We do not support gkeep
+    rm $out/bin/tw_gkeep_sync
+  '';
+
+  pythonImportsCheck = [ "syncall" ];
+
+  meta = with lib; {
+    description = "Bi-directional synchronization between services such as Taskwarrior, Google Calendar, Notion, Asana, and more";
+    homepage = "https://github.com/bergercookie/syncall";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/bubop/default.nix
+++ b/pkgs/development/python-modules/bubop/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, loguru
+, python-dateutil
+, pyyaml
+, tqdm
+, click
+}:
+
+buildPythonPackage rec {
+  pname = "bubop";
+  version = "0.1.12";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "bergercookie";
+    repo = "bubop";
+    rev = "v${version}";
+    hash = "sha256-p4Mv73oX5bsYKby7l0nGon89KyAMIUhDAEKSTNB++Cw=";
+  };
+
+  postPatch = ''
+    # Those versions seems to work with `bubop`.
+    substituteInPlace pyproject.toml \
+    --replace-fail 'loguru = "^0.5.3"' 'loguru = "^0.7"' \
+    --replace-fail 'PyYAML = "~5.3.1"' 'PyYAML = "^6.0"'
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    loguru
+    python-dateutil
+    pyyaml
+    tqdm
+    click
+  ];
+
+  pythonImportsCheck = [ "bubop" ];
+
+  meta = with lib; {
+    description = "Bergercookie's Useful Bits Of Python; helper libraries for Bergercookie's programs";
+    homepage = "https://github.com/bergercookie/bubop";
+    changelog = "https://github.com/bergercookie/bubop/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/item-synchronizer/default.nix
+++ b/pkgs/development/python-modules/item-synchronizer/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, bidict
+, bubop
+}:
+
+buildPythonPackage rec {
+  pname = "item-synchronizer";
+  version = "1.1.5";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "bergercookie";
+    repo = "item_synchronizer";
+    rev = "v${version}";
+    hash = "sha256-+mviKtCLlJhYV576Q07kcFJvtls5qohKSrqZtBqE/s4=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail 'bidict = "^0.21.4"' 'bidict = "^0.23"'
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    bidict
+    bubop
+  ];
+
+  pythonImportsCheck = [ "item_synchronizer" ];
+
+  meta = with lib; {
+    description = "";
+    homepage = "https://github.com/bergercookie/item_synchronizer";
+    changelog = "https://github.com/bergercookie/item_synchronizer/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/taskw-ng/default.nix
+++ b/pkgs/development/python-modules/taskw-ng/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, poetry-dynamic-versioning
+, kitchen
+, packaging
+, python-dateutil
+, pytz
+, taskwarrior
+}:
+
+buildPythonPackage rec {
+  pname = "taskw-ng";
+  version = "0.2.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bergercookie";
+    repo = "taskw-ng";
+    rev = "v${version}";
+    hash = "sha256-tlidTt0TzWnvfajYiIfvRv7OfakHY6zWAicmAwq/Z8w=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'pytz = "^2023.3.post1"' 'pytz = "*"'
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
+
+  propagatedBuildInputs = [
+    kitchen
+    packaging
+    python-dateutil
+    pytz
+  ];
+
+  checkInputs = [
+    taskwarrior
+  ];
+
+  # TODO: doesn't pass because `can_use` fails and `task --version` seems not to be answering.
+  # pythonImportsCheck = [ "taskw_ng" ];
+
+  meta = with lib; {
+    description = "";
+    homepage = "https://github.com/bergercookie/taskw-ng";
+    changelog = "https://github.com/bergercookie/taskw-ng/blob/${src.rev}/CHANGELOG.rst";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1772,6 +1772,8 @@ self: super: with self; {
 
   btsocket = callPackage ../development/python-modules/btsocket { };
 
+  bubop = callPackage ../development/python-modules/bubop { };
+
   bucketstore = callPackage ../development/python-modules/bucketstore { };
 
   bugsnag = callPackage ../development/python-modules/bugsnag { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5874,6 +5874,8 @@ self: super: with self; {
 
   itanium-demangler = callPackage ../development/python-modules/itanium-demangler { };
 
+  item-synchronizer = callPackage ../development/python-modules/item-synchronizer { };
+
   itemadapter = callPackage ../development/python-modules/itemadapter { };
 
   itemdb = callPackage ../development/python-modules/itemdb { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14569,6 +14569,8 @@ self: super: with self; {
 
   taskw = callPackage ../development/python-modules/taskw { };
 
+  taskw-ng = callPackage ../development/python-modules/taskw-ng { };
+
   tatsu = callPackage ../development/python-modules/tatsu { };
 
   taxi = callPackage ../development/python-modules/taxi { };


### PR DESCRIPTION
## Description of changes

Bi-directional synchronization between services such as Taskwarrior, Google Calendar, Notion, Asana, and more tooling.

https://github.com/bergercookie/syncall

I am planning to offer a home-manager module probably for calendar infrastructure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
