### PR TITLE
dioxus-cli: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/development/tools/rust/dioxus-cli/default.nix
+++ b/pkgs/development/tools/rust/dioxus-cli/default.nix
@@ -6,18 +6,20 @@
 , cacert
 , openssl
 , darwin
+, testers
+, dioxus-cli
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "dioxus-cli";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-4BIuD/rrA398hPEoNt5PwWylPAR0fA1UKc90xyH5Fd0=";
+    hash = "sha256-h2l6SHty06nLNbdlnSzH7I4XY53yyxNbx663cHYmPG0=";
   };
 
-  cargoHash = "sha256-ok+fjvwz4k0/M5j7wut2A2AK6tuO3UfZtgoCXaCaHXY=";
+  cargoHash = "sha256-3pFkEC1GAJmTqXAymX4WRIq7EEtY17u1TCg+OhqL3bA=";
 
   nativeBuildInputs = [ pkg-config cacert ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [
@@ -32,10 +34,11 @@ rustPlatform.buildRustPackage rec {
     "--skip=server::web::proxy::test::add_proxy_trailing_slash"
   ];
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/dx --version | grep "dioxus ${version}"
-  '';
+  passthru.tests.version = testers.testVersion {
+    package = dioxus-cli;
+    command = "${meta.mainProgram} --version";
+    inherit version;
+  };
 
   meta = with lib; {
     homepage = "https://dioxuslabs.com";


### PR DESCRIPTION
* update src
* use testers.testVersion

## Description of changes

[Release notes](https://github.com/DioxusLabs/dioxus/releases/tag/v0.4.1).

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
nix shell .#dioxus-cli
dx
dx -V
dx create  # enter data
# further testing requires rust toolchain
```
