### PR TITLE
linux_xanmod, linux_xanmod_latest: cleanup extra config

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -903,6 +903,8 @@ let
       CLEANCACHE = whenOlder "5.17" (option yes);
       CRASH_DUMP = option no;
 
+      FSCACHE_STATS = yes;
+
       DVB_DYNAMIC_MINORS = option yes; # we use udev
 
       EFI_STUB            = yes; # EFI bootloader in the bzImage itself

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -2,6 +2,9 @@
 
 let
   # These names are how they are designated in https://xanmod.org.
+
+  # NOTE: When updating these, please also take a look at the changes done to
+  # kernel config in the xanmod version commit
   ltsVariant = {
     version = "6.1.47";
     hash = "sha256-yF05EkQ/sAvmoNW2waxNJRGGB0gnL85fFdl6pc6U8Eo=";

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -34,10 +34,6 @@ let
       NET_SCH_DEFAULT = yes;
       DEFAULT_FQ_PIE = yes;
 
-      # Futex WAIT_MULTIPLE implementation for Wine / Proton Fsync.
-      FUTEX = yes;
-      FUTEX_PI = yes;
-
       # WineSync driver for fast kernel-backed Wine
       WINESYNC = module;
 

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -30,10 +30,6 @@ let
       TCP_CONG_BBR = yes;
       DEFAULT_BBR = yes;
 
-      # FQ-PIE Packet Scheduling
-      NET_SCH_DEFAULT = yes;
-      DEFAULT_FQ_PIE = yes;
-
       # WineSync driver for fast kernel-backed Wine
       WINESYNC = module;
 

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -26,9 +26,6 @@ let
     };
 
     structuredExtraConfig = with lib.kernel; {
-      # AMD P-state driver
-      X86_AMD_PSTATE = lib.mkOverride 60 yes;
-
       # Google's BBRv3 TCP congestion Control
       TCP_CONG_BBR = yes;
       DEFAULT_BBR = yes;


### PR DESCRIPTION
## Description of changes

In light of the discussion in https://github.com/NixOS/nixpkgs/pull/249861, I took another look at xanmod kernel options and tried to match them up with the upstream options/what upstream claims to modify.

# Xanmod claims on the website checklist

- [ ] Core and Process Scheduling, Load Balancing, Caching, Virtual
  Memory Manager and CPUFreq Governor optimized for heavy workloads.
  - We took over `HZ_500`; that can't be all the "Core and Process
    Scheduling" optimisation, right?
- No idea what "load balancing" even means here
  - No difference in `VM_*` config
  - CPUFreq seems pretty much default? Our drivers are modules rather
    than yes but I don't think that's significant
- [x] Full multi-core block layer runqueue requests for high I/O
  throughput.
  - On by default?
- [x] AMD's P-state CPPC driver for Zen2/3/4 processors
  - Enabled by default
- [ ] Intel's SMT task migration scheduler rework
  - Not configurable?
- [x] Futex waitv and legacy WAIT<sub>MULTIPLE</sub> implementation for
  Wine / Proton Fsync support.
  - Included in regular futex
- [ ] Cloudflare's TCP collapse processing for high throughput and low
  latency
  - Not configurable?
- [x] Google's Multigenerational LRU framework
  - Enabled by default
- [x] Google's BBRv3 TCP congestion control
  - Enabled via config
- [x] Netfilter nf<sub>tables</sub> RFC3489 full-cone NAT support
  - Default
- [x] Netfilter FLOWOFFLOAD target to speed up processing of packets
  - Default
- [x] WineSync driver for fast kernel-backed Wine
  - Already enabled in our xanmod kernel
- [ ] PCIe ACS Override for bypassing IOMMU groups support
  - Not configurable?
- [ ] Graysky's additional GCC and Clang CPU options
  - Don't care? We've got our own and compiler optimisations in the
    kernel have always been questionable at best
- [ ] Clear Linux patchset
  - Not configurable?
- [x] Android Binder IPC driver as module for Waydroid.
  - Default

As you can see, many of these options aren't entirely cleared up yet. It'd be great if @xanmod themself could chime in. Especially about the "Core and Process Scheduling, Load Balancing, Caching, Virtual Memory Manager and CPUFreq Governor" optimisations as I believe they're core to the xanmod formula and rather hard to extract.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
