### PR TITLE
nixos/virtualisation: allow configuring openssh root login on GCE

### DIFF
--- a/nixos/modules/virtualisation/google-compute-config.nix
+++ b/nixos/modules/virtualisation/google-compute-config.nix
@@ -39,7 +39,7 @@ in
   # Allow root logins only using SSH keys
   # and disable password authentication in general
   services.openssh.enable = true;
-  services.openssh.settings.PermitRootLogin = "prohibit-password";
+  services.openssh.settings.PermitRootLogin = mkDefault "prohibit-password";
   services.openssh.settings.PasswordAuthentication = mkDefault false;
 
   # enable OS Login. This also requires setting enable-oslogin=TRUE metadata on


### PR DESCRIPTION
## Description of changes

This commit makes the OpenSSH option `PermitRootLogin` available to be
configured by other NixOS modules when using the Google Cloud Engine
(GCE) NixOS image builder. Other options like `PasswordAuthentication`
were already configurable, so I think it makes sense to make `PermitRootLogin`
configurable as well is order to disable it completely, for example.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (I deployed and tested the image with the setting to `"no"` and was able to connect)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).