### PR TITLE
simplex-chat-desktop: init at 5.3.1

### DIFF
--- a/pkgs/by-name/si/simplex-chat-desktop/package.nix
+++ b/pkgs/by-name/si/simplex-chat-desktop/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, appimageTools
+, fetchurl
+}:
+
+let
+  pname = "simplex-chat-desktop";
+  version = "5.3.1";
+
+  src = fetchurl {
+    url = "https://github.com/simplex-chat/simplex-chat/releases/download/v${version}/simplex-desktop-x86_64.AppImage";
+    hash = "sha256-vykdi7SXKKsjYE/yixGrKQoWuUIOAjofLUn/fsdmLMc=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+in appimageTools.wrapType2 {
+    inherit pname version src;
+
+    extraPkgs = pkgs: with pkgs; [
+      makeWrapper
+    ];
+
+    extraBwrapArgs = [
+      "--setenv _JAVA_AWT_WM_NONREPARENTING 1"
+    ];
+
+    extraInstallCommands = ''
+      mv $out/bin/${pname}-${version} $out/bin/${pname}
+
+      install --mode=444 -D ${appimageContents}/chat.simplex.app.desktop --target-directory=$out/share/applications
+      substituteInPlace $out/share/applications/chat.simplex.app.desktop \
+        --replace 'Exec=simplex' 'Exec=${pname}'
+      cp -r ${appimageContents}/usr/share/icons $out/share
+    '';
+
+  meta = with lib; {
+    description = "Desktop application for SimpleX Chat";
+    homepage = "https://simplex.chat";
+    changelog = "https://github.com/simplex-chat/simplex-chat/releases/tag/v${version}";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ yuu ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

add simplex-chat-desktop AppImage https://github.com/simplex-chat/simplex-chat/releases/tag/v5.3.1

simpex-chat-desktop.nix instead of default.nix because there are other clients like the CLI which someone might add in the future in that same directory...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
