### PR TITLE
minimal-bootstrap.tinycc-musl: init at 0.9.27

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -162,6 +162,10 @@ lib.makeScope
 
     tinycc-bootstrappable = lib.recurseIntoAttrs (callPackage ./tinycc/bootstrappable.nix { });
     tinycc-mes = lib.recurseIntoAttrs (callPackage ./tinycc/mes.nix { });
+    tinycc-musl = lib.recurseIntoAttrs (callPackage ./tinycc/musl.nix {
+      bash = bash_2_05;
+      musl = musl11;
+    });
 
     xz = callPackage ./xz {
       bash = bash_2_05;
@@ -194,6 +198,7 @@ lib.makeScope
       echo ${mes.compiler.tests.get-version}
       echo ${musl.tests.hello-world}
       echo ${tinycc-mes.compiler.tests.chain}
+      echo ${tinycc-musl.compiler.tests.hello-world}
       echo ${xz.tests.get-version}
       mkdir ''${out}
     '';

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -144,6 +144,13 @@ lib.makeScope
     mes = lib.recurseIntoAttrs (callPackage ./mes { });
     mes-libc = callPackage ./mes/libc.nix { };
 
+    musl11 = callPackage ./musl/1.1.nix {
+      bash = bash_2_05;
+      tinycc = tinycc-mes;
+      gnused = gnused-mes;
+      gawk = gawk-mes;
+    };
+
     musl = callPackage ./musl {
       gcc = gcc46;
       gawk = gawk-mes;

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -148,12 +148,10 @@ lib.makeScope
       bash = bash_2_05;
       tinycc = tinycc-mes;
       gnused = gnused-mes;
-      gawk = gawk-mes;
     };
 
     musl = callPackage ./musl {
       gcc = gcc46;
-      gawk = gawk-mes;
     };
 
     stage0-posix = callPackage ./stage0-posix { };

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/1.1.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/1.1.nix
@@ -8,7 +8,6 @@
 , gnupatch
 , gnused
 , gnugrep
-, gawk
 , gnutar
 , gzip
 }:
@@ -74,7 +73,6 @@ bash.runCommand "${pname}-${version}" {
     gnupatch
     gnused
     gnugrep
-    gawk
     gnutar
     gzip
   ];

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/1.1.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/1.1.nix
@@ -1,0 +1,116 @@
+{ lib
+, buildPlatform
+, hostPlatform
+, fetchurl
+, bash
+, tinycc
+, gnumake
+, gnupatch
+, gnused
+, gnugrep
+, gawk
+, gnutar
+, gzip
+}:
+
+let
+  inherit (import ./common.nix { inherit lib; }) pname meta;
+  version = "1.1.24";
+
+  src = fetchurl {
+    url = "https://musl.libc.org/releases/musl-${version}.tar.gz";
+    hash = "sha256-E3DJqBKyzyp9koAlEMygBYzDfmanvt1wBR8KNAFQIqM=";
+  };
+
+  # Thanks to the live-bootstrap project!
+  # See https://github.com/fosslinux/live-bootstrap/blob/d98f97e21413efc32c770d0356f1feda66025686/sysa/musl-1.1.24/musl-1.1.24.sh
+  liveBootstrap = "https://github.com/fosslinux/live-bootstrap/raw/d98f97e21413efc32c770d0356f1feda66025686/sysa/musl-1.1.24";
+  patches = [
+    (fetchurl {
+      url = "${liveBootstrap}/patches/avoid_set_thread_area.patch";
+      hash = "sha256-TsbBZXk4/KMZG9EKi7cF+sullVXrxlizLNH0UHGXsPs=";
+    })
+    (fetchurl {
+      url = "${liveBootstrap}/patches/avoid_sys_clone.patch";
+      hash = "sha256-/ZmH64J57MmbxdfQ4RNjamAiBdkImMTlHsHdgV4gMj4=";
+    })
+    (fetchurl {
+      url = "${liveBootstrap}/patches/fenv.patch";
+      hash = "sha256-vMVGjoN4deAJW5gsSqA207SJqAbvhrnOsGK49DdEiTI=";
+    })
+    (fetchurl {
+      url = "${liveBootstrap}/patches/makefile.patch";
+      hash = "sha256-03iYBAUnsrEdLIIhhhq5mM6BGnPn2EfUmIHu51opxbw=";
+    })
+    (fetchurl {
+      url = "${liveBootstrap}/patches/musl_weak_symbols.patch";
+      hash = "sha256-/d9a2eUkpe9uyi1ye6T4CiYc9MR3FZ9na0Gb90+g4v0=";
+    })
+    (fetchurl {
+      url = "${liveBootstrap}/patches/set_thread_area.patch";
+      hash = "sha256-RIZYqbbRSx4X/0iFUhriwwBRmoXVR295GNBUjf2UrM0=";
+    })
+    (fetchurl {
+      url = "${liveBootstrap}/patches/sigsetjmp.patch";
+      hash = "sha256-wd2Aev1zPJXy3q933aiup5p1IMKzVJBquAyl3gbK4PU=";
+    })
+    # FIXME: this patch causes the build to fail
+    # (fetchurl {
+    #   url = "${liveBootstrap}/patches/stdio_flush_on_exit.patch";
+    #   hash = "sha256-/z5ze3h3QTysay8nRvyvwPv3pmTcKptdkBIaMCoeLDg=";
+    # })
+    (fetchurl {
+      url = "${liveBootstrap}/patches/va_list.patch";
+      hash = "sha256-UmcMIl+YCi3wIeVvjbsCyqFlkyYsM4ECNwTfXP+s7vg=";
+    })
+  ];
+in
+bash.runCommand "${pname}-${version}" {
+  inherit pname version meta;
+
+  nativeBuildInputs = [
+    tinycc.compiler
+    gnumake
+    gnupatch
+    gnused
+    gnugrep
+    gawk
+    gnutar
+    gzip
+  ];
+} ''
+  # Unpack
+  tar xzf ${src}
+  cd musl-${version}
+
+  # Patch
+  ${lib.concatMapStringsSep "\n" (f: "patch -Np0 -i ${f}") patches}
+  # tcc does not support complex types
+  rm -rf src/complex
+  # Configure fails without this
+  mkdir -p /dev
+  # https://github.com/ZilchOS/bootstrap-from-tcc/blob/2e0c68c36b3437386f786d619bc9a16177f2e149/using-nix/2a3-intermediate-musl.nix
+  sed -i 's|/bin/sh|${bash}/bin/bash|' \
+    tools/*.sh
+  chmod 755 tools/*.sh
+  # patch popen/system to search in PATH instead of hardcoding /bin/sh
+  sed -i 's|posix_spawn(&pid, "/bin/sh",|posix_spawnp(\&pid, "sh",|' \
+    src/stdio/popen.c src/process/system.c
+  sed -i 's|execl("/bin/sh", "sh", "-c",|execlp("sh", "-c",|'\
+    src/misc/wordexp.c
+
+  # Configure
+  bash ./configure \
+    --prefix=$out \
+    --build=${buildPlatform.config} \
+    --host=${hostPlatform.config} \
+    --disable-shared \
+    CC=tcc
+
+  # Build
+  make AR="tcc -ar" RANLIB=true CFLAGS="-DSYSCALL_NO_TLS"
+
+  # Install
+  make install
+  cp ${tinycc.libs}/lib/libtcc1.a $out/lib
+''

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/common.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/common.nix
@@ -1,0 +1,13 @@
+{ lib }:
+
+{
+  pname = "musl";
+
+  meta = with lib; {
+    description = "An efficient, small, quality libc implementation";
+    homepage = "https://musl.libc.org";
+    license = licenses.mit;
+    maintainers = teams.minimal-bootstrap.members;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/default.nix
@@ -8,7 +8,6 @@
 , gnumake
 , gnugrep
 , gnused
-, gawk
 , gnutar
 , gzip
 }:
@@ -30,7 +29,6 @@ bash.runCommand "${pname}-${version}" {
     gnumake
     gnused
     gnugrep
-    gawk
     gnutar
     gzip
   ];

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/default.nix
@@ -13,7 +13,7 @@
 , gzip
 }:
 let
-  pname = "musl";
+  inherit (import ./common.nix { inherit lib; }) pname meta;
   version = "1.2.4";
 
   src = fetchurl {
@@ -22,7 +22,7 @@ let
   };
 in
 bash.runCommand "${pname}-${version}" {
-  inherit pname version;
+  inherit pname version meta;
 
   nativeBuildInputs = [
     gcc
@@ -50,14 +50,6 @@ bash.runCommand "${pname}-${version}" {
         ./test
         mkdir $out
       '';
-
-  meta = with lib; {
-    description = "An efficient, small, quality libc implementation";
-    homepage = "https://musl.libc.org";
-    license = licenses.mit;
-    maintainers = teams.minimal-bootstrap.members;
-    platforms = platforms.unix;
-  };
 } ''
   # Unpack
   tar xzf ${src}

--- a/pkgs/os-specific/linux/minimal-bootstrap/tinycc/musl.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/tinycc/musl.nix
@@ -1,0 +1,155 @@
+# Build steps adapted from https://github.com/fosslinux/live-bootstrap/blob/1bc4296091c51f53a5598050c8956d16e945b0f5/sysa/tcc-0.9.27/tcc-musl-pass1.sh
+#
+# SPDX-FileCopyrightText: 2021-22 fosslinux <fosslinux@aussies.space>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+{ lib
+, fetchurl
+, callPackage
+, bash
+, tinycc-bootstrappable
+, musl
+, gnupatch
+, gnutar
+, bzip2
+}:
+let
+  pname = "tinycc-musl";
+  version = "0.9.27";
+
+  src = fetchurl {
+    url = "https://download.savannah.gnu.org/releases/tinycc/tcc-${version}.tar.bz2";
+    hash = "sha256-3iOvePypDOMt/y3UWzQysjNHQLubt7Bb9g/b/Dls65w=";
+  };
+
+  # Thanks to the live-bootstrap project!
+  # See https://github.com/fosslinux/live-bootstrap/blob/424aa5be38a3023aa6842883a3954599b1597986/sysa/tcc-0.9.27/tcc-musl-pass1.sh
+  liveBootstrap = "https://github.com/fosslinux/live-bootstrap/raw/424aa5be38a3023aa6842883a3954599b1597986/sysa/tcc-0.9.27";
+  patches = [
+    (fetchurl {
+      url = "${liveBootstrap}/patches/ignore-duplicate-symbols.patch";
+      hash = "sha256-6Js8HkzjYlA8ETxeEYRWu+03OJI60NvR5h1QPkcMTlQ=";
+    })
+    (fetchurl {
+      url = "${liveBootstrap}/patches/ignore-static-inside-array.patch";
+      hash = "sha256-IF4RevLGjzRBuYqhuyG7+x6SVljzMAsYRKicNsmtbDY=";
+    })
+    (fetchurl {
+      url = "${liveBootstrap}/patches/static-link.patch";
+      hash = "sha256-gX/hJ9a/0Zg29KIBUme+mOA8WrPQvp0SvojP8DN9mSI=";
+    })
+  ];
+
+  meta = with lib; {
+      description = "Small, fast, and embeddable C compiler and interpreter";
+      homepage = "http://savannah.nongnu.org/projects/tinycc";
+      license = licenses.lgpl21Only;
+      maintainers = teams.minimal-bootstrap.members;
+      platforms = [ "i686-linux" ];
+    };
+
+  tinycc-musl = bash.runCommand "${pname}-${version}" {
+    inherit pname version meta;
+
+    nativeBuildInputs = [
+      tinycc-bootstrappable.compiler
+      gnupatch
+      gnutar
+      bzip2
+    ];
+  } ''
+    # Unpack
+    cp ${src} tinycc.tar.bz2
+    bunzip2 tinycc.tar.bz2
+    tar xf tinycc.tar
+    rm tinycc.tar
+    cd tcc-${version}
+
+    # Patch
+    ${lib.concatMapStringsSep "\n" (f: "patch -Np0 -i ${f}") patches}
+
+    # Configure
+    touch config.h
+
+    # Build
+    # We first have to recompile using tcc-0.9.26 as tcc-0.9.27 is not self-hosting,
+    # but when linked with musl it is.
+    ln -s ${musl}/lib/libtcc1.a ./libtcc1.a
+
+    tcc -v \
+      -static \
+      -o tcc-musl \
+      -D TCC_TARGET_I386=1 \
+      -D CONFIG_TCCDIR=\"\" \
+      -D CONFIG_TCC_CRTPREFIX=\"{B}\" \
+      -D CONFIG_TCC_ELFINTERP=\"/musl/loader\" \
+      -D CONFIG_TCC_LIBPATHS=\"{B}\" \
+      -D CONFIG_TCC_SYSINCLUDEPATHS=\"${musl}/include\" \
+      -D TCC_LIBGCC=\"libc.a\" \
+      -D TCC_LIBTCC1=\"libtcc1.a\" \
+      -D CONFIG_TCC_STATIC=1 \
+      -D CONFIG_USE_LIBGCC=1 \
+      -D TCC_VERSION=\"0.9.27\" \
+      -D ONE_SOURCE=1 \
+      -B . \
+      -B ${tinycc-bootstrappable.libs}/lib \
+      tcc.c
+    # libtcc1.a
+    rm -f libtcc1.a
+    tcc -c -D HAVE_CONFIG_H=1 lib/libtcc1.c
+    tcc -ar cr libtcc1.a libtcc1.o
+
+    # Rebuild tcc-musl with itself
+    ./tcc-musl \
+      -v \
+      -static \
+      -o tcc-musl \
+      -D TCC_TARGET_I386=1 \
+      -D CONFIG_TCCDIR=\"\" \
+      -D CONFIG_TCC_CRTPREFIX=\"{B}\" \
+      -D CONFIG_TCC_ELFINTERP=\"/musl/loader\" \
+      -D CONFIG_TCC_LIBPATHS=\"{B}\" \
+      -D CONFIG_TCC_SYSINCLUDEPATHS=\"${musl}/include\" \
+      -D TCC_LIBGCC=\"libc.a\" \
+      -D TCC_LIBTCC1=\"libtcc1.a\" \
+      -D CONFIG_TCC_STATIC=1 \
+      -D CONFIG_USE_LIBGCC=1 \
+      -D TCC_VERSION=\"0.9.27\" \
+      -D ONE_SOURCE=1 \
+      -B . \
+      -B ${musl}/lib \
+      tcc.c
+    # libtcc1.a
+    rm -f libtcc1.a
+    ./tcc-musl -c -D HAVE_CONFIG_H=1 lib/libtcc1.c
+    ./tcc-musl -ar cr libtcc1.a libtcc1.o
+
+    # Install
+    install -D tcc-musl $out/bin/tcc
+    install -Dm444 libtcc1.a $out/lib/libtcc1.a
+  '';
+in
+{
+  compiler = bash.runCommand "${pname}-${version}-compiler" {
+    inherit pname version meta;
+    passthru.tests.hello-world = result:
+      bash.runCommand "${pname}-simple-program-${version}" {} ''
+        cat <<EOF >> test.c
+        #include <stdio.h>
+        int main() {
+          printf("Hello World!\n");
+          return 0;
+        }
+        EOF
+        ${result}/bin/tcc -v -static -B${musl}/lib -o test test.c
+        ./test
+        mkdir $out
+      '';
+    passthru.tinycc-musl = tinycc-musl;
+  } "install -D ${tinycc-musl}/bin/tcc $out/bin/tcc";
+
+  libs = bash.runCommand "${pname}-${version}-libs" {
+    inherit pname version meta;
+  } "install -D ${tinycc-musl}/lib/libtcc1.a $out/lib/libtcc1.a";
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Works towards replacing glibc-2.2 in the bootstrap chain. musl should also let tinycc bootstrap gcc4.7, skipping gcc2 as well.

I've chosen not to reuse the existing tinycc build helpers as they are somewhat coupled with meslibc. Stylistically I've been thinking it might be preferable to start using less abstractions for simpler code and better readability at the cost of some duplication.

Related #227914

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
