### PR TITLE
androidndkPkgs: improvements

### DIFF
--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -11,15 +11,17 @@ let
   # than we do. We don't just use theirs because ours are less ambiguous and
   # some builds need that clarity.
   #
-  # FIXME:
-  # There's some dragons here. Build host and target concepts are being mixed up.
-  ndkInfoFun = { config, ... }: {
+  ndkBuildInfoFun = { config, ... }: {
     x86_64-apple-darwin = {
       double = "darwin-x86_64";
     };
     x86_64-unknown-linux-gnu = {
       double = "linux-x86_64";
     };
+  }.${config} or
+    (throw "Android NDK doesn't support building on ${config}, as far as we know");
+
+  ndkTargetInfoFun = { config, ... }: {
     i686-unknown-linux-android = {
       triple = "i686-linux-android";
       arch = "x86";
@@ -37,11 +39,10 @@ let
       triple = "aarch64-linux-android";
     };
   }.${config} or
-    (throw "Android NDK doesn't support ${config}, as far as we know");
+    (throw "Android NDK doesn't support targetting ${config}, as far as we know");
 
-  buildInfo = ndkInfoFun stdenv.buildPlatform;
-  hostInfo = ndkInfoFun stdenv.hostPlatform;
-  targetInfo = ndkInfoFun stdenv.targetPlatform;
+  buildInfo = ndkBuildInfoFun stdenv.buildPlatform;
+  targetInfo = ndkTargetInfoFun stdenv.targetPlatform;
 
   inherit (stdenv.targetPlatform) sdkVer;
   suffixSalt = lib.replaceStrings ["-" "."] ["_" "_"] stdenv.targetPlatform.config;

--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -29,7 +29,7 @@
       # these two really are the same.
       buildAndroidndk = buildAndroidComposition.ndk-bundle;
       androidndk = androidComposition.ndk-bundle;
-      targetAndroidndkPkgs = targetPackages.androidndkPkgs_21;
+      targetAndroidndkPkgs = if targetPackages ? androidndkPkgs_21 then targetPackages.androidndkPkgs_21 else throw "androidndkPkgs_21: no targetPackages, use `buildPackages.androidndkPkgs_21";
     };
 
   "23b" =
@@ -59,7 +59,7 @@
       # these two really are the same.
       buildAndroidndk = buildAndroidComposition.ndk-bundle;
       androidndk = androidComposition.ndk-bundle;
-      targetAndroidndkPkgs = targetPackages.androidndkPkgs_23b;
+      targetAndroidndkPkgs = if targetPackages ? androidndkPkgs_23b then targetPackages.androidndkPkgs_23b else throw "androidndkPkgs_23b: no targetPackages, use `buildPackages.androidndkPkgs_23b";
     };
 
   "24" =
@@ -89,7 +89,7 @@
       # these two really are the same.
       buildAndroidndk = buildAndroidComposition.ndk-bundle;
       androidndk = androidComposition.ndk-bundle;
-      targetAndroidndkPkgs = targetPackages.androidndkPkgs_24;
+      targetAndroidndkPkgs = if targetPackages ? androidndkPkgs_24 then targetPackages.androidndkPkgs_24 else throw "androidndkPkgs_24: no targetPackages, use `buildPackages.androidndkPkgs_24";
     };
 
 }


### PR DESCRIPTION
Proper ways to to use `androidndkPkgs` AFAIK.

`with import ./. { crossSystem = (import ./lib).systems.examples.aarch64-android-prebuilt; }; buildPackages.androidndkPkgs`

or

`pkgsCross.aarch64-android-prebuilt.buildPackages.androidndkPkgs`

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
