### PR TITLE
maintainers: Fix github account names

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2429,12 +2429,6 @@
     githubId = 1743184;
     name = "Boris Babić";
   };
-  borlaag = {
-    email = "borlaag@proton.me";
-    github = "Borlaag";
-    githubId = 114830266;
-    name = "Børlaag";
-  };
   bosu = {
     email = "boriss@gmail.com";
     github = "bosu";
@@ -3115,7 +3109,7 @@
   };
   christianharke = {
     email = "christian@harke.ch";
-    github = "christianharke";
+    github = "rake5k";
     githubId = 13007345;
     name = "Christian Harke";
     keys = [{
@@ -4471,7 +4465,7 @@
   DomesticMoth = {
     name = "Andrew";
     email = "silkmoth@protonmail.com";
-    github = "DomesticMoth";
+    github = "asciimoth";
     githubId = 91414737;
     keys = [{
       fingerprint = "7D6B AE0A A98A FDE9 3396  E721 F87E 15B8 3AA7 3087";
@@ -4856,12 +4850,6 @@
     github = "edwtjo";
     githubId = 54799;
     name = "Edward Tjörnhammar";
-  };
-  ee2500 = {
-    email = "earthengine@skiff.com";
-    github = "ee2500";
-    githubId = 134107129;
-    name = "EarthEngine";
   };
   eelco = {
     email = "edolstra+nixpkgs@gmail.com";
@@ -7349,7 +7337,7 @@
   };
   imalison = {
     email = "IvanMalison@gmail.com";
-    github = "IvanMalison";
+    github = "colonelpanic8";
     githubId = 1246619;
     name = "Ivan Malison";
   };
@@ -7773,7 +7761,7 @@
   jayesh-bhoot = {
     name = "Jayesh Bhoot";
     email = "jb@jayeshbhoot.com";
-    github = "bhootjb";
+    github = "jyssh";
     githubId = 1915507;
   };
   jayman2000 = {
@@ -8445,7 +8433,7 @@
   };
   jonnybolton = {
     email = "jonnybolton@gmail.com";
-    github = "jonnybolton";
+    github = "jonnynightingale";
     githubId = 8580434;
     name = "Jonny Bolton";
   };
@@ -8480,11 +8468,6 @@
     email = "johannes@jorsn.eu";
     github = "jorsn";
     githubId = 4646725;
-  };
-  joscha = {
-    name = "joscha Loos";
-    email = "j.loos@posteo.net";
-    githubId = 57965027;
   };
   josephst = {
     name = "Joseph Stahl";
@@ -9786,7 +9769,7 @@
   };
   lethalman = {
     email = "lucabru@src.gnome.org";
-    github = "lethalman";
+    github = "lucabrunox";
     githubId = 480920;
     name = "Luca Bruno";
   };
@@ -10458,12 +10441,6 @@
     name = "Mac Chaffee";
     github = "mac-chaffee";
     githubId = 7581860;
-  };
-  maddiethecafebabe = {
-    email = "maddie@cafebabe.date";
-    github = "maddiethecafebabe";
-    githubId = 75337286;
-    name = "Madeline S.";
   };
   madjar = {
     email = "georges.dubus@compiletoi.net";
@@ -12211,12 +12188,6 @@
     githubId = 77314501;
     name = "Maurice Zhou";
   };
-  nebulka = {
-    email = "arapun@proton.me";
-    github = "nebulka1";
-    githubId = 121920704;
-    name = "Nebulka";
-  };
   Necior = {
     email = "adrian@sadlocha.eu";
     github = "Necior";
@@ -13040,7 +13011,7 @@
   };
   orichter = {
     email = "richter-oliver@gmx.net";
-    github = "RichterOliver";
+    github = "ORichterSec";
     githubId = 135209509;
     name = "Oliver Richter";
   };
@@ -13649,7 +13620,7 @@
   };
   pjbarnoy = {
     email = "pjbarnoy@gmail.com";
-    github = "pjbarnoy";
+    github = "waaamb";
     githubId = 119460;
     name = "Perry Barnoy";
   };
@@ -13695,7 +13666,7 @@
   PlayerNameHere = {
     name = "Dixon Sean Low Yan Feng";
     email = "dixonseanlow@protonmail.com";
-    github = "PlayerNameHere";
+    github = "dixslyf";
     githubId = 56017218;
     keys = [{
       fingerprint = "E6F4 BFB4 8DE3 893F 68FC  A15F FF5F 4B30 A41B BAC8";
@@ -14401,7 +14372,7 @@
   };
   razvan = {
     email = "razvan.panda@gmail.com";
-    github = "razvan-flavius-panda";
+    github = "freeman42x";
     githubId = 1758708;
     name = "Răzvan Flavius Panda";
   };
@@ -17130,7 +17101,7 @@
     name = "The Hedgehog";
     email = "hedgehog@mrhedgehog.xyz";
     matrix = "@mrhedgehog:jupiterbroadcasting.com";
-    github = "theHedgehog0";
+    github = "pyrox0";
     githubId = 35778371;
     keys = [{
       fingerprint = "38A0 29B0 4A7E 4C13 A4BB  86C8 7D51 0786 6B1C 6752";

--- a/pkgs/applications/virtualization/rvvm/default.nix
+++ b/pkgs/applications/virtualization/rvvm/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     description = "The RISC-V Virtual Machine";
     license = with licenses; [ gpl3 /* or */ mpl20 ];
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ nebulka ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/yas/default.nix
+++ b/pkgs/development/libraries/yas/default.nix
@@ -22,7 +22,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/niXman/yas";
     description = "Yet Another Serialization";
     license = licenses.boost;
-    maintainers = with maintainers; [ ee2500 ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/extism-cli/default.nix
+++ b/pkgs/development/tools/extism-cli/default.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation rec {
     description = "The extism CLI is used to manage Extism installations";
     homepage = "https://github.com/extism/cli";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ borlaag ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/virtualization/uefi-run/default.nix
+++ b/pkgs/tools/virtualization/uefi-run/default.nix
@@ -20,6 +20,6 @@ rustPlatform.buildRustPackage rec {
     description = "Directly run UEFI applications in qemu";
     homepage = "https://github.com/Richard-W/uefi-run";
     license = licenses.mit;
-    maintainers = [ maintainers.maddiethecafebabe ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
```
PlayerNameHere is now known on github as dixslyf. Editing maintainer-list.nix…
Borlaag likely deleted their github account
bhootjb is now known on github as jyssh. Editing maintainer-list.nix…
IvanMalison is now known on github as colonelpanic8. Editing maintainer-list.nix…
jonnybolton is now known on github as jonnynightingale. Editing maintainer-list.nix…
ee2500 likely deleted their github account
lethalman is now known on github as lucabrunox. Editing maintainer-list.nix…
theHedgehog0 is now known on github as pyrox0. Editing maintainer-list.nix…
maddiethecafebabe likely deleted their github account
nebulka1 likely deleted their github account
christianharke is now known on github as rake5k. Editing maintainer-list.nix…
razvan-flavius-panda is now known on github as freeman42x. Editing maintainer-list.nix…
joscha has no github handle
RichterOliver is now known on github as ORichterSec. Editing maintainer-list.nix…
DomesticMoth is now known on github as asciimoth. Editing maintainer-list.nix…
pjbarnoy is now known on github as waaamb. Editing maintainer-list.nix…
```

None of the deleted maintainers hold any package maintainership.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
