### PR TITLE
lemminx: init at 0.27.0

### DIFF
--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -1,0 +1,103 @@
+{ lib
+, fetchFromGitHub
+, makeWrapper
+, jre
+, maven
+, writeScript
+, lemminx
+}:
+
+maven.buildMavenPackage rec {
+  pname = "lemminx";
+  version = "0.27.0";
+
+  src = fetchFromGitHub {
+    owner = "eclipse";
+    repo = "lemminx";
+    rev = version;
+    hash = "sha256-VWYTkYlPziNRyxHdvIWVuDlABpKdzhC/F6BUBj/opks=";
+    # Lemminx reads this git information at runtime from a git.properties
+    # file on the classpath
+    leaveDotGit = true;
+    postFetch = ''
+      cat > $out/org.eclipse.lemminx/src/main/resources/git.properties << EOF
+      git.build.version=${version}
+      git.commit.id.abbrev=$(git -C $out rev-parse --short HEAD)
+      git.commit.message.short=$(git -C $out log -1 --pretty=format:%s)
+      git.branch=main
+      EOF
+      rm -rf $out/.git
+    '';
+  };
+
+  manualMvnArtifacts = [
+    "org.apache.maven.surefire:surefire-junit-platform:3.1.2"
+    "org.junit.platform:junit-platform-launcher:1.10.0"
+  ];
+
+  mvnHash = "sha256-sIiCp1AorVQXt13Tq0vw9jGioG3zcQMqqKS/Q0Tf4MQ=";
+
+  buildOffline = true;
+
+  # disable gitcommitid plugin which needs a .git folder which we
+  # don't have
+  mvnDepsParameters = "-Dmaven.gitcommitid.skip=true";
+
+  # disable failing tests which either need internet access or are flaky
+  mvnParameters = lib.escapeShellArgs [
+    "-Dmaven.gitcommitid.skip=true"
+    "-Dtest=!XMLValidationCommandTest,
+    !XMLValidationExternalResourcesBasedOnDTDTest,
+    !XMLSchemaPublishDiagnosticsTest,
+    !PlatformTest,
+    !XMLValidationExternalResourcesBasedOnXSDTest,
+    !XMLExternalTest,
+    !XMLSchemaCompletionExtensionsTest,
+    !XMLSchemaDiagnosticsTest,
+    !MissingChildElementCodeActionTest,
+    !XSDValidationExternalResourcesTest"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share
+    install -Dm644 org.eclipse.lemminx/target/org.eclipse.lemminx-uber.jar \
+      $out/share
+
+    makeWrapper ${jre}/bin/java $out/bin/lemminx \
+      --add-flags "-jar $out/share/org.eclipse.lemminx-uber.jar"
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  passthru.updateScript = writeScript "update-lemminx" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl pcre common-updater-scripts jq gnused
+    set -eu -o pipefail
+
+    LATEST_TAG=$(curl https://api.github.com/repos/eclipse/lemminx/tags | \
+      jq -r '[.[] | select(.name | test("^[0-9]"))] | sort_by(.name | split(".") |
+      map(tonumber)) | reverse | .[0].name')
+    update-source-version lemminx "$LATEST_TAG"
+    sed -i '0,/mvnHash *= *"[^"]*"/{s/mvnHash = "[^"]*"/mvnHash = ""/}' ${lemminx}
+
+    echo -e "\nFetching all mvn dependencies to calculate the mvnHash. This may take a while ..."
+    nix-build -A lemminx.fetchedMavenDeps 2> lemminx-stderr.log || true
+
+    NEW_MVN_HASH=$(cat lemminx-stderr.log | grep "got:" | awk '{print ''$2}')
+    rm lemminx-stderr.log
+    # escaping double quotes looks ugly but is needed for variable substitution
+    # use # instead of / as separator because the sha256 might contain the / character
+    sed -i "0,/mvnHash *= *\"[^\"]*\"/{s#mvnHash = \"[^\"]*\"#mvnHash = \"$NEW_MVN_HASH\"#}" ${lemminx}
+  '';
+
+  meta = with lib; {
+    description = "XML Language Server";
+    homepage = "https://github.com/eclipse/lemminx";
+    license = licenses.epl20;
+    maintainers = with maintainers; [ tricktron ];
+  };
+}

--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -55,7 +55,8 @@ maven.buildMavenPackage rec {
     !XMLSchemaCompletionExtensionsTest,
     !XMLSchemaDiagnosticsTest,
     !MissingChildElementCodeActionTest,
-    !XSDValidationExternalResourcesTest"
+    !XSDValidationExternalResourcesTest,
+    !DocumentLifecycleParticipantTest"
   ];
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

Adds Lemminx, an implementation of the Language Server Protocol for XML files.

Closes https://github.com/NixOS/nixpkgs/issues/100164 and supersedes https://github.com/NixOS/nixpkgs/pull/132335 and https://github.com/NixOS/nixpkgs/pull/201885.

CC @wegank for review since this uses the newly added buildOffline feature flag of https://github.com/NixOS/nixpkgs/pull/255243#event-10424279507.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
