### PR TITLE
opentofu: init at v1.6.0-alpha1

### DIFF
--- a/pkgs/applications/networking/cluster/opentofu/default.nix
+++ b/pkgs/applications/networking/cluster/opentofu/default.nix
@@ -1,0 +1,172 @@
+{ stdenv
+, lib
+, buildGoModule
+, fetchFromGitHub
+, makeWrapper
+, coreutils
+, runCommand
+, runtimeShell
+, writeText
+, terraform-providers
+, installShellFiles
+}:
+
+let
+  package =  buildGoModule rec {
+    pname = "opentofu";
+    version = "1.6.0-alpha1";
+
+    src = fetchFromGitHub {
+      owner = "opentofu";
+      repo = "opentofu";
+      rev = "v${version}";
+      hash = "sha256-0FO55H1nOyhAd+ex1zA0XycH6x/HKkLlxzuIJNoaI9g=";
+    };
+    vendorHash = "sha256-3jQfIIZOgOmNHQ06rXz+3QTZ37WcuCc7A7/MhC7udrg=";
+    ldflags = [ "-s" "-w" ];
+
+    postConfigure = ''
+      # speakeasy hardcodes /bin/stty https://github.com/bgentry/speakeasy/issues/22
+      substituteInPlace vendor/github.com/bgentry/speakeasy/speakeasy_unix.go \
+        --replace "/bin/stty" "${coreutils}/bin/stty"
+    '';
+
+    nativeBuildInputs = [ installShellFiles ];
+    patches = [ ./provider-path-0_15.patch ];
+
+    passthru = {
+      inherit plugins withPlugins;
+      tests = { inherit opentofu_plugins_test; };
+    };
+
+    # https://github.com/posener/complete/blob/9a4745ac49b29530e07dc2581745a218b646b7a3/cmd/install/bash.go#L8
+    postInstall = ''
+      installShellCompletion --bash --name tofu <(echo complete -C tofu tofu)
+    '';
+
+    preCheck = ''
+      export HOME=$TMPDIR
+      export TF_SKIP_REMOTE_TESTS=1
+    '';
+
+    subPackages = [ "./cmd/..." ];
+
+    meta = with lib; {
+      description = "Tool for building, changing, and versioning infrastructure";
+      homepage = "https://opentofu.org/";
+      changelog = "https://github.com/opentofu/opentofu/blob/v${version}/CHANGELOG.md";
+      license = licenses.mpl20;
+      maintainers = with maintainers; [
+        gmemstr
+      ];
+      mainProgram = "tofu";
+    };
+  };
+
+  opentofu_plugins_test = let
+    mainTf = writeText "main.tf" ''
+      resource "random_id" "test" {}
+    '';
+    opentofu = package.withPlugins (p: [ p.random ]);
+    test = runCommand "opentofu-plugin-test" {
+      buildInputs = [ opentofu ];
+    } ''
+      # make it fail outside of sandbox
+      export HTTP_PROXY=http://127.0.0.1:0 HTTPS_PROXY=https://127.0.0.1:0
+      cp ${mainTf} main.tf
+      tofu init
+      touch $out
+    '';
+  in
+    test;
+
+  plugins = removeAttrs terraform-providers [
+    "override"
+    "overrideDerivation"
+    "recurseForDerivations"
+  ];
+
+  withPlugins = plugins:
+    let
+      actualPlugins = plugins package.plugins;
+
+      # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
+      wrapperInputs = lib.unique (lib.flatten
+        (lib.catAttrs "propagatedBuildInputs"
+          (builtins.filter (x: x != null) actualPlugins)));
+
+      passthru = {
+        withPlugins = newplugins:
+          withPlugins (x: newplugins x ++ actualPlugins);
+        full = withPlugins (p: lib.filter lib.isDerivation (lib.attrValues p.actualProviders));
+
+        # Expose wrappers around the override* functions of the terraform
+        # derivation.
+        #
+        # Note that this does not behave as anyone would expect if plugins
+        # are specified. The overrides are not on the user-visible wrapper
+        # derivation but instead on the function application that eventually
+        # generates the wrapper. This means:
+        #
+        # 1. When using overrideAttrs, only `passthru` attributes will
+        #    become visible on the wrapper derivation. Other overrides that
+        #    modify the derivation *may* still have an effect, but it can be
+        #    difficult to follow.
+        #
+        # 2. Other overrides may work if they modify the terraform
+        #    derivation, or they may have no effect, depending on what
+        #    exactly is being changed.
+        #
+        # 3. Specifying overrides on the wrapper is unsupported.
+        #
+        # See nixpkgs#158620 for details.
+        overrideDerivation = f:
+          (package.overrideDerivation f).withPlugins plugins;
+        overrideAttrs = f:
+          (package.overrideAttrs f).withPlugins plugins;
+        override = x:
+          (package.override x).withPlugins plugins;
+      };
+      # Don't bother wrapping unless we actually have plugins, since the wrapper will stop automatic downloading
+      # of plugins, which might be counterintuitive if someone just wants a vanilla Terraform.
+    in
+      if actualPlugins == [ ] then
+        package.overrideAttrs
+          (orig: { passthru = orig.passthru // passthru; })
+      else
+        lib.appendToName "with-plugins" (stdenv.mkDerivation {
+          inherit (package) meta pname version;
+          nativeBuildInputs = [ makeWrapper ];
+
+          # Expose the passthru set with the override functions
+          # defined above, as well as any passthru values already
+          # set on `terraform` at this point (relevant in case a
+          # user overrides attributes).
+          passthru = package.passthru // passthru;
+
+          buildCommand = ''
+            # Create wrappers for terraform plugins because Terraform only
+            # walks inside of a tree of files.
+            for providerDir in ${toString actualPlugins}
+            do
+              for file in $(find $providerDir/libexec/terraform-providers -type f)
+              do
+                relFile=''${file#$providerDir/}
+                mkdir -p $out/$(dirname $relFile)
+                cat <<WRAPPER > $out/$relFile
+            #!${runtimeShell}
+            exec "$file" "$@"
+            WRAPPER
+                chmod +x $out/$relFile
+              done
+            done
+
+            # Create a wrapper for opentofu to point it to the plugins dir.
+            mkdir -p $out/bin/
+            makeWrapper "${package}/bin/tofu" "$out/bin/tofu" \
+              --set NIX_TERRAFORM_PLUGIN_DIR $out/libexec/terraform-providers \
+              --prefix PATH : "${lib.makeBinPath wrapperInputs}"
+          '';
+        });
+in
+package

--- a/pkgs/applications/networking/cluster/opentofu/provider-path-0_15.patch
+++ b/pkgs/applications/networking/cluster/opentofu/provider-path-0_15.patch
@@ -1,0 +1,23 @@
+diff -Naur terraform.old/internal/command/init.go terraform.new/internal/command/init.go
+--- terraform.old/internal/command/init.go
++++ terraform.new/internal/command/init.go
+@@ -3,6 +3,7 @@
+ import (
+ 	"context"
+ 	"fmt"
++	"os"
+ 	"log"
+ 	"strings"
+ 
+@@ -55,6 +56,11 @@
+ 
+ 	var diags tfdiags.Diagnostics
+ 
++	val, ok := os.LookupEnv("NIX_TERRAFORM_PLUGIN_DIR")
++	if ok {
++		flagPluginPath = append(flagPluginPath, val)
++	}
++
+ 	if len(flagPluginPath) > 0 {
+ 		c.pluginPath = flagPluginPath
+ 	}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11619,6 +11619,8 @@ with pkgs;
 
   opensp = callPackage ../tools/text/sgml/opensp { };
 
+  opentofu = callPackage ../applications/networking/cluster/opentofu { };
+
   opentrack = libsForQt5.callPackage ../applications/misc/opentrack { };
 
   opentracker = callPackage ../applications/networking/p2p/opentracker { };


### PR DESCRIPTION
## Description of changes

OpenTofu is a fork of Terraform pre-BSL, so the package is pretty similar to the Terraform one with names swapped around. Happy to take this further if needed but given the current state of opentofu I felt this was probably? okay. That said, I did remove the existing Terraform maintainers as well, but am happy to re-add them if they're good with maintaining opentofu as well.

~~Opentofu is not yet tagged with a version so I've opted to go with the latest commit at the time of creation.~~

Closes https://github.com/NixOS/nixpkgs/issues/253469

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
