### PR TITLE
keepass: 2.53.1 -> 2.54

### DIFF
--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -4,11 +4,11 @@ let
   inherit (builtins) add length readFile replaceStrings unsafeDiscardStringContext toString map;
 in buildDotnetPackage rec {
   pname = "keepass";
-  version = "2.53.1";
+  version = "2.54";
 
   src = fetchurl {
     url = "mirror://sourceforge/keepass/KeePass-${version}-Source.zip";
-    hash = "sha256-R7KWxlxrhl55nOaDNYwA/cJJl+kd5ZYy6eZVqyrxxnM=";
+    hash = "sha256-fDXT4XxoJfPV8tU8uL94bnL//zKlvXGS9EzNls52kJg=";
   };
 
   sourceRoot = ".";

--- a/pkgs/applications/misc/keepass/fix-paths.patch
+++ b/pkgs/applications/misc/keepass/fix-paths.patch
@@ -53,44 +53,43 @@ index af02803..8a32c9d 100644
  
  			int iSep = str.IndexOf(':');
 diff --git a/KeePass/Util/ClipboardUtil.Unix.cs b/KeePass/Util/ClipboardUtil.Unix.cs
-index ab49ee2..7f6c50f 100644
 --- a/KeePass/Util/ClipboardUtil.Unix.cs
 +++ b/KeePass/Util/ClipboardUtil.Unix.cs
-@@ -62,7 +62,7 @@ namespace KeePass.Util
- 			//	"-out -selection clipboard");
- 			// if(str != null) return str;
+@@ -65,7 +65,7 @@
+ 				//	"-out -selection clipboard");
+ 				// if(str != null) return str;
  
--			string str = NativeLib.RunConsoleApp("xsel",
-+			string str = NativeLib.RunConsoleApp("@xsel@",
- 				"--output --clipboard", null, XSelFlags);
- 			if(str != null) return str;
- 
-@@ -83,10 +83,10 @@ namespace KeePass.Util
- 			if(string.IsNullOrEmpty(str))
- 			{
- 				// xsel with an empty input can hang, thus use --clear
--				if(NativeLib.RunConsoleApp("xsel", "--clear --primary",
-+				if(NativeLib.RunConsoleApp("@xsel@", "--clear --primary",
- 					null, XSelFlags) != null)
+-				string str = NativeLib.RunConsoleApp("xsel",
++				string str = NativeLib.RunConsoleApp("@xsel@",
+ 					"--output --clipboard", null, XSelFlags);
+ 				if(str != null) return str;
+ 			}
+@@ -93,10 +93,10 @@
+ 				if(string.IsNullOrEmpty(str))
  				{
--					NativeLib.RunConsoleApp("xsel", "--clear --clipboard",
-+					NativeLib.RunConsoleApp("@xsel@", "--clear --clipboard",
- 						null, XSelFlags);
+ 					// xsel with an empty input can hang, thus use --clear
+-					if(NativeLib.RunConsoleApp("xsel", "--clear --primary",
++					if(NativeLib.RunConsoleApp("@xsel@", "--clear --primary",
+ 						null, XSelFlags) != null)
+ 					{
+-						NativeLib.RunConsoleApp("xsel", "--clear --clipboard",
++						NativeLib.RunConsoleApp("@xsel@", "--clear --clipboard",
+ 							null, XSelFlags);
+ 						return;
+ 					}
+@@ -107,10 +107,10 @@
+ 				}
+ 
+ 				// xsel does not support --primary and --clipboard together
+-				if(NativeLib.RunConsoleApp("xsel", "--input --primary",
++				if(NativeLib.RunConsoleApp("@xsel@", "--input --primary",
+ 					str, XSelFlags) != null)
+ 				{
+-					NativeLib.RunConsoleApp("xsel", "--input --clipboard",
++					NativeLib.RunConsoleApp("@xsel@", "--input --clipboard",
+ 						str, XSelFlags);
  					return;
  				}
-@@ -97,10 +97,10 @@ namespace KeePass.Util
- 			}
- 
- 			// xsel does not support --primary and --clipboard together
--			if(NativeLib.RunConsoleApp("xsel", "--input --primary",
-+			if(NativeLib.RunConsoleApp("@xsel@", "--input --primary",
- 				str, XSelFlags) != null)
- 			{
--				NativeLib.RunConsoleApp("xsel", "--input --clipboard",
-+				NativeLib.RunConsoleApp("@xsel@", "--input --clipboard",
- 					str, XSelFlags);
- 				return;
- 			}
 diff --git a/KeePassLib/Native/ClipboardU.cs b/KeePassLib/Native/ClipboardU.cs
 index 291c51d..3c76380 100644
 --- a/KeePassLib/Native/ClipboardU.cs


### PR DESCRIPTION
## Description of changes

Changelog: https://keepass.info/news/n230603_2.54.html

This release fixes https://nvd.nist.gov/vuln/detail/CVE-2023-32784

The patch changes are just whitespace changes that allow the patch to apply after whitespace changes in upstream source.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

FYI:
* keepass maintainers: @evelant, @obadz
* @dotlambda, author of last two keepass version bumps:
    * https://github.com/NixOS/nixpkgs/pull/214677
    * https://github.com/NixOS/nixpkgs/pull/215548