### PR TITLE
python310Packages.hyperpyyaml: fix

### DIFF
--- a/pkgs/development/python-modules/hyperpyyaml/default.nix
+++ b/pkgs/development/python-modules/hyperpyyaml/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , pyyaml
 , ruamel-yaml
 , pytestCheckHook
@@ -17,6 +18,15 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-tC4kLJAY9MVgjWwU2Qu0rPCVDw7CjKVIciRZgYhnR9I=";
   };
+
+  patches = [
+    # This patch is needed to comply with the newer versions of ruamel.yaml.
+    # PR to upstream this change: https://github.com/speechbrain/HyperPyYAML/pull/23
+    (fetchpatch {
+      url = "https://github.com/speechbrain/HyperPyYAML/commit/95c6133686c42764770a77429eab55f6dfe5581c.patch";
+      hash = "sha256-WrHDo17f5pYNXSSqI8t1tlAloYms9oLFup7D2qCKwWw=";
+    })
+  ];
 
   propagatedBuildInputs = [
     pyyaml
@@ -35,7 +45,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/speechbrain/HyperPyYAML/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ GaetanLepage ];
-    # hyperpyyaml is not compatible with the too new version of `ruaml-yaml`
-    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

`hyperpyyaml` has been broken by a breaking change in its dependency `ruamel-yaml`.
This PR adds a patch that adapts to the new behavior.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
