### PR TITLE
curlftpfs: apply SUSE patches

### DIFF
--- a/pkgs/tools/filesystems/curlftpfs/default.nix
+++ b/pkgs/tools/filesystems/curlftpfs/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     # it is known to cause problems. Search online for "rpl_malloc" and
     # "rpl_realloc" to find out more.
     ./fix-rpl_malloc.patch
+    ./suse-bug-580609.patch
+    ./suse-bug-955687.patch
   ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];

--- a/pkgs/tools/filesystems/curlftpfs/suse-bug-580609.patch
+++ b/pkgs/tools/filesystems/curlftpfs/suse-bug-580609.patch
@@ -1,0 +1,10 @@
+--- a/ftpfs.c	2008-04-30 01:05:47.000000000 +0200
++++ b/ftpfs.c	2010-05-21 13:01:42.569006163 +0200
+@@ -503,7 +503,6 @@ static void *ftpfs_write_thread(void *da
+   
+   curl_easy_setopt_or_die(fh->write_conn, CURLOPT_URL, fh->full_path);
+   curl_easy_setopt_or_die(fh->write_conn, CURLOPT_UPLOAD, 1);
+-  curl_easy_setopt_or_die(fh->write_conn, CURLOPT_INFILESIZE, -1);
+   curl_easy_setopt_or_die(fh->write_conn, CURLOPT_READFUNCTION, write_data_bg);
+   curl_easy_setopt_or_die(fh->write_conn, CURLOPT_READDATA, fh);
+   curl_easy_setopt_or_die(fh->write_conn, CURLOPT_LOW_SPEED_LIMIT, 1);

--- a/pkgs/tools/filesystems/curlftpfs/suse-bug-955687.patch
+++ b/pkgs/tools/filesystems/curlftpfs/suse-bug-955687.patch
@@ -1,0 +1,11 @@
+--- a/ftpfs.c
++++ b/ftpfs.c
+@@ -614,6 +614,8 @@ static void free_ftpfs_file(struct ftpfs
+   sem_destroy(&fh->data_need);
+   sem_destroy(&fh->data_written);
+   sem_destroy(&fh->ready);
++  if (fh->buf.size) { buf_free(&fh->buf); }
++  if (fh->stream_buf.size) { buf_free(&fh->stream_buf); }
+   free(fh);
+ }
+ 


### PR DESCRIPTION


## Description of changes

Fixes this bug in particular:
https://sourceforge.net/p/curlftpfs/bugs/70/

## Things done

Applied two patches from SUSE distro

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
