### PR TITLE
[Backport release-23.05] llvmPackages_16: 16.0.1 -> 16.0.6; chromium,ungoogled-chromium,chromedriver: 116.0.5845.187/96 -> 117.0.5938.88

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -241,6 +241,12 @@ let
       # We need the fix for https://bugs.chromium.org/p/chromium/issues/detail?id=1254408:
       base64 --decode ${clangFormatPython3} > buildtools/linux64/clang-format
 
+      # Add final newlines to scripts that do not end with one.
+      # This is a temporary workaround until https://github.com/NixOS/nixpkgs/pull/255463 (or similar) has been merged,
+      # as patchShebangs hard-crashes when it encounters files that contain only a shebang and do not end with a final
+      # newline.
+      find . -type f -perm -0100 -exec sed -i -e '$a\' {} +
+
       patchShebangs .
       # Link to our own Node.js and Java (required during the build):
       mkdir -p third_party/node/linux/node-linux-x64/bin

--- a/pkgs/applications/networking/browsers/chromium/ungoogled-flags.toml
+++ b/pkgs/applications/networking/browsers/chromium/ungoogled-flags.toml
@@ -4,7 +4,6 @@ clang_use_chrome_plugins=false
 disable_fieldtrial_testing_config=true
 enable_hangout_services_extension=false
 enable_mdns=false
-enable_mse_mpeg2ts_stream_parser=true
 enable_nacl=false
 enable_reading_list=false
 enable_remoting=false

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -48,18 +48,18 @@
   ungoogled-chromium = {
     deps = {
       gn = {
-        rev = "4bd1a77e67958fb7f6739bd4542641646f264e5d";
-        sha256 = "14h9jqspb86sl5lhh6q0kk2rwa9zcak63f8drp7kb3r4dx08vzsw";
+        rev = "811d332bd90551342c5cbd39e133aa276022d7f8";
+        sha256 = "0jlg3d31p346na6a3yk0x29pm6b7q03ck423n5n6mi8nv4ybwajq";
         url = "https://gn.googlesource.com/gn";
-        version = "2023-06-09";
+        version = "2023-08-01";
       };
       ungoogled-patches = {
-        rev = "116.0.5845.187-1";
-        sha256 = "0br5lms6mxg2mg8ix5mkb79bg6wk5f2hn0xy1xc7gk9h3rl58is1";
+        rev = "117.0.5938.88-1";
+        sha256 = "1wz15ib56j8c84bgrbf0djk5wli49b1lvaqbg18pdclkp1mqy5w9";
       };
     };
-    sha256 = "152lyrw8k36gbmf4fmfny4ajqh0523y5d48yrshbgwn5klmbhaji";
-    sha256bin64 = "118sk39939d52srws2vgs1mfizpikswxh5ihd9x053vzn0aj8cfa";
-    version = "116.0.5845.187";
+    sha256 = "01n9aqnilsjrbpv5kkx3c6nxs9p5l5lfwxj67hd5s5g4740di4a6";
+    sha256bin64 = "1dhgagphdzbd19gkc7vpl1hxc9vn0l7sxny346qjlmrwafqlhbgi";
+    version = "117.0.5938.88";
   };
 }

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -27,11 +27,11 @@
   };
   stable = {
     chromedriver = {
-      sha256_darwin = "0gzx3zka8i2ngsdiqp8sr0v6ir978vywa1pj7j08vsf8kmb93iiy";
+      sha256_darwin = "0phhcqid7wjw923qdi65zql3fid25swwszksgnw3b8fgz67jn955";
       sha256_darwin_aarch64 =
-        "18iyapwjg0yha8qgbw7f605n0j54nd36shv3497bd84lc9k74b14";
-      sha256_linux = "0d8mqzjc11g1bvxvffk0xyhxfls2ycl7ym4ssyjq752g2apjblhp";
-      version = "116.0.5845.96";
+        "00fwq8slvjm6c7krgwjd4mxhkkrp23n4icb63qlvi2hy06gfj4l6";
+      sha256_linux = "0ws8ch1j2hzp483vr0acvam1zxmzg9d37x6gqdwiqwgrk6x5pvkh";
+      version = "117.0.5938.88";
     };
     deps = {
       gn = {

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -35,15 +35,15 @@
     };
     deps = {
       gn = {
-        rev = "4bd1a77e67958fb7f6739bd4542641646f264e5d";
-        sha256 = "14h9jqspb86sl5lhh6q0kk2rwa9zcak63f8drp7kb3r4dx08vzsw";
+        rev = "811d332bd90551342c5cbd39e133aa276022d7f8";
+        sha256 = "0jlg3d31p346na6a3yk0x29pm6b7q03ck423n5n6mi8nv4ybwajq";
         url = "https://gn.googlesource.com/gn";
-        version = "2023-06-09";
+        version = "2023-08-01";
       };
     };
-    sha256 = "152lyrw8k36gbmf4fmfny4ajqh0523y5d48yrshbgwn5klmbhaji";
-    sha256bin64 = "118sk39939d52srws2vgs1mfizpikswxh5ihd9x053vzn0aj8cfa";
-    version = "116.0.5845.187";
+    sha256 = "01n9aqnilsjrbpv5kkx3c6nxs9p5l5lfwxj67hd5s5g4740di4a6";
+    sha256bin64 = "1dhgagphdzbd19gkc7vpl1hxc9vn0l7sxny346qjlmrwafqlhbgi";
+    version = "117.0.5938.88";
   };
   ungoogled-chromium = {
     deps = {

--- a/pkgs/development/compilers/llvm/16/default.nix
+++ b/pkgs/development/compilers/llvm/16/default.nix
@@ -25,7 +25,7 @@
   #   rev-version = /* human readable version; i.e. "unstable-2022-26-07" */;
   #   sha256 = /* checksum for this release, can omit if specifying your own `monorepoSrc` */;
   # }
-, officialRelease ? { version = "16.0.1"; sha256 = "sha256-Vr978ZY0i0NkdE/uuwcTccshfAT61KIN6KNq0TdwBNE="; }
+, officialRelease ? { version = "16.0.6"; sha256 = "sha256-fspqSReX+VD+Nl/Cfq+tDcdPtnQPV1IRopNDfd5VtUs="; }
   # i.e.:
   # {
   #   version = /* i.e. "15.0.0" */;

--- a/pkgs/development/compilers/llvm/16/llvm/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/16/llvm/gnu-install-dirs.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 45399dc0537e..5d946e9e6583 100644
+index 7e25e0407db2..72f031a82b75 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -942,7 +942,7 @@ if (NOT TENSORFLOW_AOT_PATH STREQUAL "")
+@@ -995,7 +995,7 @@ if (NOT TENSORFLOW_AOT_PATH STREQUAL "")
    add_subdirectory(${TENSORFLOW_AOT_PATH}/xla_aot_runtime_src
      ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/tf_runtime)
    install(TARGETS tf_xla_runtime EXPORT LLVMExports
@@ -12,10 +12,10 @@ index 45399dc0537e..5d946e9e6583 100644
    # Once we add more modules, we should handle this more automatically.
    if (DEFINED LLVM_OVERRIDE_MODEL_HEADER_INLINERSIZEMODEL)
 diff --git a/cmake/modules/AddLLVM.cmake b/cmake/modules/AddLLVM.cmake
-index 057431208322..56f0dcb258da 100644
+index 93e6d67551de..8d367457af5a 100644
 --- a/cmake/modules/AddLLVM.cmake
 +++ b/cmake/modules/AddLLVM.cmake
-@@ -844,8 +844,8 @@ macro(add_llvm_library name)
+@@ -874,8 +874,8 @@ macro(add_llvm_library name)
        get_target_export_arg(${name} LLVM export_to_llvmexports ${umbrella})
        install(TARGETS ${name}
                ${export_to_llvmexports}
@@ -26,7 +26,7 @@ index 057431208322..56f0dcb258da 100644
                RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT ${name})
  
        if (NOT LLVM_ENABLE_IDE)
-@@ -2007,7 +2007,7 @@ function(llvm_install_library_symlink name dest type)
+@@ -2043,7 +2043,7 @@ function(llvm_install_library_symlink name dest type)
    set(full_name ${CMAKE_${type}_LIBRARY_PREFIX}${name}${CMAKE_${type}_LIBRARY_SUFFIX})
    set(full_dest ${CMAKE_${type}_LIBRARY_PREFIX}${dest}${CMAKE_${type}_LIBRARY_SUFFIX})
  
@@ -35,7 +35,7 @@ index 057431208322..56f0dcb258da 100644
    if(WIN32 AND "${type}" STREQUAL "SHARED")
      set(output_dir "${CMAKE_INSTALL_BINDIR}")
    endif()
-@@ -2271,15 +2271,15 @@ function(llvm_setup_rpath name)
+@@ -2312,16 +2312,37 @@ function(llvm_setup_rpath name)
  
    if (APPLE)
      set(_install_name_dir INSTALL_NAME_DIR "@rpath")
@@ -49,7 +49,30 @@ index 057431208322..56f0dcb258da 100644
 -    set(_install_rpath "${LLVM_LIBRARY_OUTPUT_INTDIR}" "${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
 +    set(_install_rpath "${LLVM_LIBRARY_OUTPUT_INTDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
    elseif(UNIX)
--    set(_install_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+-    set(_build_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+-    set(_install_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}")
++    # Note that we add `extra_libdir` (aka `LLVM_LIBRARY_DIR` in our case) back
++    # to `_install_rpath` here.
++    #
++    # In nixpkgs we do not build and install LLVM alongside rdeps of LLVM (i.e.
++    # clang); instead LLVM is its own package and thus lands at its own nix
++    # store path. This makes it so that the default relative rpath (`../lib/`)
++    # does not point at the LLVM shared objects.
++    #
++    # More discussion here:
++    #   - https://github.com/NixOS/nixpkgs/pull/235624#discussion_r1220150329
++    #   - https://reviews.llvm.org/D146918 (16.0.5+)
++    #
++    # Note that we leave `extra_libdir` in `_build_rpath`: without FHS there is
++    # no potential that this will result in us pulling in the "wrong" LLVM.
++    # Adding this to the build rpath means we aren't forced to use
++    # `installCheckPhase` instead of `checkPhase` (i.e. binaries in the build
++    # dir, pre-install, will have the right rpath for LLVM).
++    #
++    # As noted in the differential above, an alternative solution is to have
++    # all rdeps of nixpkgs' LLVM (that use the AddLLVM.cmake machinery) set
++    # `CMAKE_INSTALL_RPATH`.
++    set(_build_rpath "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
 +    set(_install_rpath "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
      if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
        set_property(TARGET ${name} APPEND_STRING PROPERTY
@@ -71,10 +94,10 @@ index 891c9e6d618c..8d963f3b0069 100644
    list(APPEND ocaml_flags "-ldopt" "-Wl,-rpath,${ocaml_rpath}")
  
 diff --git a/cmake/modules/CMakeLists.txt b/cmake/modules/CMakeLists.txt
-index d4b0ab959148..26ed981fd09f 100644
+index d99af79aa38e..21e794224b99 100644
 --- a/cmake/modules/CMakeLists.txt
 +++ b/cmake/modules/CMakeLists.txt
-@@ -128,7 +128,7 @@ set(LLVM_CONFIG_INCLUDE_DIRS
+@@ -127,7 +127,7 @@ set(LLVM_CONFIG_INCLUDE_DIRS
    )
  list(REMOVE_DUPLICATES LLVM_CONFIG_INCLUDE_DIRS)
  
@@ -84,7 +107,7 @@ index d4b0ab959148..26ed981fd09f 100644
    "${LLVM_CONFIG_LIBRARY_DIR}"
    # FIXME: Should there be other entries here?
 diff --git a/docs/CMake.rst b/docs/CMake.rst
-index 879b7b231d4c..9c31d14e8950 100644
+index 7926de258ec8..5ae01adc3905 100644
 --- a/docs/CMake.rst
 +++ b/docs/CMake.rst
 @@ -250,7 +250,7 @@ description is in `LLVM-related variables`_ below.
@@ -120,10 +143,10 @@ index 370005cd8d7d..7e790bc52111 100644
  #define LLVM_INSTALL_PACKAGE_DIR "@LLVM_INSTALL_PACKAGE_DIR@"
  #define LLVM_TARGETS_BUILT "@LLVM_TARGETS_BUILT@"
 diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
-index 2c6c55f89d38..f6d2068a0827 100644
+index b1d795a0a349..de6cb1514f05 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -369,7 +369,11 @@ int main(int argc, char **argv) {
+@@ -366,7 +366,11 @@ int main(int argc, char **argv) {
        sys::fs::make_absolute(ActivePrefix, Path);
        ActiveBinDir = std::string(Path.str());
      }


### PR DESCRIPTION
## Description of changes

Partial backport of #235624 and all of #255653, after #255696 had to be reverted in #256291, due to the newly backported `chromium` no longer building with `llvmPackages_16` `16.0.1`.

This PR backports of two separate PRs, so they don't end up in two separate evals.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
