### PR TITLE
catppuccin-sddm: init at unstable-2023-08-08

### DIFF
--- a/pkgs/data/themes/catppuccin-sddm/default.nix
+++ b/pkgs/data/themes/catppuccin-sddm/default.nix
@@ -1,0 +1,98 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qtsvg
+, qtquickcontrols2
+, qtgraphicaleffects
+, flavor ? "mocha"
+, themeConfig ? { }
+}:
+
+let
+  customToString = x:
+    if builtins.isInt x then toString x
+    else if builtins.isBool x then "\"${lib.boolToString x}\""
+    else "\"${toString x}\"";
+  configLines = lib.mapAttrsToList (name: value: lib.nameValuePair name value) themeConfig;
+  configureTheme = ''
+    for style_dir in src/catppuccin-{latte,frappe,macchiato,mocha}; do
+      cp $style_dir/theme.conf $style_dir/theme.conf.orig
+      ${lib.concatMapStringsSep "\n"
+        (configLine: ''
+          grep -q '^${configLine.name}=' $style_dir/theme.conf || echo '${configLine.name}=' >> "$style_dir/theme.conf"
+          sed -i -e 's/^${configLine.name}=.*$/${configLine.name}=${lib.escape [ "/" "&" "\\"] (customToString configLine.value)}/' $style_dir/theme.conf
+        '')
+        configLines}
+    done
+  '';
+
+  validFlavors = [ "latte" "frappe" "macchiato" "mocha" ];
+  pname = "catppuccin-sddm";
+in
+
+lib.checkListOfEnum "${pname}: flavor" validFlavors [ flavor ]
+
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname;
+  version = "unstable-2023-08-08";
+
+  src = fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "sddm";
+    rev = "7fc67d1027cdb7f4d833c5d23a8c34a0029b0661";
+    hash = "sha256-SjYwyUvvx/ageqVH5MmYmHNRKNvvnF3DYMJ/f2/L+Go=";
+  };
+
+  propagatedBuildInputs = [
+    qtsvg
+    qtquickcontrols2
+    qtgraphicaleffects
+  ];
+
+  dontWrapQtApps = true;
+
+  preInstall = configureTheme;
+
+  postInstall = ''
+    mkdir -p $out/share/sddm/themes
+
+    mv src/catppuccin-${flavor} $out/share/sddm/themes/catppuccin-${flavor}
+  '';
+
+  postFixup = ''
+    mkdir -p $out/nix-support
+
+    echo ${qtsvg} >> $out/nix-support/propagated-user-env-packages
+    echo ${qtquickcontrols2} >> $out/nix-support/propagated-user-env-packages
+    echo ${qtgraphicaleffects} >> $out/nix-support/propagated-user-env-packages
+  '';
+
+  meta = with lib; {
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ gigglesquid ];
+    platforms = platforms.linux;
+    homepage = "https://github.com/catppuccin/sddm";
+    description = "Soothing pastel theme for SDDM";
+     longDescription = ''
+       Installs one of the Latte, Frappé, Macchiato, or Mocha flavors, including dependencies via propagated-user-env-packages.
+       Defaults to Mocha flavor.
+
+       Available SDDM themes: `catppuccin-latte` `catppuccin-frappe` `catppuccin-macchiato` `catppuccin-mocha`.
+
+      `flavor` can be set to select the catppuccin flavor to install
+       Valid values are: `latte` `frappe` `macchiato` `mocha`.
+
+      `themeConfig` can be set to adjust vaulues as per https://github.com/catppuccin/sddm#configuration.
+       All values should be strings with the exception of FontSize, which should be an int (Bools can also be bools).
+       ---
+       Example:
+       ```
+       environment.systemPackages = with pkgs; [
+         (catppuccin-sddm { flavor = "mocha"; themeConfig = { Font = "Some Other Font"; FontSize = 10; ClockEnabled = "false"; }; })
+       ];
+
+       services.xserver.displayManager.sddm.theme = "catppuccin-mocha";
+       ```
+    '';
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -437,6 +437,8 @@ with pkgs;
 
   catppuccin-plymouth = callPackage ../data/themes/catppuccin-plymouth { };
 
+  catppuccin-sddm = libsForQt5.callPackage ../data/themes/catppuccin-sddm { };
+
   catppuccin-sddm-corners = callPackage ../data/themes/catppuccin-sddm-corners { };
 
   btdu = callPackage ../tools/misc/btdu { };


### PR DESCRIPTION
## Description of changes
Added the catppuccin SDDM theme
https://github.com/catppuccin/sddm

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
