### PR TITLE
HentaiAtHome: 1.6.1 -> 1.6.2

### DIFF
--- a/pkgs/applications/misc/HentaiAtHome/default.nix
+++ b/pkgs/applications/misc/HentaiAtHome/default.nix
@@ -10,12 +10,11 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "HentaiAtHome";
-  version = "1.6.1";
+  version = "1.6.2";
 
   src = fetchzip {
     url = "https://repo.e-hentai.org/hath/HentaiAtHome_${version}_src.zip";
-    hash =
-      "sha512-j+B0kx6fjUibI3MjVJ5PVTq9xxtSOTTY/XizAJKjeNkpExJF9DIV4VCwf+sfLlg+7W4UBosnyb8hZNNoidRBKA==";
+    hash = "sha256-ioL/GcnbYjt1IETH8521d1TcLGtENdFzceJui1ywXTY=";
     stripRoot = false;
   };
 


### PR DESCRIPTION
## Description of changes

Release notes: <https://forums.e-hentai.org/index.php?showtopic=234458>

I've been running this new version for about half an hour, and everything looks fine.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).