### PR TITLE
python310Packages.fabric: 3.0.0 -> 3.2.2

### DIFF
--- a/pkgs/development/python-modules/fabric/default.nix
+++ b/pkgs/development/python-modules/fabric/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , cryptography
+, decorator
 , invoke
 , mock
 , paramiko
@@ -11,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "fabric";
-  version = "3.0.0";
+  version = "3.2.2";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-v+lgwa6QTnYkr51ArVubmVge2cT9CTScDQK3SG4dD4k=";
+    hash = "sha256-h4PKQuOwB28IsmkBqsa52bHxnEEAdOesz6uQLBhP9KM=";
   };
 
   # only relevant to python < 3.4
@@ -24,7 +25,7 @@ buildPythonPackage rec {
         --replace ', "pathlib2"' ' '
   '';
 
-  propagatedBuildInputs = [ invoke paramiko cryptography ];
+  propagatedBuildInputs = [ invoke paramiko cryptography decorator ];
 
   nativeCheckInputs = [ pytestCheckHook pytest-relaxed mock ];
 


### PR DESCRIPTION
## Description of changes

Note: This was originally written to add the missing decorator dep, but given azure-cli is the only reverse dependency, this was rewritten to be a version bump instead.

This adds a missing decorator dep that was originally included in invoke, but with the 2.2.0 invoke update it stopped vendoring it. Fabric started requiring it as a separate dep with 3.1.0.

I mostly want this so that azure-cli can be fixed, but I'm going to make another PR (edit: PR made - #255669) to fix an unrelated issue since while this fixes it on `nixos-unstable`, there's another azure-cli regression on `master`...

Refs:
* Invoke package bump in nixpkgs - #253552
* Upstream PR where invoke removed vendored decorator - pyinvoke/invoke#906
* Fabric bump including decorator as a separate dependency - fabric/fabric@d42d510138f7c463c56cd0f5877ef9829cc4476a

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).