### PR TITLE
gpx-viewer: 0.4.0 → 0.5.0

### DIFF
--- a/pkgs/applications/misc/gpx-viewer/default.nix
+++ b/pkgs/applications/misc/gpx-viewer/default.nix
@@ -1,31 +1,58 @@
-{ lib, stdenv, fetchurl, intltool, libxml2, pkg-config, gnome, libchamplain, gdl, wrapGAppsHook }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, libxml2
+, meson
+, ninja
+, vala
+, pkg-config
+, gnome
+, libchamplain
+, gdl
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "gpx-viewer";
-  version = "0.4.0";
+  version = "0.5.0";
 
-  src = fetchurl {
-    url = "https://launchpad.net/gpx-viewer/trunk/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "956acfaf870ac436300cd9953dece630df7fd7dff8e4ae2577a6002884466f80";
+  src = fetchFromGitHub {
+    owner = "DaveDavenport";
+    repo = "gpx-viewer";
+    rev = version;
+    hash = "sha256-6AChX0UEIrQExaq3oo9Be5Sr13+POHFph7pZegqcjio=";
   };
 
-  patches = fetchurl {
-    url = "https://code.launchpad.net/~chkr/gpx-viewer/gtk3-bugfix/+merge/260766/+preview-diff/628965/+files/preview.diff";
-    sha256 = "1yl7jk7skkcx10nny5zdixswcymjd9s9c1zhm1i5y3aqhchvmfs7";
-  };
-  patchFlags = [ "-p0" ];
-
-  configureFlags = [ "--disable-database-updates" ];
+  patches = [
+    # Compile with libchamplain>=0.12.21
+    (fetchpatch {
+      url = "https://github.com/DaveDavenport/gpx-viewer/commit/12ed6003bdad840586351bdb4e00c18719873c0e.patch";
+      hash = "sha256-2/r0M3Yxj+vWgny1Pd5G7NYMb0uC/ByZ7y3tqLVccOc=";
+    })
+  ];
 
   nativeBuildInputs = [
-    intltool pkg-config
+    meson
+    ninja
+    pkg-config
+    vala
     wrapGAppsHook # Fix error: GLib-GIO-ERROR **: No GSettings schemas are installed on the system
   ];
-  buildInputs = [ gdl libchamplain gnome.adwaita-icon-theme libxml2 ];
+
+  buildInputs = [
+    gdl
+    libchamplain
+    gnome.adwaita-icon-theme
+    libxml2
+  ];
+
+  hardeningDisable = [ "format" ];
 
   meta = with lib; {
     homepage = "https://blog.sarine.nl/tag/gpxviewer/";
     description = "Simple tool to visualize tracks and waypoints stored in a gpx file";
+    changelog = "https://github.com/DaveDavenport/gpx-viewer/blob/${src.rev}/NEWS";
     platforms = with platforms; linux;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ dotlambda ];


### PR DESCRIPTION
## Description of changes
[Changelog](https://github.com/DaveDavenport/gpx-viewer/blob/master/NEWS)

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
