### PR TITLE
Write meta attribute as JSON into the derivation

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -131,7 +131,7 @@ let
   strictDeps ? if config.strictDepsByDefault then true else stdenv.hostPlatform != stdenv.buildPlatform
 
 , enableParallelBuilding ? config.enableParallelBuildingByDefault
-
+, enablePropagateMeta ? false
 , meta ? {}
 , passthru ? {}
 , pos ? # position used in error messages and for meta.position
@@ -296,6 +296,9 @@ else let
        "__impureHostDeps" "__propagatedImpureHostDeps"
        "sandboxProfile" "propagatedSandboxProfile"]
        ++ lib.optional (__structuredAttrs || envIsExportable) "env"))
+    // (lib.optionalAttrs (enablePropagateMeta && attrs ? meta)) {
+      metaJSON = builtins.toJSON attrs.meta;
+    }
     // (lib.optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
       name =
         let


### PR DESCRIPTION
This allows to generate SBOMs and filter derivations based on license without relying on evaluation time information.

The downside is that changing meta attributes triggers a rebuild (which shouldn't have much impact with CA derivations).

Another downside is disk space usage, for example pkgs.git closure of .drv files goes from 3.8MB to 4.4MB.

This is part of a larger effort to bring security vulnerability notifications to https://cachix.org and anyone else that wants to have the automation.