### PR TITLE
treewide: define default C&C++ versions for compilers

### DIFF
--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -413,6 +413,8 @@ ${""}          done
   passthru = {
     inherit langC langCC langObjC langObjCpp langAda langFortran langGo langD version;
     isGNU = true;
+    defaultCStandard = if atLeast11 then 17 else if atleast5 then 11 else 89;
+    defaultCxxStandard = if atLeast11 then 17 else if atleast6 then 14 else 98;
   } // lib.optionalAttrs (!atLeast12) {
     hardeningUnsupportedFlags = lib.optionals is48 [ "stackprotector" ] ++ [ "fortify3" ];
   };

--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -90,6 +90,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 11;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/11/clang/default.nix
+++ b/pkgs/development/compilers/llvm/11/clang/default.nix
@@ -95,6 +95,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 17;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/12/clang/default.nix
+++ b/pkgs/development/compilers/llvm/12/clang/default.nix
@@ -89,6 +89,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 17;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/13/clang/default.nix
+++ b/pkgs/development/compilers/llvm/13/clang/default.nix
@@ -83,6 +83,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 17;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/14/clang/default.nix
+++ b/pkgs/development/compilers/llvm/14/clang/default.nix
@@ -86,6 +86,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 17;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/15/clang/default.nix
+++ b/pkgs/development/compilers/llvm/15/clang/default.nix
@@ -97,6 +97,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 17;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/16/clang/default.nix
+++ b/pkgs/development/compilers/llvm/16/clang/default.nix
@@ -92,6 +92,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 17;
+      defaultCxxStandard = 17;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -84,6 +84,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 11;
+      defaultCxxStandard = 98;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -84,6 +84,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 11;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -96,6 +96,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 11;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -102,6 +102,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 11;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -97,6 +97,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      defaultCStandard = 11;
+      defaultCxxStandard = 14;
       hardeningUnsupportedFlags = [ "fortify3" ];
     };
 

--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -70,14 +70,10 @@ stdenv.mkDerivation rec {
   # problematic, because the compatibility types in abseil will have different
   # interface definitions than the ones used for building abseil itself.
   # [1] https://github.com/grpc/grpc/blob/v1.57.0/CMakeLists.txt#L239-L243
-  ++ (let
-    defaultCxxIsOlderThan17 =
-      (stdenv.cc.isClang && lib.versionAtLeast stdenv.cc.cc.version "16.0")
-       || (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.cc.version "11.0");
-    in lib.optionals (stdenv.hostPlatform.isDarwin && defaultCxxIsOlderThan17)
-  [
+  # TODO: Patching that line out would be a better solution.
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.cc.cc.defaultCxxStandard >= 17) [
     "-DCMAKE_CXX_STANDARD=17"
-  ]);
+  ];
 
   # CMake creates a build directory by default, this conflicts with the
   # basel BUILD file on case-insensitive filesystems.

--- a/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
@@ -80,6 +80,8 @@ let
       "-Dprotobuf_ABSL_PROVIDER=package"
     ] ++ lib.optionals (!stdenv.targetPlatform.isStatic) [
       "-Dprotobuf_BUILD_SHARED_LIBS=ON"
+    ] ++ lib.optionals (stdenv.cc.cc.defaultCxxStandard < 14) [
+      "-DCMAKE_CXX_STANDARD=14"
     ]
     # Tests fail to build on 32-bit platforms; fixed in 3.22
     # https://github.com/protocolbuffers/protobuf/issues/10418


### PR DESCRIPTION
## Description of changes

The variables `defaultCStandard` and `defaultCXXStandard` make the defaults of the `-std` option known to Nix. This knowledge can be used to decide whether that option must be passed explictly for packages with specific standard requirements.

Usage is demonstrated in `protobuf` and `grpc`.

This should not cause any rebuilds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
