### PR TITLE
font-manager: allow building without webkit

### DIFF
--- a/pkgs/applications/misc/font-manager/default.nix
+++ b/pkgs/applications/misc/font-manager/default.nix
@@ -29,9 +29,9 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "FontManager";
-    repo = "master";
+    repo = "font-manager";
     rev = version;
-    sha256 = "sha256-M13Q9d2cKhc0tudkvw0zgqPAFTlmXwK+LltXeuDPWxo=";
+    hash = "sha256-M13Q9d2cKhc0tudkvw0zgqPAFTlmXwK+LltXeuDPWxo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/font-manager/default.nix
+++ b/pkgs/applications/misc/font-manager/default.nix
@@ -18,9 +18,8 @@
 , desktop-file-utils
 , wrapGAppsHook
 , gobject-introspection
-, libsoup
-, glib-networking
-, webkitgtk
+# withWebkit enables the "webkit" feature, also known as Google Fonts
+, withWebkit ? true, glib-networking, libsoup, webkitgtk
 }:
 
 stdenv.mkDerivation rec {
@@ -56,13 +55,15 @@ stdenv.mkDerivation rec {
     gsettings-desktop-schemas # for font settings
     gtk3
     gnome.adwaita-icon-theme
-    libsoup
+  ] ++ lib.optionals withWebkit [
     glib-networking # for SSL so that Google Fonts can load
+    libsoup
     webkitgtk
   ];
 
   mesonFlags = [
     "-Dreproducible=true" # Do not hardcode build directory…
+    (lib.mesonBool "webkit" withWebkit)
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

webkit is only beneficial if browsing non-local fonts and building without it greatly reduces closure size (measurements from `nix path-info -S` on x86_64):

- `withWebkit=true`: 1203033312
- `withWebkit=false`: 372203760

upstream calls this feature "Google Font integration" here:
- <https://github.com/FontManager/font-manager#building-from-source>

but it's controlled via the "webkit" meson flag:
- <https://github.com/FontManager/font-manager/blob/master/meson.build#L29>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
