### PR TITLE
perlPackages.MathCalcParser: mark as broken

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14674,6 +14674,7 @@ with self; {
     meta = {
       description = "Parse and evaluate mathematical expressions";
       homepage = "https://github.com/Grinnz/Math-Calc-Parser";
+      broken = true;
       license = with lib.licenses; [ artistic2 ];
       maintainers = with maintainers; [ sgo ];
     };


### PR DESCRIPTION
Apparently it hasn't succeeded for several months:
https://hydra.nixos.org/job/nixpkgs/trunk/perl536Packages.MathCalcParser.x86_64-linux/all 
https://hydra.nixos.org/job/nixpkgs/trunk/perl538Packages.MathCalcParser.x86_64-linux/all

And I also caught the build eating lots of RAM, like 50G. That can cause issues for other builds running alongside.

_The usual checklist doesn't really apply here._