### PR TITLE
python310Packages.keras: 2.11.0 -> 2.13.1

### DIFF
--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -1,23 +1,69 @@
-{ lib, buildPythonPackage, fetchPypi
+{ lib, buildPythonPackage, buildBazelPackage, fetchFromGitHub
+, bazel_5, tensorflow, python
 , pytest, pytest-cov, pytest-xdist
 , six, numpy, scipy, pyyaml, h5py
 , keras-applications, keras-preprocessing
 }:
 
-buildPythonPackage rec {
+let
   pname = "keras";
-  version = "2.11.0";
-  format = "wheel";
+  version = "2.13.1";
+in
+let
+  pythonEnv = python.withPackages (_: [ tensorflow ]);
 
-  src = fetchPypi {
-    inherit format pname version;
-    hash = "sha256-OMb/8OqaiwaicXc2VlySpzyM2bHCOecSXMsYi3hI9l4=";
+  git-src = fetchFromGitHub {
+    owner = "keras-team";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-DHomnFXiTeT7hwTvKU3dZtSGA6bFIb1xFVswCk70BTM=";
   };
+in
+let
+  bazel-build = buildBazelPackage rec {
+    inherit pname version;
 
-  nativeCheckInputs = [
-    pytest
-    pytest-cov
-    pytest-xdist
+    bazel = bazel_5;
+
+    postPatch = ''
+      rm -f .bazelversion
+    '';
+
+    bazelTargets = [
+      "'//keras/protobuf:*'"
+      "'//keras/api:*'"
+    ];
+
+    fetchAttrs = {
+      sha256 = "sha256-oBY2VRJGvxVxZRfYJBKSSlO6Zjcxed1CEck+FVIvmvU=";
+    };
+
+    buildAttrs = {
+      outputs = [ "out" ];
+
+      installPhase = ''
+        mkdir -p "$out"
+        cp -r "$bazelOut/execroot/org_keras/bazel-out/k8-opt/bin/keras" "$out"
+      '';
+    };
+
+    nativeBuildInputs = [ pythonEnv ];
+
+    src = git-src;
+  };
+in buildPythonPackage rec {
+  inherit pname version;
+  src = git-src;
+
+  postPatch = ''
+    ln -s keras/tools/pip_package/setup.py .
+    cp -r ${bazel-build}/keras/protobuf/* keras/protobuf
+    cp -r ${bazel-build}/keras/api/* keras/api
+    touch keras/protobuf/__init__.py
+  '';
+
+  buildInputs = [
+    tensorflow
   ];
 
   propagatedBuildInputs = [
@@ -25,8 +71,28 @@ buildPythonPackage rec {
     keras-applications keras-preprocessing
   ];
 
-  # Couldn't get tests working
-  doCheck = false;
+  nativeCheckInputs = [
+    tensorflow
+  ];
+
+  # Couldn't get bundled tests working
+  # Fit a simple model to random data
+  checkPhase = ''
+    ${python.interpreter} <<EOF
+    import tensorflow as tf
+    import numpy as np
+    np.random.seed(0)
+    tf.random.set_seed(0)
+    model = tf.keras.models.Sequential([
+        tf.keras.layers.Dense(1, activation="linear")
+    ])
+    model.compile(optimizer="sgd", loss="mse")
+
+    x = np.random.uniform(size=(1,1))
+    y = np.random.uniform(size=(1,))
+    model.fit(x, y, epochs=1)
+    EOF
+  '';
 
   meta = with lib; {
     description = "Deep Learning library for Theano and TensorFlow";


### PR DESCRIPTION
## Description of changes

When running on a newer version of `tensorflow` (recommendable as per https://github.com/NixOS/nixpkgs/issues/250245#issuecomment-1685373609, possible through https://github.com/NixOS/nixpkgs/pull/255998), `keras` `2.11.0` runs into issues on certain layers (e.g. `keras/layers/rnn/gru_lstm_utils.py`) due to `tensorflow` API changes. Therefore, an update seems necessary.

I moved to `2.13.1`. I also moved over to building the package from source since the `whl` distribution contains build artifacts. Building from source enables future packagers e.g. to solve binary compatibility issues with respect to libraries like `protobuf`.

Finally, I added the small test script which was previously part of the `tensorflow` build, which actually belongs here since being a build dependency of `keras`, `tensorflow` cannot require `keras` to be already present for testing.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
