### PR TITLE
heroku: 7.66.4 -> 8.4.3 (and then 8.7.1)

### DIFF
--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -1,12 +1,19 @@
-{ stdenv, lib, fetchurl, makeWrapper, nodejs }:
+{ stdenv, lib, fetchzip, makeWrapper, nodejs }:
 
-stdenv.mkDerivation rec {
+let
+  # version and commit pairs can be found in the URLs at
+  # https://cli-assets.heroku.com/versions/heroku-linux-x64-tar-xz.json
+  version = "8.4.3";
+  commit = "8226515";
+  hash = "sha256-G3WlHEV3qGMDH9vVu7PU33JUOAyLryW/Xm0fejn5F58=";
+in
+stdenv.mkDerivation {
   pname = "heroku";
-  version = "7.66.4";
+  inherit version;
 
-  src = fetchurl {
-    url = "https://cli-assets.heroku.com/heroku-v${version}/heroku-v${version}.tar.xz";
-    sha256 = "sha256-AAiC88RBqR5RXeIj39in7hlvI3JNQB6KUwGmt9jo93A=";
+  src = fetchzip {
+    url = "https://cli-assets.heroku.com/versions/${version}/${commit}/heroku-v${version}-${commit}-linux-x64.tar.xz";
+    inherit hash;
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -3,9 +3,9 @@
 let
   # version and commit pairs can be found in the URLs at
   # https://cli-assets.heroku.com/versions/heroku-linux-x64-tar-xz.json
-  version = "8.4.3";
-  commit = "8226515";
-  hash = "sha256-G3WlHEV3qGMDH9vVu7PU33JUOAyLryW/Xm0fejn5F58=";
+  version = "8.7.1";
+  commit = "3f5e369";
+  hash = "sha256-3pCutQBS8N1Yw4JKTvU046UrOxBi0wLRQywxwezAEeU";
 in
 stdenv.mkDerivation {
   pname = "heroku";


### PR DESCRIPTION
## Description of changes

Update heroku package. The URL format has changed with the v8 series to include the commit hash (ref: https://github.com/heroku/cli/issues/2477)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Tested the new heroku command on my arm mac, and a linux nixos vm running on the mac host. Don't have easy access to x86 computers at the moment.