### PR TITLE
libspelling: unstable-2023-07-17 -> 0.2.0

### DIFF
--- a/pkgs/development/libraries/libspelling/default.nix
+++ b/pkgs/development/libraries/libspelling/default.nix
@@ -12,11 +12,12 @@
 , gtksourceview5
 , enchant
 , icu
+, nix-update-script
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "libspelling";
-  version = "unstable-2023-07-17";
+  version = "0.2.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
@@ -24,8 +25,8 @@ stdenv.mkDerivation {
     domain = "gitlab.gnome.org";
     owner = "chergert";
     repo = "libspelling";
-    rev = "65185023db95ec464970aeaeab766fe3ba26ae7d";
-    hash = "sha256-R3nPs16y8XGamQvMSF7wb52h0jxt17H2FZPwauLDI/c=";
+    rev = version;
+    hash = "sha256-OOSQgdtnEx6/5yKwavCGdY/5L0Mr3XW0Srmd42ZTdUk=";
   };
 
   nativeBuildInputs = [
@@ -50,10 +51,13 @@ stdenv.mkDerivation {
     moveToOutput "share/doc" "$devdoc"
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = with lib; {
     description = "Spellcheck library for GTK 4";
     homepage = "https://gitlab.gnome.org/chergert/libspelling";
     license = licenses.lgpl21Plus;
+    changelog = "https://gitlab.gnome.org/chergert/libspelling/-/raw/${version}/NEWS";
     maintainers = with maintainers; [ chuangzhu ];
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
