### PR TITLE
Revert "libsoup{,_3}: enable `separateDebugInfo`"

### DIFF
--- a/pkgs/development/libraries/libsoup/3.x.nix
+++ b/pkgs/development/libraries/libsoup/3.x.nix
@@ -81,7 +81,6 @@ stdenv.mkDerivation rec {
 
   # HSTS tests fail.
   doCheck = false;
-  separateDebugInfo = true;
 
   postPatch = ''
     patchShebangs libsoup/

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -72,7 +72,6 @@ stdenv.mkDerivation rec {
   env.NIX_CFLAGS_COMPILE = "-lpthread";
 
   doCheck = false; # ERROR:../tests/socket-test.c:37:do_unconnected_socket_test: assertion failed (res == SOUP_STATUS_OK): (2 == 200)
-  separateDebugInfo = true;
 
   postPatch = ''
     # fixes finding vapigen when cross-compiling


### PR DESCRIPTION
Reverts NixOS/nixpkgs#256536

Missed that this is not towards staging.