### PR TITLE
armbian-firmware: init at unstable-2023-09-16

### DIFF
--- a/pkgs/by-name/ar/armbian-firmware/package.nix
+++ b/pkgs/by-name/ar/armbian-firmware/package.nix
@@ -1,0 +1,33 @@
+{ stdenvNoCC, lib, fetchFromGitHub }:
+stdenvNoCC.mkDerivation rec {
+  pname = "armbian-firmware";
+  version = "unstable-2023-09-16";
+
+  src = fetchFromGitHub {
+    owner = "armbian";
+    repo = "firmware";
+    rev = "01f9809bb0c4bd60c0c84b9438486b02d58b03f7";
+    hash = "sha256-ozKADff7lFjIT/Zf5dkNlCe8lOK+kwYb/60NaCJ8i2k=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/firmware
+    cp -a * $out/lib/firmware/
+
+    runHook postInstall
+  '';
+
+  # Firmware blobs do not need fixing and should not be modified
+  dontBuild = true;
+  dontFixup = true;
+
+  meta = with lib; {
+    description = "Firmware from Armbian";
+    homepage = "https://github.com/armbian/firmware";
+    license = licenses.unfree;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ zaldnoay ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add armbian firmware.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
