### PR TITLE
outputcheck: init at 0.4.2

### DIFF
--- a/pkgs/by-name/ou/outputcheck/package.nix
+++ b/pkgs/by-name/ou/outputcheck/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, python3
+, fetchFromGitHub
+, lit
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "outputcheck";
+  version = "0.4.2";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "stp";
+    repo = "OutputCheck";
+    rev = "eab62a5dd5129f6a4ebfbe4bbe41d35611f7c48d";
+    hash = "sha256-0D5Lljn66jB/EW/ntC2eTuXAt0w0cceeeqf3aKuyeF0=";
+  };
+
+  # - Fix deprecated 'U' mode in python 3.11
+  #   https://github.com/python/cpython/blob/3.11/Doc/library/functions.rst?plain=1#L1386
+  # - Fix expected error and actual parser error mismatch
+  # - Fix version number cannot find error
+  postPatch = ''
+    substituteInPlace OutputCheck/Driver.py \
+      --replace "argparse.FileType('rU')" "argparse.FileType('r')"
+
+    substituteInPlace tests/invalid-regex-syntax.smt2 \
+      --replace "unbalanced parenthesis" "missing ), unterminated subpattern"
+
+    echo ${version} > RELEASE-VERSION
+  '';
+
+  nativeCheckInputs = [ lit ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    lit -v tests/
+
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "OutputCheck" ];
+
+  meta = with lib; {
+    description = "A tool for checking tool output inspired by LLVM's FileCheck";
+    homepage = "https://github.com/stp/OutputCheck";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fsagbuya ];
+    mainProgram = "OutputCheck";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
