### PR TITLE
grpc: add missing whitespace in aarch64-darwin NIX_CFLAGS_COMPILE

### DIFF
--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -95,9 +95,9 @@ stdenv.mkDerivation rec {
   '';
 
   env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " (
-    [ ] ++ lib.lists.optionals stdenv.cc.isClang [
+    lib.optionals stdenv.cc.isClang [
       "-Wno-error=unknown-warning-option"
-    ] ++ lib.lists.optionals stdenv.isAarch64 [
+    ] ++ lib.optionals stdenv.isAarch64 [
       "-Wno-error=format-security"
     ]
   );

--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -94,8 +94,13 @@ stdenv.mkDerivation rec {
     export LD_LIBRARY_PATH=$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
   '';
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=unknown-warning-option"
-    + lib.optionalString stdenv.isAarch64 "-Wno-error=format-security";
+  env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " (
+    [ ] ++ lib.lists.optionals stdenv.cc.isClang [
+      "-Wno-error=unknown-warning-option"
+    ] ++ lib.lists.optionals stdenv.isAarch64 [
+      "-Wno-error=format-security"
+    ]
+  );
 
   enableParallelBuilds = true;
 


### PR DESCRIPTION
## Description of changes

The current script has a bug where it just concatenates conditionally added `CFLAGS` to `NIX_CFLAGS_COMPILE`. At least on `aarch64-darwin` this leads to invalid flags that aren't recognized by the compiler. E.g., please see https://logs.ofborg.org/?key=nixos/nixpkgs.255998&attempt_id=adfe6f1c-2917-4a38-9a9e-89370dd2f481 where it leads to multiple warning messages like this: `warning: unknown warning option '-Werror=unknown-warning-option-Wno-error=format-security'; did you mean '-Werror=unknown-warning-option'? [-Wunknown-warning-option]`

This patch is for ensuring whitespace in presence of varying flags using `lib.concatStringsSep`.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).