### PR TITLE
hadoop: 3.3.5 -> 3.3.6, build container executor from source

### DIFF
--- a/nixos/modules/services/cluster/hadoop/default.nix
+++ b/nixos/modules/services/cluster/hadoop/default.nix
@@ -67,16 +67,16 @@ with lib;
     mapredSiteDefault = mkOption {
       default = {
         "mapreduce.framework.name" = "yarn";
-        "yarn.app.mapreduce.am.env" = "HADOOP_MAPRED_HOME=${cfg.package}/lib/${cfg.package.untarDir}";
-        "mapreduce.map.env" = "HADOOP_MAPRED_HOME=${cfg.package}/lib/${cfg.package.untarDir}";
-        "mapreduce.reduce.env" = "HADOOP_MAPRED_HOME=${cfg.package}/lib/${cfg.package.untarDir}";
+        "yarn.app.mapreduce.am.env" = "HADOOP_MAPRED_HOME=${cfg.package}";
+        "mapreduce.map.env" = "HADOOP_MAPRED_HOME=${cfg.package}";
+        "mapreduce.reduce.env" = "HADOOP_MAPRED_HOME=${cfg.package}";
       };
       defaultText = literalExpression ''
         {
           "mapreduce.framework.name" = "yarn";
-          "yarn.app.mapreduce.am.env" = "HADOOP_MAPRED_HOME=''${config.${opt.package}}/lib/''${config.${opt.package}.untarDir}";
-          "mapreduce.map.env" = "HADOOP_MAPRED_HOME=''${config.${opt.package}}/lib/''${config.${opt.package}.untarDir}";
-          "mapreduce.reduce.env" = "HADOOP_MAPRED_HOME=''${config.${opt.package}}/lib/''${config.${opt.package}.untarDir}";
+          "yarn.app.mapreduce.am.env" = "HADOOP_MAPRED_HOME=''${config.${opt.package}}";
+          "mapreduce.map.env" = "HADOOP_MAPRED_HOME=''${config.${opt.package}}";
+          "mapreduce.reduce.env" = "HADOOP_MAPRED_HOME=''${config.${opt.package}}";
         }
       '';
       type = types.attrsOf types.anything;
@@ -154,13 +154,13 @@ with lib;
     };
 
     log4jProperties = mkOption {
-      default = "${cfg.package}/lib/${cfg.package.untarDir}/etc/hadoop/log4j.properties";
+      default = "${cfg.package}/etc/hadoop/log4j.properties";
       defaultText = literalExpression ''
-        "''${config.${opt.package}}/lib/''${config.${opt.package}.untarDir}/etc/hadoop/log4j.properties"
+        "''${config.${opt.package}}/etc/hadoop/log4j.properties"
       '';
       type = types.path;
       example = literalExpression ''
-        "''${pkgs.hadoop}/lib/''${pkgs.hadoop.untarDir}/etc/hadoop/log4j.properties";
+        "''${pkgs.hadoop}/etc/hadoop/log4j.properties";
       '';
       description = lib.mdDoc "log4j.properties file added to HADOOP_CONF_DIR";
     };

--- a/nixos/modules/services/cluster/hadoop/yarn.nix
+++ b/nixos/modules/services/cluster/hadoop/yarn.nix
@@ -160,7 +160,7 @@ in
           umount /run/wrappers/yarn-nodemanager/cgroup/cpu || true
           rm -rf /run/wrappers/yarn-nodemanager/ || true
           mkdir -p /run/wrappers/yarn-nodemanager/{bin,etc/hadoop,cgroup/cpu}
-          cp ${cfg.package}/lib/${cfg.package.untarDir}/bin/container-executor /run/wrappers/yarn-nodemanager/bin/
+          cp ${cfg.package}/bin/container-executor /run/wrappers/yarn-nodemanager/bin/
           chgrp hadoop /run/wrappers/yarn-nodemanager/bin/container-executor
           chmod 6050 /run/wrappers/yarn-nodemanager/bin/container-executor
           cp ${hadoopConf}/container-executor.cfg /run/wrappers/yarn-nodemanager/etc/hadoop/

--- a/nixos/tests/hadoop/hadoop.nix
+++ b/nixos/tests/hadoop/hadoop.nix
@@ -249,7 +249,7 @@ import ../make-test-python.nix ({ package, ... }: {
     assert "standby" in client.succeed("sudo -u yarn yarn rmadmin -getAllServiceState")
     client.succeed("sudo -u yarn yarn rmadmin -getAllServiceState | systemd-cat")
 
-    assert "Estimated value of Pi is" in client.succeed("HADOOP_USER_NAME=hdfs yarn jar $(readlink $(which yarn) | sed -r 's~bin/yarn~lib/hadoop-*/share/hadoop/mapreduce/hadoop-mapreduce-examples-*.jar~g') pi 2 10")
+    assert "Estimated value of Pi is" in client.succeed("HADOOP_USER_NAME=hdfs yarn jar $(readlink $(which yarn) | sed -r 's~bin/yarn~share/hadoop/mapreduce/hadoop-mapreduce-examples-*.jar~g') pi 2 10")
     assert "SUCCEEDED" in client.succeed("yarn application -list -appStates FINISHED")
   '';
 })

--- a/pkgs/applications/networking/cluster/hadoop/containerExecutor.nix
+++ b/pkgs/applications/networking/cluster/hadoop/containerExecutor.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
     maintainers = with maintainers; [ illustris ];
-    platforms = attrNames platformAttrs;
+    platforms = filter (strings.hasSuffix "linux") (attrNames platformAttrs);
   };
 })

--- a/pkgs/applications/networking/cluster/hadoop/containerExecutor.nix
+++ b/pkgs/applications/networking/cluster/hadoop/containerExecutor.nix
@@ -1,4 +1,4 @@
-{ version, hash, stdenv, fetchurl, lib, cmake, openssl, platformAttrs, ... }:
+{ version, stdenv, fetchurl, lib, cmake, openssl, platformAttrs, ... }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hadoop-yarn-containerexecutor";
@@ -6,7 +6,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = with finalAttrs; "mirror://apache/hadoop/common/hadoop-${finalAttrs.version}/hadoop-${finalAttrs.version}-src.tar.gz";
-    inherit hash;
+    hash = platformAttrs.${stdenv.system}.srcHash;
   };
   sourceRoot = "hadoop-${finalAttrs.version}-src/hadoop-yarn-project/hadoop-yarn/"
                +"hadoop-yarn-server/hadoop-yarn-server-nodemanager/src";

--- a/pkgs/applications/networking/cluster/hadoop/containerExecutor.nix
+++ b/pkgs/applications/networking/cluster/hadoop/containerExecutor.nix
@@ -1,0 +1,37 @@
+{ version, hash, stdenv, fetchurl, lib, cmake, openssl, platformAttrs, ... }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hadoop-yarn-containerexecutor";
+  inherit version;
+
+  src = fetchurl {
+    url = with finalAttrs; "mirror://apache/hadoop/common/hadoop-${finalAttrs.version}/hadoop-${finalAttrs.version}-src.tar.gz";
+    inherit hash;
+  };
+  sourceRoot = "hadoop-${finalAttrs.version}-src/hadoop-yarn-project/hadoop-yarn/"
+               +"hadoop-yarn-server/hadoop-yarn-server-nodemanager/src";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openssl ];
+  cmakeFlags = [ "-DHADOOP_CONF_DIR=/run/wrappers/yarn-nodemanager/etc/hadoop" ];
+
+  installPhase = ''
+    mkdir $out
+    mv target/var/empty/local/bin $out/
+  '';
+
+  meta = with lib; {
+    homepage = "https://hadoop.apache.org/";
+    description = "Framework for distributed processing of large data sets across clusters of computers";
+    license = licenses.asl20;
+
+    longDescription = ''
+        The Hadoop YARN Container Executor is a native component responsible for managing the lifecycle of containers
+        on individual nodes in a Hadoop YARN cluster. It launches, monitors, and terminates containers, ensuring that
+        resources like CPU and memory are allocated according to the policies defined in the ResourceManager.
+    '';
+
+    maintainers = with maintainers; [ illustris ];
+    platforms = attrNames platformAttrs;
+  };
+})

--- a/pkgs/applications/networking/cluster/hadoop/containerExecutor.nix
+++ b/pkgs/applications/networking/cluster/hadoop/containerExecutor.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation (finalAttrs: {
   inherit version;
 
   src = fetchurl {
-    url = with finalAttrs; "mirror://apache/hadoop/common/hadoop-${finalAttrs.version}/hadoop-${finalAttrs.version}-src.tar.gz";
+    url = "mirror://apache/hadoop/common/hadoop-${finalAttrs.version}/hadoop-${finalAttrs.version}-src.tar.gz";
     hash = platformAttrs.${stdenv.system}.srcHash;
   };
   sourceRoot = "hadoop-${finalAttrs.version}-src/hadoop-yarn-project/hadoop-yarn/"

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -40,10 +40,11 @@ let
       doCheck = true;
 
       # Build the container executor binary from source
-      containerExecutor = callPackage ./containerExecutor.nix {
+      # InstallPhase is not lazily evaluating containerExecutor for some reason
+      containerExecutor = if stdenv.isLinux then (callPackage ./containerExecutor.nix {
         inherit (finalAttrs) version;
         inherit platformAttrs;
-      };
+      }) else "";
 
       nativeBuildInputs = [ makeWrapper ]
                           ++ optionals stdenv.isLinux [ autoPatchelfHook ];

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -47,7 +47,7 @@ let
 
       nativeBuildInputs = [ makeWrapper ]
                           ++ optionals stdenv.isLinux [ autoPatchelfHook ];
-      buildInputs = [ stdenv.cc.cc.lib openssl protobuf zlib snappy libtirpc ];
+      buildInputs = optionals stdenv.isLinux [ stdenv.cc.cc.lib openssl protobuf zlib snappy libtirpc ];
 
       installPhase = ''
         mkdir $out

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17869,9 +17869,7 @@ with pkgs;
 
   groovy = callPackage ../development/interpreters/groovy { };
 
-  inherit (callPackages ../applications/networking/cluster/hadoop {
-    openssl = openssl_1_1;
-  })
+  inherit (callPackages ../applications/networking/cluster/hadoop {})
     hadoop_3_3
     hadoop_3_2
     hadoop2;


### PR DESCRIPTION
## Description of changes

- hadoop: 3.3.5 -> 3.3.6
- [upgrade openssl dep from 1.x to 3.x](https://github.com/NixOS/nixpkgs/issues/210452)
    - build YARN container executor from source with openssl3
- simplify the needlessly complex directory structure of the hadoop package
    - directly extract tarball to $out instead of $out/lib/hadoop.x.x.x/
    - update module and test to account for the change
- switch to `finalAttrs` instead of rec, to simplify overriding attrs

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
