### PR TITLE
treewide: cleanup vendorSha256 references

### DIFF
--- a/pkgs/applications/misc/dstask/default.nix
+++ b/pkgs/applications/misc/dstask/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-xZFQQDK+yGAv4IbuNe2dvNa3GDASeJY2mOYw94goAIM=";
   };
 
-  # Set vendorSha256 to null because dstask vendors its dependencies (meaning
+  # Set vendorHash to null because dstask vendors its dependencies (meaning
   # that third party dependencies are stored in the repository).
   #
   # Ref <https://github.com/NixOS/nixpkgs/pull/87383#issuecomment-633204382>

--- a/pkgs/applications/version-management/sourcehut/update.sh
+++ b/pkgs/applications/version-management/sourcehut/update.sh
@@ -38,7 +38,7 @@ update_version() {
 
   (cd "$root" && update-source-version "sourcehut.python.pkgs.$1" "$version")
 
-  # Update vendorSha256 of Go modules
+  # Update vendorHash of Go modules
   retry=true
   while "$retry"; do
     retry=false;

--- a/pkgs/development/misc/haskell/hasura/update.sh
+++ b/pkgs/development/misc/haskell/hasura/update.sh
@@ -88,7 +88,7 @@ new_kritilang_version=$(curl --silent "https://api.github.com/repos/hasura/kriti
 cabal2nix --revision "$new_kritilang_version" --maintainer lassulus "https://github.com/hasura/kriti-lang.git" >> "$kritilang_derivation_file"
 
 echo "###################"
-echo "please update pkgs/servers/hasura/cli.nix vendorSha256"
+echo "please update pkgs/servers/hasura/cli.nix vendorHash"
 echo "please update pkgs/development/haskell-modules/configuration-common.nix graphql-engine version"
 echo "###################"
 


### PR DESCRIPTION
## Description of changes

All these packages now use `vendorHash`, while comments are not updated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
