### PR TITLE
go_1_21: fix cross-compiling other packages

### DIFF
--- a/pkgs/development/compilers/go/1.21.nix
+++ b/pkgs/development/compilers/go/1.21.nix
@@ -64,10 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   depsTargetTarget = lib.optional stdenv.targetPlatform.isWindows threadsCross.package;
 
-  postPatch = ''
-    patchShebangs .
-  '';
-
   patches = [
     (substituteAll {
       src = ./iana-etc-1.17.patch;
@@ -92,8 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
   GOOS = stdenv.targetPlatform.parsed.kernel.name;
   GOARCH = goarch stdenv.targetPlatform;
   # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
-  # Go will nevertheless build a for host system that we will copy over in
-  # the install phase.
   GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
   GOHOSTARCH = goarch stdenv.buildPlatform;
 
@@ -116,13 +110,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
 
+  # Note that we use distpack to avoid moving around cross-compiled binaries.
+  # The paths are slightly different when buildPlatform != hostPlatform and
+  # distpack handles assembling outputs in the right place, same as the official
+  # Go binary releases. See also https://pkg.go.dev/cmd/distpack
   buildPhase = ''
     runHook preBuild
     export GOCACHE=$TMPDIR/go-cache
     # this is compiled into the binary
     export GOROOT_FINAL=$out/share/go
-
-    export PATH=$(pwd)/bin:$PATH
 
     ${lib.optionalString isCross ''
     # Independent from host/target, CC should produce code for the building system.
@@ -132,34 +128,16 @@ stdenv.mkDerivation (finalAttrs: {
     ulimit -a
 
     pushd src
-    ./make.bash
+    bash make.bash -no-banner -distpack
     popd
     runHook postBuild
   '';
 
-  preInstall = ''
-    # Contains the wrong perl shebang when cross compiling,
-    # since it is not used for anything we can deleted as well.
-    rm src/regexp/syntax/make_perl_groups.pl
-  '' + (if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then ''
-    mv bin/*_*/* bin
-    rmdir bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
-    ''}
-  '' else lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
-    rm -rf bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
-    ''}
-  '');
-
   installPhase = ''
     runHook preInstall
-    mkdir -p $GOROOT_FINAL
-    cp -a bin pkg src lib misc api doc go.env $GOROOT_FINAL
-    mkdir -p $out/bin
-    ln -s $GOROOT_FINAL/bin/* $out/bin
+    mkdir -p $out/{share,bin}
+    tar -C $out/share -x -z -f "pkg/distpack/go${finalAttrs.version}.$GOOS-$GOARCH.tar.gz"
+    ln -s $out/share/go/bin/* $out/bin
     runHook postInstall
   '';
 


### PR DESCRIPTION
## Description of changes

Switch to distpack missed the fact that GOOS/GOARCH was set to targetPlatform instead of hostPlatform so Go package used in buildGoModule was built for the wrong platform (in this case, build = host since we need to run Go on the build platform, but host ≠ target when cross-compiling).

This change refactors build process for go1.21 to expose GOOS/GOARCH via passhtru set to targetPlatform for compatiblity (since that’s what other Go versions do), and build for hostPlatform as expected.

In addition to that, Go is a cross-compiler, that is, targetPlatform is not relevant as it can build for any supported platform out-of-the-box, and release builds are statically linked and do not require Cgo or C/C++ toolchain in general. Before this change, Go builds embedded C toolchain reference for the targetPlatform (via {CC,CXX}_FOR_TARGET environment variable). Now we expect that dependent packages configure CC/CXX for their target platform (this should already be handled automatically when using stdenv.mkDerivation and therefore buildGoModule).

Addresses https://github.com/NixOS/nixpkgs/pull/254497#issuecomment-1727653073

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
