### PR TITLE
lib: init mergeEqualOptionBy

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -262,18 +262,39 @@ rec {
     else assert length defs > 1;
       throw "The option `${showOption loc}' is defined multiple times while it's expected to be unique.\n${message}\nDefinition values:${showDefs defs}\n${prioritySuggestion}";
 
-  /* "Merge" option definitions by checking that they all have the same value. */
-  mergeEqualOption = loc: defs:
+  # Merge two values only when they are equal under a given projection function.
+  # The additional argument `printProjectedValues` can be used to disable printing
+  # the values that were used in the comparison in case of an error message.
+  mergeEqualOptionBy =
+    { project
+    , printProjectedValues ? true
+    }:
+    loc: defs:
     if defs == [] then abort "This case should never happen."
     # Return early if we only have one element
     # This also makes it work for functions, because the foldl' below would try
     # to compare the first element with itself, which is false for functions
     else if length defs == 1 then (head defs).value
     else (foldl' (first: def:
-      if def.value != first.value then
-        throw "The option `${showOption loc}' has conflicting definition values:${showDefs [ first def ]}\n${prioritySuggestion}"
+      if (project def.value) != (project first.value) then
+        let
+          projectValue = def: def // {
+            value = {
+              originalValue = def.value;
+              comparedValue = project def.value;
+            };
+          };
+          showDefs' = defs:
+            if printProjectedValues
+            then showDefs (map projectValue defs)
+            else showDefs defs;
+        in
+        throw "The option `${showOption loc}' has conflicting definition values:${showDefs' [ first def ]}\n${prioritySuggestion}"
       else
         first) (head defs) (tail defs)).value;
+
+  /* "Merge" option definitions by checking that they all have the same value. */
+  mergeEqualOption = mergeEqualOptionBy { project = lib.id; printProjectedValues = false; };
 
   /* Extracts values of all "value" keys of the given list.
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -112,6 +112,15 @@ checkConfigError 'A definition for option .* is not of type .path in the Nix sto
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ".*/store/.links"' config.pathInStore.bad4 ./types.nix
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: "/foo/bar"' config.pathInStore.bad5 ./types.nix
 
+checkConfigOutput '"foo"' config.stringOption.ok1 ./merge-equal-options.nix
+checkConfigOutput '"foo"' config.stringOption.ok2 ./merge-equal-options.nix
+checkConfigError 'The option .* has conflicting definition values' config.stringOption.bad1 ./merge-equal-options.nix
+
+checkConfigOutput '"foo"' config.stringPrefixOption.ok1 ./merge-equal-options.nix
+checkConfigOutput '"foo"' config.stringPrefixOption.ok2 ./merge-equal-options.nix
+checkConfigOutput '"foo"' config.stringPrefixOption.ok3 ./merge-equal-options.nix
+checkConfigError 'The option .* has conflicting definition values' config.stringPrefixOption.bad1 ./merge-equal-options.nix
+
 # Check boolean option.
 checkConfigOutput '^false$' config.enable ./declare-enable.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./define-enable.nix

--- a/lib/tests/modules/merge-equal-options.nix
+++ b/lib/tests/modules/merge-equal-options.nix
@@ -1,0 +1,48 @@
+{ lib, ... }:
+let
+  stringMergeEqualPrefix = lib.types.str // {
+    merge = lib.options.mergeEqualOptionBy {
+      project = lib.substring 0 3;
+    };
+  };
+in
+{
+  options = {
+    stringOption = lib.mkOption { type = lib.types.lazyAttrsOf lib.types.str; };
+    stringPrefixOption = lib.mkOption { type = lib.types.lazyAttrsOf stringMergeEqualPrefix; };
+  };
+  config = {
+    stringOption.ok1 = lib.mkMerge [
+      "foo"
+    ];
+    stringOption.ok2 = lib.mkMerge [
+      "foo"
+      "foo"
+      "foo"
+    ];
+    stringOption.bad1 = lib.mkMerge [
+      "foo"
+      "bar"
+      "foo"
+    ];
+
+    stringPrefixOption.ok1 = lib.mkMerge [
+      "foo"
+    ];
+    stringPrefixOption.ok2 = lib.mkMerge [
+      "foo"
+      "foo"
+      "foo"
+    ];
+    stringPrefixOption.ok3 = lib.mkMerge [
+      "foo"
+      "foobar"
+      "foobaz"
+    ];
+    stringPrefixOption.bad1 = lib.mkMerge [
+      "foo"
+      "bar"
+      "foo"
+    ];
+  };
+}


### PR DESCRIPTION
This allows to redefine what equality means so we can for instance compare derivations by outPath.

This could be used in #223064 and #255086 to avoid needing to duplicate the code for `mergeEqualOption`.