### PR TITLE
linux_6_1,linux_6_5: backport patch from 6.6 for NFS fix

### DIFF
--- a/nixos/tests/nfs/kerberos.nix
+++ b/nixos/tests/nfs/kerberos.nix
@@ -40,7 +40,7 @@ in
 
         virtualisation.fileSystems =
           { "/data" = {
-              device  = "server.nfs.test:/";
+              device  = "server.nfs.test:/data";
               fsType  = "nfs";
               options = [ "nfsvers=4" "sec=krb5p" "noauto" ];
             };
@@ -71,7 +71,7 @@ in
         services.nfs.server.createMountPoints = true;
         services.nfs.server.exports =
           ''
-            /data *(rw,no_root_squash,fsid=0,sec=krb5p)
+            /data *(rw,no_root_squash,fsid=1,sec=krb5p)
           '';
       };
   };

--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -6,8 +6,8 @@ let
     { pkgs, ... }:
     { virtualisation.fileSystems =
         { "/data" =
-           { # nfs4 exports the export with fsid=0 as a virtual root directory
-             device = if (version == 4) then "server:/" else "server:/data";
+           {
+             device = "server:/data";
              fsType = "nfs";
              options = [ "vers=${toString version}" ];
            };
@@ -32,7 +32,7 @@ in
         { services.nfs.server.enable = true;
           services.nfs.server.exports =
             ''
-              /data 192.168.1.0/255.255.255.0(rw,no_root_squash,no_subtree_check,fsid=0)
+              /data 192.168.1.0/255.255.255.0(rw,no_root_squash,no_subtree_check,fsid=1)
             '';
           services.nfs.server.createMountPoints = true;
           networking.firewall.enable = false; # FIXME: figure out what ports need to be allowed

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -44,6 +44,15 @@
       patch = ./modinst-arg-list-too-long.patch;
     };
 
+  selinux_empty_opts =
+    { name = "selinux-empty-opts";
+      patch = fetchurl {
+        name = "selinux-empty-opts.patch";
+        url = "https://lore.kernel.org/selinux/20230911142358.883728-1-omosnace@redhat.com/raw";
+        hash = "sha256-FP28/xMfmnDPFO2G9Jpik+t4rVfWEFpdB0Lh1QGLx6E=";
+      };
+    };
+
   cpu-cgroup-v2 = import ./cpu-cgroup-v2-patches;
 
   hardened = let

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -165,6 +165,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.dell_xps_regression
+        kernelPatches.selinux_empty_opts # backport NFS fix from 6.6
       ];
     };
 
@@ -190,6 +191,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.dell_xps_regression
+        kernelPatches.selinux_empty_opts # backport NFS fix from 6.6
       ];
     };
 


### PR DESCRIPTION
## Description of changes

fsid=0 is special, and due to its special treatment the tests failed to catch #255803, introduced during kernel updates 6.1.52->6.1.53 and 6.5.2->6.5.3. With this change, the tests correctly fail without the backported patch.

This issue currently persists on 6.1.54, and to fix the actual issue, we need to pull in "selinux: fix handling of empty opts in selinux_fs_context_submount()" (patch [here](https://git.kernel.org/pub/scm/linux/kernel/git/pcmoore/selinux.git/commit/?h=stable-6.6&id=ccf1dab96be4caed7c5235b1cfdb606ac161b996), see the Gentoo folks' work [here](https://bugs.gentoo.org/914204) and Fedora [here](https://bugzilla.redhat.com/show_bug.cgi?id=2236345)).

Tested:
- Updated tests fail on 6.1.52, unpatched 6.1.54, unpatched 6.5.4.
- Patch applies cleanly & builds linux_6_1 and linux_6_5.
- Updated tests succeed on 6.1.52, patched 6.1.54, patched 6.5.4.

Fixes #255803.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
