### PR TITLE
[Backport release-23.05] fs-uae-launcher: 3.0.5 -> 3.1.68

### DIFF
--- a/pkgs/applications/emulators/fs-uae/launcher.nix
+++ b/pkgs/applications/emulators/fs-uae/launcher.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "fs-uae-launcher";
-  version = "3.0.5";
+  version = "3.1.68";
 
   src = fetchurl {
-    url = "https://fs-uae.net/stable/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1dknra4ngz7bpppwqghmza1q68pn1yaw54p9ba0f42zwp427ly97";
+    url = "https://fs-uae.net/files/FS-UAE-Launcher/Stable/${version}/fs-uae-launcher-${version}.tar.xz";
+    hash = "sha256-42EERC2yeODx0HPbwr4vmpN80z6WSWi3WzJMOT+OwDA=";
   };
 
   nativeBuildInputs = [
@@ -33,15 +33,19 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   preFixup = ''
-      wrapQtApp "$out/bin/fs-uae-launcher" --set PYTHONPATH "$PYTHONPATH" \
-        --prefix PATH : ${lib.makeBinPath [ fsuae ]}
+    wrapQtApp "$out/bin/fs-uae-launcher" \
+      --set PYTHONPATH "$PYTHONPATH"
+
+    # fs-uae-launcher search side by side for fs-uae
+    # see $src/fsgs/plugins/pluginexecutablefinder.py#find_executable
+    ln -s ${fsuae}/bin/fs-uae $out/bin
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://fs-uae.net";
     description = "Graphical front-end for the FS-UAE emulator";
-    license = licenses.gpl2Plus;
-    maintainers = with  maintainers; [ sander AndersonTorres ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ sander AndersonTorres ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
This change was backported from this commit: e7ec942dea0ee69c24e46a8b70bc4c3993eef634

The current version is unusable as `fs-uae` was updated to an incompatible version.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
