### PR TITLE
cc-wrapper.sh, ld-wrapper.sh: unexpand @files

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -256,7 +256,8 @@ fi
 PATH="$path_backup"
 # Old bash workaround, see above.
 
-if (( "${NIX_LD_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
+if (( "${NIX_RESPONSE_FILE_EXPANDED:-0}" >= 1
+    || "${NIX_LD_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
     @prog@ @<(printf "%q\n" \
         ${extraBefore+"${extraBefore[@]}"} \
         ${params+"${params[@]}"} \

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -258,10 +258,13 @@ PATH="$path_backup"
 
 if (( "${NIX_RESPONSE_FILE_EXPANDED:-0}" >= 1
     || "${NIX_LD_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
-    @prog@ @<(printf "%q\n" \
-        ${extraBefore+"${extraBefore[@]}"} \
-        ${params+"${params[@]}"} \
-        ${extraAfter+"${extraAfter[@]}"})
+    responseFile=$(mktemp --tmpdir ld-params.XXXXXX)
+    trap 'rm -f -- "$responseFile"' EXIT
+    printf "%q\n" \
+       ${extraBefore+"${extraBefore[@]}"} \
+       ${params+"${params[@]}"} \
+       ${extraAfter+"${extraAfter[@]}"} > "$responseFile"
+    @prog@ "@$responseFile"
 else
     @prog@ \
         ${extraBefore+"${extraBefore[@]}"} \

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -245,7 +245,8 @@ if [[ -e @out@/nix-support/cc-wrapper-hook ]]; then
     source @out@/nix-support/cc-wrapper-hook
 fi
 
-if (( "${NIX_CC_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
+if (( "${NIX_RESPONSE_FILE_EXPANDED:-0}" >= 1
+    || "${NIX_CC_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
     responseFile=$(mktemp --tmpdir cc-params.XXXXXX)
     trap 'rm -f -- "$responseFile"' EXIT
     printf "%q\n" \

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -123,6 +123,7 @@ expandResponseParams() {
     local arg
     for arg in "$@"; do
         if [[ "$arg" == @* ]]; then
+            export NIX_RESPONSE_FILE_EXPANDED=1
             # phase separation makes this look useless
             # shellcheck disable=SC2157
             if [ -x "@expandResponseParams@" ]; then


### PR DESCRIPTION
When the initial invocation had an @file

To address https://github.com/NixOS/nixpkgs/issues/255359

## Description of changes

Export `NIX_RESPONSE_FILE_EXPANDED=1` when the original wrapper execution had an `@file`.
cc-wrapper and ld-wrapper check if `$NIX_RESPONSE_FILE_EXPANDED >= 1` when deciding to make an `@file`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
