### PR TITLE
alt-ergo: 2.4.3 → 2.5.1; ocamlPackages.ocplib-simplex: 0.4 → 0.5

### DIFF
--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -1,47 +1,35 @@
-{ fetchFromGitHub, fetchpatch, lib, which, ocamlPackages }:
+{ fetchurl, fetchpatch, lib, ocamlPackages }:
 
 let
   pname = "alt-ergo";
-  version = "2.4.3";
+  version = "2.5.1";
 
-  configureScript = "ocaml unix.cma configure.ml";
-
-  src = fetchFromGitHub {
-    owner = "OCamlPro";
-    repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-2XARGr8rLiPMOM0rBBoRv5tZvKYtkLkJctGqLYkMe7Q=";
+  src = fetchurl {
+    url = "https://github.com/OCamlPro/alt-ergo/releases/download/v${version}/alt-ergo-${version}.tbz";
+    hash = "sha256-nPjWmg5FepObhquioYxhVPq6UdOHtCo2Hs5V0yndYB0=";
   };
 in
 
 let alt-ergo-lib = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-lib";
-  inherit version src configureScript;
-  configureFlags = [ pname ];
-  nativeBuildInputs = [ which ];
-  buildInputs = with ocamlPackages; [ dune-configurator ];
-  propagatedBuildInputs = with ocamlPackages; [ dune-build-info num ocplib-simplex seq stdlib-shims zarith ];
-  preBuild = ''
-    substituteInPlace src/lib/util/version.ml --replace 'version="dev"' 'version="${version}"'
-  '';
+  inherit version src;
+  buildInputs = with ocamlPackages; [ ppx_blob ];
+  propagatedBuildInputs = with ocamlPackages; [ camlzip dolmen_loop dune-build-info fmt ocplib-simplex seq stdlib-shims zarith ];
 }; in
 
 let alt-ergo-parsers = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-parsers";
-  inherit version src configureScript;
-  configureFlags = [ pname ];
-  nativeBuildInputs = [ which ocamlPackages.menhir ];
-  propagatedBuildInputs = [ alt-ergo-lib ] ++ (with ocamlPackages; [ camlzip psmt2-frontend ]);
+  inherit version src;
+  nativeBuildInputs = [ ocamlPackages.menhir ];
+  propagatedBuildInputs = [ alt-ergo-lib ] ++ (with ocamlPackages; [ psmt2-frontend ]);
 }; in
 
 ocamlPackages.buildDunePackage {
 
-  inherit pname version src configureScript;
+  inherit pname version src;
 
-  configureFlags = [ pname ];
-
-  nativeBuildInputs = [ which ocamlPackages.menhir ];
-  buildInputs = [ alt-ergo-parsers ocamlPackages.cmdliner ];
+  nativeBuildInputs = [ ocamlPackages.menhir ];
+  buildInputs = [ alt-ergo-parsers ] ++ (with ocamlPackages; [ cmdliner dune-site ]);
 
   meta = {
     description = "High-performance theorem prover and SMT solver";

--- a/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
@@ -1,33 +1,24 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, ocaml, findlib }:
+{ lib, fetchFromGitHub, buildDunePackage, logs, num }:
 
-let
+buildDunePackage rec {
   pname = "ocplib-simplex";
-  version = "0.4";
-in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-${pname}-${version}";
+  version = "0.5";
 
   src = fetchFromGitHub {
     owner = "OCamlPro-Iguernlala";
     repo = pname;
     rev = "v${version}";
-    sha256 = "09niyidrjzrj8g1qwx4wgsdf5m6cwrnzg7zsgala36jliic4di60";
+    hash = "sha256-sy5QUmghG28tXlwbKWx3PpBGTtzXarTSzd1WLSYyvbc=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ocaml findlib ];
+  propagatedBuildInputs = [ logs num ];
 
-  strictDeps = true;
-
-  installFlags = [ "LIBDIR=$(OCAMLFIND_DESTDIR)" ];
-
-  createFindlibDestdir = true;
+  doCheck = true;
 
   meta = {
     description = "An OCaml library implementing a simplex algorithm, in a functional style, for solving systems of linear inequalities";
     homepage = "https://github.com/OCamlPro-Iguernlala/ocplib-simplex";
-    inherit (ocaml.meta) platforms;
-    license = lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21Only;
     maintainers = [ lib.maintainers.vbgl ];
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/OCamlPro/ocplib-simplex/blob/v0.5/CHANGES.md
https://github.com/OCamlPro/alt-ergo/blob/v2.5.1/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
