### PR TITLE
supersonic: init at 0.5.2

### DIFF
--- a/pkgs/applications/audio/supersonic/default.nix
+++ b/pkgs/applications/audio/supersonic/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, pkg-config
+, xorg
+, libglvnd
+, mpv
+, glfw3
+}:
+
+buildGoModule rec {
+  pname = "supersonic";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "dweymouth";
+    repo = "supersonic";
+    rev = "v${version}";
+    hash = "sha256-4SLAUqLMoUxTSi4I/QeHqudO62Gmhpm1XbCGf+3rPlc=";
+  };
+
+  vendorHash = "sha256-6Yp5OoybFpoBuIKodbwnyX3crLCl8hJ2r4plzo0plsY=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+  ];
+
+  buildInputs = [
+    libglvnd
+    mpv
+    xorg.libXxf86vm
+  ] ++ glfw3.buildInputs;
+
+  postInstall = ''
+    mkdir -p $out/share/icons/hicolor/{128x128,256x256,512x512}/apps
+
+    for i in 128 256 512; do
+      install -D $src/res/appicon-$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/${meta.mainProgram}.png
+    done
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = meta.mainProgram;
+      exec = meta.mainProgram;
+      icon = meta.mainProgram;
+      desktopName = "Supersonic";
+      genericName = "Subsonic Client";
+      comment = meta.description;
+      type = "Application";
+      categories = [ "Audio" "AudioVideo" ];
+    })
+  ];
+
+  meta = with lib; {
+    mainProgram = "supersonic";
+    description = "A lightweight cross-platform desktop client for Subsonic music servers";
+    homepage = "https://github.com/dweymouth/supersonic";
+    platforms = platforms.linux;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zane ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1964,6 +1964,8 @@ with pkgs;
 
   supermin = callPackage ../tools/virtualization/supermin { };
 
+  supersonic = callPackage ../applications/audio/supersonic { };
+
   sx-go = callPackage ../tools/security/sx-go { };
 
   systeroid = callPackage ../tools/system/systeroid { };


### PR DESCRIPTION
## Description of changes

Adds supersonic.

Currently not possible to use the system's `glfw`, so just pull in its build inputs.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

