### PR TITLE
rasdaemon: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/os-specific/linux/rasdaemon/default.nix
+++ b/pkgs/os-specific/linux/rasdaemon/default.nix
@@ -1,22 +1,22 @@
 { lib, stdenv, fetchFromGitHub
-, autoreconfHook
+, autoreconfHook, pkg-config
 , glibcLocales, kmod, coreutils, perl
-, dmidecode, hwdata, sqlite
+, dmidecode, hwdata, sqlite, libtraceevent
 , nixosTests
 }:
 
 stdenv.mkDerivation rec {
   pname = "rasdaemon";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "mchehab";
     repo = "rasdaemon";
     rev = "v${version}";
-    sha256 = "sha256-oLwR+bNgKceVgLTOLYiKHNUkRmLouaQshdp/8UJnfqg=";
+    sha256 = "sha256-BX3kc629FOh5cnD6Sa/69wKdhmhT3Rpz5ZvhnD4MclQ=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [
     coreutils
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     hwdata
     kmod
     sqlite
+    libtraceevent
     (perl.withPackages (ps: with ps; [ DBI DBDSQLite ]))
   ]
   ++ lib.optionals (!stdenv.isAarch64) [ dmidecode ];
@@ -32,20 +33,8 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--with-sysconfdefdir=${placeholder "out"}/etc/sysconfig"
-    "--enable-sqlite3"
-    "--enable-aer"
-    "--enable-mce"
-    "--enable-extlog"
-    "--enable-non-standard"
-    "--enable-abrt-report"
-    "--enable-hisi-ns-decode"
-    "--enable-devlink"
-    "--enable-diskerror"
-    "--enable-memory-failure"
-    "--enable-memory-ce-pfa"
-    "--enable-amp-ns-decode"
-  ]
-  ++ lib.optionals (stdenv.isAarch64) [ "--enable-arm" ];
+    "--enable-all"
+  ];
 
   # The installation attempts to create the following directories:
   # /var/lib/rasdaemon


### PR DESCRIPTION
## Description of changes

kinda forgot about this, finally got it working with some help from Matrix :)

[changelog](https://github.com/mchehab/rasdaemon/blob/v0.8.0/ChangeLog)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
