### PR TITLE
sublime-merge: 2083 → 2091, sublime-merge-dev: 2085 → 2090, add aarch64 support

### DIFF
--- a/pkgs/applications/version-management/sublime-merge/common.nix
+++ b/pkgs/applications/version-management/sublime-merge/common.nix
@@ -1,4 +1,4 @@
-{ buildVersion, x64sha256, dev ? false }:
+{ buildVersion, aarch64sha256, x64sha256, dev ? false }:
 
 { fetchurl, lib, stdenv, xorg, glib, libGL, glibcLocales, gtk3, cairo, pango, libredirect, makeWrapper, wrapGAppsHook
 , pkexecPath ? "/run/wrappers/bin/pkexec"
@@ -85,6 +85,10 @@ in let
 
     passthru = {
       sources = {
+        "aarch64-linux" = fetchurl {
+          url = downloadUrl "arm64";
+          sha256 = aarch64sha256;
+        };
         "x86_64-linux" = fetchurl {
           url = downloadUrl "x64";
           sha256 = x64sha256;
@@ -146,6 +150,6 @@ in stdenv.mkDerivation (rec {
     maintainers = with maintainers; [ zookatron ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "aarch64-linux" "x86_64-linux" ];
   };
 })

--- a/pkgs/applications/version-management/sublime-merge/common.nix
+++ b/pkgs/applications/version-management/sublime-merge/common.nix
@@ -8,9 +8,10 @@
 let
   pnameBase = "sublime-merge";
   packageAttribute = "sublime-merge${lib.optionalString dev "-dev"}";
-  binaries = [ "sublime_merge" "crash_reporter" "git-credential-sublime" "ssh-askpass-sublime" ];
+  binaries = [ "sublime_merge" crashHandlerBinary "git-credential-sublime" "ssh-askpass-sublime" ];
   primaryBinary = "sublime_merge";
   primaryBinaryAliases = [ "smerge" ];
+  crashHandlerBinary = if lib.versionAtLeast buildVersion "2086" then "crash_handler" else "crash_reporter";
   downloadUrl = arch: "https://download.sublimetext.com/sublime_merge_build_${buildVersion}_${arch}.tar.xz";
   versionUrl = "https://www.sublimemerge.com/${if dev then "dev" else "download"}";
   versionFile = builtins.toString ./default.nix;

--- a/pkgs/applications/version-management/sublime-merge/default.nix
+++ b/pkgs/applications/version-management/sublime-merge/default.nix
@@ -4,8 +4,8 @@ let
   common = opts: callPackage (import ./common.nix opts);
 in {
   sublime-merge = common {
-    buildVersion = "2083";
-    x64sha256 = "bWHbP8j228jUDr1XDLRciq7hcET6o6Udr/lLODXRudc=";
+    buildVersion = "2091";
+    x64sha256 = "T5g6gHgl9xGytEOsh3VuB08IrbDvMu24o/1edCGmfd4=";
   } {};
 
   sublime-merge-dev = common {

--- a/pkgs/applications/version-management/sublime-merge/default.nix
+++ b/pkgs/applications/version-management/sublime-merge/default.nix
@@ -9,8 +9,8 @@ in {
   } {};
 
   sublime-merge-dev = common {
-    buildVersion = "2085";
-    x64sha256 = "40yI6EtP2l22aPP50an3ycvdEcAqJphhGhYYoOPyHw0=";
+    buildVersion = "2090";
+    x64sha256 = "bu51gsu0XxZBF8/HncPttcKiIRpC7qsKTgR9cktKOnI=";
     dev = true;
   } {};
 }

--- a/pkgs/applications/version-management/sublime-merge/default.nix
+++ b/pkgs/applications/version-management/sublime-merge/default.nix
@@ -5,11 +5,13 @@ let
 in {
   sublime-merge = common {
     buildVersion = "2091";
+    aarch64sha256 = "dkPKuuzQQtL3eZlaAPeL7e2p5PCxroFRSp6Rw5wHODc=";
     x64sha256 = "T5g6gHgl9xGytEOsh3VuB08IrbDvMu24o/1edCGmfd4=";
   } {};
 
   sublime-merge-dev = common {
     buildVersion = "2090";
+    aarch64sha256 = "96nJn+7bVoLM6D14pFujlj3JOQL5PwdU1+SWzEjoYhU=";
     x64sha256 = "bu51gsu0XxZBF8/HncPttcKiIRpC7qsKTgR9cktKOnI=";
     dev = true;
   } {};


### PR DESCRIPTION
## Description of changes


https://www.sublimemerge.com/download#changelog
https://www.sublimemerge.com/dev#changelog

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
