### PR TITLE
lib.types.stringLike: init

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -101,6 +101,16 @@ checkConfigError 'A definition for option .* is not of type .path in the Nix sto
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ".*/store/.links"' config.pathInStore.bad4 ./types.nix
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: "/foo/bar"' config.pathInStore.bad5 ./types.nix
 
+# types.stringLike
+checkConfigOutput '^"foo"$' config.stringLike.ok1 ./types.nix
+checkConfigOutput '^/foo/bar$' config.stringLike.ok2 ./types.nix
+checkConfigOutput '^{ outPath = "/foo/bar"; }$' config.stringLike.ok3 ./types.nix
+checkConfigOutput '^{ __toString = <CODE>; value = 42; }$' config.stringLike.ok4 ./types.nix
+checkConfigError 'A definition for option .* is not of type .string-like.\. Definition values:\n\s*- In .*: 42' config.stringLike.bad1 ./types.nix
+checkConfigError 'A definition for option .* is not of type .string-like.\. Definition values:\n\s*- In .*:\s*[\n\s*"foo"\s*]' config.stringLike.bad2 ./types.nix
+checkConfigError 'A definition for option .* is not of type .string-like.\. Definition values:\n\s*- In .*: <function>' config.stringLike.bad3 ./types.nix
+checkConfigError 'A definition for option .* is not of type .string-like.\. Definition values:\n\s*- In .*:\s*{\s*value = 42;\s*}' config.stringLike.bad4 ./types.nix
+
 # Check boolean option.
 checkConfigOutput '^false$' config.enable ./declare-enable.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./define-enable.nix

--- a/lib/tests/modules/types.nix
+++ b/lib/tests/modules/types.nix
@@ -10,6 +10,7 @@ in
 {
   options = {
     pathInStore = mkOption { type = types.lazyAttrsOf types.pathInStore; };
+    stringLike = mkOption { type = types.lazyAttrsOf types.stringLike; };
   };
   config = {
     pathInStore.ok1 = "${storeDir}/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv";
@@ -20,5 +21,14 @@ in
     pathInStore.bad3 = "${storeDir}/";
     pathInStore.bad4 = "${storeDir}/.links"; # technically true, but not reasonable
     pathInStore.bad5 = "/foo/bar";
+
+    stringLike.ok1 = "foo";
+    stringLike.ok2 = /foo/bar;
+    stringLike.ok3 = { outPath = "/foo/bar"; };
+    stringLike.ok4 = { value = 42; __toString = self: toString self.value; };
+    stringLike.bad1 = 42;
+    stringLike.bad2 = [ "foo" ];
+    stringLike.bad3 = _: 42;
+    stringLike.bad4 = { value = 42; };
   };
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -434,6 +434,14 @@ rec {
     commas = separatedString ",";
     envVar = separatedString ":";
 
+    stringLike = mkOptionType {
+      name = "stringLike";
+      description = "string-like";
+      descriptionClass = "noun";
+      check = isStringLike;
+      merge = mergeEqualOption;
+    };
+
     # Deprecated; should not be used because it quietly concatenates
     # strings, which is usually not what you want.
     # We use a lib.warn because `deprecationMessage` doesn't trigger in nested types such as `attrsOf string`

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -201,6 +201,12 @@ merging is handled.
     definitions cannot be merged. The regular expression is processed
     using `builtins.match`.
 
+`types.stringLike`
+
+:   A string-like value that can be used without explicit conversion in
+    string interpolations and in most functions that expect a string.
+    This is the type version of `lib.isStringLike`.
+
 ## Submodule types {#sec-option-types-submodule}
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).


### PR DESCRIPTION
## Description of changes

Motivation: https://github.com/astro/microvm.nix/issues/138

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
