### PR TITLE
adding vscoq language server

### DIFF
--- a/pkgs/development/coq-modules/vscoq-language-server/default.nix
+++ b/pkgs/development/coq-modules/vscoq-language-server/default.nix
@@ -1,0 +1,32 @@
+{ metaFetch, mkCoqDerivation, coq, lib, glib, gnome, wrapGAppsHook,
+  version ? null }:
+
+let ocamlPackages = coq.ocamlPackages;
+    defaultVersion = lib.switch coq.coq-version [
+      { case = "8.18"; out = "2.0.3+coq8.18"; }
+    ] null;
+    location = { domain = "github.com"; owner = "coq-community"; repo = "vscoq"; };
+    fetch = metaFetch ({
+      release."2.0.3+coq8.18".sha256 = "sha256-VXhHCP6Ni5/OcsgoI1EbJfYCpXzwkuR8kbbKrl6dfjU=";
+      release."2.0.3+coq8.18".rev = "v2.0.3+coq8.18";
+      inherit location; });
+    fetched = fetch (if version != null then version else defaultVersion);
+in
+ocamlPackages.buildDunePackage {
+  pname = "vscoq-language-server";
+  inherit (fetched) version;
+  src = "${fetched.src}/language-server";
+  buildInputs =
+    [ coq glib gnome.adwaita-icon-theme wrapGAppsHook ] ++
+    (with ocamlPackages; [ findlib
+      lablgtk3-sourceview3 yojson zarith ppx_inline_test
+      ppx_assert ppx_sexp_conv ppx_deriving ppx_import sexplib
+      ppx_yojson_conv lsp sel ]);
+
+  meta = with lib; {
+    description = "Language server for the vscoq vscode/codium extension";
+    homepage = "https://github.com/coq-community/vscoq";
+    maintainers = with maintainers; [ cohencyril ];
+    license = licenses.mit;
+  } // optionalAttrs (fetched.broken or false) { coqFilter = true; broken = true; };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -125,6 +125,7 @@ let
       vcfloat = callPackage ../development/coq-modules/vcfloat {};
       Velisarios = callPackage ../development/coq-modules/Velisarios {};
       Verdi = callPackage ../development/coq-modules/Verdi {};
+      vscoq-language-server = callPackage ../development/coq-modules/vscoq-language-server {};
       VST = callPackage ../development/coq-modules/VST ((lib.optionalAttrs
         (lib.versionAtLeast self.coq.version "8.14") {
           compcert = self.compcert.override {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->