### PR TITLE
python3Packages.fluent-pygments: init at 1.0

### DIFF
--- a/pkgs/development/python-modules/python-fluent/fluent-pygments.nix
+++ b/pkgs/development/python-modules/python-fluent/fluent-pygments.nix
@@ -1,0 +1,51 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+
+  # dependencies
+  fluent-syntax,
+  pygments,
+  six,
+}:
+
+let
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "projectfluent";
+    repo = "python-fluent";
+    rev = "fluent.pygments@${version}";
+    hash = "sha256-AR2uce3HS1ELzpoHmx7F/5/nrL+7KhYemw/00nmvLik=";
+  };
+in
+buildPythonPackage {
+  pname = "fluent-pygments";
+  inherit version;
+  pyproject = true;
+
+  inherit src;
+  sourceRoot = "${src.name}/fluent.pygments";
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    fluent-syntax
+    pygments
+    six
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "fluent.pygments" ];
+
+  meta = {
+    changelog = "https://github.com/projectfluent/python-fluent/blob/main/fluent.pygments/CHANGELOG.rst";
+    description = "Plugin for pygments to add syntax highlighting of Fluent files in Sphinx";
+    homepage = "https://projectfluent.org/python-fluent/fluent.pygments/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ getpsyched ];
+  };
+}

--- a/pkgs/development/python-modules/python-fluent/fluent-runtime.nix
+++ b/pkgs/development/python-modules/python-fluent/fluent-runtime.nix
@@ -1,0 +1,61 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+
+  # dependencies
+  attrs,
+  babel,
+  fluent-syntax,
+  pytz,
+  typing-extensions,
+}:
+
+let
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "projectfluent";
+    repo = "python-fluent";
+    rev = "fluent.runtime@${version}";
+    hash = "sha256-Crg6ybweOZ4B3WfLMOcD7+TxGEZPTHJUxr8ItLB4G+Y=";
+  };
+in
+buildPythonPackage {
+  pname = "fluent-runtime";
+  inherit version;
+  pyproject = true;
+
+  inherit src;
+  sourceRoot = "${src.name}/fluent.runtime";
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    attrs
+    babel
+    fluent-syntax
+    pytz
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    # https://github.com/projectfluent/python-fluent/pull/203
+    "test_timeZone"
+  ];
+
+  pythonImportsCheck = [ "fluent.runtime" ];
+
+  meta = {
+    changelog = "https://github.com/projectfluent/python-fluent/blob/${src.rev}/fluent.runtime/CHANGELOG.rst";
+    description = "Localization library for expressive translations";
+    downloadPage = "https://github.com/projectfluent/python-fluent/releases/tag/${src.rev}";
+    homepage = "https://projectfluent.org/python-fluent/fluent.runtime/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ getpsyched ];
+  };
+}

--- a/pkgs/development/python-modules/python-fluent/fluent-syntax.nix
+++ b/pkgs/development/python-modules/python-fluent/fluent-syntax.nix
@@ -1,0 +1,44 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+  typing-extensions,
+}:
+
+let
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "projectfluent";
+    repo = "python-fluent";
+    rev = "fluent.syntax@${version}";
+    hash = "sha256-nULngwBG/ebICRDi6HMHBdT+r/oq6tbDL7C1iMZpMsA=";
+  };
+in
+buildPythonPackage {
+  pname = "fluent-syntax";
+  inherit version;
+  pyproject = true;
+
+  inherit src;
+  sourceRoot = "${src.name}/fluent.syntax";
+
+  build-system = [ setuptools ];
+
+  dependencies = [ typing-extensions ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "fluent.syntax" ];
+
+  meta = {
+    changelog = "https://github.com/projectfluent/python-fluent/blob/${src.rev}/fluent.syntax/CHANGELOG.md";
+    description = "Parse, analyze, process, and serialize Fluent files";
+    downloadPage = "https://github.com/projectfluent/python-fluent/releases/tag/${src.rev}";
+    homepage = "https://projectfluent.org/python-fluent/fluent.syntax/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ getpsyched ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4510,6 +4510,8 @@ self: super: with self; {
 
   fluent-logger = callPackage ../development/python-modules/fluent-logger { };
 
+  fluent-pygments = callPackage ../development/python-modules/python-fluent/fluent-pygments.nix { };
+
   fluent-runtime = callPackage ../development/python-modules/python-fluent/fluent-runtime.nix { };
 
   fluent-syntax = callPackage ../development/python-modules/python-fluent/fluent-syntax.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4510,6 +4510,8 @@ self: super: with self; {
 
   fluent-logger = callPackage ../development/python-modules/fluent-logger { };
 
+  fluent-runtime = callPackage ../development/python-modules/python-fluent/fluent-runtime.nix { };
+
   fluent-syntax = callPackage ../development/python-modules/python-fluent/fluent-syntax.nix { };
 
   flufl-bounce = callPackage ../development/python-modules/flufl/bounce.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4510,6 +4510,8 @@ self: super: with self; {
 
   fluent-logger = callPackage ../development/python-modules/fluent-logger { };
 
+  fluent-syntax = callPackage ../development/python-modules/python-fluent/fluent-syntax.nix { };
+
   flufl-bounce = callPackage ../development/python-modules/flufl/bounce.nix { };
 
   flufl-i18n = callPackage ../development/python-modules/flufl/i18n.nix { };


### PR DESCRIPTION
## Description of changes

[Project Fluent](https://projectfluent.org/) is a localisation system. [`python-fluent`](https://github.com/projectfluent/python-fluent) is its Python implementation.

This PR adds all 3 of its Python packages:
- `fluent-syntax`
- `fluent-runtime`
- `fluent-pygments`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).