### PR TITLE
procps4: Init at 4.0.4

### DIFF
--- a/pkgs/os-specific/linux/procps-ng/4.nix
+++ b/pkgs/os-specific/linux/procps-ng/4.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchurl
+, ncurses
+, pkg-config
+
+  # `ps` with systemd support is able to properly report different
+  # attributes like unit name, so we want to have it on linux.
+, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
+, systemd
+
+  # procps is mostly Linux-only. Most commands require a running Linux
+  # system (or very similar like that found in Cygwin). The one
+  # exception is ‘watch’ which is portable enough to run on pretty much
+  # any UNIX-compatible system.
+, watchOnly ? !(stdenv.isLinux || stdenv.isCygwin)
+}:
+
+stdenv.mkDerivation rec {
+  pname = "procps";
+  version = "4.0.4";
+
+  # The project's releases are on SF, but git repo on gitlab.
+  src = fetchurl {
+    url = "mirror://sourceforge/procps-ng/procps-ng-${version}.tar.xz";
+    sha256 = "sha256-IocNb+skeK22F85PCaeHrdry0mDFqKp7F9iJqWLF5C4=";
+  };
+
+  buildInputs = [ ncurses ]
+    ++ lib.optional withSystemd systemd;
+  nativeBuildInputs = [ pkg-config ];
+
+  makeFlags = [ "usrbin_execdir=$(out)/bin" ]
+    ++ lib.optionals watchOnly [ "watch" "PKG_LDFLAGS=" ];
+
+  enableParallelBuilding = true;
+
+  # Too red
+  configureFlags = [ "--disable-modern-top" ]
+    ++ lib.optional withSystemd "--with-systemd"
+    ++ lib.optional stdenv.hostPlatform.isMusl "--disable-w"
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
+
+  installPhase = lib.optionalString watchOnly ''
+    install -m 0755 -D watch $out/bin/watch
+    install -m 0644 -D watch.1 $out/share/man/man1/watch.1
+  '';
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/procps-ng/procps";
+    description = "Utilities that give information about processes using the /proc filesystem";
+    priority = 11; # less than coreutils, which also provides "kill" and "uptime"
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ chkno ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28828,6 +28828,8 @@ with pkgs;
     then callPackage ../os-specific/linux/procps-ng { }
     else unixtools.procps;
 
+  procps4 = callPackage ../os-specific/linux/procps-ng/4.nix { };
+
   procdump = callPackage ../os-specific/linux/procdump { };
 
   prototool = callPackage ../development/tools/prototool { };


### PR DESCRIPTION
## Description of changes

procps 3.x is no longer maintained.  For example, https://nvd.nist.gov/vuln/detail/CVE-2023-4016 is fixed in 4.0.4, but not in any 3.x branch.

Eventually, we may want to move procps-3.x to `procps3` and make `procps` point at procps-4.x, but that's for the future.  For now, just get started by making procps 4.x available.

FYI:
* @wineee, author of pevious PR contemplating a procps4: https://github.com/NixOS/nixpkgs/pull/201194/files
* @typetetris, maintainer of procps (3.x).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
