### PR TITLE
Add 'mtime' argument to streamLayeredImage

### DIFF
--- a/doc/builders/images/dockertools.section.md
+++ b/doc/builders/images/dockertools.section.md
@@ -151,9 +151,15 @@ Create a Docker image with many of the store paths being on their own layer to i
 
 `created` _optional_
 
-: Date and time the layers were created. Follows the same `now` exception supported by `buildImage`.
+: Date and time the docker image is created. Follows the same `now` exception supported by `buildImage`.
 
     *Default:* `1970-01-01T00:00:01Z`
+
+`mtime` _optional_
+
+: Date and time set as the modification time of the files in the layers. Defaults to the value of `created`.
+
+    *Default:* `null`
 
 `maxLayers` _optional_
 

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -856,6 +856,9 @@ rec {
     , # Time of creation of the image. Passing "now" will make the
       # created date be the time of building.
       created ? "1970-01-01T00:00:01Z"
+    , # mtime to set on the files in the image. When not set, 'created' field will be used
+      # instead.
+      mtime ? null
     , # Optional bash script to run on the files prior to fixturizing the layer.
       extraCommands ? ""
     , # Optional bash script to run inside fakeroot environment.
@@ -942,7 +945,7 @@ rec {
 
         conf = runCommand "${baseName}-conf.json"
           {
-            inherit fromImage maxLayers created;
+            inherit fromImage maxLayers created mtime;
             imageName = lib.toLower name;
             preferLocalBuild = true;
             passthru.imageTag =
@@ -1021,7 +1024,8 @@ rec {
               "store_layers": $store_layers[0],
               "customisation_layer", $customisation_layer,
               "repo_tag": $repo_tag,
-              "created": $created
+              "created": $created,
+              "mtime": $mtime
             }
             ' --arg store_dir "${storeDir}" \
               --argjson from_image ${if fromImage == null then "null" else "'\"${fromImage}\"'"} \

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -8,7 +8,8 @@ image as an uncompressed tarball to stdout:
 * "architecture", "config", "os", "created", "repo_tag" correspond to
   the fields with the same name on the image spec [2].
 * "created" can be "now".
-* "created" is also used as mtime for files added to the image.
+* "mtime" is mtime for files added to the image. It defaults to "created"
+  if not specified.
 * "store_layers" is a list of layers in ascending order, where each
   layer is the list of store paths to include in that layer.
 
@@ -323,7 +324,14 @@ def main():
       if conf["created"] == "now"
       else datetime.fromisoformat(conf["created"])
     )
-    mtime = int(created.timestamp())
+
+    mtime = (
+        datetime.fromisoformat(conf["mtime"]) 
+            if conf.get("mtime") # if mtime is specified and not falsey
+            else created
+    )
+    mtime = int(mtime.timestamp())
+
     store_dir = conf["store_dir"]
 
     from_image = load_from_image(conf["from_image"])

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -326,7 +326,7 @@ def main():
     )
 
     mtime = (
-        datetime.fromisoformat(conf["mtime"]) 
+        datetime.fromisoformat(conf["mtime"])
             if conf.get("mtime") # if mtime is specified and not falsey
             else created
     )


### PR DESCRIPTION
 so 'created' can be set without invalidating the layers

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
