### PR TITLE
nixos/dolphin: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -168,6 +168,7 @@
   ./programs/digitalbitbox/default.nix
   ./programs/direnv.nix
   ./programs/dmrconfig.nix
+  ./programs/dolphin.nix
   ./programs/droidcam.nix
   ./programs/dublin-traceroute.nix
   ./programs/ecryptfs.nix

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -2,6 +2,9 @@
 
 with lib;
 
+let
+  cfg = config.programs.dolphin;
+in
 {
   meta.maintainers = with maintainers; [ MakiseKurisu ];
 
@@ -13,10 +16,31 @@ with lib;
       This option will install additional depencencies to mimic the experience
       of Dolphin in a normal KDE Plasma setup
     '');
+
+    extraPackages = mkOption {
+      type = with types; listOf package;
+      default = with pkgs.libsForQt5; [];
+      defaultText = literalExpression ''
+        with pkgs.libsForQt5; [];
+      '';
+      description = lib.mdDoc ''
+        Extra packages that enhance Dolphin's functionality.
+
+        This option reduces the clutter in environment.systemPackages, and also
+        serves as the documentation for possible optional packages.
+      '';
+      example = literalExpression ''
+        with pkgs.libsForQt5; [
+          dolphin-plugins
+          kio-extras
+          kdegraphics-thumbnailers
+        ];
+      '';
+    };
   };
 
   # implementation
-  config = mkIf config.programs.dolphin.enable {
+  config = mkIf cfg.enable {
 
     environment = {
 
@@ -35,7 +59,7 @@ with lib;
         konsole # for terminal panel
         breeze-qt5 # for theme
         breeze-icons # for icons
-      ];
+      ] ++ cfg.extraPackages;
     };
 
     services = {

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -31,11 +31,12 @@ in
           kdegraphics-thumbnailers
         ];
       '';
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Extra packages that enhance Dolphin's functionality.
 
-        These packages are not strictly needed to resolve any UI inconsistency,
-        but are nice to have in most cases.
+        These packages are not strictly required to have dolphin basically work,
+        but add useful features such as thumbnails, network/device filesystem
+        access, and similar.
       '';
       example = literalExpression ''
         with pkgs.libsForQt5; [

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -5,10 +5,10 @@ with lib;
 let
   cfg = config.programs.dolphin;
 
-  # This is needed to select the Breeze theme
+  # This is needed to select the custom theme
   dolphin-stylized = pkgs.writeShellScriptBin "dolphin" ''
     export QT_STYLE_OVERRIDE="${cfg.style}"
-    exec ${pkgs.libsForQt5.dolphin}/bin/dolphin
+    exec -a ${lib.getExe pkgs.libsForQt5.dolphin}
   '';
 in
 {
@@ -26,7 +26,6 @@ in
     style = mkOption {
       type = types.str;
       default = "breeze";
-      example = "breeze";
       description = mdDoc ''
         Set the style for Dolphin.
 
@@ -51,12 +50,6 @@ in
 
         This option should be used with `style` together.
       '';
-      example = literalExpression ''
-        with pkgs.libsForQt5; [
-          breeze-qt5
-          breeze-icons
-        ];
-      '';
     };
 
     extraPackages = mkOption {
@@ -80,36 +73,24 @@ in
         but add useful features such as thumbnails, network/device filesystem
         access, and similar.
       '';
-      example = literalExpression ''
-        with pkgs.libsForQt5; [
-          dolphin-plugins
-          kio-extras
-          kdegraphics-thumbnailers
-        ];
-      '';
     };
   };
 
-  # implementation
   config = mkIf cfg.enable {
-
     environment = {
-
       # This is needed to have Konsole colorscheme files available in Dolphin
       pathsToLink = [
         "/share/konsole"
       ];
 
-      systemPackages = with pkgs; with libsForQt5; [
-        dolphin-stylized
-        konsole # for terminal panel
+      systemPackages = [
+        pkgs.dolphin-stylized
+        libsForQt5.konsole # for terminal panel
       ] ++ cfg.extraPackages
       ++ cfg.stylePackages;
     };
 
-    services = {
-      udisks2.enable = true; # for mounting hard drives
-    };
-
+    # for mounting hard drives
+    services.udisks2.enable = true;
   };
 }

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -19,15 +19,23 @@ in
 
     extraPackages = mkOption {
       type = with types; listOf package;
-      default = with pkgs.libsForQt5; [];
+      default = with pkgs.libsForQt5; [
+        dolphin-plugins
+        kio-extras
+        kdegraphics-thumbnailers
+      ];
       defaultText = literalExpression ''
-        with pkgs.libsForQt5; [];
+        with pkgs.libsForQt5; [
+          dolphin-plugins
+          kio-extras
+          kdegraphics-thumbnailers
+        ];
       '';
       description = lib.mdDoc ''
         Extra packages that enhance Dolphin's functionality.
 
-        This option reduces the clutter in environment.systemPackages, and also
-        serves as the documentation for possible optional packages.
+        These packages are not strictly needed to resolve any UI inconsistency,
+        but are nice to have in most cases.
       '';
       example = literalExpression ''
         with pkgs.libsForQt5; [

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -6,18 +6,34 @@ let
   cfg = config.programs.dolphin;
 
   dolphin-stylized = pkgs.libsForQt5.dolphin.overrideAttrs (finalAttrs: previousAttrs: {
-    buildInputs = (previousAttrs.buildInputs or []) ++ [
+    buildInputs = (previousAttrs.buildInputs or [ ]) ++ [
       pkgs.libsForQt5.konsole # for terminal panel
     ] ++ cfg.extraPackages
-    ++ cfg.stylePackages;
+      ++ cfg.stylePackages;
 
-    nativeBuildInputs = (previousAttrs.nativeBuildInputs or []) ++ [
+    nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [
       pkgs.makeBinaryWrapper
     ];
 
     # This is needed to select the custom theme
     postInstall = ''
       wrapProgram $out/bin/dolphin --set-default QT_STYLE_OVERRIDE "${cfg.style}"
+    '';
+  });
+
+  kate-stylized = pkgs.libsForQt5.kate.overrideAttrs (finalAttrs: previousAttrs: {
+    buildInputs = (previousAttrs.buildInputs or [ ]) ++ [
+      pkgs.libsForQt5.konsole # for terminal panel
+    ] ++ cfg.extraPackages
+      ++ cfg.stylePackages;
+
+    nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [
+      pkgs.makeBinaryWrapper
+    ];
+
+    # This is needed to select the custom theme
+    postInstall = ''
+      wrapProgram $out/bin/kate --set-default QT_STYLE_OVERRIDE "${cfg.style}"
     '';
   });
 in
@@ -46,8 +62,8 @@ in
     stylePackages = mkOption {
       type = with types; listOf package;
       default = with pkgs.libsForQt5; [
-          breeze-qt5
-          breeze-icons
+        breeze-qt5
+        breeze-icons
       ];
       defaultText = literalExpression ''
         with pkgs.libsForQt5; [
@@ -90,6 +106,7 @@ in
 
     environment.systemPackages = [
       dolphin-stylized
+      kate-stylized
     ];
 
     # for mounting hard drives

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -83,14 +83,7 @@ in
         "/share/konsole"
       ];
 
-      systemPackages = [
-        pkgs.dolphin-stylized
-        libsForQt5.konsole # for terminal panel
-      ] ++ cfg.extraPackages
-      ++ cfg.stylePackages;
-    };
-
     # for mounting hard drives
-    services.udisks2.enable = true;
+    services.udisks2.enable = lib.mkDefault true;
   };
 }

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -29,7 +29,7 @@ in
       description = mdDoc ''
         Set the style for Dolphin.
 
-        This option should be used with `stylePackages` together.
+        This option should be used together with {option}`stylePackages`.
       '';
     };
 
@@ -48,7 +48,7 @@ in
       description = mdDoc ''
         Style packages for Dolphin.
 
-        This option should be used with `style` together.
+        This option should be used together with {option}`style`.
       '';
     };
 

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -1,0 +1,46 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+{
+  meta.maintainers = with maintainers; [ MakiseKurisu ];
+
+  # interface
+  options.programs.dolphin = {
+    enable = mkEnableOption (mdDoc ''
+      Dolphin, the KDE file manager.
+
+      This option will install additional depencencies to mimic the experience
+      of Dolphin in a normal KDE Plasma setup
+    '');
+  };
+
+  # implementation
+  config = mkIf config.programs.dolphin.enable {
+
+    environment = {
+
+      # This is needed to have Konsole colorscheme files available in Dolphin
+      pathsToLink = [
+        "/share/konsole"
+      ];
+
+      # This is needed to select the Breeze theme
+      variables = {
+        QT_STYLE_OVERRIDE = "breeze";
+      };
+
+      systemPackages = with pkgs.libsForQt5; [
+        dolphin
+        konsole # for terminal panel
+        breeze-qt5 # for theme
+        breeze-icons # for icons
+      ];
+    };
+
+    services = {
+      udisks2.enable = true; # for mounting hard drives
+    };
+
+  };
+}

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -4,6 +4,12 @@ with lib;
 
 let
   cfg = config.programs.dolphin;
+
+  # This is needed to select the Breeze theme
+  dolphin-stylized = pkgs.writeShellScriptBin "dolphin" ''
+    export QT_STYLE_OVERRIDE="${cfg.style}"
+    exec ${pkgs.libsForQt5.dolphin}/bin/dolphin
+  '';
 in
 {
   meta.maintainers = with maintainers; [ MakiseKurisu ];
@@ -16,6 +22,13 @@ in
       This option will install additional depencencies to mimic the experience
       of Dolphin in a normal KDE Plasma setup
     '');
+
+    style = mkOption {
+      type = types.str;
+      default = "breeze";
+      example = "breeze";
+      description = mdDoc "Set the style for Dolphin.";
+    };
 
     extraPackages = mkOption {
       type = with types; listOf package;
@@ -58,13 +71,8 @@ in
         "/share/konsole"
       ];
 
-      # This is needed to select the Breeze theme
-      variables = {
-        QT_STYLE_OVERRIDE = "breeze";
-      };
-
-      systemPackages = with pkgs.libsForQt5; [
-        dolphin
+      systemPackages = with pkgs; with libsForQt5; [
+        dolphin-stylized
         konsole # for terminal panel
         breeze-qt5 # for theme
         breeze-icons # for icons

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -27,7 +27,36 @@ in
       type = types.str;
       default = "breeze";
       example = "breeze";
-      description = mdDoc "Set the style for Dolphin.";
+      description = mdDoc ''
+        Set the style for Dolphin.
+
+        This option should be used with `stylePackages` together.
+      '';
+    };
+
+    stylePackages = mkOption {
+      type = with types; listOf package;
+      default = with pkgs.libsForQt5; [
+          breeze-qt5
+          breeze-icons
+      ];
+      defaultText = literalExpression ''
+        with pkgs.libsForQt5; [
+          breeze-qt5
+          breeze-icons
+        ];
+      '';
+      description = mdDoc ''
+        Style packages for Dolphin.
+
+        This option should be used with `style` together.
+      '';
+      example = literalExpression ''
+        with pkgs.libsForQt5; [
+          breeze-qt5
+          breeze-icons
+        ];
+      '';
     };
 
     extraPackages = mkOption {
@@ -74,9 +103,8 @@ in
       systemPackages = with pkgs; with libsForQt5; [
         dolphin-stylized
         konsole # for terminal panel
-        breeze-qt5 # for theme
-        breeze-icons # for icons
-      ] ++ cfg.extraPackages;
+      ] ++ cfg.extraPackages
+      ++ cfg.stylePackages;
     };
 
     services = {


### PR DESCRIPTION
## Description of changes

Add a convenient option to install Dolphin in other desktop environment. In my case that's Hyprland and (previously) Sway.

When only the `dolphin` package is installed, it has broken theme, and hamburger button->Show Panels->Terminal will tell you it actually needs `konsole` package despite there is nothing in the UI to show this feature is broken. It is subpar compared to how dolphin is presented in a normal KDE install, and makes adapting it in other desktop environment difficult, since there is no documentation for it.

The included options are picked from my personal [`nixos-config`](https://github.com/MakiseKurisu/nixos-config/blob/main/modules/desktop.nix), and is tested with this patch: 

[dolphin.patch.zip](https://github.com/NixOS/nixpkgs/files/12642882/dolphin.patch.zip)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
