### PR TITLE
wine: Fix missing X11 libraries for Wayland build

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
      ApplicationServices AudioToolbox CoreAudio AudioUnit CoreMIDI OpenCL Cocoa Carbon
   ])
   ++ lib.optionals (x11Support) (with pkgs.xorg; [
-     libX11 libXi libXcursor libXrandr libXrender libXxf86vm libXcomposite libXext
+     libX11 libXi libXcursor libXrandr libXrender libXxf86vm libXcomposite libXext libXfixes
   ])
   ++ lib.optionals waylandSupport (with pkgs; [
      wayland libxkbcommon wayland-protocols wayland.dev libxkbcommon.dev

--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   ++ lib.optional fontconfigSupport      pkgs.fontconfig
   ++ lib.optional alsaSupport            pkgs.alsa-lib
   ++ lib.optional pulseaudioSupport      pkgs.libpulseaudio
-  ++ lib.optional (xineramaSupport && !waylandSupport) pkgs.xorg.libXinerama
+  ++ lib.optional (xineramaSupport && x11Support) pkgs.xorg.libXinerama
   ++ lib.optional udevSupport            pkgs.udev
   ++ lib.optional vulkanSupport          (if stdenv.isDarwin then moltenvk else pkgs.vulkan-loader)
   ++ lib.optional sdlSupport             pkgs.SDL2
@@ -93,7 +93,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
      CoreServices Foundation ForceFeedback AppKit OpenGL IOKit DiskArbitration PCSC Security
      ApplicationServices AudioToolbox CoreAudio AudioUnit CoreMIDI OpenCL Cocoa Carbon
   ])
-  ++ lib.optionals (stdenv.isLinux && !waylandSupport) (with pkgs.xorg; [
+  ++ lib.optionals (x11Support) (with pkgs.xorg; [
      libX11 libXi libXcursor libXrandr libXrender libXxf86vm libXcomposite libXext
   ])
   ++ lib.optionals waylandSupport (with pkgs; [

--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
      ApplicationServices AudioToolbox CoreAudio AudioUnit CoreMIDI OpenCL Cocoa Carbon
   ])
   ++ lib.optionals (x11Support) (with pkgs.xorg; [
-     libX11 libXi libXcursor libXrandr libXrender libXxf86vm libXcomposite libXext libXfixes
+    libX11 libXcomposite libXcursor libXext libXfixes libXi libXrandr libXrender libXxf86vm
   ])
   ++ lib.optionals waylandSupport (with pkgs; [
      wayland libxkbcommon wayland-protocols wayland.dev libxkbcommon.dev

--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -47,12 +47,14 @@ let wine-build = build: release:
         wineRelease = release;
         supportFlags = {
           inherit
-            cupsSupport gettextSupport dbusSupport cairoSupport
-            odbcSupport netapiSupport cursesSupport vaSupport pcapSupport
-            v4lSupport saneSupport gphoto2Support krb5Support fontconfigSupport
-            alsaSupport pulseaudioSupport xineramaSupport gtkSupport openclSupport
-            tlsSupport openglSupport gstreamerSupport udevSupport vulkanSupport
-            sdlSupport usbSupport mingwSupport waylandSupport x11Support embedInstallers;
+            alsaSupport cairoSupport cupsSupport cursesSupport dbusSupport
+            embedInstallers fontconfigSupport gettextSupport gphoto2Support
+            gstreamerSupport gtkSupport krb5Support mingwSupport netapiSupport
+            odbcSupport openclSupport openglSupport pcapSupport
+            pulseaudioSupport saneSupport sdlSupport tlsSupport udevSupport
+            usbSupport v4lSupport vaSupport vulkanSupport waylandSupport
+            x11Support xineramaSupport
+          ;
         };
         inherit moltenvk;
       });

--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -37,6 +37,7 @@
   usbSupport ? false,
   mingwSupport ? wineRelease != "stable",
   waylandSupport ? wineRelease == "wayland",
+  x11Support ? stdenv.isLinux,
   embedInstallers ? false, # The Mono and Gecko MSI installers
   moltenvk ? darwin.moltenvk # Allow users to override MoltenVK easily
 }:
@@ -51,7 +52,7 @@ let wine-build = build: release:
             v4lSupport saneSupport gphoto2Support krb5Support fontconfigSupport
             alsaSupport pulseaudioSupport xineramaSupport gtkSupport openclSupport
             tlsSupport openglSupport gstreamerSupport udevSupport vulkanSupport
-            sdlSupport usbSupport mingwSupport waylandSupport embedInstallers;
+            sdlSupport usbSupport mingwSupport waylandSupport x11Support embedInstallers;
         };
         inherit moltenvk;
       });


### PR DESCRIPTION
The Wayland build provides both Wayland and X11 support

Wine still prioritizes X11 over Wayland by default, without these support libraries some things don't work, including missing cursor theme, causing some games maximize across multiple monitors, or worse to crash due to resolution support probe missing:

![image](https://github.com/NixOS/nixpkgs/assets/364160/8f43c084-e3b3-471d-9b53-bf06c0807f88)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
