### PR TITLE
patch-shebangs: fix crash with shebang without trailing newline

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -72,7 +72,10 @@ patchShebangs() {
     while IFS= read -r -d $'\0' f; do
         isScript "$f" || continue
 
-        read -r oldInterpreterLine < "$f"
+        # read exits unclean if the shebang does not end with a newline, but still assigns the variable.
+        # So if read returns errno != 0, we check if the assigned variable is non-empty and continue.
+        read -r oldInterpreterLine < "$f" || [ "$oldInterpreterLine" ]
+
         read -r oldPath arg0 args <<< "${oldInterpreterLine:2}"
 
         if [[ -z "${pathName:-}" ]]; then

--- a/pkgs/test/stdenv/patch-shebangs.nix
+++ b/pkgs/test/stdenv/patch-shebangs.nix
@@ -72,11 +72,26 @@ let
       };
     };
 
+    without-trailing-newline = stdenv.mkDerivation {
+      name = "without-trailing-newline";
+      strictDeps = false;
+      dontUnpack = true;
+      installPhase = ''
+        mkdir -p $out/bin
+        printf "#!/bin/bash" > $out/bin/test
+        chmod +x $out/bin/test
+        dontPatchShebangs=
+      '';
+      passthru = {
+        assertion = "grep '^#!${stdenv.shell}' $out/bin/test > /dev/null";
+      };
+    };
+
   };
 in
 stdenv.mkDerivation {
   name = "test-patch-shebangs";
-  passthru = { inherit (tests) bad-shebang ignores-nix-store updates-nix-store split-string; };
+  passthru = { inherit (tests) bad-shebang ignores-nix-store updates-nix-store split-string without-trailing-newline; };
   buildCommand = ''
     validate() {
       local name=$1


### PR DESCRIPTION
## Description of changes

This fixes a bug where `patchShebangs` crashes when trying to patch files that contain only a shebang (e.g. `#!/bin/bash`) (and nothing else) and do not end with a newline.

Such file can be produced using `printf "#!/bin/bash" > example` or `echo -n "#!/bin/bash" > example`.

I don't understand why one would want to create such files, as they do literally nothing, but the chromium tarball we are using started shipping some 🫠

Full reproducer:

```nix
with import <nixpkgs> { };

stdenv.mkDerivation {
  dontUnpack = true;
  name = "patch-shebangs-no-trailing-newline-reproducer";
  postPatch = ''
    printf "#!/bin/bash" > reproducer
    chmod +x reproducer
    patchShebangs reproducer
  '';
}
```

```
❯ nix-build reproducer.nix
this derivation will be built:
  /nix/store/vmbshdkdk4a0bayw3wi21wvxyhzpcsy2-patch-shebangs-no-trailing-newline-reproducer.drv
building '/nix/store/vmbshdkdk4a0bayw3wi21wvxyhzpcsy2-patch-shebangs-no-trailing-newline-reproducer.drv'...
patching sources
patching script interpreter paths in reproducer
/nix/store/vr6wwdxkmyy44sg0gwxi10b8fc5zhwz0-stdenv-linux/setup: line 144: pop_var_context: head of shell_variables not a function context
error: builder for '/nix/store/vmbshdkdk4a0bayw3wi21wvxyhzpcsy2-patch-shebangs-no-trailing-newline-reproducer.drv' failed with exit code 1;
       last 3 log lines:
       > patching sources
       > patching script interpreter paths in reproducer
       > /nix/store/vr6wwdxkmyy44sg0gwxi10b8fc5zhwz0-stdenv-linux/setup: line 144: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/vmbshdkdk4a0bayw3wi21wvxyhzpcsy2-patch-shebangs-no-trailing-newline-reproducer.drv'.
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
