### PR TITLE
vimPlugins.vim-sensible: patch vimrc detection

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1467,6 +1467,10 @@ self: super: {
     dependencies = with self; [ denops-vim ];
   };
 
+  vim-sensible = super.vim-sensible.overrideAttrs {
+    patches = [ ./patches/vim-sensible/fix-nix-store-path-regex.patch ];
+  };
+
   vim-snipmate = super.vim-snipmate.overrideAttrs {
     dependencies = with self; [ vim-addon-mw-utils tlib_vim ];
   };

--- a/pkgs/applications/editors/vim/plugins/patches/vim-sensible/fix-nix-store-path-regex.patch
+++ b/pkgs/applications/editors/vim/plugins/patches/vim-sensible/fix-nix-store-path-regex.patch
@@ -1,0 +1,25 @@
+From 07c799a1b170c0e28b385474b511c1034cfcb263 Mon Sep 17 00:00:00 2001
+From: Janik H <janik@aq0.de>
+Date: Sat, 16 Sep 2023 19:45:32 +0200
+Subject: [PATCH] fix nix store path regex
+
+---
+ plugin/sensible.vim | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugin/sensible.vim b/plugin/sensible.vim
+index 0fc26e0..b3ee6e9 100644
+--- a/plugin/sensible.vim
++++ b/plugin/sensible.vim
+@@ -26,7 +26,7 @@ function! s:MaySet(option) abort
+     silent verbose execute 'setglobal all' a:option . '?'
+     redir END
+   endif
+-  return out !~# " \\(\\~[\\/][^\n]*\\|Lua\\)$"
++  return out !~# "/nix/store/.*" && out !~# " \\(\\~[\\/][^\n]*\\|Lua\\)$"
+ endfunction
+ 
+ if s:MaySet('backspace')
+-- 
+2.41.0
+


### PR DESCRIPTION
The vimrc detection won't work if you are using the vim_configurable package (which the nixos and home-manager module both do)
because vim-sensbile only checks for files in the users home matches `~/...` but in our case it gets called from a wrapper script which looks something like: `vim -u /nix/store/.../vimrc`.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X} Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
