### PR TITLE
resholve: fix oildev

### DIFF
--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -9,8 +9,7 @@
 , # py-yajl deps
   git
 , # oil deps
-  cmark
-, file
+  file
 , glibcLocales
 , six
 , typing
@@ -80,8 +79,8 @@ rec {
     patchSrc = fetchFromGitHub {
       owner = "abathur";
       repo = "nix-py-dev-oil";
-      rev = "v0.14.0.0";
-      hash = "sha256-U6uR8G6yB2xwuDE/fznco23mVFSVdCxPUNdCRYz4Mj8=";
+      rev = "v0.14.0.1";
+      hash = "sha256-47+986+SohdtoNzTYAgF2vPPWgakyg0VCmR+MgxMzTk=";
     };
     patches = [
       "${patchSrc}/0001-add_setup_py.patch"
@@ -93,6 +92,7 @@ rec {
       "${patchSrc}/0010-disable-line-input.patch"
       "${patchSrc}/0011-disable-fanos.patch"
       "${patchSrc}/0012-disable-doc-cmark.patch"
+      "${patchSrc}/0013-fix-pyverify.patch"
     ];
 
     configureFlags = [
@@ -117,14 +117,6 @@ rec {
       # work around hard parse failure documented in oilshell/oil#1468
       substituteInPlace osh/cmd_parse.py --replace 'elif self.c_id == Id.Op_LParen' 'elif False'
     '';
-
-    /*
-    We did convince oil to upstream an env for specifying
-    this to support a shell.nix. Would need a patch if they
-    later drop this support. See:
-    https://github.com/oilshell/oil/blob/46900310c7e4a07a6223eb6c08e4f26460aad285/doctools/cmark.py#L30-L34
-    */
-    _NIX_SHELL_LIBCMARK = "${cmark}/lib/libcmark${stdenv.hostPlatform.extensions.sharedLibrary}";
 
     # See earlier note on glibcLocales TODO: verify needed?
     LOCALE_ARCHIVE = lib.optionalString (stdenv.buildPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";


### PR DESCRIPTION
This broke (e.g. https://hydra.nixos.org/build/235955701) after the python2 update in #256132. Also including a dep removal that I inadvertently left out the last time I updated this.

@SuperSandro2000 

Result of `nixpkgs-review pr 256612` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>23 packages built:</summary>
  <ul>
    <li>aaxtomp3</li>
    <li>arch-install-scripts</li>
    <li>bash-preexec</li>
    <li>bashup-events32</li>
    <li>bashup-events44</li>
    <li>bats</li>
    <li>dgoss</li>
    <li>git-ftp</li>
    <li>ix</li>
    <li>locate-dominating-file</li>
    <li>mons</li>
    <li>msmtp</li>
    <li>packcc</li>
    <li>pdf2odt</li>
    <li>pdfmm</li>
    <li>resholve</li>
    <li>resholve.dist</li>
    <li>s0ix-selftest-tool</li>
    <li>shunit2</li>
    <li>wgnord</li>
    <li>wsl-vpnkit</li>
    <li>yadm</li>
    <li>zxfer</li>
  </ul>
</details>

Result of `nixpkgs-review pr 256612` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>14 packages built:</summary>
  <ul>
    <li>aaxtomp3</li>
    <li>bash-preexec</li>
    <li>bashup-events32</li>
    <li>bashup-events44</li>
    <li>bats</li>
    <li>git-ftp</li>
    <li>ix</li>
    <li>locate-dominating-file</li>
    <li>mons</li>
    <li>msmtp</li>
    <li>packcc</li>
    <li>pdf2odt</li>
    <li>shunit2</li>
    <li>yadm</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

