### PR TITLE
runInMkShell: init

### DIFF
--- a/doc/builders/special.md
+++ b/doc/builders/special.md
@@ -6,6 +6,7 @@ This chapter describes several special builders.
 special/fhs-environments.section.md
 special/makesetuphook.section.md
 special/mkshell.section.md
+special/runinmkshell.section.md
 special/darwin-builder.section.md
 special/vm-tools.section.md
 ```

--- a/doc/builders/special/runinmkshell.section.md
+++ b/doc/builders/special/runinmkshell.section.md
@@ -1,0 +1,89 @@
+# pkgs.runInMkShell {#sec-pkgs-runInMkShell}
+
+`pkgs.runInMkShell` is a function that generates a wrapper script that
+receives the command to be run as arguments and then run it inside a special
+environment created with [`mkShell`](#sec-pkgs-mkShell).
+
+It's basically like the `--run` flag of `nix-shell`, but using Nix expressions.
+
+`nix-shell` works by setting some specific environment variables and then
+source the setup script from stdenv.
+
+The setup script from stdenv implements primitives such as the phase and hook
+system that allows modular logic for derivations.
+
+Because `nix-shell` is coupled with this behaviour that is implemented in
+nixpkgs it isn't used in the "nix3 cli" (in this case, `nix develop` and `nix
+shell`) that uses a much simpler but incomplete approach: just add the
+derivations bin folder to $PATH.
+
+To have the `nix-shell` behaviour in a `nix3` utility one must wrap a list of
+programs in `mkShell`, which is what `nix-shell` does under the hood
+automatically.
+
+And this function modularizes it to a wrapper script. It creates a script that
+runs the command passed as arguments in an environment built the same way as
+nix-shell does.
+
+The generated script can also be embedded in other scripts using the `source`
+command.
+
+## Usage {#sec-pkgs-runInMkShell-usage}
+
+```nix
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.runInMkShell {
+  shell = pkgs.bash + "/bin/bash"
+
+  name = "demo-environment";
+
+  drv = pkgs.mkShell {
+    buildInputs = with pkgs.python3Packages; [ numpy pandas ];
+  };
+
+  prelude = ''
+    echo Hello world
+  '';
+};
+```
+
+## Attributes {#sec-pkgs-runInMkShell-attributes}
+* `shell` (default: `${pkgs.bash} + "/bin/bash"`): Which shell to use as the
+ script shebang.
+* `name` (default: `"${drv.name}-wrapper"`): Name of the derivation for the
+ script.
+* `drv`: Result of [`mkShell`](#sec-pkgs-mkShell). Can be also only the
+ attrset of the arguments for `mkShell` or the list of the packages.
+* `prelude`: Code to be pasted just before the script runs the command
+ passed with the arguments. It has access to the arguments using the
+ standard variables such as `$@`.
+
+## Function result {#sec-pkgs-runInMkShell-result}
+
+This function will always generate a folder with a executable script in bin.
+
+The absolute path of the executable script can always be obtained by using
+`lib.getExe`.
+
+This executable script will accept a command as the arguments and will setup an
+environment like `nix-shell` does, then run the code in `prelude`, and lastly
+the command passed as parameter.
+
+Running it without parameters does nothing by default.
+
+Sourcing the script will run everything but the command that would be passed as
+argument.
+
+Let the output of the code [right above](#sec-pkgs-runInMkShell-usage) be
+defined as `$script`, an example usage of the script can be:
+
+```shell
+$script python -c 'import numpy as np; import pandas as pd; print(np, pd)'
+```
+
+In this case, the script will print "Hello world" because of the prelude, and
+the representations of `np` and `pd` because of Python.
+
+More usage examples can be found in the function tests at
+`pkgs/build-support/runinmkshell/tests.nix`. All the tests expose the script
+generated in the test.

--- a/pkgs/build-support/runinmkshell/default.nix
+++ b/pkgs/build-support/runinmkshell/default.nix
@@ -1,0 +1,105 @@
+{ mkShell
+, bash
+, coreutils
+, lib
+, writeScript
+, writeScriptBin
+, writeText
+}:
+
+# This function creates a wrapper script that runs a command in a shell context.
+{ # The shell that will execute the wrapper script
+  shell ? bash + "/bin/bash"
+, # The result of calling mkShell
+  drv
+, # Which commands to run before the payload call
+  prelude ? ""
+, # Name for the script derivation
+  name ? null
+, ...
+}:
+
+let
+  shellDrv =
+    if lib.isDerivation drv then drv
+      else if lib.isList drv then mkShell { buildInputs = drv; }
+      else mkShell drv;
+
+  drvName = if name != null then name else "${shellDrv.name}-wrapper";
+
+  # This function closely mirrors what this Nix code does:
+  # https://github.com/NixOS/nix/blob/2.8.0/src/libexpr/primops.cc#L1102
+  # https://github.com/NixOS/nix/blob/2.8.0/src/libexpr/eval.cc#L1981-L2036
+  stringValue = value:
+    # We can't just use `toString` on all derivation attributes because that
+    # would not put path literals in the closure. So we explicitly copy
+    # those into the store here
+    if builtins.typeOf value == "path" then "${value}"
+    else if builtins.typeOf value == "list" then toString (map stringValue value)
+    else toString value;
+
+  # A binary that calls the command to build the derivation
+  builder = writeScript "buildDerivation" ''
+    exec ${lib.escapeShellArg (stringValue shellDrv.drvAttrs.builder)} ${lib.escapeShellArgs (map stringValue shellDrv.drvAttrs.args)}
+  '';
+
+  # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L992-L1004
+  drvEnv = lib.mapAttrs' (name: value:
+    let str = stringValue value;
+    in if lib.elem name (shellDrv.drvAttrs.passAsFile or [])
+    then lib.nameValuePair "${name}Path" (writeText "pass-as-text-${name}" str)
+    else lib.nameValuePair name str
+  ) shellDrv.drvAttrs //
+    # A mapping from output name to the nix store path where they should end up
+    # https://github.com/NixOS/nix/blob/2.8.0/src/libexpr/primops.cc#L1253
+    lib.genAttrs shellDrv.outputs (output: builtins.unsafeDiscardStringContext shellDrv.${output}.outPath);
+
+  staticPath = "${dirOf shell}:${lib.makeBinPath [ builder coreutils ]}";
+
+  env = drvEnv // {
+    # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1027-L1030
+    # PATH = "/path-not-set";
+    # Allows calling bash and `buildDerivation` as the Cmd
+    PATH = staticPath;
+  };
+
+  variablePrelude = lib.pipe env [
+    (builtins.mapAttrs (k: v: "export ${k}=${lib.escapeShellArg v}"))
+    (builtins.attrValues)
+    (builtins.concatStringsSep "\n")
+  ];
+
+  entrypointScript = writeScriptBin drvName ''
+    #!${shell}
+    unset PATH
+    dontAddDisableDepTrack=1
+
+    ${variablePrelude}
+    # Required or source setup fails
+    NIX_BUILD_TOP=$(mktemp -d)
+
+    # TODO: https://github.com/NixOS/nix/blob/2.8.0/src/nix-build/nix-build.cc#L506
+    [ -e $stdenv/setup ] && source $stdenv/setup
+    PATH=${staticPath}:"$PATH"
+    SHELL=${lib.escapeShellArg shell}
+    BASH=${lib.escapeShellArg shell}
+    set +e
+    [ -n "$PS1" -a -z "$NIX_SHELL_PRESERVE_PROMPT" ] && PS1='\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] '
+    if [ "$(type -t runHook)" = function ]; then
+      runHook shellHook
+    fi
+    unset NIX_ENFORCE_PURITY
+    shopt -u nullglob
+    shopt -s execfail
+    ${prelude}
+
+    if [[ "${"$"}{BASH_SOURCE[0]}" == "${"$"}{0}" ]]; then
+      "$@"
+    fi
+  '';
+in entrypointScript.overrideAttrs (old: {
+  passthru = ((shellDrv.passthru or {}) // {
+    inherit shellDrv;
+  });
+  meta = (old.meta // (shellDrv.meta or {}));
+})

--- a/pkgs/build-support/runinmkshell/tests.nix
+++ b/pkgs/build-support/runinmkshell/tests.nix
@@ -1,0 +1,107 @@
+{ runInMkShell
+, mkShell
+, runCommand
+, lib
+, pkgs
+, writeText
+, writeShellScriptBin
+}:
+
+let
+  mkTest = {
+      # passed directly as name parameter to runInMkShell
+      name ? "test"
+    , # rest of flags for runInMkShell
+      args ? {}
+    , # can be either a shell script as string with $script or a list of arguments to $script
+      command ? []
+    , # passed directly as drv parameter to runInMkShell
+      drv
+    , touchOut ? false
+  }:
+  let
+    # generated wrapper script
+    script = runInMkShell (args // { inherit drv name; });
+
+    payload = if lib.isList command then "$script ${lib.escapeShellArgs command}" else toString command;
+  in runCommand "runInMkShell-${name}" {
+    passthru = { inherit script; };
+  } ''
+    script=${lib.getExe script}
+
+    ${payload}
+
+    ${lib.optionalString touchOut "touch $out"}
+  '';
+
+in lib.recurseIntoAttrs (lib.mapAttrs (k: v: mkTest (v // { name = k; })) {
+
+  identity = {  # as basic as possible test
+    command = [ "true" ];
+    drv = [];
+    touchOut = true;
+  };
+  test-the-test = { # not using the list form because it automatically creates $out
+    command = ''
+      $script test-payload 2 ${placeholder "out"}
+    '';
+    drv = [ # this way we can confirm that the wrapper is receiving the args and reacting properly
+      (writeShellScriptBin "test-payload" ''
+        [ $1 -eq 2 ]
+        echo Inner script called
+        touch $2
+      '')
+    ];
+  };
+
+  bc = { # note that you need to pass the command to run inside the wrapper context
+    command = "echo 2+2 | $script bc > $out";
+    drv = [ pkgs.bc ];
+  };
+
+  python-numpy = { # note that in nix-shell python is propagated from the library
+    command = [ "python" (writeText "script.py" ''
+      import numpy as np
+      from sys import argv
+
+      d = np.ones(10, dtype='int')
+
+      with open(argv[1], "w") as f:
+        print(d, file=f)
+    '') (placeholder "out") ];
+    drv = [ pkgs.python3Packages.numpy ];
+  };
+
+  bring-variables = { # extra variables can be passed as the other mkShell parameters
+    command = ''
+      theVar=$($script sh -c 'echo $theVar')
+      [ $theVar == 2 ] && touch $out
+    '';
+    drv = {
+      theVar = 2;
+    };
+  };
+
+  bring-variables-long = { # the same previous test can also be written using the long form
+    command = ''
+      theVar=$($script sh -c 'echo $theVar')
+      [ $theVar == 2 ] && touch $out
+    '';
+    drv = mkShell {
+      theVar = 2;
+    };
+  };
+
+  hook-simple = { # the shell primitives available in mkDerivation are also available
+    command = [ "eval" ''
+      outDir=${placeholder "out"}
+      runHook mkShellTestingHook
+    ''];
+    drv = {
+      mkShellTestingHook = ''
+        touch $outDir
+      '';
+    };
+  };
+
+})

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -153,6 +153,8 @@ with pkgs;
 
   dotnet = recurseIntoAttrs (callPackages ./dotnet { });
 
+  runInMkShell = callPackage ../build-support/runinmkshell/tests.nix { };
+
   makeHardcodeGsettingsPatch = callPackage ./make-hardcode-gsettings-patch { };
 
   makeWrapper = callPackage ./make-wrapper { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1306,6 +1306,12 @@ with pkgs;
   mkBinaryCache = callPackage ../build-support/binary-cache { };
 
   mkShell = callPackage ../build-support/mkshell { };
+
+  runInMkShell = (callPackage ../build-support/runinmkshell { })
+    // {
+      tests = pkgs.tests.runInMkShell;
+    };
+
   mkShellNoCC = mkShell.override { stdenv = stdenvNoCC; };
 
   mokutil = callPackage ../tools/security/mokutil { };


### PR DESCRIPTION
## Description of changes
This is based on code from `dockerTools.streamNixShellImage` in the hope that the same primitives could be generalized to other runtimes such as bundled executables, appimages, OCI containers and Singularity images.

I am not an expert in this domain tho but I had to adapt `dockerTools.streamNixShellImage` to use in production, also with guibou's nixGL so the GPUs get recognized.

As of `dockerTools.streamNixShellImage`, `mkShellWrapper` is based on `mkShell` but instead of generating an image it generates a script, like a `writeShellScript` that one can use directly in the entrypoint then pass the command to run inside the environment as parameters. All the nix-shell goodness should hopefully work here.

BTW drv can be either a derivation generated by `mkShell` or a attrset with `mkShell` parameters.

I am testing with the following snippet and can confirm it works:

```shell
lucasew@riverwood ~/WORKSPACE/OPENSOURCE-contrib/nixpkgs 0$ nix repl
nix-repl> :lf .
Added 17 variables.                                    

nix-repl> :b legacyPackages.x86_64-linux.mkShellWrapper { drv = { buildInputs = [ legacyPackages.x86_64-linux.python3Packages.numpy ];};}
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring

This derivation produced the following outputs:
  out -> /nix/store/5s379y8vgl8ymx5a4dcx60z9xj6lb2v4-nix-shell-wrapper

lucasew@riverwood ~/WORKSPACE/OPENSOURCE-contrib/nixpkgs 0$ /nix/store/5s379y8vgl8ymx5a4dcx60z9xj6lb2v4-nix-shell-wrapper python
Python 3.10.12 (main, Jun  6 2023, 22:43:10) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> dir(np)
['ALLOW_THREADS', 'BUFSIZE', 'CLIP', 'DataSource', 'ERR_CALL', 'ERR_DEFAULT', 'ERR_IGNORE', 'ERR_LOG', 'ERR_PRINT', 'ERR_RAISE', 'ERR_WARN', 'FLOATING_POINT_SUPPORT', 'FPE_DIVIDEBYZERO', 'FPE_INVALID', 'FPE_OVERFLOW', 'FPE_UNDERFLOW', 'False_', 'Inf', 'Infinity', 'MAXDIMS', 'MAY_SHARE_BOUNDS', 'MAY_SHARE_EXACT', 'NAN', 'NINF', 'NZERO', 'NaN', 'PINF', 'PZERO', 'RAISE', 'RankWarning', 'SHIFT_DIVIDEBYZERO', 'SHIFT_INVALID', 'SHIFT_OVERFLOW', 'SHIFT_UNDERFLOW', 'ScalarType', 'True_', 'UFUNC_BUFSIZE_DEFAULT', 'UFUNC_PYVALS_NAME', 'WRAP', '_CopyMode', '_NoValue', '_UFUNC_API', '__NUMPY_SETUP__', '__all__', '__builtins__', '__cached__', '__config__', '__deprecated_attrs__', '__dir__', '__doc__', '__expired_functions__', '__file__', '__former_attrs__', '__future_scalars__', '__getattr__', '__git_version__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '_add_newdoc_ufunc', '_builtins', '_distributor_init', '_financial_names', '_get_promotion_state', '_globals', '_int_extended_msg', '_mat', '_no_nep50_warning', '_pyinstaller_hooks_dir', '
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
