### PR TITLE
team-list.nix: nixos-modules -> module-system

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -654,7 +654,7 @@ with lib.maintainers; {
       infinisil
       roberth
     ];
-    scope = "Maintain Nixpkgs module system";
+    scope = "Maintain the Nixpkgs module system.";
     shortName = "Module system";
     enableFeatureFreezePing = true;
   };

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -651,9 +651,7 @@ with lib.maintainers; {
 
   module-system = {
     members = [
-      ericson2314
       infinisil
-      qyliss
       roberth
     ];
     scope = "Maintain Nixpkgs module system";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -649,15 +649,15 @@ with lib.maintainers; {
     enableFeatureFreezePing = true;
   };
 
-  nixos-modules = {
+  module-system = {
     members = [
       ericson2314
       infinisil
       qyliss
       roberth
     ];
-    scope = "Maintain nixpkgs module system internals.";
-    shortName = "NixOS Modules / internals";
+    scope = "Maintain Nixpkgs module system";
+    shortName = "Module system";
     enableFeatureFreezePing = true;
   };
 


### PR DESCRIPTION
The module system isn't about NixOS, so for consistent messaging, I'd like to rename this.

The descriptions are conflicted about whether it's the one or the other, so I picked one. I suppose we could have two teams instead?

If some of you would like to be in a team responsible for NixOS' _use_ of the module system, that would be great, but for consistency it should be a separate team.


@alyssais  @Ericson2314 @infinisil, what do you think the scope should be? Should we do this, or do we want this team to be about NixOS instead, and de-emphasize the module system part? In that case we could have two teams.

This attribute isn't referenced explicitly anywhere - only generically at release time for the status update pings, so it's valid as a one file change.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
