### PR TITLE
nixos/rust-motd: allow ordering sections

### DIFF
--- a/nixos/modules/programs/rust-motd.nix
+++ b/nixos/modules/programs/rust-motd.nix
@@ -50,6 +50,7 @@ in {
       path = with pkgs; [ bash ];
       documentation = [ "https://github.com/rust-motd/rust-motd/blob/v${pkgs.rust-motd.version}/README.md" ];
       description = "motd generator";
+      wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         ExecStart = "${pkgs.writeShellScript "update-motd" ''
           ${pkgs.rust-motd}/bin/rust-motd ${format.generate "motd.conf" cfg.settings} > motd

--- a/nixos/modules/programs/rust-motd.nix
+++ b/nixos/modules/programs/rust-motd.nix
@@ -5,6 +5,33 @@ with lib;
 let
   cfg = config.programs.rust-motd;
   format = pkgs.formats.toml { };
+
+  orderedSections = listToAttrs
+    (imap0
+      (i: items@{ sectionHeader, ... }: nameValuePair "env${toString i}" {
+        ${sectionHeader} = removeAttrs items [ "priority" "sectionHeader" ];
+      })
+      (sortProperties (mapAttrsToList (k: v: v // { sectionHeader = k; }) cfg.settings)));
+
+  # Order the sections in the TOML according to the `priority` field.
+  # This is done by
+  # * creating an attribute set with keys `env0`/`env1`/.../`envN`
+  #   where `env0` contains the first section and `envN` the last
+  #   (in the form of `{ sectionName = { /* ... */ }}`)
+  # * the declarations of `env0` to `envN` in ascending order are
+  #   concatenated with `jq`. Now we have a JSON representation of
+  #   the config in the correct order.
+  # * this is piped to `json2toml` to get the correct format for rust-motd.
+  motdConf = pkgs.runCommand "motd.conf"
+    (orderedSections // {
+      __structuredAttrs = true;
+      nativeBuildInputs = [ pkgs.remarshal pkgs.jq ];
+    })
+    ''
+      cat "$NIX_BUILD_TOP"/.attrs.json \
+        | jq '${concatMapStringsSep " + " (key: ''."${key}"'') (attrNames orderedSections)}' \
+        | json2toml /dev/stdin "$out"
+    '';
 in {
   options.programs.rust-motd = {
     enable = mkEnableOption (lib.mdDoc "rust-motd");
@@ -28,9 +55,35 @@ in {
       '';
     };
     settings = mkOption {
-      type = types.submodule {
+      type = types.attrsOf (types.submodule {
         freeformType = format.type;
-      };
+        options.priority = mkOption {
+          type = types.int;
+          default = modules.defaultOrderPriority;
+          description = mdDoc ''
+            In `rust-motd`, the order of the sections in TOML correlates to the order
+            of the items displayed in the resulting `motd`. Attributes in Nix are
+            ordered alphabetically, e.g. `banner` would always be before `uptime`.
+
+            To change that, this option can be used. The lower this number is, the higher
+            is the priority and the more a section is at the top of the message.
+
+            For instance
+
+            ```nix
+            {
+              banner.command = "hostname | figlet -f slant";
+              uptime = {
+                prefix = "Up";
+                priority = 0;
+              };
+            }
+            ```
+
+            would make the `uptime` appear before the banner.
+          '';
+        };
+      });
       description = mdDoc ''
         Settings on what to generate. Please read the
         [upstream documentation](https://github.com/rust-motd/rust-motd/blob/main/README.md#configuration)
@@ -53,7 +106,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         ExecStart = "${pkgs.writeShellScript "update-motd" ''
-          ${pkgs.rust-motd}/bin/rust-motd ${format.generate "motd.conf" cfg.settings} > motd
+          ${pkgs.rust-motd}/bin/rust-motd ${motdConf} > motd
         ''}";
         CapabilityBoundingSet = [ "" ];
         LockPersonality = true;

--- a/nixos/modules/programs/rust-motd.nix
+++ b/nixos/modules/programs/rust-motd.nix
@@ -28,7 +28,7 @@ let
       nativeBuildInputs = [ pkgs.remarshal pkgs.jq ];
     })
     ''
-      cat "$NIX_BUILD_TOP"/.attrs.json \
+      cat "$NIX_ATTRS_JSON_FILE" \
         | jq '${concatMapStringsSep " + " (key: ''."${key}"'') (attrNames orderedSections)}' \
         | json2toml /dev/stdin "$out"
     '';


### PR DESCRIPTION
## Description of changes

cc reporter @Niols 
cc @infinisil because I'm curious if there's a module-system feature I'm not aware of to achieve this.

------

Closes #234802

The problem here is that with e.g.

    {
      uptime.prefix = "Up";
      banner.command = "hostname | figlet -f slant";
    }

`banner` still appears before `uptime` in the final motd text because
Nix sorts attribute names alphabetically internally.

To work around this without breaking compatibility or losing the
property to override individual sections in other modules - e.g.

    {
      banner.color = mkForce "blue";
    }

I decided to introduce an option `priority` here, similar to the
priority field for `nginx`[1] and with the same semantics (i.e. higher
value means lower priority).

Internally a bunch of env vars are generated, i.e. `env0` to `envN` for
`N` sections with each of them containing a declaration for the TOML,
i.e. `env0` contains `{ uptime.prefix = "Up"; }` and `env1` contains
`{ banner.command = "hostname | figlet -f slant"; }` if `uptime.priority`
is set to a value below 1000.

In this order, the declarations are concatenated together by `jq(1)`
which doesn't sort keys alphabetically which results in a JSON
representation with `uptime` before `banner`. This is finally piped to
`json2toml` which converts this into TOML for rust-motd.

[1] https://nixos.org/manual/nixos/unstable/options#opt-services.nginx.virtualHosts._name_.locations._name_.priority

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
