### PR TITLE
arrpc: init at 3.2.0

### DIFF
--- a/pkgs/by-name/ar/arrpc/package.nix
+++ b/pkgs/by-name/ar/arrpc/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, fetchpatch
+}:
+
+buildNpmPackage {
+  pname = "arrpc";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenAsar";
+    repo = "arrpc";
+    # Release commits are not tagged
+    # release: 3.2.0
+    rev = "9c3e981437b75606c74ef058c67d1a8c083ce49a";
+    hash = "sha256-tsO58q6tqqXCJLjZmLQGt1VtKsuoqWmh5SlnuDtJafg=";
+  };
+
+  # Make installation less cumbersome
+  # Remove after next release
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/OpenAsar/arrpc/pull/50.patch";
+      hash = "sha256-qFlrbe2a4x811wpmWUcGDe2CPlt9x3HI+/t0P2v4kPc=";
+    })
+  ];
+
+  npmDepsHash = "sha256-vxx0w6UjwxIK4cgpivtjNbIgkb4wKG4ijSHdP/FeQZ4=";
+
+  dontNpmBuild = true;
+
+  meta = with lib; {
+    description = "Open Discord RPC server for atypical setups";
+    homepage = "https://arrpc.openasar.dev/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ anomalocaris ];
+    mainProgram = "arrpc";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add arrpc, a program that lets the Discord website and alternative Discord clients use Discord's Rich Presence.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
