### PR TITLE
qscintilla: move to qt{5,6}Packages.nix

### DIFF
--- a/pkgs/applications/audio/miniaudicle/default.nix
+++ b/pkgs/applications/audio/miniaudicle/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , qmake
 , wrapQtAppsHook
-, qscintilla-qt6
+, qt6Packages
 , bison
 , flex
 , which
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     alsa-lib
     libsndfile
-    qscintilla-qt6
+    qt6Packages.qscintilla
   ] ++ lib.optional (audioBackend == "pulse") libpulseaudio
     ++ lib.optional (audioBackend == "jack")  libjack2;
 

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -50,8 +50,7 @@
 , makeWrapper
 # - Build Octave Qt GUI:
 , enableQt ? false
-, qt5
-, qscintilla
+, libsForQt5
 , libiconv
 , darwin
 }:
@@ -132,9 +131,9 @@ in stdenv.mkDerivation (finalAttrs: {
       gnuplot
       python3
     ] ++ lib.optionals enableQt [
-      qt5.qtbase
-      qt5.qtsvg
-      qscintilla
+      libsForQt5.qtbase
+      libsForQt5.qtsvg
+      libsForQt5.qscintilla
     ] ++ lib.optionals (enableJava) [
       jdk
     ] ++ lib.optionals (!stdenv.isDarwin) [
@@ -149,9 +148,9 @@ in stdenv.mkDerivation (finalAttrs: {
       gfortran
       texinfo
     ] ++ lib.optionals enableQt [
-      qt5.wrapQtAppsHook
-      qt5.qtscript
-      qt5.qttools
+      libsForQt5.wrapQtAppsHook
+      libsForQt5.qtscript
+      libsForQt5.qttools
     ];
 
     doCheck = !stdenv.isDarwin;

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -6,9 +6,16 @@
 , qtmacextras ? null
 , qmake
 , fixDarwinDylibNames
+, darwin
 }:
 
-stdenv.mkDerivation rec {
+let
+  stdenv' = if stdenv.isDarwin then
+    darwin.apple_sdk_11_0.stdenv
+  else
+    stdenv
+  ;
+in stdenv'.mkDerivation rec {
   pname = "qscintilla-qt5";
   version = "2.13.2";
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1518,6 +1518,8 @@ mapAliases ({
   qlandkartegt = throw "'qlandkartegt' has been removed from nixpkgs, as it was broken and unmaintained"; # Added 2023-04-17
   qr-filetransfer = throw ''"qr-filetransfer" has been renamed to "qrcp"''; # Added 2020-12-02
   qshowdiff = throw "'qshowdiff' (Qt4) is unmaintained and not been updated since its addition in 2010"; # Added 2022-06-14
+  qscintilla = libsForQt5.qscintilla; # Added 2023-09-20
+  qscintilla-qt6 = qt6Packages.qscintilla; # Added 2023-09-20
   qtscrobbler = throw "qtscrobbler has been removed, because it was unmaintained"; # Added 2022-05-26
   qt-3 = throw "qt-3 has been removed from nixpkgs, as it's unmaintained and insecure"; # Added 2021-02-15
   qt512 = throw "Qt 5 versions prior to 5.15 are no longer supported upstream and have been removed";  # Added 2022-11-24

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12478,12 +12478,6 @@ with pkgs;
 
   qprint = callPackage ../tools/text/qprint { };
 
-  qscintilla = libsForQt5.callPackage ../development/libraries/qscintilla {
-    stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
-  };
-
-  qscintilla-qt6 = qt6Packages.callPackage ../development/libraries/qscintilla { };
-
   qrcp = callPackage ../tools/networking/qrcp { };
 
   qrscan = callPackage ../tools/misc/qrscan { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -221,6 +221,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   quazip = callPackage ../development/libraries/quazip { };
 
+  qscintilla = callPackage ../development/libraries/qscintilla { };
+
   qwt = callPackage ../development/libraries/qwt/default.nix { };
 
   qwt6_1 = callPackage ../development/libraries/qwt/6_1.nix { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -36,6 +36,8 @@ in
 
   quazip = callPackage ../development/libraries/quazip { };
 
+  qscintilla = callPackage ../development/libraries/qscintilla { };
+
   qxlsx = callPackage ../development/libraries/qxlsx { };
 
   poppler = callPackage ../development/libraries/poppler {


### PR DESCRIPTION
Since it is a somewhat common library, with support for multiple qt versions, it is safer to put each version of it in libsForQt5 and qt6Packages attribute sets. Also, it is cleaner to put the darwin if-else inside the expression, in relation to https://github.com/NixOS/rfcs/pull/140 .

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
