### PR TITLE
python3Packages.certbot-dns-ovh: init at 2.6.0 (follows python3Packages.certbot)

### DIFF
--- a/pkgs/development/python-modules/certbot-dns-ovh/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-ovh/default.nix
@@ -1,0 +1,39 @@
+{ buildPythonPackage
+, acme
+, certbot
+, dns-lexicon
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "certbot-dns-ovh";
+
+  inherit (certbot) src version;
+  disabled = pythonOlder "3.6";
+
+  sourceRoot = "${src.name}/certbot-dns-ovh";
+
+  propagatedBuildInputs = [
+    acme
+    certbot
+    dns-lexicon
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "-o cache_dir=$(mktemp -d)"
+
+    # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
+    "-W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"
+    "-W 'ignore:Package lexicon.providers is deprecated and will be removed in Lexicon 4>=.:DeprecationWarning'"
+    "-W 'ignore:Legacy configuration object has been used to load the ConfigResolver.:DeprecationWarning'"
+  ];
+
+  meta = certbot.meta // {
+    description = "OVH DNS Authenticator plugin for Certbot";
+  };
+}

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides/build-systems.json
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides/build-systems.json
@@ -2732,6 +2732,9 @@
   "certbot-dns-inwx": [
     "setuptools"
   ],
+  "certbot-dns-ovh": [
+    "setuptools"
+  ],
   "certbot-dns-rfc2136": [
     "setuptools"
   ],

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20983,6 +20983,8 @@ with pkgs;
 
   certbot-full = certbot.withPlugins (cp: with cp; [
     certbot-dns-cloudflare
+    certbot-dns-google
+    certbot-dns-ovh
     certbot-dns-rfc2136
     certbot-dns-route53
   ]);

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1853,8 +1853,9 @@ self: super: with self; {
 
   certbot-dns-inwx = callPackage ../development/python-modules/certbot-dns-inwx { };
 
-  certbot-dns-rfc2136 = callPackage ../development/python-modules/certbot-dns-rfc2136 { };
+  certbot-dns-ovh = callPackage ../development/python-modules/certbot-dns-ovh { };
 
+  certbot-dns-rfc2136 = callPackage ../development/python-modules/certbot-dns-rfc2136 { };
 
   certbot-dns-route53 = callPackage ../development/python-modules/certbot-dns-route53 { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1849,11 +1849,12 @@ self: super: with self; {
 
   certbot-dns-cloudflare = callPackage ../development/python-modules/certbot-dns-cloudflare { };
 
+  certbot-dns-google = callPackage ../development/python-modules/certbot-dns-google { };
+
   certbot-dns-inwx = callPackage ../development/python-modules/certbot-dns-inwx { };
 
   certbot-dns-rfc2136 = callPackage ../development/python-modules/certbot-dns-rfc2136 { };
 
-  certbot-dns-google = callPackage ../development/python-modules/certbot-dns-google { };
 
   certbot-dns-route53 = callPackage ../development/python-modules/certbot-dns-route53 { };
 


### PR DESCRIPTION
## Description of changes

~~Blocked by: https://github.com/NixOS/nixpkgs/pull/255084 (needs to be merged first).~~
After `dns-lexicon` is merged, we can finally add `certbot-dns-ovh` wirth some trivial additions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
