### PR TITLE
bpftrace: 0.18.1 -> 0.19.0

### DIFF
--- a/pkgs/os-specific/linux/bpftrace/default.nix
+++ b/pkgs/os-specific/linux/bpftrace/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bpftrace";
-  version = "0.18.1";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "iovisor";
     repo  = "bpftrace";
     rev   = "v${version}";
-    hash  = "sha256-hwxArrTdjJoab7Twf57PRmRhghV/9EcjRXI0lKRQC0k=";
+    hash  = "sha256-+aU27mxK4R0SHSsdGQzv02fK0L/m9uCIv7AkLyLSGQY=";
   };
 
 
@@ -44,10 +44,14 @@ stdenv.mkDerivation rec {
     "-DUSE_SYSTEM_BPF_BCC=ON"
   ];
 
+
   # Pull BPF scripts into $PATH (next to their bcc program equivalents), but do
   # not move them to keep `${pkgs.bpftrace}/share/bpftrace/tools/...` working.
   postInstall = ''
-    ln -s $out/share/bpftrace/tools/*.bt $out/bin/
+    ln -sr $out/share/bpftrace/tools/*.bt $out/bin/
+    # do not use /usr/bin/env for shipped tools
+    # If someone can get patchShebangs to work here please fix.
+    sed -i -e "1s:#!/usr/bin/env bpftrace:#!$out/bin/bpftrace:" $out/share/bpftrace/tools/*.bt
   '';
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
## Description of changes

- update version https://github.com/iovisor/bpftrace/releases/tag/v0.19.0
```
#### Added                                                                                             
- Rawtracepoint support wildcards and list show
  - [#2588](https://github.com/iovisor/bpftrace/pull/2588)
- Support all iterators
  - [#2630](https://github.com/iovisor/bpftrace/pull/2630)
- Improve working with all probe params (kfunc, uprobe)
  - [#2477](https://github.com/iovisor/bpftrace/pull/2477)
- Support func builtin for k(ret)func probes
  - [#2692](https://github.com/iovisor/bpftrace/pull/2692)
- Support casting int <-> int array
  - [#2686](https://github.com/iovisor/bpftrace/pull/2686)
- Support targeting all running processes for USDTs
  - [#2734](https://github.com/iovisor/bpftrace/pull/2734)
#### Changed                                                                                           
- Make `args` a structure (instead of a pointer)
  - [#2578](https://github.com/iovisor/bpftrace/pull/2578)
- Improve user symbol resolution
  - [#2386](https://github.com/iovisor/bpftrace/pull/2386)
- uprobes: make C++ symbol demangling explicit
  - [#2657](https://github.com/iovisor/bpftrace/pull/2657)
- uprobe: improve C++ probes listing
  - [#2693](https://github.com/iovisor/bpftrace/pull/2693)
#### Fixed                                                                                             
- Fix resolving username for malformed /etc/passwd
  - [#2631](https://github.com/iovisor/bpftrace/pull/2631)
- Fix crashes when maps are concurrently modified
  - [#2623](https://github.com/iovisor/bpftrace/pull/2623)
- Fix alignment of byte arrays inside tuples
  - [#2625](https://github.com/iovisor/bpftrace/pull/2625)
- cmake: fix linking libbfd
  - [#2673](https://github.com/iovisor/bpftrace/pull/2673)
- Allow '+' in attach point path
  - [#2696](https://github.com/iovisor/bpftrace/pull/2696)
- Improve listing and 'probe' builtin for several probe types
  - [#2691](https://github.com/iovisor/bpftrace/pull/2691)
- Allow probe builtin with aliased software/hardware probes
  - [#2711](https://github.com/iovisor/bpftrace/pull/2711)
- Support executing symlinked binaries with `-c`
  - [#2708](https://github.com/iovisor/bpftrace/pull/2708)
- Add access to `CLOCK_MONOTONIC` with `nsecs(monotonic)`
  - [#2718](https://github.com/iovisor/bpftrace/pull/2718)
- iter: Skip structures with '__safe_trusted' suffix
  - [#2732](https://github.com/iovisor/bpftrace/pull/2732)
- Improve detection of unknown typedefs in ClangParser
  - [#2763](https://github.com/iovisor/bpftrace/pull/2763)
```
- make symlinks relative directly (default postInstall was fixing links anyway, this just makes it so they are correct without fix)
- fix shebang on scripts (use store path instead of /usr/bin/env) For some reason patchShebangs didn't work here (should be done automatically in post install fixups as well), use sed directly.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
