### PR TITLE
postgresqlPackages.lantern: init at 0.0.4

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -424,6 +424,7 @@ in {
   kubo = runTest ./kubo.nix;
   ladybird = handleTest ./ladybird.nix {};
   languagetool = handleTest ./languagetool.nix {};
+  lantern = handleTest ./lantern.nix {};
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };
   leaps = handleTest ./leaps.nix {};
   lemmy = handleTest ./lemmy.nix {};

--- a/nixos/tests/lantern.nix
+++ b/nixos/tests/lantern.nix
@@ -1,0 +1,32 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "lantern";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ moody ];
+  };
+
+  nodes = {
+    master =
+      { pkgs, ... }:
+
+      {
+        services.postgresql = let mypg = pkgs.postgresql; in {
+          enable = true;
+          package = mypg;
+          extraPlugins = with mypg.pkgs; [
+            lantern
+          ];
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+    master.wait_for_unit("postgresql")
+    master.sleep(10)  # Hopefully this is long enough!!
+    master.succeed("sudo -u postgres psql -c 'CREATE EXTENSION lantern;'")
+    master.succeed("sudo -u postgres psql -c 'CREATE TABLE small_world (id integer, vector real[3]);'")
+    master.succeed("sudo -u postgres psql -c \"INSERT INTO small_world (id, vector) VALUES (0, '{0,0,0}'), (1, '{0,0,1}');\"")
+    master.succeed("sudo -u postgres psql -c 'CREATE INDEX ON small_world USING hnsw (vector);'")
+    master.succeed("sudo -u postgres psql -c 'SET enable_seqscan = false; SELECT id, l2sq_dist(vector, ARRAY[0,0,0]) AS dist FROM small_world ORDER BY vector <-> ARRAY[0,0,0] LIMIT 1;'")
+  '';
+})

--- a/pkgs/servers/sql/postgresql/ext/lantern.nix
+++ b/pkgs/servers/sql/postgresql/ext/lantern.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchgit, cmake, postgresql, nixosTests }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lantern";
+  version = "0.0.4";
+
+  src = fetchgit {
+    url = "https://github.com/lanterndata/lantern.git";
+    rev = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-SaRWJxM/Mi9eflT8C7LA987ItQRCKKES+hlhy9QXSV4=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ postgresql ];
+
+  installPhase = ''
+    install -D -t $out/lib lantern.so
+    install -D -t $out/share/postgresql/extension lantern-*.sql
+    install -D -t $out/share/postgresql/extension lantern.control
+  '';
+
+  passthru.tests.lantern = nixosTests.lantern;
+
+  meta = with lib; {
+    description = "Open-source PostgreSQL database extension to store vector data, generate embeddings, and handle vector search operations.";
+    homepage = "https://github.com/lanterndata/lantern";
+    changelog = "https://github.com/lanterndata/lantern/blob/main/CHANGELOG.md";
+    license = licenses.mit;
+    platforms = postgresql.meta.platforms;
+    broken = (stdenv.system == "x86_64-darwin"); # Dependencies use functions not available until mcOS 10.15
+    maintainers = [ maintainers.moody ];
+  };
+})

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -6,6 +6,8 @@ self: super: {
 
     jsonb_deep_sum = super.callPackage ./ext/jsonb_deep_sum.nix { };
 
+    lantern = super.callPackage ./ext/lantern.nix { };
+
     periods = super.callPackage ./ext/periods.nix { };
 
     postgis = super.callPackage ./ext/postgis.nix { };


### PR DESCRIPTION
## Description of changes

https://lantern.dev/ is a new postgresql extension for handling vector data. The source can be found here https://github.com/lanterndata/lantern.

The derivation itself was mostly based on pgvector and the tests were mostly copied from pgpostgis.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
