### PR TITLE
ocamlPackages.higlo: 0.8 → 0.9

### DIFF
--- a/pkgs/applications/misc/stog/default.nix
+++ b/pkgs/applications/misc/stog/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchFromGitLab, ocaml
+{ lib, buildDunePackage, fetchFromGitLab, fetchpatch, ocaml
 , fmt, lwt_ppx, menhir, ocf_ppx, ppx_blob, xtmpl_ppx
 , dune-build-info, dune-site, higlo, logs, lwt, ocf, ptime, uri, uutf, xtmpl
 }:
@@ -10,7 +10,6 @@ else
 buildDunePackage rec {
   pname = "stog";
   version = "0.20.0";
-  duneVersion = "3";
   minimalOCamlVersion = "4.12";
   src = fetchFromGitLab {
     domain = "framagit.org";
@@ -18,6 +17,12 @@ buildDunePackage rec {
     repo = "stog";
     rev = version;
     sha256 = "sha256:0krj5w4y05bcfx7hk9blmap8avl31gp7yi01lpqzs6ync23mvm0x";
+  };
+
+  # Compatibility with higlo 0.9
+  patches = fetchpatch {
+    url = "https://framagit.org/zoggy/stog/-/commit/ea0546ab4cda8cc5c4c820ebaf2e3dfddc2ab101.patch";
+    hash = "sha256-86GRHF9OjfcalGfA0Om2wXH99j4THCs9a4+o5ghuiJc=";
   };
 
   nativeBuildInputs = [ menhir ];

--- a/pkgs/development/ocaml-modules/higlo/default.nix
+++ b/pkgs/development/ocaml-modules/higlo/default.nix
@@ -2,14 +2,14 @@
 
 buildDunePackage rec {
   pname = "higlo";
-  version = "0.8";
-  duneVersion = "3";
+  version = "0.9";
+
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "zoggy";
     repo = "higlo";
     rev = version;
-    sha256 = "sha256:09hsbwy5asacgh4gdj0vjpy4kzfnq3qji9szbsbyswsf1nbyczir";
+    hash = "sha256-SaFFzp4FCjVLdMLH6mNIv3HzJbkXJ5Ojbku258LCfLI=";
   };
 
   propagatedBuildInputs = [ sedlex xtmpl ];


### PR DESCRIPTION
## Description of changes

https://zoggy.frama.io/higlo/#releases

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
