### PR TITLE
python3Packages.gitpython: 3.1.33 -> 3.1.37

### DIFF
--- a/pkgs/development/python-modules/gitpython/default.nix
+++ b/pkgs/development/python-modules/gitpython/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "gitpython";
-  version = "3.1.33";
+  version = "3.1.37";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "gitpython-developers";
     repo = "GitPython";
     rev = "refs/tags/${version}";
-    hash = "sha256-SqpoI8QnynHRHUdenMrOAGib/SDpix4rSXfEes4xt/Y=";
+    hash = "sha256-w3aSgIaD6tkxhYctkvvsdKlWXS8xU4+F0cCYeYTNHig=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

This version bump resolves https://nvd.nist.gov/vuln/detail/CVE-2023-41040

Changelogs:
* https://github.com/gitpython-developers/GitPython/blob/3.1.37/doc/source/changes.rst
    * 3.1.34 https://github.com/gitpython-developers/gitpython/milestone/64?closed=1
    * 3.1.35 https://github.com/gitpython-developers/gitpython/milestone/65?closed=1
        * https://github.com/gitpython-developers/GitPython/pull/1644
    * 3.1.36 https://github.com/gitpython-developers/gitpython/milestone/66?closed=1
    * 3.1.37 https://github.com/gitpython-developers/gitpython/milestone/67?closed=1
        * "properly fixes"  CVE-2023-41040 / GHSA-cwvm-v4w8-q58c

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

        8 packages failed to build:
        python310Packages.mmcv python310Packages.mmcv.dist python310Packages.skrl python310Packages.skrl.dist
        python311Packages.mmcv python311Packages.mmcv.dist python311Packages.skrl python311Packages.skrl.dist

        448 packages built: ...
    These build failures are probably not caused by this PR: I'm unable to build these packages on my machine with or without this change because the build fills ram and swap and then earlyoom kills it.  :(
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

FYI: @fabaff, maintainer