### PR TITLE
pulumiPackages.pulumi-command: 0.7.1 -> 0.9.0

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/pulumi-command.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-command.nix
@@ -4,14 +4,14 @@
 mkPulumiPackage rec {
   owner = "pulumi";
   repo = "pulumi-command";
-  version = "0.7.1";
+  version = "0.9.0";
   rev = "v${version}";
-  hash = "sha256-QrKtnpJGWoc5WwV6bnERrN3iBJpyoFKFwlqBtNNK7F8=";
-  vendorHash = "sha256-HyzWPRYfjdjGGBByCc8N91qWhX2QBJoQMpudHWrkmFM=";
+  hash = "sha256-VnbtPhMyTZ4Oy+whOK6Itr2vqUagwZUODONL13fjMaU=";
+  vendorHash = "sha256-MBWDEVA29uzHD3B/iPe68ntGjMM1SCTDq/TL+NgMc6c=";
   cmdGen = "pulumi-gen-command";
   cmdRes = "pulumi-resource-command";
   extraLdflags = [
-    "-X github.com/pulumi/${repo}/provider/v4/pkg/version.Version=v${version}"
+    "-X github.com/pulumi/${repo}/provider/pkg/version.Version=v${version}"
   ];
 
   postConfigure = ''


### PR DESCRIPTION
## Description of changes

* New upstream releases
   - [v0.9.0](https://github.com/pulumi/pulumi-command/releases/tag/v0.9.0)
   - [v.0.8.2](https://github.com/pulumi/pulumi-command/releases/tag/v0.8.2)
   - [v.0.8.1](https://github.com/pulumi/pulumi-command/releases/tag/v0.8.1)
   - [v0.7.2](https://github.com/pulumi/pulumi-command/releases/tag/v0.7.2)
* Adapted Python package(s) to SDK changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
