### PR TITLE
cc-wrapper: add libcxxabi include flag for LLVM

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -469,6 +469,7 @@ stdenv.mkDerivation {
     ''
     + optionalString (libcxx.isLLVM or false) ''
       echo "-isystem ${lib.getDev libcxx}/include/c++/v1" >> $out/nix-support/libcxx-cxxflags
+      echo "-isystem ${lib.getDev libcxx.cxxabi}/include/c++/v1" >> $out/nix-support/libcxx-cxxflags
       echo "-stdlib=libc++" >> $out/nix-support/libcxx-ldflags
       echo "-l${libcxx.cxxabi.libName}" >> $out/nix-support/libcxx-ldflags
     ''

--- a/pkgs/development/compilers/llvm/16/default.nix
+++ b/pkgs/development/compilers/llvm/16/default.nix
@@ -255,14 +255,6 @@ in let
         [ "-rtlib=compiler-rt"
           "-Wno-unused-command-line-argument"
           "-B${targetLlvmLibraries.compiler-rt}/lib"
-
-          # Combat "__cxxabi_config.h not found". Maybe this could be fixed by
-          # copying these headers into libcxx? Note that building libcxx
-          # outside of monorepo isn't supported anymore, might be related to
-          # https://github.com/llvm/llvm-project/issues/55632
-          # ("16.0.3 libcxx, libcxxabi: circular build dependencies")
-          # Looks like the machinery changed in https://reviews.llvm.org/D120727.
-          "-I${lib.getDev targetLlvmLibraries.libcxx.cxxabi}/include/c++/v1"
         ]
         ++ lib.optional (!stdenv.targetPlatform.isWasm) "--unwindlib=libunwind"
         ++ lib.optional

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -30,6 +30,13 @@ in stdenv.mkDerivation {
     $CXX -o cxx-check ${./cxx-main.cc}
     ${emulator} ./cxx-check
 
+    # test for https://github.com/NixOS/nixpkgs/issues/214524#issuecomment-1431745905
+    # .../include/cxxabi.h:20:10: fatal error: '__cxxabi_config.h' file not found
+    # in libcxxStdenv
+    echo "checking whether cxxabi.h can be included... " >&2
+    $CXX -o include-cxxabi ${./include-cxxabi.cc}
+    ${emulator} ./include-cxxabi
+
     ${lib.optionalString (stdenv.isDarwin && stdenv.cc.isClang) ''
       echo "checking whether compiler can build with CoreFoundation.framework... " >&2
       mkdir -p foo/lib

--- a/pkgs/test/cc-wrapper/include-cxxabi.cc
+++ b/pkgs/test/cc-wrapper/include-cxxabi.cc
@@ -1,0 +1,8 @@
+#include <cxxabi.h>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+  std::cerr << "ok" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Description of changes
Should fix https://github.com/NixOS/nixpkgs/issues/255487

## Things done
Added `-isystem ${libcxxabi}/include/c++/v1` to `libcxx-cxxflags` for clang

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
