### PR TITLE
luastatus: init at 0.6.0

### DIFF
--- a/pkgs/by-name/lu/luastatus/package.nix
+++ b/pkgs/by-name/lu/luastatus/package.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+# Native Build Inputs
+, cmake
+, pkg-config
+, makeWrapper
+# Dependencies
+, yajl
+, alsa-lib
+, libpulseaudio
+, glib
+, libnl
+, udev
+, libXau
+, libXdmcp
+, pcre2
+, pcre
+, util-linux
+, libselinux
+, libsepol
+, lua5
+, docutils
+, libxcb
+, libX11
+, xcbutil
+, xcbutilwm
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "luastatus";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "shdown";
+    repo = "luastatus";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-whO5pjUPaCwEb2GDCIPnTk39MejSQOoRRQ5kdYEQ0Pc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libxcb
+    libX11
+    xcbutil
+    xcbutilwm
+    libXdmcp
+    libXau
+    libpulseaudio
+    libnl
+    libselinux
+    libsepol
+    yajl
+    alsa-lib
+    glib
+    udev
+    pcre2
+    pcre
+    util-linux
+    lua5
+    docutils
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/luastatus-stdout-wrapper \
+      --prefix LUASTATUS : $out/bin/luastatus
+
+    wrapProgram $out/bin/luastatus-i3-wrapper \
+      --prefix LUASTATUS : $out/bin/luastatus
+
+    wrapProgram $out/bin/luastatus-lemonbar-launcher \
+      --prefix LUASTATUS : $out/bin/luastatus
+  '';
+
+  meta = with lib; {
+    description = "Universal status bar content generator";
+    homepage = "https://github.com/shdown/luastatus";
+    changelog = "https://github.com/shdown/luastatus/releases/tag/${finalAttrs.version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ kashw2 ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/256021

luastatus is a universal status bar content generator. It allows you to configure the way the data from event sources is processed and shown, with Lua.

https://github.com/shdown/luastatus

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
