### PR TITLE
qt5.qtModule,qt6.qtModule: deprecate qtInputs

### DIFF
--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   pname = "qgroundcontrol";
   version = "4.2.8";
 
-  qtInputs = [
+  propagatedBuildInputs = [
     qtbase qtcharts qtlocation qtserialport qtsvg qtquickcontrols2
     qtgraphicaleffects qtspeech qtx11extras
   ];
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     wayland
   ];
 
-  buildInputs = [ SDL2 ] ++ gstInputs ++ qtInputs;
+  buildInputs = [ SDL2 ] ++ gstInputs ++ propagatedBuildInputs;
   nativeBuildInputs = [ pkg-config qmake qttools wrapQtAppsHook ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/qt-5/modules/qt3d.nix
+++ b/pkgs/development/libraries/qt-5/modules/qt3d.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qt3d";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
   # error: use of undeclared identifier 'stat64'
   env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) "-Dstat64=stat";

--- a/pkgs/development/libraries/qt-5/modules/qtcharts.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtcharts.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtcharts";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtconnectivity.nix
@@ -2,8 +2,12 @@
 
 qtModule {
   pname = "qtconnectivity";
-  qtInputs = [ qtbase qtdeclarative ];
   buildInputs = lib.optional stdenv.isLinux bluez;
-  propagatedBuildInputs = lib.optionals stdenv.isDarwin [ IOBluetooth ];
+  propagatedBuildInputs = [
+    qtbase
+    qtdeclarative
+  ] ++ lib.optionals stdenv.isDarwin [
+    IOBluetooth
+  ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtdatavis3d.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdatavis3d.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtdatavis3d";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
   # error: use of undeclared identifier 'stat64'
   env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) "-Dstat64=stat";

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtdeclarative";
-  qtInputs = [ qtbase qtsvg ];
+  propagatedBuildInputs = [ qtbase qtsvg ];
   nativeBuildInputs = [ python3 ];
   outputs = [ "out" "dev" "bin" ];
   preConfigure = ''

--- a/pkgs/development/libraries/qt-5/modules/qtdoc.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdoc.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtdoc";
-  qtInputs = [ qtdeclarative ];
+  propagatedBuildInputs = [ qtdeclarative ];
   outputs = [ "out" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtgamepad.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtgamepad.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtgamepad";
-  qtInputs = [ qtbase qtdeclarative ]
+  propagatedBuildInputs = [ qtbase qtdeclarative ]
     ++ lib.optional stdenv.isDarwin GameController;
   buildInputs = [ ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/libraries/qt-5/modules/qtgraphicaleffects.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtgraphicaleffects.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtgraphicaleffects";
-  qtInputs = [ qtdeclarative ];
+  propagatedBuildInputs = [ qtdeclarative ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtimageformats.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtimageformats.nix
@@ -8,6 +8,5 @@
 
 qtModule {
   pname = "qtimageformats";
-  qtInputs = [ qtbase ];
-  propagatedBuildInputs = [ libwebp jasper libmng libtiff ];
+  propagatedBuildInputs = [ qtbase libwebp jasper libmng libtiff ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtlocation.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtlocation";
-  qtInputs = [ qtbase qtmultimedia ];
+  propagatedBuildInputs = [ qtbase qtmultimedia ];
   outputs = [ "bin" "out" "dev" ];
   qmakeFlags = lib.optionals stdenv.isDarwin [
      # boost uses std::auto_ptr which has been disabled in clang with libcxx

--- a/pkgs/development/libraries/qt-5/modules/qtlottie.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtlottie.nix
@@ -5,5 +5,5 @@
 
 qtModule {
   pname = "qtlottie";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtmacextras.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmacextras.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtmacextras";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
   meta = with lib; {
     maintainers = with maintainers; [ periklis ];
     platforms = platforms.darwin;

--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -13,7 +13,7 @@
 
 qtModule {
   pname = "qtmultimedia";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ gstreamer gst-plugins-base ]
     # https://github.com/NixOS/nixpkgs/pull/169336 regarding libpulseaudio

--- a/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtnetworkauth";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtpim.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtpim.nix
@@ -12,7 +12,7 @@ qtModule {
     "dev"
   ];
 
-  qtInputs = [
+  propagatedBuildInputs = [
     qtbase
     qtdeclarative
   ];

--- a/pkgs/development/libraries/qt-5/modules/qtpositioning.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtpositioning.nix
@@ -8,7 +8,7 @@
 
 qtModule {
   pname = "qtpositioning";
-  qtInputs = [ qtbase qtdeclarative qtserialport ];
+  propagatedBuildInputs = [ qtbase qtdeclarative qtserialport ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtquickcontrols";
-  qtInputs = [ qtdeclarative ];
+  propagatedBuildInputs = [ qtdeclarative ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtquickcontrols2";
-  qtInputs = [ qtdeclarative ];
+  propagatedBuildInputs = [ qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtremoteobjects.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtremoteobjects.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtremoteobjects";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   # cycle is detected in build when adding "dev" "bin" too
   outputs = [ "out" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtscript.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtscript.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtscript";
-  qtInputs = [ qtbase qttools ];
+  propagatedBuildInputs = [ qtbase qttools ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtscxml.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtscxml.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtscxml";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtsensors.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtsensors.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtsensors";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtserialbus.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtserialbus.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtserialbus";
-  qtInputs = [ qtbase qtserialport ];
+  propagatedBuildInputs = [ qtbase qtserialport ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtserialport.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtserialport.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtserialport";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isLinux "-DNIXPKGS_LIBUDEV=\"${lib.getLib systemd}/lib/libudev\"";
 }

--- a/pkgs/development/libraries/qt-5/modules/qtspeech.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtspeech.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtspeech";
-  qtInputs = [ ];
+  propagatedBuildInputs = [ ];
   buildInputs = lib.optionals stdenv.isLinux [ speechd ];
   nativeBuildInputs = [ pkg-config ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/qt-5/modules/qtsvg.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtsvg.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtsvg";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtsystems.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtsystems.nix
@@ -20,7 +20,7 @@ qtModule {
     "bin"
   ];
 
-  qtInputs = [
+  propagatedBuildInputs = [
     qtbase
   ];
 

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qttools";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 
   # fixQtBuiltinPaths overwrites a builtin path we should keep

--- a/pkgs/development/libraries/qt-5/modules/qtvirtualkeyboard.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtvirtualkeyboard.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtvirtualkeyboard";
-  qtInputs = [ qtbase qtdeclarative qtsvg hunspell ];
+  propagatedBuildInputs = [ qtbase qtdeclarative qtsvg hunspell ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtwayland";
-  qtInputs = [ qtbase qtquickcontrols ];
+  propagatedBuildInputs = [ qtbase qtquickcontrols ];
   buildInputs = [ wayland ];
   nativeBuildInputs = [ pkg-config ];
   outputs = [ "out" "dev" "bin" ];

--- a/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
@@ -2,7 +2,6 @@
 
 qtModule {
   pname = "qtwebchannel";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }
-

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -31,7 +31,6 @@
 
 qtModule {
   pname = "qtwebengine";
-  qtInputs = [ qtdeclarative qtquickcontrols qtlocation qtwebchannel ];
   nativeBuildInputs = [
     bison flex git gperf ninja pkg-config python which gn nodejs
   ] ++ lib.optional stdenv.isDarwin xcbuild;
@@ -127,6 +126,8 @@ qtModule {
     ++ lib.optional enableProprietaryCodecs "-proprietary-codecs";
 
   propagatedBuildInputs = [
+    qtdeclarative qtquickcontrols qtlocation qtwebchannel
+
     # Image formats
     libjpeg libpng libtiff libwebp
 

--- a/pkgs/development/libraries/qt-5/modules/qtwebglplugin.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebglplugin.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtwebglplugin";
-  qtInputs = [ qtbase qtwebsockets ];
+  propagatedBuildInputs = [ qtbase qtwebsockets ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -22,7 +22,7 @@ let
 in
 qtModule {
   pname = "qtwebkit";
-  qtInputs = [ qtbase qtdeclarative qtlocation qtsensors qtwebchannel ]
+  propagatedBuildInputs = [ qtbase qtdeclarative qtlocation qtsensors qtwebchannel ]
     ++ lib.optional stdenv.isDarwin qtmultimedia;
   buildInputs = [ fontconfig libwebp libxml2 libxslt sqlite glib gst_all_1.gstreamer gst_all_1.gst-plugins-base hyphen ]
     ++ lib.optionals stdenv.isDarwin [ ICU OpenGL ];

--- a/pkgs/development/libraries/qt-5/modules/qtwebsockets.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebsockets.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtwebsockets";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebview.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebview.nix
@@ -2,7 +2,7 @@
 
 qtModule {
   pname = "qtwebview";
-  qtInputs = [ qtdeclarative qtwebengine ];
+  propagatedBuildInputs = [ qtdeclarative qtwebengine ];
   buildInputs = lib.optionals stdenv.isDarwin [
     CoreFoundation
     WebKit

--- a/pkgs/development/libraries/qt-5/modules/qtx11extras.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtx11extras.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtx11extras";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtxmlpatterns.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtxmlpatterns.nix
@@ -2,6 +2,6 @@
 
 qtModule {
   pname = "qtxmlpatterns";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   devTools = [ "bin/xmlpatterns" "bin/xmlpatternsvalidator" ];
 }

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -17,7 +17,9 @@ mkDerivation (args // {
   patches = (args.patches or []) ++ (patches.${pname} or []);
 
   nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ perl self.qmake ];
-  propagatedBuildInputs = (args.qtInputs or []) ++ (args.propagatedBuildInputs or []);
+  propagatedBuildInputs =
+    (lib.warnIf (args ? qtInputs) "qt5.qtModule's qtInputs argument is deprecated" args.qtInputs or []) ++
+    (args.propagatedBuildInputs or []);
 
   outputs = args.outputs or [ "out" "dev" ];
   setOutputFlags = args.setOutputFlags or false;

--- a/pkgs/development/libraries/qt-6/modules/qt3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qt3d.nix
@@ -7,6 +7,5 @@
 
 qtModule {
   pname = "qt3d";
-  qtInputs = [ qtbase qtdeclarative qtmultimedia ];
-  propagatedBuildInputs = [ assimp ];
+  propagatedBuildInputs = [ qtbase qtdeclarative qtmultimedia assimp ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qt5compat.nix
+++ b/pkgs/development/libraries/qt-6/modules/qt5compat.nix
@@ -8,6 +8,6 @@
 
 qtModule {
   pname = "qt5compat";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   buildInputs = [ libiconv icu openssl ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtcharts.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtcharts.nix
@@ -5,5 +5,5 @@
 
 qtModule {
   pname = "qtcharts";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtconnectivity.nix
@@ -11,8 +11,13 @@
 
 qtModule {
   pname = "qtconnectivity";
-  qtInputs = [ qtbase qtdeclarative ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optionals stdenv.isLinux [ bluez ];
-  propagatedBuildInputs = lib.optionals stdenv.isDarwin [ IOBluetooth PCSC ];
+  propagatedBuildInputs = [
+    qtbase
+    qtdeclarative
+  ] ++ lib.optionals stdenv.isDarwin [
+    IOBluetooth
+    PCSC
+  ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtdatavis3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdatavis3d.nix
@@ -5,5 +5,5 @@
 
 qtModule {
   pname = "qtdatavis3d";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative.nix
@@ -8,8 +8,7 @@
 
 qtModule {
   pname = "qtdeclarative";
-  qtInputs = [ qtbase qtlanguageserver qtshadertools ];
-  propagatedBuildInputs = [ openssl python3 ];
+  propagatedBuildInputs = [ qtbase qtlanguageserver qtshadertools openssl python3 ];
   patches = [
     # prevent headaches from stale qmlcache data
     ../patches/qtdeclarative-default-disable-qmlcache.patch

--- a/pkgs/development/libraries/qt-6/modules/qtdoc.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdoc.nix
@@ -14,7 +14,7 @@ qtModule {
     done
   '';
   nativeBuildInputs = [ (qttools.override { withClang = true; }) ];
-  qtInputs = [ qtdeclarative ];
+  propagatedBuildInputs = [ qtdeclarative ];
   cmakeFlags = [
     "-DCMAKE_MESSAGE_LOG_LEVEL=STATUS"
   ];

--- a/pkgs/development/libraries/qt-6/modules/qtgrpc.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtgrpc.nix
@@ -7,6 +7,6 @@
 
 qtModule {
   pname = "qtgrpc";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   buildInputs = [ protobuf grpc ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qthttpserver.nix
+++ b/pkgs/development/libraries/qt-6/modules/qthttpserver.nix
@@ -5,5 +5,5 @@
 
 qtModule {
   pname = "qthttpserver";
-  qtInputs = [ qtbase qtwebsockets ];
+  propagatedBuildInputs = [ qtbase qtwebsockets ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtimageformats.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtimageformats.nix
@@ -8,6 +8,6 @@
 
 qtModule {
   pname = "qtimageformats";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
   buildInputs = [ libwebp jasper libmng libtiff ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtlanguageserver.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtlanguageserver.nix
@@ -4,7 +4,7 @@
 
 qtModule {
   pname = "qtlanguageserver";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
 
   # Doesn't have version set
   dontCheckQtModuleVersion = true;

--- a/pkgs/development/libraries/qt-6/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtlocation.nix
@@ -6,5 +6,5 @@
 
 qtModule {
   pname = "qtlocation";
-  qtInputs = [ qtbase qtdeclarative qtpositioning ];
+  propagatedBuildInputs = [ qtbase qtdeclarative qtpositioning ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtlottie.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtlottie.nix
@@ -5,5 +5,5 @@
 
 qtModule {
   pname = "qtlottie";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
@@ -12,5 +12,5 @@ qtModule rec {
     rev = "v${version}";
     hash = "sha256-yyerVzz+nGT5kjNo24zYqZcJmrE50KCp38s3+samjd0=";
   };
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
@@ -22,12 +22,11 @@
 
 qtModule {
   pname = "qtmultimedia";
-  qtInputs = [ qtbase qtdeclarative qtsvg qtshadertools ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libunwind orc ]
     ++ lib.optionals stdenv.isLinux [ libpulseaudio elfutils alsa-lib wayland ];
-  propagatedBuildInputs =
-    lib.optionals stdenv.isLinux [ gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi ]
+  propagatedBuildInputs = [ qtbase qtdeclarative qtsvg qtshadertools ]
+    ++ lib.optionals stdenv.isLinux [ gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi ]
     ++ lib.optionals stdenv.isDarwin [ VideoToolbox ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin

--- a/pkgs/development/libraries/qt-6/modules/qtnetworkauth.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtnetworkauth.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtnetworkauth";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtpositioning.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtpositioning.nix
@@ -8,7 +8,7 @@
 
 qtModule {
   pname = "qtpositioning";
-  qtInputs = [ qtbase qtdeclarative qtserialport ];
+  propagatedBuildInputs = [ qtbase qtdeclarative qtserialport ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
@@ -6,6 +6,6 @@
 
 qtModule {
   pname = "qtquick3d";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   buildInputs = [ openssl ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquick3dphysics.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquick3dphysics.nix
@@ -7,7 +7,7 @@
 
 qtModule {
   pname = "qtquick3dphysics";
-  qtInputs = [ qtbase qtquick3d ];
+  propagatedBuildInputs = [ qtbase qtquick3d ];
   env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64)
     "-faligned-allocation";
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker.nix
@@ -5,5 +5,5 @@
 
 qtModule {
   pname = "qtquickeffectmaker";
-  qtInputs = [ qtbase qtquick3d ];
+  propagatedBuildInputs = [ qtbase qtquick3d ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquicktimeline.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquicktimeline.nix
@@ -5,5 +5,5 @@
 
 qtModule {
   pname = "qtquicktimeline";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
@@ -5,5 +5,5 @@
 
 qtModule {
   pname = "qtremoteobjects";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtscxml.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtscxml.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtscxml";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtsensors.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtsensors.nix
@@ -6,5 +6,5 @@
 
 qtModule {
   pname = "qtsensors";
-  qtInputs = [ qtbase qtdeclarative qtsvg ];
+  propagatedBuildInputs = [ qtbase qtdeclarative qtsvg ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtserialbus.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtserialbus.nix
@@ -2,5 +2,5 @@
 
 qtModule {
   pname = "qtserialbus";
-  qtInputs = [ qtbase qtserialport ];
+  propagatedBuildInputs = [ qtbase qtserialport ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtserialport.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtserialport.nix
@@ -8,7 +8,6 @@
 
 qtModule {
   pname = "qtserialport";
-  qtInputs = [ qtbase ];
   nativeBuildInputs = [ pkg-config ];
-  propagatedBuildInputs = lib.optionals stdenv.isLinux [ udev ];
+  propagatedBuildInputs = [ qtbase ] ++ lib.optionals stdenv.isLinux [ udev ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtshadertools.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtshadertools.nix
@@ -4,5 +4,5 @@
 
 qtModule {
   pname = "qtshadertools";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtspeech.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtspeech.nix
@@ -12,8 +12,8 @@
 
 qtModule {
   pname = "qtspeech";
-  qtInputs = [ qtbase qtmultimedia ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optionals stdenv.isLinux [ flite alsa-lib speechd ];
-  propagatedBuildInputs = lib.optionals stdenv.isDarwin [ Cocoa ];
+  propagatedBuildInputs = [ qtbase qtmultimedia ]
+    ++ lib.optionals stdenv.isDarwin [ Cocoa ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtsvg.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtsvg.nix
@@ -9,7 +9,7 @@
 
 qtModule {
   pname = "qtsvg";
-  qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase ];
   buildInputs = [ libwebp jasper libmng zlib ];
   nativeBuildInputs = [ pkg-config ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-6/modules/qttools.nix
@@ -15,8 +15,8 @@ qtModule {
     llvmPackages.libclang
     llvmPackages.llvm
   ];
-  qtInputs = [ qtbase qtdeclarative ];
-  propagatedBuildInputs = lib.optionals stdenv.isDarwin [ cups ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ]
+    ++ lib.optionals stdenv.isDarwin [ cups ];
   patches = [
     ../patches/qttools-paths.patch
   ];

--- a/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
@@ -8,7 +8,6 @@
 
 qtModule {
   pname = "qtvirtualkeyboard";
-  qtInputs = [ qtbase qtdeclarative qtsvg ];
-  propagatedBuildInputs = [ hunspell ];
+  propagatedBuildInputs = [ qtbase qtdeclarative qtsvg hunspell ];
   nativeBuildInputs = [ pkg-config ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -9,7 +9,7 @@
 
 qtModule {
   pname = "qtwayland";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   buildInputs = [ wayland libdrm ];
   nativeBuildInputs = [ pkg-config ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebchannel.nix
@@ -7,6 +7,6 @@
 
 qtModule {
   pname = "qtwebchannel";
-  qtInputs = [ qtbase qtdeclarative qtwebsockets ];
+  propagatedBuildInputs = [ qtbase qtdeclarative qtwebsockets ];
   buildInputs = [ openssl ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -93,7 +93,6 @@
 
 qtModule {
   pname = "qtwebengine";
-  qtInputs = [ qtdeclarative qtwebchannel qtwebsockets qtpositioning ];
   nativeBuildInputs = [
     bison
     coreutils
@@ -201,6 +200,11 @@ qtModule {
   ];
 
   propagatedBuildInputs = [
+    qtdeclarative
+    qtwebchannel
+    qtwebsockets
+    qtpositioning
+
     # Image formats
     libjpeg
     libpng

--- a/pkgs/development/libraries/qt-6/modules/qtwebsockets.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebsockets.nix
@@ -6,6 +6,6 @@
 
 qtModule {
   pname = "qtwebsockets";
-  qtInputs = [ qtbase qtdeclarative ];
+  propagatedBuildInputs = [ qtbase qtdeclarative ];
   buildInputs = [ openssl ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtwebview.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebview.nix
@@ -8,7 +8,7 @@
 
 qtModule {
   pname = "qtwebview";
-  qtInputs = [ qtdeclarative ]
-    ++ lib.optionals (!stdenv.isDarwin) [ qtwebengine ];
-  propagatedBuildInputs = lib.optionals stdenv.isDarwin [ WebKit ];
+  propagatedBuildInputs = [ qtdeclarative ]
+    ++ lib.optionals (!stdenv.isDarwin) [ qtwebengine ]
+    ++ lib.optionals stdenv.isDarwin [ WebKit ];
 }

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -22,7 +22,9 @@ stdenv.mkDerivation (args // {
   buildInputs = args.buildInputs or [ ];
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cmake ninja perl ]
     ++ lib.optionals stdenv.isDarwin [ moveBuildTree ];
-  propagatedBuildInputs = (args.qtInputs or [ ]) ++ (args.propagatedBuildInputs or [ ]);
+  propagatedBuildInputs =
+    (lib.warnIf (args ? qtInputs) "qt6.qtModule's qtInputs argument is deprecated" args.qtInputs or []) ++
+    (args.propagatedBuildInputs or []);
 
   moveToDev = false;
 


### PR DESCRIPTION
## Description of changes

This is just an alias for propagatedBuildInputs.  Having two names for the same thing just makes things confusing.

~Let's see if we can get this to be rebuild-0.~ <ins>Never mind, this is impossible, because `qtInputs` is passed through to `mkDerivation`.</ins>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
