### PR TITLE
ktfmt: init at 0.46

### DIFF
--- a/pkgs/by-name/kt/ktfmt/package.nix
+++ b/pkgs/by-name/kt/ktfmt/package.nix
@@ -1,0 +1,38 @@
+{ lib, fetchFromGitHub, jre_headless, makeWrapper, maven }:
+
+maven.buildMavenPackage rec {
+  pname = "ktfmt";
+  version = "0.46";
+
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "ktfmt";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-OIbJ+J5LX6SPv5tuAiY66v/edeM7nFPHj90GXV6zaxw=";
+  };
+
+  mvnHash = "sha256-pzMjkkdkbVqVxZPW2I0YWPl5/l6+SyNkhd6gkm9Uoyc=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -Dm644 core/target/ktfmt-*-jar-with-dependencies.jar $out/share/ktfmt/ktfmt.jar
+
+    makeWrapper ${jre_headless}/bin/java $out/bin/ktfmt \
+      --add-flags "-jar $out/share/ktfmt/ktfmt.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions.";
+    homepage = "https://github.com/facebook/ktfmt";
+    license = licenses.apsl20;
+    mainProgram = "ktfmt";
+    maintainers = with maintainers; [ ghostbuster91 ];
+    inherit (jre_headless.meta) platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add ktfmt package.
Homepage: https://github.com/facebook/ktfmt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
