### PR TITLE
perccli: 7.2110.00 -> 7.2313.00

### DIFF
--- a/pkgs/tools/misc/perccli/default.nix
+++ b/pkgs/tools/misc/perccli/default.nix
@@ -6,16 +6,18 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "perccli";
-  version = "7.2110.00";
+
+  # On a new release, update version, URL, hash, and meta.homepage
+  version = "7.2313.00";
 
   src = fetchzip {
     # On pkg update: manually adjust the version in the URL because of the different format.
-    url = "https://dl.dell.com/FOLDER09074160M/1/PERCCLI_7.211.0_Linux.tar.gz";
-    sha256 = "sha256-8gk+0CrgeisfN2hNpaO1oFey57y7KuNy2i6PWTikDls=";
+    url = "https://dl.dell.com/FOLDER09770976M/1/PERCCLI_7.2313.0_A14_Linux.tar.gz";
+    hash = "sha256-IhclHVkdihRx5CzyO2dlOEhCon+0/HB3Fkue7MWsWnw=";
 
     # Dell seems to block "uncommon" user-agents, such as Nixpkgs's custom one.
-    # Sending no user-agent at all seems to be fine though.
-    curlOptsList = [ "--user-agent" "" ];
+    # 403 otherwise
+    curlOptsList = [ "--user-agent" "Mozilla/5.0" ];
   };
 
   nativeBuildInputs = [ rpmextract ];
@@ -43,6 +45,10 @@ stdenvNoCC.mkDerivation rec {
 
   meta = with lib; {
     description = "Perccli Support for PERC RAID controllers";
+
+    # Must be updated with every release
+    homepage = "https://www.dell.com/support/home/en-us/drivers/driversdetails?driverid=tdghn";
+
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ panicgh ];


### PR DESCRIPTION
## Description of changes

https://www.dell.com/support/home/en-us/drivers/driversdetails?driverid=tdghn

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).