### PR TITLE
libosmium: 2.19.0 → 2.20.0, osmium-tool: 1.15.0 → 1.16.0

### DIFF
--- a/pkgs/applications/misc/osmium-tool/default.nix
+++ b/pkgs/applications/misc/osmium-tool/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "osmium-tool";
-  version = "1.15.0";
+  version = "1.16.0";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "osmium-tool";
     rev = "v${version}";
-    sha256 = "sha256-xV/1LFby0L/o648XEQQ9gS9/eHssWhMIG7R1E8bfIDU=";
+    sha256 = "sha256-DObqbzdPA4RlrlcZhqA0MQtWBE+D6GRD1pd9U4DARIk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libosmium/default.nix
+++ b/pkgs/development/libraries/libosmium/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libosmium";
-  version = "2.19.0";
+  version = "2.20.0";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "libosmium";
     rev = "v${version}";
-    sha256 = "sha256-R7kOhQFfGYuHNkIZV4BTE+WKjHnCJwKeIWjCJNrvyTQ=";
+    sha256 = "sha256-QM6Nj2cmrhUysR2enFKhTWXdBXNqM21/Yqdn/zXEfYE=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/pyosmium/default.nix
+++ b/pkgs/development/python-modules/pyosmium/default.nix
@@ -1,8 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , cmake
-, python
 , libosmium
 , protozero
 , boost
@@ -31,6 +31,14 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-+YJQGPQm2FGOPhNzlXX2GM+ad4QdipJhwViOKGHtqBk=";
   };
+
+  patches = [
+    # Compatibility with recent pybind versions
+    (fetchpatch {
+      url = "https://github.com/osmcode/pyosmium/commit/31b1363389b423f49e14140ce868ecac83e92f69.patch";
+      hash = "sha256-maBuwzyZ4/wVLLGVr4gZFZDKvJckUXiBluxZRPGETag=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Description of changes
* libosmium: [Changelog](https://github.com/osmcode/libosmium/releases/tag/v2.20.0)
* osmium-tool: [Changelog](https://github.com/osmcode/osmium-tool/releases/tag/v1.16.0)
* pyosmium: fix build (https://hydra.nixos.org/build/235359331)

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
