### PR TITLE
rlaunch: 1.3.13 -> 1.3.14

### DIFF
--- a/pkgs/applications/misc/rlaunch/default.nix
+++ b/pkgs/applications/misc/rlaunch/default.nix
@@ -7,25 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rlaunch";
-  version = "1.3.13";
+  version = "1.3.14";
 
   src = fetchFromGitHub {
     owner = "PonasKovas";
     repo = pname;
     rev = version;
-    sha256 = "1w8qvny72l5358wnk4dmqnrv4mrpzxrzf49svav9grzxzzf8mqy2";
+    hash = "sha256-PyCR/ob947W+6T56y1se74aNy1avJDb2ELyv2aGf1og=";
   };
 
-  cargoSha256 = "00lnw48kn97gp45lylv5c6v6pil74flzpsq9k69xgvvjq9yqjzrx";
-
-  patches = [
-    # Fixes "error[E0308]: mismatched types; expected `u8`, found `i8`" on aarch64
-    # Remove with next version update
-    (fetchpatch {
-      url = "https://github.com/PonasKovas/rlaunch/commit/f78f36876bba45fe4e7310f58086ddc63f27a57e.patch";
-      hash = "sha256-rTS1khw1zt3i1AJ11BhAILcmaohAwVc7Qfl6Fc76Kvs=";
-    })
-  ];
+  cargoHash = "sha256-/a1SjGDcauOy1vmXvmWBZmag8G+T2au+Z7b0y1Vj3C8=";
 
   # The x11_dl crate dlopen()s these libraries, so we have to inject them into rpath.
   postFixup = ''


### PR DESCRIPTION
## Description of changes

https://github.com/PonasKovas/rlaunch/releases/tag/1.3.14

Suggestions are now sorted by name ascending (instead of descending).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~[ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).