### PR TITLE
kbd: 2.6.2 -> 2.6.3

### DIFF
--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "kbd";
-  version = "2.6.2";
+  version = "2.6.3";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/kbd/${pname}-${version}.tar.xz";
-    sha256 = "sha256-M+O7PD9VkzsQ8FOxS19pouJMKFQ+nsdpAkb+R2KN2U8=";
+    sha256 = "sha256-BJlsCNfRxGCWb7JEo9OIM1LCZ0t61SIAPZ9Oy4q0jes=";
   };
 
   # vlock is moved into its own output, since it depends on pam. This

--- a/pkgs/os-specific/linux/kbd/search-paths.patch
+++ b/pkgs/os-specific/linux/kbd/search-paths.patch
@@ -18,34 +18,30 @@ Without this patch, kbd will only look inside
  	DATADIR "/" KEYMAPDIR "/mac/include/",
 --- a/src/libkfont/context.c
 +++ b/src/libkfont/context.c
-@@ -13,6 +13,7 @@
+@@ -13,5 +13,6 @@
  /* search for the map file in these directories (with trailing /) */
  static const char *const mapdirpath[]  = {
- 	"",
 +	"/etc/kbd/" TRANSDIR "/",
  	DATADIR "/" TRANSDIR "/",
  	NULL
  };
-@@ -28,6 +29,7 @@ static const char *const mapsuffixes[] = {
+@@ -28,5 +29,6 @@ static const char *const mapsuffixes[] = {
  /* search for the font in these directories (with trailing /) */
  static const char *const fontdirpath[]  = {
- 	"",
 +	"/etc/kbd/" FONTDIR "/",
  	DATADIR "/" FONTDIR "/",
  	NULL
  };
-@@ -42,6 +44,7 @@ static char const *const fontsuffixes[] = {
+@@ -42,5 +44,6 @@ static char const *const fontsuffixes[] = {
  
  static const char *const unidirpath[]  = {
- 	"",
 +	"/etc/kbd/" UNIMAPDIR "/",
  	DATADIR "/" UNIMAPDIR "/",
  	NULL
  };
-@@ -55,6 +58,7 @@ static const char *const unisuffixes[] = {
+@@ -55,5 +58,6 @@ static const char *const unisuffixes[] = {
  /* hide partial fonts a bit - loading a single one is a bad idea */
  const char *const partfontdirpath[]  = {
- 	"",
 +	"/etc/kbd/" FONTDIR "/" PARTIALDIR "/",
  	DATADIR "/" FONTDIR "/" PARTIALDIR "/",
  	NULL


### PR DESCRIPTION
Changes: https://github.com/legionus/kbd/releases/tag/v2.6.3

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
