### PR TITLE
python310Packages.svg2tikz: 1.2.0 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/svg2tikz/default.nix
+++ b/pkgs/development/python-modules/svg2tikz/default.nix
@@ -10,9 +10,9 @@
 
 buildPythonPackage rec {
   pname = "svg2tikz";
-  version = "1.2.0";
+  version = "2.1.0";
 
-  disabled = pythonOlder "3.10";
+  disabled = pythonOlder "3.7";
 
   format = "pyproject";
 
@@ -20,13 +20,8 @@ buildPythonPackage rec {
     owner = "xyz2tex";
     repo = "svg2tikz";
     rev = "refs/tags/v${version}";
-    hash = "sha256-oFcKRcXef1Uz0qFi6Gga/D4u8zW0RjXAnHDlhRr33Ts=";
+    hash = "sha256-v8+0h90uJlkI5eJcwCG55nxPz8n2aJXwP8Ocp48cl9M=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "+dairiki.1" ""
-  '';
 
   nativeBuildInputs = [
     poetry-core
@@ -44,7 +39,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "svg2tikz" ];
 
   meta = with lib; {
-    changelog = "https://github.com/xyz2tex/svg2tikz/blob/${src.rev}/README.md#changes-bug-fixes-and-known-problems-from-the-original";
+    changelog = "https://github.com/xyz2tex/svg2tikz/blob/${src.rev}/CHANGELOG.md";
     homepage = "https://github.com/xyz2tex/svg2tikz";
     description = "Set of tools for converting SVG graphics to TikZ/PGF code";
     license = licenses.gpl2Plus;


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/xyz2tex/svg2tikz/compare/refs/tags/v1.2.0...v2.1.0

Changelog: https://github.com/xyz2tex/svg2tikz/blob/refs/tags/v2.1.0/CHANGELOG.md


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
