### PR TITLE
static-server: init at 1.2.1

### DIFF
--- a/pkgs/by-name/st/static-server/package.nix
+++ b/pkgs/by-name/st/static-server/package.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildGo121Module
+, fetchFromGitHub
+, curl
+, stdenv
+, testers
+, static-server
+, substituteAll
+}:
+
+buildGo121Module rec {
+  pname = "static-server";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "eliben";
+    repo = "static-server";
+    rev = "v${version}";
+    hash = "sha256-AZcNh/kF6IdAceA7qe+nhRlwU4yGh19av/S1Zt7iKIs=";
+  };
+
+  vendorHash = "sha256-1p3dCLLo+MTPxf/Y3zjxTagUi+tq7nZSj4ZB/aakJGY=";
+
+  patches = [
+    # patch out debug.ReadBuidlInfo since version information is not available with buildGoModule
+    (substituteAll {
+      src = ./version.patch;
+      inherit version;
+    })
+  ];
+
+  nativeCheckInputs = [
+    curl
+  ];
+
+  ldflags = [ "-s" "-w" ];
+
+  # tests sometimes fail with SIGQUIT on darwin
+  doCheck = !stdenv.isDarwin;
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = static-server;
+    };
+  };
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = with lib; {
+    description = "A simple, zero-configuration HTTP server CLI for serving static files";
+    homepage = "https://github.com/eliben/static-server";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ figsoda ];
+    mainProgram = "static-server";
+  };
+}

--- a/pkgs/by-name/st/static-server/version.patch
+++ b/pkgs/by-name/st/static-server/version.patch
@@ -1,0 +1,23 @@
+--- a/internal/server/server.go
++++ b/internal/server/server.go
+@@ -15,7 +15,6 @@ import (
+ 	"net"
+ 	"net/http"
+ 	"os"
+-	"runtime/debug"
+ 	"strings"
+ )
+ 
+@@ -50,11 +49,7 @@ func Main() int {
+ 	flags.Parse(os.Args[1:])
+ 
+ 	if *versionFlag {
+-		if buildInfo, ok := debug.ReadBuildInfo(); ok {
+-			fmt.Printf("%v %v\n", programName, buildInfo.Main.Version)
+-		} else {
+-			errorLog.Printf("version info unavailable! run 'go version -m %v'", programName)
+-		}
++		fmt.Printf("%v %v\n", programName, "@version@")
+ 		os.Exit(0)
+ 	}
+ 


### PR DESCRIPTION
https://github.com/eliben/static-server

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
