### PR TITLE
ocamlPackages.apron: 0.9.13 → 0.9.14 & enable PPLite support

### DIFF
--- a/pkgs/development/libraries/pplite/default.nix
+++ b/pkgs/development/libraries/pplite/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, lib, fetchurl, flint, gmp }:
+
+stdenv.mkDerivation {
+  pname = "pplite";
+  version = "0.11";
+
+  src = fetchurl {
+    url = "https://github.com/ezaffanella/PPLite/raw/main/releases/pplite-0.11.tar.gz";
+    hash = "sha256-6IS5zVab8X+gnhK8/qbPH5FODFaG6vIsIG9TTEpfHEI=";
+  };
+
+  buildInputs = [ flint gmp ];
+
+  meta = {
+    homepage = "https://github.com/ezaffanella/PPLite";
+    description = "Convex polyhedra library for Abstract Interpretation";
+    license = lib.licenses.gpl3Only;
+  };
+}

--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -1,4 +1,5 @@
 { stdenv, lib, fetchFromGitHub, perl, gmp, mpfr, ppl, ocaml, findlib, camlidl, mlgmpidl
+, flint, pplite
 }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ ocaml findlib perl ];
-  buildInputs = [ gmp mpfr ppl camlidl ];
+  buildInputs = [ gmp mpfr ppl camlidl flint pplite ];
   propagatedBuildInputs = [ mlgmpidl ];
 
   # TODO: Doesn't produce the library correctly if true

--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -1,26 +1,24 @@
 { stdenv, lib, fetchFromGitHub, perl, gmp, mpfr, ppl, ocaml, findlib, camlidl, mlgmpidl
-, gnumake42
 }:
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-apron";
-  version = "0.9.13";
+  version = "0.9.14";
   src = fetchFromGitHub {
     owner = "antoinemine";
     repo = "apron";
     rev = "v${version}";
-    sha256 = "14ymjahqdxj26da8wik9d5dzlxn81b3z1iggdl7rn2nn06jy7lvy";
+    hash = "sha256-e8bSf0FPB6E3MFHHoSrE0x/6nrUStO+gOKxJ4LDHBi0=";
   };
 
-  # fails with make 4.4
-  nativeBuildInputs = [ ocaml findlib perl gnumake42 ];
+  nativeBuildInputs = [ ocaml findlib perl ];
   buildInputs = [ gmp mpfr ppl camlidl ];
   propagatedBuildInputs = [ mlgmpidl ];
 
   # TODO: Doesn't produce the library correctly if true
   strictDeps = false;
 
-  outputs = [ "out" "bin" "dev" ];
+  outputs = [ "out" "dev" ];
 
   configurePhase = ''
     runHook preConfigure
@@ -32,8 +30,6 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $dev/lib
     mv $out/lib/ocaml $dev/lib/
-    mkdir -p $bin
-    mv $out/bin $bin/
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12205,6 +12205,8 @@ with pkgs;
 
   ppl = callPackage ../development/libraries/ppl { };
 
+  pplite = callPackage ../development/libraries/pplite { };
+
   ppp = callPackage ../tools/networking/ppp { };
 
   pptp = callPackage ../tools/networking/pptp { };


### PR DESCRIPTION
## Description of changes

https://github.com/antoinemine/apron/blob/v0.9.14/Changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
