### PR TITLE
stdenv: option to determine SOURCE_DATE_EPOCH in fetchers

### DIFF
--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -13,6 +13,7 @@ $SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" \
   ${fetchLFS:+--fetch-lfs} \
   ${deepClone:+--deepClone} \
   ${fetchSubmodules:+--fetch-submodules} \
+  ${keepSourceDate:+--keep-source-date} \
   ${sparseCheckout:+--sparse-checkout "$sparseCheckout"} \
   ${nonConeMode:+--non-cone-mode} \
   ${branchName:+--branch-name "$branchName"}

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -28,6 +28,7 @@ lib.makeOverridable (lib.fetchers.withNormalizedHash { } (
   postFetch ? ""
 , preferLocalBuild ? true
 , fetchLFS ? false
+, keepSourceDate ? false
 , # Shell code to build a netrc file for BASIC auth
   netrcPhase ? null
 , # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
@@ -100,7 +101,7 @@ stdenvNoCC.mkDerivation {
   # > from standard in as a newline-delimited list instead of from the arguments.
   sparseCheckout = builtins.concatStringsSep "\n" sparseCheckout;
 
-  inherit url leaveDotGit fetchLFS fetchSubmodules deepClone branchName nonConeMode postFetch;
+  inherit url leaveDotGit fetchLFS fetchSubmodules deepClone keepSourceDate branchName nonConeMode postFetch;
   rev = revWithTag;
 
   postHook = if netrcPhase == null then null else ''
@@ -114,7 +115,6 @@ stdenvNoCC.mkDerivation {
   impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ netrcImpureEnvVars ++ [
     "GIT_PROXY_COMMAND" "NIX_GIT_SSL_CAINFO" "SOCKS_SERVER"
   ];
-
 
   inherit preferLocalBuild meta allowedRequisites;
 

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -8,6 +8,7 @@ expHash=
 hashType=$NIX_HASH_ALGO
 deepClone=$NIX_PREFETCH_GIT_DEEP_CLONE
 leaveDotGit=$NIX_PREFETCH_GIT_LEAVE_DOT_GIT
+keepSourceDate=$NIX_PREFETCH_GIT_KEEP_SOURCE_DATE
 fetchSubmodules=
 fetchLFS=
 builder=
@@ -39,6 +40,12 @@ else
     leaveDotGit=true
 fi
 
+if test "$keepSourceDate" != 1; then
+    keepSourceDate=
+else
+    keepSourceDate=true
+fi
+
 usage(){
     echo  >&2 "syntax: nix-prefetch-git [options] [URL [REVISION [EXPECTED-HASH]]]
 
@@ -53,6 +60,7 @@ Options:
       --deepClone     Clone the entire repository.
       --no-deepClone  Make a shallow clone of just the required ref.
       --leave-dotGit  Keep the .git directories.
+      --keep-source-date Keep source date in nix-support/SOURCE_DATE_EPOCH
       --fetch-lfs     Fetch git Large File Storage (LFS) files.
       --fetch-submodules Fetch submodules.
       --builder       Clone as fetchgit does, but url, rev, and out option are mandatory.
@@ -84,6 +92,7 @@ for arg; do
             --leave-dotGit) leaveDotGit=true;;
             --fetch-lfs) fetchLFS=true;;
             --fetch-submodules) fetchSubmodules=true;;
+            --keep-source-date) keepSourceDate=true;;
             --builder) builder=true;;
             -h|--help) usage; exit;;
             *)
@@ -323,6 +332,12 @@ clone_user_rev() {
     humanReadableRev=$(git describe "$fullRev" 2> /dev/null || git describe --tags "$fullRev" 2> /dev/null || echo -- none --)
     commitDate=$(git show -1 --no-patch --pretty=%ci "$fullRev")
     commitDateStrict8601=$(git show -1 --no-patch --pretty=%cI "$fullRev")
+
+    if [ -n "$keepSourceDate" ]; then
+      mkdir nix-support || true
+      git show -1 --no-patch --pretty=%ct "$fullRev" > nix-support/SOURCE_DATE_EPOCH
+    fi
+
     popd >/dev/null
 
     # Allow doing additional processing before .git removal
@@ -401,7 +416,8 @@ print_results() {
   "fetchLFS": $([[ -n "$fetchLFS" ]] && echo true || echo false),
   "fetchSubmodules": $([[ -n "$fetchSubmodules" ]] && echo true || echo false),
   "deepClone": $([[ -n "$deepClone" ]] && echo true || echo false),
-  "leaveDotGit": $([[ -n "$leaveDotGit" ]] && echo true || echo false)
+  "leaveDotGit": $([[ -n "$leaveDotGit" ]] && echo true || echo false),
+  "keepSourceDate: $([[ -n "$keepSourceDate" ]] && echo true || echo false)
 }
 EOF
     fi

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -6,7 +6,7 @@ lib.makeOverridable (
 , rev ? null
 , name ? "source"
 , fetchSubmodules ? false, leaveDotGit ? null
-, deepClone ? false, private ? false, forceFetchGit ? false
+, deepClone ? false, private ? false, forceFetchGit ? false, keepSourceDate ? false
 , fetchLFS ? false
 , sparseCheckout ? []
 , githubBase ? "github.com", varPrefix ? null
@@ -63,7 +63,7 @@ let
 
   fetcherArgs = (if useFetchGit
     then {
-      inherit tag rev deepClone fetchSubmodules sparseCheckout fetchLFS; url = gitRepoUrl;
+      inherit tag rev deepClone keepSourceDate fetchSubmodules sparseCheckout fetchLFS; url = gitRepoUrl;
     } // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
     else {
       url = "${baseUrl}/archive/${revWithTag}.tar.gz";

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -28,6 +28,9 @@
   # an appropriate unpacking tool.
   extension ? null,
 
+  # put the archive timestamp into $out/nix-support/SOURCE_DATE_EPOCH
+  keepSourceDate ? false,
+
   # the rest are given to fetchurl as is
   ...
 }@args:
@@ -91,6 +94,11 @@ fetchurl (
             mv "$unpackDir" "$out"
           ''
       )
+      + (lib.optionalString keepSourceDate ''
+        stat -c '%Y' "$out" > SOURCE_DATE_EPOCH
+        mkdir -p $out/nix-support
+        mv SOURCE_DATE_EPOCH $out/nix-support
+      '')
       + ''
         ${postFetch}
         ${extraPostFetch}
@@ -105,5 +113,6 @@ fetchurl (
     "postFetch"
     "extension"
     "nativeBuildInputs"
+    "keepSourceDate"
   ]
 )

--- a/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
+++ b/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
@@ -4,6 +4,16 @@ updateSourceDateEpoch() {
     #   https://salsa.debian.org/reproducible-builds/diffoscope/-/issues/378
     [[ $path == -* ]] && path="./$path"
 
+    # If a derivation can reliably determine the source date,
+    # it can pass along this information in /nix-support/SOURCE_DATE_EPOCH
+    # (as any file timestamps are cleared from the NAR format)
+    if [ -f "$1/nix-support/SOURCE_DATE_EPOCH" ]; then
+        local time=$(cat "$1/nix-support/SOURCE_DATE_EPOCH")
+        echo "setting SOURCE_DATE_EPOCH to timestamp $time from $1/nix-support/SOURCE_DATE_EPOCH"
+        export SOURCE_DATE_EPOCH="$time"
+        return
+    fi
+
     # Get the last modification time of all regular files, sort them,
     # and get the most recent. Maybe we should use
     # https://github.com/0-wiz-0/findnewest here.

--- a/pkgs/by-name/sc/scorecard/package.nix
+++ b/pkgs/by-name/sc/scorecard/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
     owner = "ossf";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-9DuADuEIoZNwkvdKyqus2zNfIK31Jc3+bPW3/z8fvlc=";
+    hash = "sha256-8o5tE/9Bx4y7x2Y+1JX1b6UyayXGbjnyf2S0TjXok/Q=";
     # populate values otherwise taken care of by goreleaser,
     # unfortunately these require us to use git. By doing
     # this in postFetch we can delete .git afterwards and
@@ -24,10 +24,9 @@ buildGoModule rec {
     postFetch = ''
       cd "$out"
       git rev-parse HEAD > $out/COMMIT
-      # 0000-00-00T00:00:00Z
-      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
+    keepSourceDate = true;
   };
   vendorHash = "sha256-apOVAlGjaYSrW4qtUdDNgqwWxnVlBLhrefWEUvN4lzE=";
 
@@ -45,7 +44,7 @@ buildGoModule rec {
   # ldflags based on metadata from git and source
   preBuild = ''
     ldflags+=" -X sigs.k8s.io/release-utils/version.gitCommit=$(cat COMMIT)"
-    ldflags+=" -X sigs.k8s.io/release-utils/version.buildDate=$(cat SOURCE_DATE_EPOCH)"
+    ldflags+=" -X sigs.k8s.io/release-utils/version.buildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" "+%Y-%m-%dT%H:%M:%SZ")"
   '';
 
   preCheck = ''

--- a/pkgs/test/stdenv/hooks.nix
+++ b/pkgs/test/stdenv/hooks.nix
@@ -139,5 +139,22 @@
       touch $out
     '';
   };
+  set-source-date-epoch-to-recorded = stdenv.mkDerivation {
+    name = "test-set-source-date-epoch-to-recorded";
+    buildCommand = ''
+      sourceRoot=$NIX_BUILD_TOP/source
+      mkdir -p $sourceRoot/nix-support
+      # Even when an older (unchanged) or newer (generated?) date
+      # is found in the repo timestamps:
+      touch --date=1/1/2014 $sourceRoot/foo
+      touch --date=1/1/2016 $sourceRoot/foo
+      echo 1420070400 > $sourceRoot/nix-support/SOURCE_DATE_EPOCH
+
+      _updateSourceDateEpochFromSourceRoot
+
+      [[ $SOURCE_DATE_EPOCH == "1420070400" ]]
+      touch $out
+    '';
+  };
   # TODO: add strip
 }


### PR DESCRIPTION
Currently, `set-source-date-epoch-to-latest.sh` only correctly populates the `SOURCE_DATE_EPOCH` environment variable for archives that are unpacked during the derivation unpack phase. For fetchers that produce the source already-unpacked, such as `fetchFromGitea` and `fetchFromGitHub`, the timestamp is lost because the NAR format does not preserve file timestamps.

## Description of changes

This change introduces a `keepSourceDate` option to those fetchers which instructs them to retain the archive timestamp in `out/nix-support/SOURCE_DATE_EPOCH`, and updates `set-source-date-epoch-to-latest.sh` to pick it up.

TODO: more testing: 
* [ ] does this work on darwin
* [ ] other filesystem types
* [ ] timezones
* [ ] different forges
* [x] FODs
* [ ] other fetchers
* [ ] derivations combining multiple sources


## Things done

You can test with:

```
{ pkgs ? import <nixpkgs> {} }:

pkgs.stdenv.mkDerivation {
  pname = "hello";
  version = "snapshot";

  src = pkgs.fetchFromGitea {
    domain = "codeberg.org";
    owner = "raboof";
    repo = "hello";
    rev = "81f51c650c8731a888b8418e86115269edf0c98d";
    hash = "sha256-3UcB/Fwmo+dIGzUImNOWwXHETXzYcWc/zjfx49I3Omo=";
    keepSourceDate = true;
  };

  installPhase = ''
    mkdir -p $out/bin
    cp hello $out/bin
  '';
}
```

```
$ $(nix-build hello.nix -I nixpkgs=/home/aengelen/nixpkgs-r13y)/bin/hello
Hello! 2023-09-19 19:02:06 called!
```


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
