### PR TITLE
coredns: add support for plugins

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -306,6 +306,24 @@ The module update takes care of the new config syntax and the data itself (user 
   - `keepTerminfo` controls whether `TERMINFO` and `TERMINFO_DIRS` are preserved
     for `root` and the `wheel` group.
 
+- CoreDNS can now be built with external plugins by overriding `externalPlugins` and `vendorHash` arguments like this:
+
+  ```
+  services.coredns = {
+    enable = true;
+    package = pkgs.coredns.override {
+      externalPlugins = [
+        {name = "fanout"; repo = "github.com/networkservicemesh/fanout"; version = "v1.9.1";}
+      ];
+      vendorHash = "<SRI hash>";
+    };
+  };
+  ```
+
+  To get the necessary SRI hash, set `vendorHash = "";`. The build will fail and produce the correct `vendorHash` in the error message.
+
+  If you use this feature, updates to CoreDNS may require updating `vendorHash` by following these steps again.
+
 
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 

--- a/pkgs/servers/dns/coredns/default.nix
+++ b/pkgs/servers/dns/coredns/default.nix
@@ -3,9 +3,16 @@
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
+, externalPlugins ? []
+, vendorHash ? "sha256-TvIswNQ7DL/MtYmMSxXf+VqKHcmzZVZwohOCvRWxBkY="
 }:
 
-buildGoModule rec {
+let
+  attrsToPlugins = attrs:
+    builtins.map ({name, repo, version}: "${name}:${repo}") attrs;
+  attrsToSources = attrs:
+    builtins.map ({name, repo, version}: "${repo}@${version}") attrs;
+in buildGoModule rec {
   pname = "coredns";
   version = "1.11.0";
 
@@ -16,11 +23,31 @@ buildGoModule rec {
     sha256 = "sha256-Mn8hOsODTlnl6PJaevMcyIKkIx/1Lk2HGA7fSSizR20=";
   };
 
-  vendorHash = "sha256-9LFwrG6RxZaCLxrNabdnq++U5Aw+d2w90Zqt/wszNTY=";
+  inherit vendorHash;
 
   nativeBuildInputs = [ installShellFiles ];
 
   outputs = [ "out" "man" ];
+
+  # Override the go-modules fetcher derivation to fetch plugins
+  modBuildPhase = ''
+    for plugin in ${builtins.toString (attrsToPlugins externalPlugins)}; do echo $plugin >> plugin.cfg; done
+    for src in ${builtins.toString (attrsToSources externalPlugins)}; do go get $src; done
+    go generate
+    go mod vendor
+  '';
+
+  modInstallPhase = ''
+    mv -t vendor go.mod go.sum plugin.cfg
+    cp -r --reflink=auto vendor "$out"
+  '';
+
+  preBuild = ''
+    chmod -R u+w vendor
+    mv -t . vendor/go.{mod,sum} vendor/plugin.cfg
+
+    go generate
+  '';
 
   postPatch = ''
     substituteInPlace test/file_cname_proxy_test.go \
@@ -29,6 +56,11 @@ buildGoModule rec {
 
     substituteInPlace test/readme_test.go \
       --replace "TestReadme" "SkipReadme"
+
+    # this test fails if any external plugins were imported.
+    # it's a lint rather than a test of functionality, so it's safe to disable.
+    substituteInPlace test/presubmit_test.go \
+      --replace "TestImportOrdering" "SkipImportOrdering"
   '' + lib.optionalString stdenv.isDarwin ''
     # loopback interface is lo0 on macos
     sed -E -i 's/\blo\b/lo0/' plugin/bind/setup_test.go


### PR DESCRIPTION
## Description of changes

Solves https://github.com/NixOS/nixpkgs/issues/146603

Usage:

```
coredns-fanout = pkgs.coredns.override {
  externalPlugins = [
    {name = "fanout"; repo = "github.com/networkservicemesh/fanout"; version = "v1.9.1";}
  ];
  vendorHash = "<SRI hash>";
};
```

This PR is based on https://github.com/NixOS/nixpkgs/pull/205649 . I've made 3 changes:

- rebased it on master
- added `go mod vendor` to the end of `modBuildPhase`
- modified the `externalPlugins` argument to take the plugin name, repo and version
  - this allows plugins to be pinned, which was a request made on the original PR
- dropped the list of official upstream plugins (`external-plugins.nix`)
  - this was convenient but not necessary. removing it means it doesn't need to be kept up to date.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
