### PR TITLE
goss,dgoss: use wrapProgram to set $PATH for sh, getent, systemctl 

### DIFF
--- a/pkgs/tools/misc/dgoss/default.nix
+++ b/pkgs/tools/misc/dgoss/default.nix
@@ -42,7 +42,8 @@ resholve.mkDerivation rec {
     changelog = "https://github.com/goss-org/goss/releases/tag/v${version}";
     description = "Convenience wrapper around goss that aims to bring the simplicity of goss to docker containers";
     license = licenses.asl20;
-    platforms = platforms.linux;
+    mainProgram = "dgoss";
     maintainers = with maintainers; [ hyzual anthonyroussel ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/dgoss/default.nix
+++ b/pkgs/tools/misc/dgoss/default.nix
@@ -44,6 +44,6 @@ resholve.mkDerivation rec {
     license = licenses.asl20;
     mainProgram = "dgoss";
     maintainers = with maintainers; [ hyzual anthonyroussel ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/tools/misc/goss/default.nix
+++ b/pkgs/tools/misc/goss/default.nix
@@ -51,7 +51,8 @@ buildGoModule rec {
       Once the test suite is written they can be executed, waited-on, or served as a health endpoint.
     '';
     license = licenses.asl20;
-    platforms = platforms.linux ++ platforms.darwin;
+    mainProgram = "goss";
     maintainers = with maintainers; [ hyzual jk anthonyroussel ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
## Description of changes

This will fix the failing `command` resource of `goss` which requires the `sh` binary in the `PATH`.

This happens when running `goss` as SystemD service with a `command` ressource, in that case, `goss` fails with a `sh: command not found` error when the /healthz endpoint is called. Because `sh` is not in the `PATH`.

See

* https://github.com/goss-org/goss/blob/v0.4.2/system/command_posix.go#L8
* https://github.com/goss-org/goss/blob/v0.4.2/system/service_systemd.go#L37
* https://github.com/goss-org/goss/blob/v0.4.2/system/file.go#L230

Required to continue my work on the goss NixOS module.

Also added meta.mainProgram to goss and dgoss.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
