### PR TITLE
{caffe,mxnet,sdrangel,video2midi,waifu2x-converter-cpp}: opencv3 -> opencv4

### DIFF
--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -24,7 +24,7 @@
 , libbladeRF
 , mbelib
 , ninja
-, opencv3
+, opencv4
 , pkg-config
 , qtcharts
 , qtdeclarative
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     libusb1
     limesuite
     mbelib
-    opencv3
+    opencv4
     qtcharts
     qtdeclarative
     qtgamepad

--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -1,12 +1,13 @@
 { config, stdenv, lib
 , fetchFromGitHub
 , fetchurl
+, fetchpatch
 , cmake
 , boost
 , gflags
 , glog
 , hdf5-cpp
-, opencv3
+, opencv4
 , protobuf
 , doxygen
 , blas
@@ -71,7 +72,7 @@ stdenv.mkDerivation rec {
       ++ ["-DUSE_LEVELDB=${toggle leveldbSupport}"]
       ++ ["-DUSE_LMDB=${toggle lmdbSupport}"];
 
-  buildInputs = [ boost gflags glog protobuf hdf5-cpp opencv3 blas ]
+  buildInputs = [ boost gflags glog protobuf hdf5-cpp opencv4 blas ]
                 ++ lib.optional cudaSupport cudatoolkit
                 ++ lib.optional cudnnSupport cudnn
                 ++ lib.optional lmdbSupport lmdb
@@ -96,6 +97,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./darwin.patch
+    (fetchpatch {
+       name = "support-opencv4";
+       url = "https://github.com/BVLC/caffe/pull/6638/commits/0a04cc2ccd37ba36843c18fea2d5cbae6e7dd2b5.patch";
+       hash = "sha256-ZegTvp0tTHlopQv+UzHDigs6XLkP2VfqLCWXl6aKJSI=";
+     })
   ] ++ lib.optional pythonSupport (substituteAll {
     src = ./python.patch;
     inherit (python.sourceVersion) major minor;  # Should be changed in case of PyPy

--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -148,7 +148,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://caffe.berkeleyvision.org/";
     maintainers = with maintainers; [ ];
-    broken = pythonSupport && (python.isPy310);
+    broken = (pythonSupport && (python.isPy310)) || cudaSupport;
     license = licenses.bsd2;
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -1,5 +1,5 @@
 { config, stdenv, lib, fetchurl, fetchpatch, bash, cmake
-, opencv3, gtest, blas, gomp, llvmPackages, perl
+, opencv4, gtest, blas, gomp, llvmPackages, perl
 , cudaSupport ? config.cudaSupport, cudaPackages ? { }, nvidia_x11
 , cudnnSupport ? cudaSupport
 }:
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake perl ];
 
-  buildInputs = [ opencv3 gtest blas.provider ]
+  buildInputs = [ opencv4 gtest blas.provider ]
     ++ lib.optional stdenv.cc.isGNU gomp
     ++ lib.optional stdenv.cc.isClang llvmPackages.openmp
     # FIXME: when cuda build is fixed, remove nvidia_x11, and use /run/opengl-driver/lib

--- a/pkgs/tools/audio/video2midi/default.nix
+++ b/pkgs/tools/audio/video2midi/default.nix
@@ -1,7 +1,7 @@
-{ lib, fetchFromGitHub, pythonPackages, opencv3 }:
+{ lib, fetchFromGitHub, pythonPackages, opencv4 }:
 
 let
-  opencv3_ = pythonPackages.toPythonModule (opencv3.override {
+  opencv4_ = pythonPackages.toPythonModule (opencv4.override {
     inherit pythonPackages;
     enablePython = true;
     enableFfmpeg = true;
@@ -19,7 +19,7 @@ in pythonPackages.buildPythonApplication rec {
     sha256 = "0qzrxqhsxn0h71nfrsi9g78hx3pqm3b8sr6fjq01k4k6dd2nwfam";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ opencv3_ midiutil pygame pyopengl ];
+  propagatedBuildInputs = with pythonPackages; [ opencv4_ midiutil pygame pyopengl ];
 
   installPhase = ''
     install -Dm755 v2m.py $out/bin/v2m.py

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -17,7 +17,6 @@
 , libtiff
 , ninja
 , nix-update
-, opencv3
 , openexr
 , pkg-config
 , qtbase
@@ -78,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
     libjpeg
     libtiff
     libpng
-    opencv3
     openexr
     graphicsmagick
     curl

--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -1,4 +1,4 @@
-{ cmake, fetchFromGitHub, makeWrapper, opencv3, lib, stdenv, ocl-icd, opencl-headers, OpenCL
+{ cmake, fetchFromGitHub, makeWrapper, opencv4, lib, stdenv, ocl-icd, opencl-headers, OpenCL
 , config
 , cudaSupport ? config.cudaSupport, cudatoolkit ? null
 }:
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    opencv3
+    opencv4
   ] ++ lib.optional cudaSupport cudatoolkit
     ++ lib.optional stdenv.isDarwin OpenCL
     ++ lib.optionals stdenv.isLinux [ ocl-icd opencl-headers ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39829,7 +39829,7 @@ with pkgs;
   caffe = callPackage ../applications/science/math/caffe ({
     inherit (config) cudaSupport;
     cudaPackages = cudaPackages_10_1;
-    opencv3 = opencv3WithoutCuda; # Used only for image loading.
+    opencv4 = opencv4WithoutCuda; # Used only for image loading.
     blas = openblas;
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
   } // (config.caffe or {}));

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24336,6 +24336,10 @@ with pkgs;
     ffmpeg = ffmpeg_4;
   };
 
+  opencv4WithoutCuda = opencv4.override {
+    enableCuda = false;
+  };
+
   opencv = opencv4;
 
   imath = callPackage ../development/libraries/imath { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24325,10 +24325,6 @@ with pkgs;
     ffmpeg = ffmpeg_4;
   };
 
-  opencv3WithoutCuda = opencv3.override {
-    enableCuda = false;
-  };
-
   opencv4 = callPackage ../development/libraries/opencv/4.x.nix {
     inherit (darwin.apple_sdk.frameworks)
       AVFoundation Cocoa VideoDecodeAcceleration CoreMedia MediaToolbox Accelerate;


### PR DESCRIPTION
opencv4WithoutCuda: init at opencv4.version
opencv3WithoutCuda: remove
gmic-qt: remove apparently unused opencv3 dependency
caffeWithCuda: mark broken

## Description of changes

Removing all non-Python/Haskell uses of `opencv3`.

Results of `nixpkgs-review` on x86_64-Linux:
```
17 packages marked as broken and skipped:
caffeWithCuda caffeWithCuda.bin cntk python310Packages.caffe python310Packages.caffe.bin python310Packages.caffeWithCuda python310Packages.caffeWithCuda.bin python310Packages.cntk python310Packages.cntk.dist python310Packages.insightface python310Packages.insightface.dist python311Packages.caffeWithCuda python311Packages.caffeWithCuda.bin python311Packages.cntk python311Packages.cntk.dist python311Packages.insightface python311Packages.insightface.dist

17 packages built:
caffe caffe.bin gimp-with-plugins gimpPlugins.gmic gmic-qt mxnet opencv4WithoutCuda opencv4WithoutCuda.package_tests python310Packages.mxnet python310Packages.mxnet.dist python311Packages.caffe python311Packages.caffe.bin python311Packages.mxnet python311Packages.mxnet.dist sdrangel video2midi waifu2x-converter-cpp
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
