### PR TITLE
procps: Backport the CVE-2023-4016 fix

### DIFF
--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -27,7 +27,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-RRiz56r9NOwH0AY9JQ/UdJmbILIAIYw65W9dIRPxQbQ=";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isMusl [
+  patches = [
+    ./v3-CVE-2023-4016.patch
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
     # NOTE: Starting from 4.x we will not need a patch anymore, but need to add
     # "--disable-w" to configureFlags instead to prevent the utmp errors
     (fetchpatch {

--- a/pkgs/os-specific/linux/procps-ng/v3-CVE-2023-4016.patch
+++ b/pkgs/os-specific/linux/procps-ng/v3-CVE-2023-4016.patch
@@ -1,0 +1,63 @@
+This is https://gitlab.com/procps-ng/procps/-/commit/2c933ecba3bb1d3041a5a7a53a7b4078a6003413.diff
+back-ported to procps 3.3.17.  That commit changes xmalloc to xcalloc.  This patch differs in two ways:
+
+* We modify it to change malloc (no x-) to xcalloc instead
+* We pull in procps-4's definition of xcalloc
+
+Alternative considered: Also pull in commits that changed malloc to xmalloc and defined xcalloc.
+This alternative is rejected because those commits contain many other unrelated changes.
+
+diff --git a/ps/parser.c b/ps/parser.c
+index 4263a1fb..ee9a57d9 100644
+--- a/ps/parser.c
++++ b/ps/parser.c
+@@ -36,6 +36,14 @@
+ #include "common.h"
+ #include "c.h"
+ 
++static void *xxcalloc(const size_t nelems, const size_t size)
++{
++  void *ret = calloc(nelems, size);
++  if (!ret && size && nelems)
++    xerrx(EXIT_FAILURE, "cannot allocate %zu bytes", nelems*size);
++  return ret;
++}
++
+ #define ARG_GNU  0
+ #define ARG_END  1
+ #define ARG_PGRP 2
+@@ -184,7 +192,6 @@ static const char *parse_list(const char *arg, const char *(*parse_fn)(char *, s
+   const char *err;       /* error code that could or did happen */
+   /*** prepare to operate ***/
+   node = malloc(sizeof(selection_node));
+-  node->u = malloc(strlen(arg)*sizeof(sel_union)); /* waste is insignificant */
+   node->n = 0;
+   buf = strdup(arg);
+   /*** sanity check and count items ***/
+@@ -205,6 +212,7 @@ static const char *parse_list(const char *arg, const char *(*parse_fn)(char *, s
+   } while (*++walk);
+   if(need_item) goto parse_error;
+   node->n = items;
++  node->u = xxcalloc(items, sizeof(sel_union));
+   /*** actually parse the list ***/
+   walk = buf;
+   while(items--){
+@@ -1031,15 +1039,15 @@ static const char *parse_trailing_pids(void){
+   thisarg = ps_argc - 1;   /* we must be at the end now */
+ 
+   pidnode = malloc(sizeof(selection_node));
+-  pidnode->u = malloc(i*sizeof(sel_union)); /* waste is insignificant */
++  pidnode->u = xxcalloc(i, sizeof(sel_union)); /* waste is insignificant */
+   pidnode->n = 0;
+ 
+   grpnode = malloc(sizeof(selection_node));
+-  grpnode->u = malloc(i*sizeof(sel_union)); /* waste is insignificant */
++  grpnode->u = xxcalloc(i, sizeof(sel_union)); /* waste is insignificant */
+   grpnode->n = 0;
+ 
+   sidnode = malloc(sizeof(selection_node));
+-  sidnode->u = malloc(i*sizeof(sel_union)); /* waste is insignificant */
++  sidnode->u = xxcalloc(i, sizeof(sel_union)); /* waste is insignificant */
+   sidnode->n = 0;
+ 
+   while(i--){


### PR DESCRIPTION
## Description of changes

The upstream patch from the 4.x branch: https://gitlab.com/procps-ng/procps/-/commit/2c933ecba3bb1d3041a5a7a53a7b4078a6003413.diff

FYI:
* @wineee, author of pevious PR contemplating a procps4: https://github.com/NixOS/nixpkgs/pull/201194/files
* @typetetris, maintainer of procps (3.x).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
