### PR TITLE
nixos/meme-bingo-web: fixed documentation for baseUrl option; updated meme-bingo-web

### DIFF
--- a/nixos/modules/services/web-apps/meme-bingo-web.nix
+++ b/nixos/modules/services/web-apps/meme-bingo-web.nix
@@ -17,7 +17,7 @@ in {
 
       baseUrl = mkOption {
         description = ''
-          URL to be used for the HTML <base> element on all HTML routes.
+          URL to be used for the HTML \<base\> element on all HTML routes.
         '';
         type = types.str;
         default = "http://localhost:41678/";
@@ -36,7 +36,7 @@ in {
 
   config = mkIf cfg.enable {
     systemd.services.meme-bingo-web = {
-      description = "A web app for playing meme bingos.";
+      description = "A web app for playing meme bingos";
       wantedBy = [ "multi-user.target" ];
 
       environment = {
@@ -59,6 +59,7 @@ in {
         # Hardening
         CapabilityBoundingSet = [ "" ];
         DeviceAllow = [ "/dev/random" ];
+        InaccessiblePaths = [ "/dev/shm" "/sys" ];
         LockPersonality = true;
         PrivateDevices = true;
         PrivateUsers = true;
@@ -73,6 +74,7 @@ in {
         ProtectKernelTunables = true;
         ProtectProc = "invisible";
         RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictFilesystems = [ "@basic-api" "~sysfs" ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
         SystemCallArchitectures = "native";

--- a/pkgs/servers/web-apps/meme-bingo-web/default.nix
+++ b/pkgs/servers/web-apps/meme-bingo-web/default.nix
@@ -1,18 +1,23 @@
-{ lib, fetchFromGitea, rustPlatform, makeWrapper }:
+{ lib
+, fetchFromGitea
+, rustPlatform
+, makeWrapper
+, nix-update-script
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "meme-bingo-web";
-  version = "0.2.0";
+  version = "1.0.1";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "annaaurora";
     repo = "meme-bingo-web";
     rev = "v${version}";
-    hash = "sha256-6hQra+10TaaQGzwiYfL+WHmGc6f0Hn8Tybd0lA5t0qc=";
+    hash = "sha256-mOcN9WIXJYRK23tMX29mT5/eSRpqb++zlnJnMizzIfY=";
   };
 
-  cargoHash = "sha256-/hBymxNAzyfapUL5Whkg4NBLA7Fc8A1npXEa9MXTAz4=";
+  cargoHash = "sha256-JWVsmw8ha2TSkCXyLPf9Qe1eL2OHB5uu+bSfCaF0lV8=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -24,6 +29,8 @@ rustPlatform.buildRustPackage rec {
       --set MEME_BINGO_TEMPLATES $out/share/meme-bingo-web/templates \
       --set MEME_BINGO_STATIC $out/share/meme-bingo-web/static
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Play meme bingo using this neat web app";


### PR DESCRIPTION
## Description of changes

- I noticed that the `<base>` in the documentation for the baseUrl option is interpreted as an HTML element on https://search.nixos.org because it's written in Markdown. This should make it be interpreted as just text from my Markdown experience.
- In some places systemd adds a period to the service description. Since this service description already has a period, systemd makes it a double period. This PR removes the period.
- some hardening a friend suggested, supposedly increases `systemd-analyze security` score

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
