### PR TITLE
python310Packages.pytensor: 2.11.3 -> 2.17.1

### DIFF
--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -1,40 +1,51 @@
-{ stdenv
-, lib
+{ lib
 , buildPythonPackage
-, cons
-, cython
-, etuples
 , fetchFromGitHub
+, cython
+, versioneer
+, cons
+, etuples
 , filelock
-, jax
-, jaxlib
 , logical-unification
 , minikanren
-, numba
-, numba-scipy
 , numpy
-, pytestCheckHook
-, pythonOlder
 , scipy
 , typing-extensions
+, jax
+, jaxlib
+, numba
+, numba-scipy
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+# Tensorflow is currently (2023/10/04) broken.
+# Thus, we don't provide this optional test dependency.
+# , tensorflow-probability
+, stdenv
 }:
 
 buildPythonPackage rec {
   pname = "pytensor";
-  version = "2.11.3";
-  format = "setuptools";
+  version = "2.17.1";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "pymc-devs";
-    repo = pname;
+    repo = "pytensor";
     rev = "refs/tags/rel-${version}";
-    hash = "sha256-4GDur8S19i8pZkywKHZUelmd2e0jZmC5HzF7o2esDl4=";
+    hash = "sha256-OG7ZvXJOTQzSpMoj94K9JwG6ZQRQSSp+k2slkK6BJ9I=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "versioneer[toml]==0.28" "versioneer[toml]"
+  '';
 
   nativeBuildInputs = [
     cython
+    versioneer
   ];
 
   propagatedBuildInputs = [
@@ -48,18 +59,17 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     jax
     jaxlib
     numba
     numba-scipy
+    pytest-mock
     pytestCheckHook
+    # Tensorflow is currently (2023/10/04) broken.
+    # Thus, we don't provide this optional test dependency.
+    # tensorflow-probability
   ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "--durations=50" ""
-  '';
 
   preBuild = ''
     export HOME=$(mktemp -d)
@@ -76,13 +86,14 @@ buildPythonPackage rec {
     "test_logsumexp_benchmark"
     "test_scan_multiple_output"
     "test_vector_taps_benchmark"
+    # Temporarily disabled because of broken tensorflow-probability
+    "test_tfp_ops"
   ];
 
   disabledTestPaths = [
     # Don't run the most compute-intense tests
     "tests/scan/"
     "tests/tensor/"
-    "tests/sandbox/"
     "tests/sparse/sandbox/"
   ];
 


### PR DESCRIPTION
## Description of changes

Update `pytensor` to the latest version.
Changelog: https://github.com/pymc-devs/pytensor/releases/tag/rel-2.17.0

Note: the package does not build currently because tensorboard is broken.

cc @bcdarwin 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
