### PR TITLE
trilium-desktop: fix missing metadata on Linux

### DIFF
--- a/pkgs/applications/office/trilium/desktop.nix
+++ b/pkgs/applications/office/trilium/desktop.nix
@@ -20,8 +20,7 @@ let
   };
 
   linux = stdenv.mkDerivation rec {
-    pname = "trilium-desktop";
-    inherit version;
+    inherit pname version meta;
 
     src = fetchurl linuxSource;
 


### PR DESCRIPTION
## Description of changes

It _looks_ like by accident, the metadata for `trilium-desktop` is missing on Linux (and not Darwin.)  This seems to have been introduced by 739b153f972a86003b3e5a4cf3cc43138ae9d1e7. I can't find any strong evidence this was intended, it seems to have been done by accident when trying to de-duplicate the meta information that #210772 would've otherwise added. (@eliandoran, feel free to chime in if there is a reason for this that maybe I have missed.)

I noticed because running `nix run nixpkgs#trilium-desktop` on NixOS failed despite the apparent `mainProgram` entry. With this patch, `nix run .#trilium-desktop` works.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).