### PR TITLE
nixos/redis: ensure conf var and conf run dirs exist

### DIFF
--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -349,6 +349,7 @@ in {
           redisConfRun = "/run/${redisName name}/nixos.conf";
           redisConfStore = redisConfig conf.settings;
         in ''
+          mkdir -p "$(dirname "${redisConfVar}")" "$(dirname "${redisConfRun}")"
           touch "${redisConfVar}" "${redisConfRun}"
           chown '${conf.user}' "${redisConfVar}" "${redisConfRun}"
           chmod 0600 "${redisConfVar}" "${redisConfRun}"


### PR DESCRIPTION
## Description of changes

...prior to `touch`'ing those files

I found this when tracing through a deploy-time error that I'd thought was due to a config problem:

```sh-session
$ cat /var/lib/redis-mastodon/redis.conf
include "/run/redis-mastodon/nixos.conf"

# cat /run/redis-mastodon/nixos.conf
cat: /run/redis-mastodon/nixos.conf: No such file or directory

$ bash -x -e /nix/store/99b55pxjcj6achbxmswqd5d310r3lnm0-redis-mastodon-prep-conf
+ touch /var/lib/redis-mastodon/redis.conf /run/redis-mastodon/nixos.conf
touch: cannot touch '/run/redis-mastodon/nixos.conf': No such file or directory
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
