### PR TITLE
matrix-appservice-discord: 3.1.1 -> 4.0.0, fix update script

### DIFF
--- a/pkgs/servers/matrix-appservice-discord/package.json
+++ b/pkgs/servers/matrix-appservice-discord/package.json
@@ -1,11 +1,11 @@
 {
   "name": "matrix-appservice-discord",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "A bridge between Matrix and Discord",
   "main": "discordas.js",
   "engines": {
     "npm": "please-use-yarn",
-    "node": ">=16 <=18"
+    "node": ">=18 <=20"
   },
   "scripts": {
     "test": "mocha -r ts-node/register test/config.ts test/test_*.ts test/**/test_*.ts",
@@ -13,8 +13,8 @@
     "coverage": "tsc && nyc mocha build/test/config.js build/test",
     "build": "tsc",
     "postinstall": "yarn build",
-    "start": "yarn build && node ./build/src/discordas.js -c config.yaml",
-    "debug": "yarn build && node --inspect ./build/src/discordas.js -c config.yaml",
+    "start": "node ./build/src/discordas.js",
+    "debug": "node --inspect ./build/src/discordas.js",
     "addbot": "node ./build/tools/addbot.js",
     "adminme": "node ./build/tools/adminme.js",
     "usertool": "node ./build/tools/userClientTools.js",
@@ -40,16 +40,16 @@
   },
   "homepage": "https://github.com/Half-Shot/matrix-appservice-discord#readme",
   "dependencies": {
-    "@mx-puppet/matrix-discord-parser": "0.1.10",
-    "better-discord.js": "github:matrix-org/better-discord.js#5024781db755259e88abe915630b7d5b3ba5f48f",
-    "better-sqlite3": "^7.1.0",
+    "@mx-puppet/better-discord.js": "^12.5.1",
+    "@mx-puppet/matrix-discord-parser": "^0.1.10",
+    "better-sqlite3": "^8.6.0",
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.0",
     "escape-html": "^1.0.3",
     "escape-string-regexp": "^4.0.0",
     "js-yaml": "^3.14.0",
     "marked": "^1.2.2",
-    "matrix-appservice-bridge": "^5.0.0",
+    "matrix-appservice-bridge": "^9.0.1",
     "mime": "^2.4.6",
     "p-queue": "^6.4.0",
     "pg-promise": "^10.5.6",

--- a/pkgs/servers/matrix-appservice-discord/pin.json
+++ b/pkgs/servers/matrix-appservice-discord/pin.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.1",
-  "srcHash": "sha256-g681w7RD96/xKP+WnIyY4bcVHVQhysgDPZo4TgCRiuY=",
-  "yarnSha256": "0cm9yprj0ajmrdpap3p2lx3xrrkar6gghlxnj9127ks6p5c1ji3r"
+  "version": "4.0.0",
+  "srcHash": "sha256-UyRMMbnX4aJVv8oQfgn/rkZT1cRATtcgFj4fXszDKqo=",
+  "yarnSha256": "11zw1nkvsplnsiddyi1nb9zgdxn1mkh24nlcvaa69rpsjns9rj5k"
 }

--- a/pkgs/servers/matrix-appservice-discord/update.sh
+++ b/pkgs/servers/matrix-appservice-discord/update.sh
@@ -36,7 +36,7 @@ curl -O "$src/package.json"
 cat > pin.json << EOF
 {
   "version": "$(echo $tag | grep -P '(\d|\.)+' -o)",
-  "srcSha256": "$src_hash",
+  "srcHash": "$src_hash",
   "yarnSha256": "$yarn_sha256"
 }
 EOF


### PR DESCRIPTION
## Description of changes

See individual commit messages.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
