### PR TITLE
threema-desktop: 1.2.31 -> 1.2.36

### DIFF
--- a/pkgs/applications/networking/instant-messengers/threema-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/threema-desktop/default.nix
@@ -1,15 +1,27 @@
-{ lib, stdenv, fetchurl, dpkg, autoPatchelfHook, makeWrapper, electron
-, alsa-lib, glibc, gtk3, libxshmfence, mesa, nss }:
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+, electron
+, alsa-lib
+, glibc
+, gtk3
+, libxshmfence
+, mesa
+, nss
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "threema-desktop";
-  version = "1.2.31";
+  version = "1.2.36";
 
   src = fetchurl {
     # As Threema only offers a Latest Release url, the plan is to upload each
     # new release url to web.archive.org until their Github releases page gets populated.
-    url = "https://web.archive.org/web/20230731230034if_/https://releases.threema.ch/web-electron/v1/release/Threema-Latest.deb";
-    hash = "sha256-eZ/bjcSnrnzub1G4sbwPn3GCTwhDfFuYv9Plf5SJL90=";
+    url = "https://web.archive.org/web/20230918134428/https://releases.threema.ch/web-electron/v1/release/Threema-Latest.deb";
+    hash = "sha256-CunyfAU33Cq6oCTraS7LigP3ezI+MCSYZEv12tXy/xc=";
   };
 
   nativeBuildInputs = [
@@ -18,10 +30,14 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  buildInputs = [ alsa-lib glibc gtk3 libxshmfence mesa nss ];
-
-  dontBuild = true;
-  dontConfigure = true;
+  buildInputs = [
+    alsa-lib
+    glibc
+    gtk3
+    libxshmfence
+    mesa
+    nss
+  ];
 
   unpackPhase = ''
     # Can't unpack with the common dpkg-deb -x method
@@ -34,6 +50,8 @@ stdenv.mkDerivation rec {
     # This will cause confusion, not needed
     rm -r usr/bin
     mv usr $out
+    # https://github.com/NixOS/nixpkgs/issues/254798#issuecomment-1722604390, this is not used
+    rm $out/lib/threema/threema-web
 
     runHook postInstall
   '';
@@ -50,6 +68,7 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.agpl3Only;
     maintainers = with maintainers; [ wolfangaukang ];
+    mainProgram = "threema";
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/issues/254798: Removing `lib/threema/threema-web` which is not being used 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
