### PR TITLE
nodePackages.protoc-gen-ts: init at 2.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13011,6 +13011,15 @@
     githubId = 1237862;
     name = "Ollie Bunting";
   };
+  ollieP = {
+    email = "mrpauffley@gmail.com";
+    github = "oliverpauffley";
+    githubId = 17577623;
+    name = "Oliver Pauffley";
+    keys = [{
+      fingerprint = "898E 9AF3 BA55 8BBD 27CC  EC76 7763 33D2 65A5 4BED";
+    }];
+  };
   oluceps = {
     email = "nixos@oluceps.uk";
     github = "oluceps";

--- a/pkgs/by-name/pr/protoc-gen-ts/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-ts/package.nix
@@ -1,0 +1,30 @@
+{ lib, buildNpmPackage, fetchurl }:
+
+buildNpmPackage rec {
+  pname = "protoc-gen-ts";
+  version = "2.9.1";
+
+  packageName = "@protobuf-ts/protoc";
+  src = fetchurl {
+    url =
+      "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-${version}.tgz";
+    # this isnt the correct hash
+    sha512 =
+      "/q2iVDwVDijfZlFZnnm3W6ALbybNskNSww88TfYBaJH49PuQMqhcXUPRu28UouJr9sc/Lr5k6t0TB9Nff3UIsA==";
+  };
+  # this isnt the correct hash
+  npmDepsHash = "sha256-diGu53lJi+Fs7pTAQGCXoDtP7YyKZLIN/2Wo+e1Mzc4=";
+
+  env.PUPPETEER_SKIP_DOWNLOAD = true;
+  dontNpmBuild = true;
+
+  meta = {
+    changelog =
+      "https://github.com/timostamm/protobuf-ts/releases/tag/v${version}";
+    description = "Protobuf and RPC for Typescript";
+    homepage = "https://github.com/timostamm/protobuf-ts";
+    license = lib.licenses.asl20;
+    mainProgram = "@protobuf-ts/plugin";
+    maintainers = with lib.maintainers; [ ollieP ];
+  };
+}


### PR DESCRIPTION
Adds the node package protoc-gen-ts. This is a widely used plugin by
the protoc ecosystem to generate typescript messages from protobuf definitions.

-------

## Description of changes

Adds new nodePackage [protoc-gen-ts](https://github.com/timostamm/protobuf-ts) that is used to generate typescript from protobuf messages.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->