### PR TITLE
[23.05] trafficserver: add patches for CVE-2022-47185 & CVE-2023-33934

### DIFF
--- a/pkgs/servers/http/trafficserver/9.1.4-CVE-2023-33934.supplemental.patch
+++ b/pkgs/servers/http/trafficserver/9.1.4-CVE-2023-33934.supplemental.patch
@@ -1,0 +1,101 @@
+Based on upstream fbb6acb1caac752e6719b912e0de971691c1ad99, adjusted to
+apply cleanly to 9.1.4
+
+diff --git a/proxy/hdrs/URL.cc b/proxy/hdrs/URL.cc
+index 8124bb9f2..90973bbdd 100644
+--- a/proxy/hdrs/URL.cc
++++ b/proxy/hdrs/URL.cc
+@@ -1524,8 +1524,13 @@ done:
+       // correcting this behavior, therefore, we maintain the current
+       // functionality but add state to determine whether the path was
+       // absolutely empty so we can reconstruct such URLs.
+-      ++path_start;
++      //
++      // Remove all preceding slashes
++      while (path_start < path_end && *path_start == '/') {
++        ++path_start;
++      }
+     }
++
+     url_path_set(heap, url, path_start, path_end - path_start, copy_strings);
+   } else if (!nothing_after_host) {
+     // There was no path set via '/': it is absolutely empty. However, if there
+@@ -1577,7 +1582,10 @@ url_parse_http_regex(HdrHeap *heap, URLImpl *url, const char **start, const char
+   cur              = static_cast<const char *>(memchr(cur, '/', end - cur));
+   if (cur) {
+     host_end = cur;
+-    ++cur;
++    // Remove all preceding slashes
++    while (cur < end && *cur == '/') {
++      cur++;
++    }
+   } else {
+     host_end = cur = end;
+   }
+diff --git a/proxy/hdrs/unit_tests/test_URL.cc b/proxy/hdrs/unit_tests/test_URL.cc
+index 115aeee5d..a06d1d5d0 100644
+--- a/proxy/hdrs/unit_tests/test_URL.cc
++++ b/proxy/hdrs/unit_tests/test_URL.cc
+@@ -173,6 +173,14 @@ constexpr bool VERIFY_HOST_CHARACTERS = true;
+ 
+ // clang-format off
+ std::vector<url_parse_test_case> url_parse_test_cases = {
++  {
++    "///dir////index.html",
++    "/dir////index.html",
++    VERIFY_HOST_CHARACTERS,
++    "/dir////index.html",
++    IS_VALID,
++    IS_VALID
++  },
+   {
+     "/index.html",
+     "/index.html",
+@@ -183,9 +191,9 @@ std::vector<url_parse_test_case> url_parse_test_cases = {
+   },
+   {
+     "//index.html",
+-    "//index.html",
++    "/index.html",
+     VERIFY_HOST_CHARACTERS,
+-    "//index.html",
++    "/index.html",
+     IS_VALID,
+     IS_VALID
+   },
+@@ -215,9 +223,9 @@ std::vector<url_parse_test_case> url_parse_test_cases = {
+     // with two slash characters ("//"). We have historically allowed this,
+     // however, and will continue to do so.
+     "https:////",
+-    "https:////",
++    "https:///",
+     VERIFY_HOST_CHARACTERS,
+-    "https:////",
++    "https:///",
+     IS_VALID,
+     IS_VALID
+   },
+@@ -257,9 +265,9 @@ std::vector<url_parse_test_case> url_parse_test_cases = {
+   },
+   {
+     "https://www.example.com//",
+-    "https://www.example.com//",
++    "https://www.example.com/",
+     VERIFY_HOST_CHARACTERS,
+-    "https://www.example.com//",
++    "https://www.example.com/",
+     IS_VALID,
+     IS_VALID
+   },
+@@ -313,9 +321,9 @@ std::vector<url_parse_test_case> url_parse_test_cases = {
+   },
+   {
+     "https://www.example.com//a/path",
+-    "https://www.example.com//a/path",
++    "https://www.example.com/a/path",
+     VERIFY_HOST_CHARACTERS,
+-    "https://www.example.com//a/path",
++    "https://www.example.com/a/path",
+     IS_VALID,
+     IS_VALID
+   },

--- a/pkgs/servers/http/trafficserver/default.nix
+++ b/pkgs/servers/http/trafficserver/default.nix
@@ -74,6 +74,18 @@ stdenv.mkDerivation rec {
     })
     ./9.1.4-CVE-2023-33933.patch
     ./9.1.4-CVE-2023-30631.patch
+
+    (fetchpatch {
+      name = "CVE-2022-47185.patch";
+      url = "https://github.com/apache/trafficserver/commit/5d0835ea5a57003798497d07331fa4f89823c750.patch";
+      sha256 = "sha256-h4vaa7UwWFmJ9ZOtZsHuExcZQMFG8IER4WFp1r7Ym+U=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-33934.patch";
+      url = "https://github.com/apache/trafficserver/commit/32d93ad084d18ee592754e3736d960a4fd8ddfd2.patch";
+      sha256 = "sha256-z3rCUe7MhKwnn8wzW6ba5ojdSAIhHkL/PNZqm04gNf4=";
+    })
+    ./9.1.4-CVE-2023-33934.supplemental.patch
   ];
 
   # NOTE: The upstream README indicates that flex is needed for some features,


### PR DESCRIPTION
## Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-47185
https://nvd.nist.gov/vuln/detail/CVE-2023-33934

See #255716 for unstable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
