### PR TITLE
tortoisehg: Add qt5.qtwayland support

### DIFF
--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -14,40 +14,47 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-Xbvg/FcuX/AL2reWsaM2oaFyLby3+HDCfYtRyswE7DA=";
   };
 
-  # Extension point for when thg's mercurial is lagging behind mainline.
-  tortoiseMercurial = mercurial;
-
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+  ];
   propagatedBuildInputs = with python3Packages; [
-    tortoiseMercurial
+    mercurial
+    # The one from python3Packages
     qscintilla-qt5
     iniparse
   ];
-  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
 
-  doCheck = true;
+  # In order to spare double wrapping, we use:
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+  # Convenient alias
   postInstall = ''
-    mkdir -p $out/share/doc/tortoisehg
-    cp COPYING.txt $out/share/doc/tortoisehg/Copying.txt
-    # convenient alias
     ln -s $out/bin/thg $out/bin/tortoisehg
-    wrapQtApp $out/bin/thg
   '';
 
+  # In python3Packages.buildPythonApplication doCheck is always true, and we
+  # override it to not run the default unittests
   checkPhase = ''
-    export QT_QPA_PLATFORM=offscreen
-    echo "test: thg smoke test"
+    runHook preCheck
+
+    $out/bin/thg version | grep -q "${version}"
+    # Detect breakage of thg in case of out-of-sync mercurial update. In that
+    # case any thg subcommand just opens up an gui dialog with a description of
+    # version mismatch.
+    echo "thg smoke test"
     $out/bin/thg -h > help.txt &
     sleep 1s
-    if grep "list of commands" help.txt; then
-      echo "thg help output was captured. Seems like package in a working state."
-      exit 0
-    else
-      echo "thg help output was not captured. Seems like package is broken."
-      exit 1
-    fi
+    grep -q "list of commands" help.txt
+
+    runHook postCheck
   '';
 
-  passthru.mercurial = tortoiseMercurial;
+  passthru = {
+    # If at some point we'll override this argument, it might be useful to have
+    # access to it here.
+    inherit mercurial;
+  };
 
   meta = {
     description = "Qt based graphical tool for working with Mercurial";

--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -23,6 +23,10 @@ python3Packages.buildPythonApplication rec {
     qscintilla-qt5
     iniparse
   ];
+  buildInputs = [
+    # Makes wrapQtAppsHook add these qt libraries to the wrapper search paths
+    qt5.qtwayland
+  ];
 
   # In order to spare double wrapping, we use:
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
