### PR TITLE
glasgow: update to latest git commit, along with fx2 and amaranth

### DIFF
--- a/nixos/modules/hardware/glasgow.nix
+++ b/nixos/modules/hardware/glasgow.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.glasgow;
+
+in
+{
+  options.hardware.glasgow = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Enables Glasgow udev rules and ensures 'plugdev' group exists.
+        This is a prerequisite to using Glasgow without being root.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.udev.packages = [ pkgs.glasgow ];
+    users.groups.plugdev = { };
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -61,6 +61,7 @@
   ./hardware/flipperzero.nix
   ./hardware/flirc.nix
   ./hardware/gkraken.nix
+  ./hardware/glasgow.nix
   ./hardware/gpgsmartcards.nix
   ./hardware/hackrf.nix
   ./hardware/i2c.nix

--- a/pkgs/development/python-modules/amaranth-soc/default.nix
+++ b/pkgs/development/python-modules/amaranth-soc/default.nix
@@ -8,15 +8,15 @@
 
 buildPythonPackage rec {
   pname = "amaranth-soc";
-  version = "unstable-2021-12-10";
+  version = "unstable-2023-09-15";
   # python setup.py --version
-  realVersion = "0.1.dev49+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.1.dev70+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "amaranth-lang";
     repo = "amaranth-soc";
-    rev = "217d4ea76ad3b3bbf146980d168bc7b3b9d95a18";
-    sha256 = "dMip82L7faUn16RDeG3NgMv0nougpwTwDWLX0doD2YA=";
+    rev = "cce8a79a37498f4d5900be21a295ba77e51e6c9d";
+    sha256 = "sha256-hfkJaqICuy3iSTwLM9lbUPvSMDBLW8GdxqswyAOsowo=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/python-modules/amaranth/default.nix
+++ b/pkgs/development/python-modules/amaranth/default.nix
@@ -3,8 +3,8 @@
 , pythonOlder
 , fetchFromGitHub
 , fetchpatch
-, setuptools
-, setuptools-scm
+, pdm
+, python3
 , pyvcd
 , jinja2
 , importlib-resources
@@ -20,52 +20,27 @@
 
 buildPythonPackage rec {
   pname = "amaranth";
-  version = "0.3";
-  # python setup.py --version
-  realVersion = "0.3";
-  disabled = pythonOlder "3.6";
+  format = "pyproject";
+  # python -m setuptools_scm
+  version = "0.4.dev197+g${lib.substring 0 7 src.rev}";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "amaranth-lang";
     repo = "amaranth";
-    rev = "39a83f4d995d16364cc9b99da646ff8db6394166";
-    sha256 = "P9AG3t30eGeeCN5+t7mjhRoOWIGZVzWQji9eYXphjA0=";
+    rev = "11d5bb19eb34463918c07dc5e2e0eac7dbf822b0";
+    sha256 = "sha256-Ji5oYfF2hKSunAdAQTniv8Ajj6NE/bvW5cvadrGKa+U=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-for-setuptools-64.0.2-preparation.patch";
-      url = "https://github.com/amaranth-lang/amaranth/commit/64771a065a280fa683c1e6692383bec4f59f20fa.patch";
-      hash = "sha256-Rsh9vVvUQj9nIcrsRirmR6XwFrfZ2VMaYJ4RCQ8sBE0=";
-      # This commit removes support for Python 3.6, which is unnecessary to fix
-      # the build when using new setuptools. Include only one file, which has a
-      # harmless comment change so that the subsequent patch applies cleanly.
-      includes = ["amaranth/_toolchain/cxx.py"];
-    })
-    (fetchpatch {
-      name = "fix-for-setuptools-64.0.2.patch";
-      url = "https://github.com/amaranth-lang/amaranth/pull/722/commits/e5a56b07c568e5f4cc2603eefebd14c5cc4e13d8.patch";
-      hash = "sha256-C8FyMSKHA7XsEMpO9eYNZx/X5rGaK7p3eXP+jSb6wVg=";
-    })
-    (fetchpatch {
-      name = "add-python-3.11-support.patch";
-      url = "https://github.com/amaranth-lang/amaranth/commit/851546bf2d16db62663d7002bece51f07078d0a5.patch";
-      hash = "sha256-eetlFCLqmpCfTKViD16OScJbkql1yhdi5uJGnfnpcCE=";
-    })
-  ];
-
-  SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}";
 
   nativeBuildInputs = [
     git
-    setuptools
-    setuptools-scm
   ];
 
   propagatedBuildInputs = [
     jinja2
+    pdm
     pyvcd
-    setuptools
+    python3.pkgs.pdm-backend
   ] ++
     lib.optional (pythonOlder "3.9") importlib-resources ++
     lib.optional (pythonOlder "3.8") importlib-metadata;
@@ -76,17 +51,6 @@ buildPythonPackage rec {
     yices
     yosys
   ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "Jinja2~=2.11" "Jinja2>=2.11" \
-      --replace "pyvcd~=0.2.2" "pyvcd" \
-      --replace "amaranth-yosys>=0.10.*" "amaranth-yosys>=0.10"
-
-    # jinja2.contextfunction was removed in jinja2 v3.1
-    substituteInPlace amaranth/build/plat.py \
-      --replace "@jinja2.contextfunction" "@jinja2.pass_context"
-  '';
 
   pythonImportsCheck = [ "amaranth" ];
 

--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "fx2";
-  version = "0.11";
+  version = "unstable-2023-09-20";
 
   src = fetchFromGitHub {
     owner = "whitequark";
     repo = "libfx2";
-    rev = "v${version}";
-    hash = "sha256-uJpXsUMFqJY7mjj1rtfc0XWEfNDxO1xXobgBDGFHnp4=";
+    rev = "73fa811818d56a86b82c12e07327946aeddd2b3e";
+    hash = "sha256-AGQPOVTdaUCUeVVNQTBmoNvz5CGxcBOK7+oL+X8AcIw=";
   };
 
   nativeBuildInputs = [ sdcc ];

--- a/pkgs/tools/misc/glasgow/default.nix
+++ b/pkgs/tools/misc/glasgow/default.nix
@@ -52,6 +52,11 @@ python3.pkgs.buildPythonApplication rec {
   # installCheck tries to build_ext again
   doInstallCheck = false;
 
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d
+    cp $src/config/99-glasgow.rules $out/etc/udev/rules.d
+  '';
+
   checkPhase = ''
     ${python3.interpreter} -W ignore::DeprecationWarning test.py
   '';

--- a/pkgs/tools/misc/glasgow/default.nix
+++ b/pkgs/tools/misc/glasgow/default.nix
@@ -9,17 +9,15 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "glasgow";
-  version = "unstable-2023-04-15";
+  version = "unstable-2023-09-20";
   # python -m setuptools_scm
-  realVersion = "0.1.dev2+g${lib.substring 0 7 src.rev}";
-
-  patches = [ ./0001-Relax-Amaranth-git-dependency.patch ];
+  realVersion = "0.1.dev1798+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "GlasgowEmbedded";
     repo = "glasgow";
-    rev = "406e06fae5c85f6f773c9839747513874bc3ec77";
-    sha256 = "sha256-s4fWpKJj6n2+CIAsD2bjr5K8RhJz1H1sFnjiartNGf0=";
+    rev = "e9a9801d5be3dcba0ee188dd8a6e9115e337795d";
+    sha256 = "sha256-ztB3I/jrDSm1gKB1e5igivUVloq+YYhkshDlWg75NMA=";
   };
 
   nativeBuildInputs = [
@@ -30,6 +28,7 @@ python3.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python3.pkgs; [
     aiohttp
     amaranth
+    appdirs
     bitarray
     crc
     fx2
@@ -58,6 +57,8 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   checkPhase = ''
+    # tests attempt to cache bitstreams
+    export XDG_CACHE_HOME=$TMPDIR
     ${python3.interpreter} -W ignore::DeprecationWarning test.py
   '';
 


### PR DESCRIPTION
## Description of changes

* bump of glasgow, fx2, and amaranth
* inclusion of udev rules (#256347) 
* simple nixos module for udev rules inclusion

## Things done

Tested functions with actual hardware (revC3-ish)
 * `glasgow flash`
 * from `selftest` applet: `leds`, `loopback`, `voltage` (others are known-broken on revC3)
 * `jtag-pinout` and `jtag-probe`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
