### PR TITLE
kmsbd-tools: move rundir and sysconfdir out of store

### DIFF
--- a/pkgs/os-specific/linux/ksmbd-tools/default.nix
+++ b/pkgs/os-specific/linux/ksmbd-tools/default.nix
@@ -22,13 +22,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-GZccOlp9zZMqtv3+u8JnKFfIe8sjwbZBLkDk8lt3CGk=";
   };
 
+  patches = [ ./fix-sample-config-install-dir.patch ];
+
   buildInputs = [ glib libnl ] ++ lib.optional withKerberos libkrb5;
 
   nativeBuildInputs = [ autoconf automake libtool pkg-config ];
 
   preConfigure = "./autogen.sh";
 
-  configureFlags = lib.optional withKerberos "--enable-krb5";
+  configureFlags = ["--with-rundir=/run" "--sysconfdir=/etc"] ++ lib.optionals withKerberos ["--enable-krb5"];
 
   meta = with lib; {
     description = "Userspace utilities for the ksmbd kernel SMB server";

--- a/pkgs/os-specific/linux/ksmbd-tools/fix-sample-config-install-dir.patch
+++ b/pkgs/os-specific/linux/ksmbd-tools/fix-sample-config-install-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index 0014d7e..620477f 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -11,7 +11,7 @@ EXTRA_DIST = include \
+ 	     meson.build \
+ 	     meson_options.txt
+
+-pkgsysconfdir = $(sysconfdir)/ksmbd
++pkgsysconfdir = $(out)$(sysconfdir)/ksmbd
+ dist_pkgsysconf_DATA = ksmbd.conf.example
+
+ man_MANS = ksmbd.conf.5 ksmbdpwd.db.5


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Otherwise, the binaries will try to create files in `/nix/.../etc` and `/nix/.../run` instead of `/etc` and `/run`. This change requires a small patch to the source to ensure that the sample config file still gets installed in `$out`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
I tested `ksmbd.control` to run an SMB-server with a config-file and `ksmbd.adduser` to create a user with the patch.
