### PR TITLE
ocamlPackages.batteries: 3.6.0 → 3.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -1,33 +1,24 @@
-{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, qcheck, num, camlp-streams
+{ stdenv, lib, fetchFromGitHub, buildDunePackage, ocaml, qtest, qcheck, num, camlp-streams
 , doCheck ? lib.versionAtLeast ocaml.version "4.08" && !stdenv.isAarch64
 }:
 
-if lib.versionOlder ocaml.version "4.02"
-then throw "batteries is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-batteries";
-  version = "3.6.0";
+buildDunePackage rec {
+  pname = "batteries";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "ocaml-batteries-team";
     repo = "batteries-included";
     rev = "v${version}";
-    hash = "sha256-D/0h0/70V8jmzHIUR6i2sT2Jz9/+tfR2dQgp4Bxtimc=";
+    hash = "sha256-0ZCaJA9xowO9QxCWcyJ1zhqG7+GNkMYJt62+VPOFj4Y=";
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
   nativeCheckInputs = [ qtest ];
   checkInputs = [ qcheck ];
   propagatedBuildInputs = [ camlp-streams num ];
 
-  strictDeps = true;
-
   inherit doCheck;
   checkTarget = "test";
-
-  createFindlibDestdir = true;
 
   meta = {
     homepage = "https://ocaml-batteries-team.github.io/batteries-included/hdoc2/";
@@ -38,7 +29,6 @@ stdenv.mkDerivation rec {
       language.
     '';
     license = lib.licenses.lgpl21Plus;
-    inherit (ocaml.meta) platforms;
     maintainers = [
       lib.maintainers.maggesi
     ];

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, buildDunePackage, ocaml, qtest, qcheck, num, camlp-streams
-, doCheck ? lib.versionAtLeast ocaml.version "4.08" && !stdenv.isAarch64
+, doCheck ? lib.versionAtLeast ocaml.version "4.08"
 }:
 
 buildDunePackage rec {

--- a/pkgs/development/ocaml-modules/telegraml/default.nix
+++ b/pkgs/development/ocaml-modules/telegraml/default.nix
@@ -10,7 +10,6 @@
 buildDunePackage rec {
   pname = "telegraml";
   version = "unstable-2021-06-17";
-  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "nv-vn";
@@ -18,6 +17,10 @@ buildDunePackage rec {
     rev = "3e28933a287e5eacd34c46b434c487f155397abc";
     sha256 = "sha256-2bMHARatwl8Zl/fWppvwbH6Ut+igJVKzwyQb8Q4gem4=";
   };
+
+  postPatch = ''
+    substituteInPlace src/dune --replace batteries batteries.unthreaded
+  '';
 
   propagatedBuildInputs = [
     batteries


### PR DESCRIPTION
## Description of changes

https://github.com/ocaml-batteries-team/batteries-included/blob/v3.7.1/ChangeLog

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
