### PR TITLE
pam_rssh: fix 1.1.0 update

### DIFF
--- a/pkgs/os-specific/linux/pam_rssh/default.nix
+++ b/pkgs/os-specific/linux/pam_rssh/default.nix
@@ -1,25 +1,32 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, coreutils
 , pkg-config
 , openssl
 , pam
 , openssh
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "pam_rssh";
   version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "z4yx";
     repo = "pam_rssh";
-    rev = "92c240bd079e9711c7afa8bacfcf01de48f42577";
-    hash = "sha256-mIQeItPh6RrF3cFbAth2Kmb2E/Xj+lOgatvjcLE4Yag=";
+    rev = "v${version}";
+    hash = "sha256-SDtMqGy2zhq9jEQVwSEl4EwRp2jgXfTVLrCX7k/kBeU=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-QMyMqsjZ91WimIaaSCXtbRScS3BoB+yFtHjx3xViq7U=";
+  cargoHash = "sha256-gNy1tcHDUOG1XduGAIMapvx5dlq+U1LitUQkccGfb9o=";
+
+  postPatch = ''
+    substituteInPlace src/auth_keys.rs \
+      --replace '/bin/echo' '${coreutils}/bin/echo' \
+      --replace '/bin/false' '${coreutils}/bin/false'
+  '';
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes

Fixes the `pam_rssh` update attempted in https://github.com/NixOS/nixpkgs/pull/249074.

The version was bumped in 661d2a9275a14082e92d37942b93331e3dcce8a2 but the source rev and hash were not updated.

- Tied source rev to version.
- Updated the hashes.
- Added a patch to fix new tests that expect coreutils in /bin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Ping maintainers

@Kranzes 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
