### PR TITLE
nixos/sysctl: Stop disabling yama by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -285,6 +285,10 @@
 
 - Package `cloud-sql-proxy` was renamed to `google-cloud-sql-proxy` as it cannot be used with other cloud providers.;
 
+- The Yama LSM is now enabled by default in the kernel, which prevents ptracing non-child processes.
+  This means you will not be able to attach gdb to an existing process, but will need to start that process from gdb (so it is a child).
+  Or you can set `boot.kernel.sysctl."kernel.yama.ptrace_scope"` to 0.
+
 - Package `pash` was removed due to being archived upstream. Use `powershell` as an alternative.
 
 - `security.sudo.extraRules` now includes `root`'s default rule, with ordering

--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -69,9 +69,6 @@ in
     # users as these make it easier to exploit kernel vulnerabilities.
     boot.kernel.sysctl."kernel.kptr_restrict" = mkDefault 1;
 
-    # Disable YAMA by default to allow easy debugging.
-    boot.kernel.sysctl."kernel.yama.ptrace_scope" = mkDefault 0;
-
     # Improve compatibility with applications that allocate
     # a lot of memory, like modern games
     boot.kernel.sysctl."vm.max_map_count" = mkDefault 1048576;

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -79,10 +79,6 @@ with lib;
     "ufs"
   ];
 
-  # Restrict ptrace() usage to processes with a pre-defined relationship
-  # (e.g., parent/child)
-  boot.kernel.sysctl."kernel.yama.ptrace_scope" = mkOverride 500 1;
-
   # Hide kptrs even for processes with CAP_SYSLOG
   boot.kernel.sysctl."kernel.kptr_restrict" = mkOverride 500 2;
 


### PR DESCRIPTION
## Description of changes

Yama is a LSM which restricts debugging. This prevents processes from snooping on another. It can be easily disabled with sysctl.

This was initially included in #14392 and disabled by default by 86721a5f78718caf10c578e9501f8b4d19c0eb44.

This has been part of the hardened configuration, but many other distros ship this for quite some time (Ubuntu for about ten years), so I'd say it might make sense to enable this per default.

## Things done

This is just a configuration change. I changed this in the configuration of a NixOS VM and it kept working.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
