### PR TITLE
testers.testMetaPkgConfig: fix warning

### DIFF
--- a/pkgs/build-support/testers/testMetaPkgConfig/tester.nix
+++ b/pkgs/build-support/testers/testMetaPkgConfig/tester.nix
@@ -6,9 +6,7 @@ runCommand "check-meta-pkg-config-modules-for-${package.name}" {
   meta = {
     description = "Test whether ${package.name} exposes all pkg-config modules ${toString package.meta.pkgConfigModules}";
   };
-  dependsOn = map
-    (moduleName: testers.hasPkgConfigModule { inherit package moduleName; })
-    package.meta.pkgConfigModules;
+  dependsOn = testers.hasPkgConfigModules { inherit package; };
 } ''
   echo "found all of ${toString package.meta.pkgConfigModules}" > "$out"
 ''


### PR DESCRIPTION
## Description of changes
follow-up to feabc3db0fa3c875a45116734aa4ae4751c6ef76 / https://github.com/NixOS/nixpkgs/pull/247920

before:
```
$ nix-instantiate -A curl.passthru.tests
/nix/store/69hkq0f92kvhmaa2snhs8sngxq848ypj-coeurl-0.3.0.drv
/nix/store/6vrl59bswmggpgvvk2wj99g6jxh123lk-curlpp-0.8.1.drv
/nix/store/fvbvg8yj2m0wvjdbijsfg395d2rk2hfn-source-salted-1dgvmnzzhxfq.drv
/nix/store/balx26mkxhjri9rdz22yycnhvjni6c2v-curl-1.3.8.drv
/nix/store/lj9q8bv3py8mnzv6139735lfvl781370-vm-test-run-nginx-http3.drv
/nix/store/pdl6ybssy397r488r2pky3y2kbzhr8yn-ocaml4.14.1-curly-0.2.0.drv
/nix/store/ljxh8wyyaw9zn807dqwqsb5cl8zcchnr-php-curl-8.2.10.drv
trace: warning: testers.hasPkgConfigModule has been deprecated in favor of testers.hasPkgConfigModules. It accepts a list of strings via the moduleNames argument instead of a single moduleName.
/nix/store/0svvl3vnfa844xnk0v4yfs5mgklcm9sw-check-meta-pkg-config-modules-for-curl-8.2.1.drv
/nix/store/w10x055i8jcw7s0n13dp3msj6rzmx0n5-python3.10-pycurl-7.45.1.drv
/nix/store/h5p2zwbj8h51clfyj5bbydrw6cy1d9ih-curl-8.2.1.drv!bin
```
after:
```
$ nix-instantiate -A curl.passthru.tests
/nix/store/69hkq0f92kvhmaa2snhs8sngxq848ypj-coeurl-0.3.0.drv
/nix/store/6vrl59bswmggpgvvk2wj99g6jxh123lk-curlpp-0.8.1.drv
/nix/store/fvbvg8yj2m0wvjdbijsfg395d2rk2hfn-source-salted-1dgvmnzzhxfq.drv
/nix/store/balx26mkxhjri9rdz22yycnhvjni6c2v-curl-1.3.8.drv
/nix/store/lj9q8bv3py8mnzv6139735lfvl781370-vm-test-run-nginx-http3.drv
/nix/store/pdl6ybssy397r488r2pky3y2kbzhr8yn-ocaml4.14.1-curly-0.2.0.drv
/nix/store/ljxh8wyyaw9zn807dqwqsb5cl8zcchnr-php-curl-8.2.10.drv
/nix/store/0svvl3vnfa844xnk0v4yfs5mgklcm9sw-check-meta-pkg-config-modules-for-curl-8.2.1.drv
/nix/store/w10x055i8jcw7s0n13dp3msj6rzmx0n5-python3.10-pycurl-7.45.1.drv
/nix/store/h5p2zwbj8h51clfyj5bbydrw6cy1d9ih-curl-8.2.1.drv!bin
```

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).