### PR TITLE
gettext-pseudolocale: init at 0-unstable-2023-03-15

### DIFF
--- a/pkgs/development/libraries/gettext-pseudolocale/default.nix
+++ b/pkgs/development/libraries/gettext-pseudolocale/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, glib
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gettext-pseudolocale";
+  version = "0-unstable-2023-03-15";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "hadess";
+    repo = "gettext-pseudolocale";
+    rev = "2dc0491ea2ac016b8e8b746782595e56ae0c071b";
+    hash = "sha256-+uL8VjNjWCpt9i3SQ0FuMe160sAtSUQHT2IRxSIq0z4=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+  ];
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "LD_PRELOAD library that hooks into gettext to highlight i18n bugs";
+    homepage = "https://gitlab.freedesktop.org/hadess/gettext-pseudolocale";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21614,6 +21614,8 @@ with pkgs;
 
   gettext = callPackage ../development/libraries/gettext { };
 
+  gettext-pseudolocale = callPackage ../development/libraries/gettext-pseudolocale { };
+
   gf2x = callPackage ../development/libraries/gf2x { };
 
   gd = callPackage ../development/libraries/gd {


### PR DESCRIPTION
## Description of changes

Helps detecting untranslatable strings.

https://gitlab.freedesktop.org/hadess/gettext-pseudolocale
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - Ran nonemast with this: ![nonemast-with-pseudolocale](https://github.com/NixOS/nixpkgs/assets/705123/f0962545-3362-4898-9d77-6b1ea8334656)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
