### PR TITLE
libdatachannel: 0.18.5 -> 0.19.1

### DIFF
--- a/pkgs/development/libraries/libdatachannel/default.nix
+++ b/pkgs/development/libraries/libdatachannel/default.nix
@@ -12,28 +12,15 @@
 , usrsctp
 }:
 
-let
-  # Use usrsctp version specified at https://github.com/paullouisageneau/libdatachannel/tree/master/deps
-  # Older or newer usrsctp might break libdatachannel, please keep it synced with upstream.
-  customUsrsctp = usrsctp.overrideAttrs (finalAttrs: previousAttrs: {
-    version = "unstable-2021-10-08";
-    src = fetchFromGitHub {
-      owner = "sctplab";
-      repo = "usrsctp";
-      rev = "7c31bd35c79ba67084ce029511193a19ceb97447";
-      hash = "sha256-KeOR/0WDtG1rjUndwTUOhE21PoS+ETs1Vk7jQYy/vNs=";
-    };
-  });
-in
 stdenv.mkDerivation rec {
   pname = "libdatachannel";
-  version = "0.18.5";
+  version = "0.19.1";
 
   src = fetchFromGitHub {
     owner = "paullouisageneau";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-ognjEDw68DpdQ/4JqcTejP5f9K0zLZGnpr99P/dvHK4=";
+    hash = "sha256-jsJTECSR3ptiByfYQ00laeKMKJCv5IDkZmilY3jpRrU=";
   };
 
   outputs = [ "out" "dev" ];
@@ -48,21 +35,15 @@ stdenv.mkDerivation rec {
     libnice
     openssl
     srtp
+    usrsctp
+    plog
   ];
 
   cmakeFlags = [
     "-DUSE_NICE=ON"
-    "-DUSE_SYSTEM_SRTP=ON"
+    "-DPREFER_SYSTEM_LIB=ON"
     "-DNO_EXAMPLES=ON"
   ];
-
-  postPatch = ''
-    # TODO: Remove when updating to 0.19.x, and add
-    # -DUSE_SYSTEM_USRSCTP=ON and -DUSE_SYSTEM_PLOG=ON to cmakeFlags instead
-    mkdir -p deps/{usrsctp,plog}
-    cp -r --no-preserve=mode ${srcOnly customUsrsctp}/. deps/usrsctp
-    cp -r --no-preserve=mode ${srcOnly plog}/. deps/plog
-  '';
 
   postFixup = ''
     # Fix shared library path that will be incorrect on move to "dev" output


### PR DESCRIPTION
## Description of changes

Update libdatachannel to 0.19.1.
Use Nixpkgs usrsctp version as it no longer breaks OBS Studio WHIP 🎉 . 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable: streamed WHIP with OBS Studio 30 beta 2
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
