### PR TITLE
fuse3: 3.11.0 -> 3.16.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -238,6 +238,18 @@
 
 - `fileSystems.<name>.autoResize` now uses `systemd-growfs` to resize the file system online in stage 2. This means that `f2fs` and `ext2` can no longer be auto resized, while `xfs` and `btrfs` now can be.
 
+- `fuse3` has been updated from 3.11.0 to 3.16.2; see [ChangeLog.rst](https://github.com/libfuse/libfuse/blob/fuse-3.16.2/ChangeLog.rst#libfuse-3162-2023-10-10) for an overview of the changes.
+
+  Unsupported mount options are no longer silently accepted [(since 3.15.0)](https://github.com/libfuse/libfuse/blob/fuse-3.16.2/ChangeLog.rst#libfuse-3150-2023-06-09). The [affected mount options](https://github.com/libfuse/libfuse/commit/dba6b3983af34f30de01cf532dff0b66f0ed6045) are: `atime`, `diratime`, `lazytime`, `nolazytime`, `relatime`, `norelatime`, `strictatime`.
+
+  For example,
+
+  ```bash
+  $ sshfs 127.0.0.1:/home/test/testdir /home/test/sshfs_mnt -o atime`
+  ```
+
+  would previously terminate successfully with the mount point established, now it outputs the error message ``fuse: unknown option(s): `-o atime'`` and terminates with exit status 1.
+
 - `nixos-rebuild {switch,boot,test,dry-activate}` now runs the system activation inside `systemd-run`, creating an ephemeral systemd service and protecting the system switch against issues like network disconnections during remote (e.g. SSH) sessions. This has the side effect of running the switch in an isolated environment, that could possible break post-switch scripts that depends on things like environment variables being set. If you want to opt-out from this behavior for now, you may set the `NIXOS_SWITCH_USE_DIRTY_ENV` environment variable before running `nixos-rebuild`. However, keep in mind that this option will be removed in the future.
 
 - The `services.vaultwarden.config` option default value was changed to make Vaultwarden only listen on localhost, following the [secure defaults for most NixOS services](https://github.com/NixOS/nixpkgs/issues/100192).

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -1,4 +1,4 @@
-{ version, sha256Hash }:
+{ version, hash }:
 
 { lib, stdenv, fetchFromGitHub, fetchpatch
 , fusePackages, util-linux, gettext, shadow
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
     owner = "libfuse";
     repo = "libfuse";
     rev = "${pname}-${version}";
-    sha256 = sha256Hash;
+    inherit hash;
   };
 
   preAutoreconf = "touch config.rpath";
@@ -48,6 +48,7 @@ in stdenv.mkDerivation rec {
   mesonFlags = lib.optionals isFuse3 [
     "-Dudevrulesdir=/udev/rules.d"
     "-Duseroot=false"
+    "-Dinitscriptdir="
   ];
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -7,11 +7,11 @@ let
 in {
   fuse_2 = mkFuse {
     version = "2.9.9";
-    sha256Hash = "1yxxvm58c30pc022nl1wlg8fljqpmwnchkywic3r74zirvlcq23n";
+    hash = "sha256-dgjM6M7xk5MHi9xPyCyvF0vq0KM8UCsEYBcMhkrdvfs=";
   };
 
   fuse_3 = mkFuse {
-    version = "3.11.0";
-    sha256Hash = "1wx80xxlvjn0wxhmkr1g91vwrgxssyzds1hizzxc2xrd4kjh9dfb";
+    version = "3.16.1";
+    hash = "sha256-9UYrZ+aYwoa7OmsmUGvOW9uBzTw+p+ugjTMiQIHQ804=";
   };
 }

--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -11,7 +11,7 @@ in {
   };
 
   fuse_3 = mkFuse {
-    version = "3.16.1";
-    hash = "sha256-9UYrZ+aYwoa7OmsmUGvOW9uBzTw+p+ugjTMiQIHQ804=";
+    version = "3.16.2";
+    hash = "sha256-QO9s+IkR0rkqIYNqt2IYST6AVBkCr56jcuuz5nKJuA4=";
   };
 }

--- a/pkgs/os-specific/linux/fuse/fuse3-Do-not-set-FUSERMOUNT_DIR.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-Do-not-set-FUSERMOUNT_DIR.patch
@@ -1,12 +1,13 @@
+diff --git a/lib/meson.build b/lib/meson.build
 --- a/lib/meson.build
 +++ b/lib/meson.build
 @@ -37,8 +37,7 @@ libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
                    soversion: '3', include_directories: include_dirs,
                    dependencies: deps, install: true,
                    link_depends: 'fuse_versionscript',
--                  c_args: [ '-DFUSE_USE_VERSION=35',
+-                  c_args: [ '-DFUSE_USE_VERSION=312',
 -                            '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ],
-+                  c_args: [ '-DFUSE_USE_VERSION=35' ],
++                  c_args: [ '-DFUSE_USE_VERSION=312' ],
                    link_args: ['-Wl,--version-script,' + meson.current_source_dir()
                                + '/fuse_versionscript' ])
  

--- a/pkgs/os-specific/linux/fuse/fuse3-install.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-install.patch
@@ -1,18 +1,20 @@
---- a/util/install_helper.sh	2019-07-10 12:00:15.984840142 +0200
-+++ b/util/install_helper.sh	2019-07-10 12:28:56.343011401 +0200
-@@ -37,10 +37,10 @@
- fi
+--- a/util/install_helper.sh	2023-08-26 22:12:11.028651669 +0200
++++ b/util/install_helper.sh	2023-08-26 22:38:03.165058694 +0200
+@@ -39,12 +39,12 @@
  
- install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
+ if [ "${udevrulesdir}" != "" ]; then
+     install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
 -        "${DESTDIR}${udevrulesdir}/99-fuse3.rules"
 +        "${sysconfdir}${udevrulesdir}/99-fuse3.rules"
+ fi
  
- install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
--        "${DESTDIR}/etc/init.d/fuse3"
-+        "${sysconfdir}/init.d/fuse3"
+ if [ "$initscriptdir" != "" ]; then
+     install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
+-            "${DESTDIR}${initscriptdir}/fuse3"
++            "${sysconfdir}${initscriptdir}/fuse3"
  
- 
- if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
+     if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
+         /usr/sbin/update-rc.d fuse3 start 34 S . start 41 0 6 . || /bin/true
 diff --git a/util/meson.build b/util/meson.build
 index aa0e734..06d4378 100644
 --- a/util/meson.build


### PR DESCRIPTION
## Description of changes

https://github.com/libfuse/libfuse/blob/fuse-3.16.2/ChangeLog.rst#libfuse-3162-2023-10-10
https://github.com/libfuse/libfuse/compare/fuse-3.11.0...fuse-3.16.2

---

One change can be expected to break some setups:
- Unsupported mount options are no longer silently accepted [[commit](https://github.com/libfuse/libfuse/commit/dba6b3983af34f30de01cf532dff0b66f0ed6045)]

For example, `sshfs` built against the present libfuse 3.11.0,

`$ sshfs 127.0.0.1:/home/test/testdir /home/test/sshfs_mnt -o atime`

terminates successfully (with the mount point established), while when built against 3.16.1, it outputs the error message ``fuse: unknown option(s): `-o atime'`` and terminates with exit status 1.

libfuse 3.12.0 introduced a new API version [[commit](https://github.com/libfuse/libfuse/commit/30a126c5f9009e8ff8e369c563eb941679bec252)]. From what I can tell, since file system implementations are supposed to define themselves the FUSE API version they want to be compiled against (failing that, nixpkgs would have to set it via a build parameter and keep it in sync with upstream), this is supposed to come into play on an opt-in basis only, and the change should be fully backwards-compatible to current derivations that (directly) depend on `fuse3`.

## Things done

Tested using `sshfs`.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->