### PR TITLE
meli: re-introduce at 0.8.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/meli/default.nix
+++ b/pkgs/applications/networking/mailreaders/meli/default.nix
@@ -1,0 +1,79 @@
+{ stdenv
+, lib
+, fetchgit
+, rustPlatform
+
+# native build inputs
+, pkg-config
+, installShellFiles
+, makeWrapper
+, mandoc
+, rustfmt
+, file
+
+# build inputs
+, openssl
+, dbus
+, sqlite
+
+# runtime deps
+, gnum4
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "meli";
+  version = "0.8.1";
+
+  src = fetchgit {
+    url = "https://git.meli.delivery/meli/meli.git";
+    rev = "v${version}";
+    hash = "sha256-sHpW2yjqYz4ePR6aQFUBD6BZwgDt3DT22/kWuKr9fAc=";
+  };
+
+  cargoSha256 = "sha256-Pg3V6Bd+drFPiJtUwsoKxu6snN88KvM+lsvnWBK/rvk=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+    makeWrapper
+    mandoc
+    (rustfmt.override { asNightly = true; })
+  ];
+
+  buildInputs = [
+    openssl
+    dbus
+    sqlite
+  ];
+
+  nativeCheckInputs = [
+    file
+  ];
+
+  postInstall = ''
+    installManPage meli/docs/*.{1,5,7}
+
+    wrapProgram $out/bin/meli \
+      --prefix PATH : ${lib.makeBinPath [ gnum4 ]}
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkFlags = [
+    "--skip=conf::test_config_parse"        # panicking due to sandbox
+    "--skip=smtp::test::test_smtp"          # requiring network
+    "--skip=utils::xdg::query_default_app"  # doesn't build
+    "--skip=utils::xdg::query_mime_info"    # doesn't build
+  ];
+
+  meta = with lib; {
+    broken = (stdenv.isLinux && stdenv.isAarch64);
+    description = "Terminal e-mail client and e-mail client library";
+    homepage = "https://meli.delivery";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ _0x4A6F matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1101,7 +1101,6 @@ mapAliases ({
   mcgrid = throw "mcgrid has been removed from nixpkgs, as it's not compatible with rivet 3"; # Added 2020-05-23
   mcomix3 = mcomix; # Added 2022-06-05
   mediatomb = throw "mediatomb is no longer maintained upstream, use gerbera instead"; # added 2022-01-04
-  meli = throw "'meli' has been removed as it requires an outdated version of openssl"; # added 2023-05-12
   meme = meme-image-generator; # Added 2021-04-21
   memtest86 = throw "'memtest86' has been renamed to/replaced by 'memtest86plus'"; # Converted to throw 2022-02-22
   mercurial_4 = throw "mercurial_4 has been removed as it's unmaintained"; # Added 2021-10-18

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33866,6 +33866,8 @@ with pkgs;
 
   meld = callPackage ../applications/version-management/meld { };
 
+  meli = callPackage ../applications/networking/mailreaders/meli { };
+
   melmatcheq.lv2 = callPackage ../applications/audio/melmatcheq.lv2 { };
 
   melody = callPackage ../tools/misc/melody { };


### PR DESCRIPTION
## Description of changes

This package had been dropped in ac019b9 because it required an
insecure version of openssl. This is no longer the case with this
update.

This new version also enables notmuch support by default in upstream,
detecting the presence of the binary purely at runtime. Therefore,
the matching package build switch has been removed.

CC previous package maintainers: @0x4A6F, @matthiasbeyer


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
