### PR TITLE
wl-screenrec: unstable-2023-05-31 -> unstable-2023-09-17

### DIFF
--- a/pkgs/tools/wayland/wl-screenrec/default.nix
+++ b/pkgs/tools/wayland/wl-screenrec/default.nix
@@ -2,22 +2,23 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
-, wayland
+, libdrm
 , ffmpeg
+, wayland
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wl-screenrec";
-  version = "unstable-2023-05-31";
+  version = "unstable-2023-09-17";
 
   src = fetchFromGitHub {
     owner = "russelltg";
     repo = pname;
-    rev = "fc918f7898900c1882c6f64c96ed2de8cb9a6300";
-    hash = "sha256-P/JELiw0qGcwLFgNPccN/uetNy8CNCJdlCLhgq0h4sc=";
+    rev = "a36c5923009b44f2131196d8a3a234948f8e0102";
+    hash = "sha256-V29eB9vozVKIBq8dO7zgA4nirsh1eDBjJN+rwVkeDLE=";
   };
 
-  cargoHash = "sha256-r9zmAiLiAntHcb5W/WKmKbVP9c9+15ElIWtHkks0wig=";
+  cargoHash = "sha256-uUfEweLWn/NdqgY8O7Ld+YnGPKQV1tpJi/Gd4MZB4xI=";
 
   nativeBuildInputs = [
     pkg-config
@@ -26,8 +27,11 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     wayland
+    libdrm
     ffmpeg
   ];
+
+  doCheck = false; # tests use host compositor, etc
 
   meta = with lib; {
     description = "High performance wlroots screen recording, featuring hardware encoding";


### PR DESCRIPTION
## Description of changes

bump to latest available.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
