### PR TITLE
python310Packages.skorch: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/development/python-modules/skorch/default.nix
+++ b/pkgs/development/python-modules/skorch/default.nix
@@ -2,28 +2,46 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
-, pytestCheckHook
-, flaky
+, pythonOlder
 , numpy
-, pandas
-, torch
 , scikit-learn
 , scipy
 , tabulate
+, torch
 , tqdm
+, flaky
+, pandas
+, pytestCheckHook
+, safetensors
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
   pname = "skorch";
-  version = "0.14.0";
+  version = "0.15.0";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-/d0s0N40W18uGfVbD9VEbhbWfduoo+TBqDjmTkjMUxs=";
+    hash = "sha256-39XVBlCmbg162z9uL84GZrU+v+M8waXbGdVV72ZYf84=";
   };
 
-  propagatedBuildInputs = [ numpy torch scikit-learn scipy tabulate tqdm ];
-  nativeCheckInputs = [ flaky pandas pytestCheckHook ];
+  disabled = pythonOlder "3.8";
+
+  propagatedBuildInputs = [
+    numpy
+    scikit-learn
+    scipy
+    tabulate
+    torch
+    tqdm
+  ];
+
+  nativeCheckInputs = [
+    flaky
+    pandas
+    pytestCheckHook
+    safetensors
+  ];
 
   # patch out pytest-cov dep/invocation
   postPatch = ''
@@ -40,6 +58,10 @@ buildPythonPackage rec {
     "test_pickle_load"
   ] ++ lib.optionals stdenv.isDarwin [
     # there is a problem with the compiler selection
+    "test_fit_and_predict_with_compile"
+  ] ++ lib.optionals (pythonAtLeast "3.11") [
+    # Python 3.11+ not yet supported for torch.compile
+    # https://github.com/pytorch/pytorch/blob/v2.0.1/torch/_dynamo/eval_frame.py#L376-L377
     "test_fit_and_predict_with_compile"
   ];
 


### PR DESCRIPTION
## Description of changes

Update `skorch` (and fix it as well).
Changelog: https://github.com/skorch-dev/skorch/releases/tag/v0.15.0

cc @bcdarwin 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
