### PR TITLE
python310Packages.flask-cors: 3.0.10 -> 4.0.0

### DIFF
--- a/pkgs/development/python-modules/flask-cors/default.nix
+++ b/pkgs/development/python-modules/flask-cors/default.nix
@@ -1,27 +1,37 @@
-{ lib, fetchPypi, buildPythonPackage
-, nose, flask, six, packaging }:
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, flask
+, packaging
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "Flask-Cors";
-  version = "3.0.10";
+  version = "4.0.0";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b60839393f3b84a0f3746f6cdca56c1ad7426aa738b70d6c61375857823181de";
+  src = fetchFromGitHub {
+    owner = "corydolphin";
+    repo = "flask-cors";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-dRrgSJ5CADM0/VNSMYPPk3CALmyMH18OofrONVEKNMU=";
   };
 
-  nativeCheckInputs = [ nose packaging ];
-  propagatedBuildInputs = [ flask six ];
+  propagatedBuildInputs = [
+    flask
+  ];
 
-  # Exclude test_acl_uncaught_exception_500 test case because is not compatible
-  # with Flask>=1.1.0. See: https://github.com/corydolphin/flask-cors/issues/253
-  checkPhase = ''
-    nosetests --exclude test_acl_uncaught_exception_500
-  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+    packaging
+  ];
 
   meta = with lib; {
     description = "A Flask extension adding a decorator for CORS support";
     homepage = "https://github.com/corydolphin/flask-cors";
+    changelog = "https://github.com/corydolphin/flask-cors/releases/tag/v${version}";
     license = with licenses; [ mit ];
+    maintainers = with maintainers; [ nickcao ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/corydolphin/flask-cors/compare/3.0.10...v4.0.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
