### PR TITLE
nuget: 6.3.1.1 -> 6.6.1.2, move out of dotnetPackages

### DIFF
--- a/pkgs/by-name/nu/nuget/package.nix
+++ b/pkgs/by-name/nu/nuget/package.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation (attrs: {
   pname = "Nuget";
-  version = "6.3.1.1";
+  version = "6.6.1.2";
 
   src = fetchFromGitHub {
     owner = "mono";
     repo = "linux-packaging-nuget";
     rev = "upstream/${attrs.version}.bin";
-    sha256 = "sha256-D7F4B23HK5ElY68PYKVDsyi8OF0DLqqUqQzj5CpMfkc=";
+    sha256 = "sha256-9/dSeVshHbpYIgGE/8OzrB4towrWVB3UxDi8Esmbu7Y=";
   };
 
   nativeBuildInputs = [
@@ -16,6 +16,8 @@ stdenv.mkDerivation (attrs: {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/lib/${attrs.pname}
     cp -r . $out/lib/${attrs.pname}/
 
@@ -24,6 +26,8 @@ stdenv.mkDerivation (attrs: {
       "${mono}/bin/mono" \
       "$out/bin/nuget" \
       --add-flags "$out/lib/${attrs.pname}/nuget.exe"
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/nu/nuget/package.nix
+++ b/pkgs/by-name/nu/nuget/package.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, makeWrapper, mono, lib }:
+
+stdenv.mkDerivation (attrs: {
+  pname = "Nuget";
+  version = "6.3.1.1";
+
+  src = fetchFromGitHub {
+    owner = "mono";
+    repo = "linux-packaging-nuget";
+    rev = "upstream/${attrs.version}.bin";
+    sha256 = "sha256-D7F4B23HK5ElY68PYKVDsyi8OF0DLqqUqQzj5CpMfkc=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/${attrs.pname}
+    cp -r . $out/lib/${attrs.pname}/
+
+    mkdir -p $out/bin
+    makeWrapper \
+      "${mono}/bin/mono" \
+      "$out/bin/nuget" \
+      --add-flags "$out/lib/${attrs.pname}/nuget.exe"
+  '';
+
+  meta = with lib; {
+    description = "A package manager for the .NET platform";
+    homepage = "https://www.mono-project.com/";
+    longDescription = ''
+      NuGet is the package manager for the .NET platform.
+      This derivation bundles the Mono NuGet CLI, which is mostly used by
+      older projects based on .NET Framework.
+
+      Newer .NET projects can use the dotnet CLI, which has most of this
+      packages functionality built-in.
+    '';
+    # https://learn.microsoft.com/en-us/nuget/resources/nuget-faq#what-is-the-license-for-nuget-exe-
+    license = licenses.mit;
+    sourceProvenance = [ sourceTypes.binaryBytecode ];
+    maintainers = [ maintainers.mdarocha ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/development/tools/build-managers/msbuild/default.nix
+++ b/pkgs/development/tools/build-managers/msbuild/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, makeWrapper, glibcLocales, mono, dotnetPackages, unzip, dotnetCorePackages, writeText, roslyn }:
+{ lib, stdenv, fetchurl, fetchpatch, makeWrapper, glibcLocales, mono, nuget, unzip, dotnetCorePackages, writeText, roslyn }:
 
 let
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    dotnetPackages.Nuget
+    nuget
     glibcLocales
   ];
 

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -10,12 +10,14 @@
 , mono
 , overrides ? {}
 , boogie
+, nuget
 }:
 
 let self = dotnetPackages // overrides; dotnetPackages = with self; {
   # ALIASES FOR MOVED PACKAGES
 
   Boogie = boogie;
+  Nuget = nuget;
 
   # BINARY PACKAGES
 
@@ -166,27 +168,6 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     version = "11.0.2";
     sha256 = "07na27n4mlw77f3hg5jpayzxll7f4gyna6x7k9cybmxpbs6l77k7";
     outputFiles = [ "*" ];
-  };
-
-  Nuget = buildDotnetPackage rec {
-    pname = "Nuget";
-    version = "6.3.1.1";
-
-    src = fetchFromGitHub {
-      owner = "mono";
-      repo = "linux-packaging-nuget";
-      rev = "upstream/${version}.bin";
-      sha256 = "sha256-D7F4B23HK5ElY68PYKVDsyi8OF0DLqqUqQzj5CpMfkc=";
-    };
-
-    # configurePhase breaks the binary and results in
-    # `File does not contain a valid CIL image.`
-    dontConfigure = true;
-    dontBuild = true;
-    dontPlacateNuget = true;
-
-    outputFiles = [ "*" ];
-    exeFiles = [ "nuget.exe" ];
   };
 
   Paket = fetchNuGet {


### PR DESCRIPTION
## Description of changes

Helps with #234775

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@NixOS/dotnet