### PR TITLE
python3Packages.dtw-python: init at 1.3.0

### DIFF
--- a/pkgs/development/python-modules/dtw-python/default.nix
+++ b/pkgs/development/python-modules/dtw-python/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, oldest-supported-numpy
+, setuptools
+, wheel
+, scipy
+, numpy
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "dtw-python";
+  version = "1.3.0";
+  format = "pyproject";
+
+  disable = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "DynamicTimeWarping";
+    repo = "dtw-python";
+    rev = "v${version}";
+    hash = "sha256-7hQuo7dES9f08YZhCf+kxUkMlrr+bg1P7HHRCMv3bLk=";
+  };
+
+  nativeBuildInputs = [
+    cython
+    oldest-supported-numpy
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    scipy
+    numpy
+  ];
+
+  # We need to run tests on real built package: https://github.com/NixOS/nixpkgs/issues/255262
+  preCheck = "cd $out";
+  nativeCheckInputs = [ pytestCheckHook ];
+  # tests/ are not included to output package, so we have to set path explicitly
+  pytestFlagsArray = [
+    "$src/tests"
+  ];
+
+  pythonImportsCheck = [ "dtw" ];
+
+  meta = with lib; {
+    description = "Python port of R's Comprehensive Dynamic Time Warp algorithms package";
+    homepage = "https://github.com/DynamicTimeWarping/dtw-python";
+    changelog = "https://github.com/DynamicTimeWarping/dtw-python/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mbalatsko ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3254,6 +3254,8 @@ self: super: with self; {
 
   dtschema = callPackage ../development/python-modules/dtschema { };
 
+  dtw-python = callPackage ../development/python-modules/dtw-python { };
+
   ducc0 = callPackage ../development/python-modules/ducc0 { };
 
   duckdb = callPackage ../development/python-modules/duckdb {


### PR DESCRIPTION
## Description of changes
Adding one of the requirements needed for https://github.com/NixOS/nixpkgs/issues/247089 . I want to separate `mindsdb` requirements initialization into separate PRs bacause adding it to `nixpkgs` requires more than 15 new packages. I believe this way it would be easier to review.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
