### PR TITLE
nixos/sshd: Specify connection parameters for configuration validation

### DIFF
--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -52,6 +52,36 @@ in {
         };
       };
 
+    server_match_rule =
+      { ... }:
+
+      {
+        services.openssh = {
+          enable = true; listenAddresses = [ { addr = "127.0.0.1"; port = 22; } ];
+          extraConfig = ''
+            # Combined test for two (predictable) Match criterias
+            Match LocalAddress 127.0.0.1 LocalPort 22
+              PermitRootLogin yes
+
+            # Separate tests for Match criterias
+            Match User root
+              PermitRootLogin yes
+            Match Group root
+              PermitRootLogin yes
+            Match Host nohost.example
+              PermitRootLogin yes
+            Match LocalAddress 127.0.0.1
+              PermitRootLogin yes
+            Match LocalPort 22
+              PermitRootLogin yes
+            Match RDomain nohost.example
+              PermitRootLogin yes
+            Match Address 127.0.0.1
+              PermitRootLogin yes
+          '';
+        };
+      };
+
     client =
       { ... }: { };
 
@@ -114,5 +144,8 @@ in {
     with subtest("localhost-only"):
         server_localhost_only.succeed("ss -nlt | grep '127.0.0.1:22'")
         server_localhost_only_lazy.succeed("ss -nlt | grep '127.0.0.1:22'")
+
+    with subtest("match-rules"):
+        server_match_rule.succeed("ss -nlt | grep '127.0.0.1:22'")
   '';
 })


### PR DESCRIPTION
## Description of changes

After #253427, I had [the problem that my `Match`rules trigger a failing config verification](https://github.com/NixOS/nixpkgs/pull/253427#issuecomment-1724408816). I did not create an issue so far.

This PR 
 - Tests with specific `laddr`,`lport` as described in the documentation for the `-C` flag (see below). This iterates over all specified `ports` and `listenAddresses` from the nix configuration.
 - Adds a test case that has all possible `Match` rules (at the time of writing) to test for this type of configurations.

Note that the test would fail without the change to the config validation.

One remaining thing to discuss would be whether there is a way of testing the other connection parameters:
```
       -C connection_spec
              Specify the connection parameters to use for the -T extended test mode.  If provided, any Match direc‐
              tives  in  the  configuration file that would apply are applied before the configuration is written to
              standard output.  The connection parameters are supplied as keyword=value pairs and may be supplied in
              any order, either with multiple -C options or as a comma-separated list.  The keywords  are  ‘‘addr'',
              ‘‘user'',  ‘‘host'', ‘‘laddr'', ‘‘lport'', and ‘‘rdomain'' and correspond to source address, user, re‐
              solved source host name, local address, local port number and routing domain respectively.
```

Relevant pings: @Ma27 @Yarny0 

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).