### PR TITLE
pytestCheckHook: proof of concept of a solution to recursive imports in some modules

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -91,12 +91,13 @@ in {
       inherit (pythonForBuild.pkgs) installer;
     };
 
-  pytestCheckHook = callPackage ({ makePythonHook, pytest }:
+  pytestCheckHook = callPackage ({ makePythonHook, pytest, which }:
     makePythonHook {
       name = "pytest-check-hook";
-      propagatedBuildInputs = [ pytest ];
+      propagatedBuildInputs = [ pytest which ];
       substitutions = {
         inherit pythonCheckInterpreter;
+        pytestPython = pytest.pythonModule;
       };
     } ./pytest-check-hook.sh) {};
 

--- a/pkgs/development/python-modules/itypes/default.nix
+++ b/pkgs/development/python-modules/itypes/default.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  pytest,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -16,11 +16,9 @@ buildPythonPackage rec {
     sha256 = "1ljhjp9pacbrv2phs58vppz1dlxix01p98kfhyclvbml6dgjcr52";
   };
 
-  nativeCheckInputs = [ pytest ];
-  checkPhase = ''
-    mv itypes.py itypes.py.hidden
-    pytest tests.py
-  '';
+  pytestFlagsArray = [ "tests.py" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Simple immutable types for python";


### PR DESCRIPTION
## Description of changes
Related https://github.com/NixOS/nixpkgs/issues/255262

Proposed solution for the issue that `python -m pytest` adds the current directory to `sys.path` and mess stuff up.

I wanted to test with more significant packages such as Orange3 and `rg -l cython $(rg -l pytestCheckHook)`

I was also trying to write a proof of concept python module to reproduce the issue but it seems that Cython was tricky to be imported that I linked to that issue
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
