### PR TITLE
protobuf: build with c++14

### DIFF
--- a/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
@@ -80,6 +80,11 @@ let
       "-Dprotobuf_ABSL_PROVIDER=package"
     ] ++ lib.optionals (!stdenv.targetPlatform.isStatic) [
       "-Dprotobuf_BUILD_SHARED_LIBS=ON"
+    ] ++ lib.optionals (stdenv.isDarwin) [
+      # on darwin stdenv.cc is clang which defaults to 11.0 which
+      # uses c++11 by default
+      # protobuf's minimum c++ version should be 14
+      "-DCMAKE_CXX_STANDARD=14"
     ]
     # Tests fail to build on 32-bit platforms; fixed in 3.22
     # https://github.com/protocolbuffers/protobuf/issues/10418


### PR DESCRIPTION
## Description of changes

the [readme](https://github.com/protocolbuffers/protobuf/blob/v24.3/cmake/README.md?plain=1#L15-L17) explicitely states that protobuf should be built with c++14.
I was wondering if this was a discussion that was made before.
Is there a reason not to ?
should we use c++17 ? I'm not sure if it will have some impacts downstream ?
(I know that if this is merged, it will have to be merged on staging, but I'm opening this PR to discuss the idea).
@acairncross is the one who noticed it. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
