### PR TITLE
Revert "[Backport release-23.05] chromium,ungoogled-chromium,chromedriver: 116.0.5845.187/96 -> 117.0.5938.88"

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -241,12 +241,6 @@ let
       # We need the fix for https://bugs.chromium.org/p/chromium/issues/detail?id=1254408:
       base64 --decode ${clangFormatPython3} > buildtools/linux64/clang-format
 
-      # Add final newlines to scripts that do not end with one.
-      # This is a temporary workaround until https://github.com/NixOS/nixpkgs/pull/255463 (or similar) has been merged,
-      # as patchShebangs hard-crashes when it encounters files that contain only a shebang and do not end with a final
-      # newline.
-      find . -type f -perm -0100 -exec sed -i -e '$a\' {} +
-
       patchShebangs .
       # Link to our own Node.js and Java (required during the build):
       mkdir -p third_party/node/linux/node-linux-x64/bin

--- a/pkgs/applications/networking/browsers/chromium/ungoogled-flags.toml
+++ b/pkgs/applications/networking/browsers/chromium/ungoogled-flags.toml
@@ -4,6 +4,7 @@ clang_use_chrome_plugins=false
 disable_fieldtrial_testing_config=true
 enable_hangout_services_extension=false
 enable_mdns=false
+enable_mse_mpeg2ts_stream_parser=true
 enable_nacl=false
 enable_reading_list=false
 enable_remoting=false

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -27,39 +27,39 @@
   };
   stable = {
     chromedriver = {
-      sha256_darwin = "0phhcqid7wjw923qdi65zql3fid25swwszksgnw3b8fgz67jn955";
+      sha256_darwin = "0gzx3zka8i2ngsdiqp8sr0v6ir978vywa1pj7j08vsf8kmb93iiy";
       sha256_darwin_aarch64 =
-        "00fwq8slvjm6c7krgwjd4mxhkkrp23n4icb63qlvi2hy06gfj4l6";
-      sha256_linux = "0ws8ch1j2hzp483vr0acvam1zxmzg9d37x6gqdwiqwgrk6x5pvkh";
-      version = "117.0.5938.88";
+        "18iyapwjg0yha8qgbw7f605n0j54nd36shv3497bd84lc9k74b14";
+      sha256_linux = "0d8mqzjc11g1bvxvffk0xyhxfls2ycl7ym4ssyjq752g2apjblhp";
+      version = "116.0.5845.96";
     };
     deps = {
       gn = {
-        rev = "811d332bd90551342c5cbd39e133aa276022d7f8";
-        sha256 = "0jlg3d31p346na6a3yk0x29pm6b7q03ck423n5n6mi8nv4ybwajq";
+        rev = "4bd1a77e67958fb7f6739bd4542641646f264e5d";
+        sha256 = "14h9jqspb86sl5lhh6q0kk2rwa9zcak63f8drp7kb3r4dx08vzsw";
         url = "https://gn.googlesource.com/gn";
-        version = "2023-08-01";
+        version = "2023-06-09";
       };
     };
-    sha256 = "01n9aqnilsjrbpv5kkx3c6nxs9p5l5lfwxj67hd5s5g4740di4a6";
-    sha256bin64 = "1dhgagphdzbd19gkc7vpl1hxc9vn0l7sxny346qjlmrwafqlhbgi";
-    version = "117.0.5938.88";
+    sha256 = "152lyrw8k36gbmf4fmfny4ajqh0523y5d48yrshbgwn5klmbhaji";
+    sha256bin64 = "118sk39939d52srws2vgs1mfizpikswxh5ihd9x053vzn0aj8cfa";
+    version = "116.0.5845.187";
   };
   ungoogled-chromium = {
     deps = {
       gn = {
-        rev = "811d332bd90551342c5cbd39e133aa276022d7f8";
-        sha256 = "0jlg3d31p346na6a3yk0x29pm6b7q03ck423n5n6mi8nv4ybwajq";
+        rev = "4bd1a77e67958fb7f6739bd4542641646f264e5d";
+        sha256 = "14h9jqspb86sl5lhh6q0kk2rwa9zcak63f8drp7kb3r4dx08vzsw";
         url = "https://gn.googlesource.com/gn";
-        version = "2023-08-01";
+        version = "2023-06-09";
       };
       ungoogled-patches = {
-        rev = "117.0.5938.88-1";
-        sha256 = "1wz15ib56j8c84bgrbf0djk5wli49b1lvaqbg18pdclkp1mqy5w9";
+        rev = "116.0.5845.187-1";
+        sha256 = "0br5lms6mxg2mg8ix5mkb79bg6wk5f2hn0xy1xc7gk9h3rl58is1";
       };
     };
-    sha256 = "01n9aqnilsjrbpv5kkx3c6nxs9p5l5lfwxj67hd5s5g4740di4a6";
-    sha256bin64 = "1dhgagphdzbd19gkc7vpl1hxc9vn0l7sxny346qjlmrwafqlhbgi";
-    version = "117.0.5938.88";
+    sha256 = "152lyrw8k36gbmf4fmfny4ajqh0523y5d48yrshbgwn5klmbhaji";
+    sha256bin64 = "118sk39939d52srws2vgs1mfizpikswxh5ihd9x053vzn0aj8cfa";
+    version = "116.0.5845.187";
   };
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#255696

This is due to some obscure linking issue in the past linking step.
I'll try to look into this, and hopefully revert the revert soon-ish.

The chromium bump is not too severe, in the context of chromium releases
at least, as they are "only" medium severity CVEs 🫠

This has not been caught by ofborg, because it never reached the final
linking step in the buildPhase, due to the globally hardcoded 3600s
timeout.

Failed hydra builds: https://hydra.nixos.org/build/235844127

This reverts merge commit d6274e5a50df8f3c1c8a617cf98ac0d1ae7a00a8.
Which in turn reverts a9e1b120f2e2c4fd9f4a85b99ffe8f64871d108f, 020a58950c8bf52782f6fc57d825884e77466cf5, f5d7664e4c751da3982d702eb1f49414bc565912 and 95ee3b768c16bd2e9f5c95af0232b45c08f71d6f.