### PR TITLE
kernel/common-config: arm: configure alignment traps

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1071,6 +1071,28 @@ let
       # Keeping it a built-in ensures it will be used if possible.
       FB_SIMPLE = yes;
 
+      # https://docs.kernel.org/arch/arm/mem_alignment.html
+      # tldr:
+      #  when buggy userspace code emits illegal misaligned LDM, STM,
+      #  LDRD and STRDs, the instructions trap, are caught, and then
+      #  are emulated by the kernel.
+      #
+      #  This is the default on armv7l, anyway, but it is explicitly
+      #  enabled here for the sake of providing context for the
+      #  aarch64 compat option which follows.
+      ALIGNMENT_TRAP = mkIf (stdenv.hostPlatform.system == "armv7l-linux") yes;
+
+      # https://patchwork.kernel.org/project/linux-arm-kernel/patch/20220701135322.3025321-1-ardb@kernel.org/
+      # tldr:
+      #  when encountering alignment faults under aarch64, this option
+      #  makes the kernel attempt to handle the fault by doing the
+      #  same style of misaligned emulation that is performed under
+      #  armv7l (see above option).
+      #
+      #  This minimizes the potential for aarch32 userspace to behave
+      #  differently when run under aarch64 kernels compared to when
+      #  it is run under an aarch32 kernel.
+      COMPAT_ALIGNMENT_FIXUPS = mkIf (stdenv.hostPlatform.system == "aarch64-linux") (whenAtLeast "6.1" yes);
     } // optionalAttrs (versionAtLeast version "5.4" && (stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "aarch64-linux")) {
       # Required for various hardware features on Chrome OS devices
       CHROME_PLATFORMS = yes;


### PR DESCRIPTION
## Description of changes

under armv7l, config.gz already had CONFIG_ALIGNMENT_TRAP=y, but explicitly enable it and provide some context for the option.

under aarch64, on kernels that are new enough to support it, specify CONFIG_COMPAT_ALIGNMENT_FIXUPS=y to attempt to resolve alignment faults identically to how they are handled under 32-bit kernels. This minimizes the potential for aarch32 userspace to behave differently under an aarch64 kernel.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] armv7l-linux 
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

