### PR TITLE
hubot-sans: 1.0 -> 1.0.1

### DIFF
--- a/pkgs/data/fonts/hubot-sans/default.nix
+++ b/pkgs/data/fonts/hubot-sans/default.nix
@@ -1,26 +1,31 @@
 { lib
+, fetchzip
 , stdenvNoCC
-, fetchFromGitHub
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "hubot-sans";
-  version = "1.0";
+  version = "1.0.1";
 
-  src = fetchFromGitHub {
-    rev = "v" + version;
-    owner = "github";
-    repo = pname;
-    sha256 = "GOql+V5TH4b3TmhlgnKcx3jzUAO2jm4HRJRNzdIKxgg=";
+  src = fetchzip {
+    url = "https://github.com/github/hubot-sans/releases/download/v${finalAttrs.version}/Hubot-Sans.zip";
+    hash = "sha256-EWTyoGNqyZcqlF1H1Tdcodc8muHIo8C9gbSPAjiogRk=";
+    stripRoot = false;
   };
 
   installPhase = ''
-    install -m644 --target $out/share/fonts/truetype/hubot-sans -D $src/dist/hubot-sans.ttf
+    runHook preInstall
+
+    install -Dm644 Hubot\ Sans/TTF/*.ttf -t $out/share/fonts/truetype/
+    install -Dm644 Hubot\ Sans/OTF/*.otf -t $out/share/fonts/opentype/
+
+    runHook postInstall
   '';
 
   meta = {
     description = "A variable font from GitHub";
     homepage = "https://github.com/github/hubot-sans";
+    changelog = "https://github.com/github/hubot-sans/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.ofl;
     longDescription = ''
       Hubot Sans is Mona Sans’s robotic sidekick. The typeface is designed with
@@ -34,4 +39,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with lib.maintainers; [ drupol ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/github/hubot-sans/compare/v1.0...v1.0.1

Changelog: https://github.com/github/hubot-sans/releases/tag/v1.0.1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
