### PR TITLE
linux-kernel: Add HP drivers on 6.1+

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1012,6 +1012,7 @@ let
 
       X86_AMD_PLATFORM_DEVICE = yes;
       X86_PLATFORM_DRIVERS_DELL = whenAtLeast "5.12" yes;
+      X86_PLATFORM_DRIVERS_HP = whenAtLeast "6.1" yes;
 
       LIRC = mkMerge [ (whenOlder "4.16" module) (whenAtLeast "4.17" yes) ];
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Redoing #255470. Sorry, I'm new.

Added one line to the linux kernel build config.

Similar to https://github.com/NixOS/nixpkgs/pull/127917, there was a change to the kernel config that moved the HP drivers to its own submenu (https://github.com/torvalds/linux/commit/6e9b8992b122cb12688bd259fc99e67d1be234eb).

This change was introduced in 6.2 and was backported to 6.1.30 (https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.30) and 5.15.113 (https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.113). I've set it on 6.1, since every subsequent v6.x version after 6.1.30 included this commit. Let me know if I should change that to 6.2 or 5.15.

Arch added the line [here](https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/blame/main/config?page=10#L9048)

The modules that compiles with this option are, `hp-wmi`, `hp_accel,` and `tc1100-wmi` on 6.1.30. With 6.6 there's the `hp-bioscfg` module for secure remote bios management.

My motivation for this change is the recently updated hp-wmi module, which enables driver support for my particular laptop (Omen 15-en0xxx), which includes the support for the Omen button and controlling EC thermal profiles on kernel 6.5.x.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
