### PR TITLE
build-npm-package: give a hint when npm prune fails

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -34,7 +34,16 @@ npmInstallHook() {
 
     if [ ! -d "$nodeModulesPath" ]; then
         if [ -z "${dontNpmPrune-}" ]; then
-            npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} $npmPruneFlags "${npmPruneFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"
+            if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} $npmPruneFlags "${npmPruneFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+              echo
+              echo
+              echo "ERROR: npm prune step failed"
+              echo
+              echo 'If npm tried to download additional dependencies above, try setting `dontNpmPrune = true`.'
+              echo
+
+              exit 1
+            fi
         fi
 
         find node_modules -maxdepth 1 -type d -empty -delete


### PR DESCRIPTION
## Description of changes

based on an error when packaging pageres-cli

```
pageres-cli> rebuilt dependencies successfully
pageres-cli> patching script interpreter paths in node_modules
pageres-cli> Finished npmConfigHook
pageres-cli> updateAutotoolsGnuConfigScriptsPhase
pageres-cli> configuring
pageres-cli> no configure script, doing nothing
pageres-cli> building
pageres-cli> no Makefile or custom buildPhase, doing nothing
pageres-cli> installing
pageres-cli> Executing npmInstallHook
pageres-cli> invalid type nullnpm ERR! code ENOTCACHED
pageres-cli> npm ERR! request to https://registry.npmjs.org/array-differ failed: cache mode is 'only-if-cached' but no cached response is available.
pageres-cli>
pageres-cli> npm ERR! A complete log of this run can be found in: /build/.npm/_logs/2023-09-18T23_36_54_309Z-debug-0.log
pageres-cli>
note: keeping build directory '/tmp/nix-build-pageres-cli-7.0.0.drv-7'
error: builder for '/nix/store/9ydw4b8k2nnzra1z6d3f0xbisfqnqgcb-pageres-cli-7.0.0.drv' failed with exit code 1
```

now:

```
patching script interpreter paths in node_modules
Finished npmConfigHook
updateAutotoolsGnuConfigScriptsPhase
configuring
no configure script, doing nothing
building
no Makefile or custom buildPhase, doing nothing
installing
Executing npmInstallHook
invalid type nullnpm ERR! code ENOTCACHED
npm ERR! request to https://registry.npmjs.org/array-differ failed: cache mode is 'only-if-cached' but no cached response is available.

npm ERR! A complete log of this run can be found in: /build/.npm/_logs/2023-09-18T23_46_49_064Z-debug-0.log


ERROR: `npm prune --omit=dev` failed

If npm tried to download additional dependencies above, try setting `dontNpmPrune = true`

error: builder for '/nix/store/szd3l9fxp5mqya3z8h56yhbflxy1x32g-pageres-cli-7.0.0.drv' failed with exit code 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
