### PR TITLE
top-level: add goPlatform for Go packages

### DIFF
--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -164,3 +164,19 @@ Specified as a string or list of strings. Limits the builder from building child
 ### `excludedPackages` {#var-go-excludedPackages}
 
 Specified as a string or list of strings. Causes the builder to skip building child packages that match any of the provided values. If `excludedPackages` is not specified, all child packages will be built.
+
+## Cross compilation {#ssec-go-cross-compilation}
+
+By default, Go packages are compiled for the host platform, just like any other
+package is. That is, `GOOS`, `GOARCH` and other environment variables passed to
+Go toolchain are computed from `stdenv.hostPlatform`. It is possible to
+customize them, for example, to fine-tune architecture-specific environment
+variables:
+
+```nix
+import <nixpkgs> {
+  crossSystem = (import <nixpkgs/lib>).systems.examples.gnu32 // {
+    goPlatform.GO386 = "softfloat";
+  };
+}
+```

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -160,8 +160,9 @@ rec {
           linux-kernel = args.linux-kernel or {};
           gcc = args.gcc or {};
           rustc = args.rustc or {};
+          go = args.go or {};
         } // platforms.select final)
-        linux-kernel gcc rustc;
+        linux-kernel gcc rustc go;
 
       linuxArch =
         if final.isAarch32 then "arm"

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -3,7 +3,7 @@
 # targetPlatform, etc) containing at least the minimal set of attrs
 # required (see types.parsedPlatform in lib/systems/parse.nix).  This
 # file takes an already-valid platform and further elaborates it with
-# optional fields; currently these are: linux-kernel, gcc, and rustc.
+# optional fields; currently these are: linux-kernel, gcc, rustc, go.
 
 { lib }:
 rec {

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -324,6 +324,12 @@ The module update takes care of the new config syntax and the data itself (user 
   };
   ```
 
+- `GOOS`, `GOARCH` and other system-specific attributes exposed from `go`
+  package are considered to be an implementation detail and should not be used.
+  Packages using them should use `goPlatform.{build,host,target}.env` attribute
+  set that contains environment variables to build Go programs for
+  `stdenv.{build,host,target}Platform` respectively.
+
 - The `qemu-vm.nix` module by default now identifies block devices via
   persistent names available in `/dev/disk/by-*`. Because the rootDevice is
   identfied by its filesystem label, it needs to be formatted before the VM is

--- a/pkgs/build-support/go/lib/default.nix
+++ b/pkgs/build-support/go/lib/default.nix
@@ -1,0 +1,42 @@
+{ lib, ... }:
+lib.makeExtensible (self: {
+  toGOOS = platform:
+    if platform.isAndroid then "android"
+    else if platform.isWasi then "wasip1"
+    else if platform.isWasm then "js"
+    else platform.parsed.kernel.name;
+
+  toGOARCH = platform:
+    if platform.isx86_32 then "386"
+    else if platform.isx86_64 then "amd64"
+    else if platform.isAarch32 then "arm"
+    else if platform.isAarch64 then "arm64"
+    else if platform.isLoongArch64 then "loong64"
+    else if platform.isMips then
+      "mips"
+      + lib.optionalString platform.is64bit "64"
+      + lib.optionalString platform.isLittleEndian "le"
+    else if platform.isPower64 then
+      "ppc64" + lib.optionalString platform.isLittleEndian "le"
+    # Go does not support 32-bit WASM. See https://go.dev/issue/63131
+    else if platform.isWasm && platform.is64bit then "wasm"
+    else platform.parsed.cpu.name;
+
+  # Returns Go environment variables to build for the given platform.
+  toGoEnv = platform: {
+    GOOS = self.toGOOS platform;
+    GOARCH = self.toGOARCH platform;
+  } // lib.optionalAttrs (platform.isAarch32) {
+    GOARM = toString (lib.intersectLists [ (platform.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
+  } // (platform.go or { });
+
+  # Allows detecting whether Go will install binaries under ${GOOS}_${GOARCH}
+  # subdirectory (that is, whether we are cross-compiling).
+  isCross = build: host:
+    let
+      GOHOSTOS = build.GOOS;
+      GOHOSTARCH = build.GOARCH;
+      inherit (host) GOOS GOARCH;
+    in
+    GOHOSTOS != GOOS || GOHOSTARCH != GOARCH;
+})

--- a/pkgs/build-support/go/platform.nix
+++ b/pkgs/build-support/go/platform.nix
@@ -1,0 +1,19 @@
+{ lib, stdenv, callPackage }@prev:
+{ go }:
+let
+  # Pass go to lib so functions can implement version-specific behavior.
+  lib' = import ./lib { inherit lib go; };
+  inherit (lib') toGoEnv isCross;
+in
+lib.makeExtensible (goPlatform: {
+  buildGoModule = callPackage ./module.nix { inherit go goPlatform; };
+  buildGoPackage = callPackage ./package.nix { inherit go goPlatform; };
+
+  build.env = toGoEnv stdenv.buildPlatform;
+  host.env = toGoEnv stdenv.hostPlatform;
+  target.env = toGoEnv stdenv.targetPlatform;
+
+  isCross = isCross
+    goPlatform.build.env
+    goPlatform.host.env;
+})

--- a/pkgs/development/compilers/go/1.18.nix
+++ b/pkgs/development/compilers/go/1.18.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, makeGoPlatform
 , fetchpatch
 , fetchurl
 , tzdata
@@ -14,30 +15,11 @@
 , threadsCross
 , testers
 , skopeo
-, buildGo118Module
 }:
 
 let
   useGccGoBootstrap = stdenv.buildPlatform.isMusl || stdenv.buildPlatform.isRiscV;
   goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap116.nix { };
-
-  skopeoTest = skopeo.override { buildGoModule = buildGo118Module; };
-
-  goarch = platform: {
-    "aarch64" = "arm64";
-    "arm" = "arm";
-    "armv5tel" = "arm";
-    "armv6l" = "arm";
-    "armv7l" = "arm";
-    "i686" = "386";
-    "mips" = "mips";
-    "mips64el" = "mips64le";
-    "mipsel" = "mipsle";
-    "powerpc64le" = "ppc64le";
-    "riscv64" = "riscv64";
-    "s390x" = "s390x";
-    "x86_64" = "amd64";
-  }.${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
 
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
@@ -45,7 +27,12 @@ let
 
   isCross = stdenv.buildPlatform != stdenv.targetPlatform;
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs:
+let
+  goPlatform = makeGoPlatform { go = finalAttrs.finalPackage; };
+  skopeoTest = skopeo.override { inherit (goPlatform) buildGoModule; };
+in
+{
   pname = "go";
   version = "1.18.10";
 
@@ -96,32 +83,24 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  GOOS = stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
-  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
-  # Go will nevertheless build a for host system that we will copy over in
-  # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
+  env = goPlatform.target.env // {
+    # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+    # Go will nevertheless build a for host system that we will copy over in
+    # the install phase.
+    GOHOSTOS = goPlatform.build.env.GOOS;
+    GOHOSTARCH = goPlatform.build.env.GOARCH;
 
-  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
-  # to be different from CC/CXX
-  CC_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}cc"
-    else
-      null;
-  CXX_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}c++"
-    else
-      null;
+    GOARM = goPlatform.host.env.GOARM or "";
+    GO386 = goPlatform.host.env.GO386 or "softfloat"; # from Arch: don't assume sse2 on i686
+    CGO_ENABLED = 1;
 
-  GOARM = toString (lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
-  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  CGO_ENABLED = 1;
-
-  GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
+    GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
+  } // lib.optionalAttrs (isCross) {
+    # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expects those
+    # to be different from CC/CXX.
+    CC_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}cc";
+    CXX_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}c++";
+  };
 
   buildPhase = ''
     runHook preBuild
@@ -152,13 +131,13 @@ stdenv.mkDerivation (finalAttrs: {
   '' + (if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then ''
     mv bin/*_*/* bin
     rmdir bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
+    ${lib.optionalString (!(finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS)) ''
+      rm -rf pkg/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH} pkg/tool/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH}
     ''}
   '' else lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
     rm -rf bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
+    ${lib.optionalString (!(finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS)) ''
+      rm -rf pkg/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH} pkg/tool/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH}
     ''}
   '');
 

--- a/pkgs/development/compilers/go/1.19.nix
+++ b/pkgs/development/compilers/go/1.19.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, makeGoPlatform
 , fetchpatch
 , fetchurl
 , tzdata
@@ -14,30 +15,11 @@
 , threadsCross
 , testers
 , skopeo
-, buildGo119Module
 }:
 
 let
   useGccGoBootstrap = stdenv.buildPlatform.isMusl || stdenv.buildPlatform.isRiscV;
   goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap116.nix { };
-
-  skopeoTest = skopeo.override { buildGoModule = buildGo119Module; };
-
-  goarch = platform: {
-    "aarch64" = "arm64";
-    "arm" = "arm";
-    "armv5tel" = "arm";
-    "armv6l" = "arm";
-    "armv7l" = "arm";
-    "i686" = "386";
-    "mips" = "mips";
-    "mips64el" = "mips64le";
-    "mipsel" = "mipsle";
-    "powerpc64le" = "ppc64le";
-    "riscv64" = "riscv64";
-    "s390x" = "s390x";
-    "x86_64" = "amd64";
-  }.${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
 
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
@@ -45,7 +27,12 @@ let
 
   isCross = stdenv.buildPlatform != stdenv.targetPlatform;
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs:
+let
+  goPlatform = makeGoPlatform { go = finalAttrs.finalPackage; };
+  skopeoTest = skopeo.override { inherit (goPlatform) buildGoModule; };
+in
+{
   pname = "go";
   version = "1.19.13";
 
@@ -96,32 +83,24 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  GOOS = stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
-  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
-  # Go will nevertheless build a for host system that we will copy over in
-  # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
+  env = goPlatform.target.env // {
+    # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+    # Go will nevertheless build a for host system that we will copy over in
+    # the install phase.
+    GOHOSTOS = goPlatform.build.env.GOOS;
+    GOHOSTARCH = goPlatform.build.env.GOARCH;
 
-  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
-  # to be different from CC/CXX
-  CC_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}cc"
-    else
-      null;
-  CXX_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}c++"
-    else
-      null;
+    GOARM = goPlatform.host.env.GOARM or "";
+    GO386 = goPlatform.host.env.GO386 or "softfloat"; # from Arch: don't assume sse2 on i686
+    CGO_ENABLED = 1;
 
-  GOARM = toString (lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
-  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  CGO_ENABLED = 1;
-
-  GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
+    GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
+  } // lib.optionalAttrs (isCross) {
+    # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expects those
+    # to be different from CC/CXX.
+    CC_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}cc";
+    CXX_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}c++";
+  };
 
   buildPhase = ''
     runHook preBuild
@@ -152,13 +131,13 @@ stdenv.mkDerivation (finalAttrs: {
   '' + (if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then ''
     mv bin/*_*/* bin
     rmdir bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
+    ${lib.optionalString (!(finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS)) ''
+      rm -rf pkg/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH} pkg/tool/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH}
     ''}
   '' else lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
     rm -rf bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
+    ${lib.optionalString (!(finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS)) ''
+      rm -rf pkg/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH} pkg/tool/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH}
     ''}
   '');
 

--- a/pkgs/development/compilers/go/1.20.nix
+++ b/pkgs/development/compilers/go/1.20.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, makeGoPlatform
 , fetchurl
 , tzdata
 , substituteAll
@@ -13,30 +14,11 @@
 , threadsCross
 , testers
 , skopeo
-, buildGo120Module
 }:
 
 let
   useGccGoBootstrap = stdenv.buildPlatform.isMusl || stdenv.buildPlatform.isRiscV;
   goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap117.nix { };
-
-  skopeoTest = skopeo.override { buildGoModule = buildGo120Module; };
-
-  goarch = platform: {
-    "aarch64" = "arm64";
-    "arm" = "arm";
-    "armv5tel" = "arm";
-    "armv6l" = "arm";
-    "armv7l" = "arm";
-    "i686" = "386";
-    "mips" = "mips";
-    "mips64el" = "mips64le";
-    "mipsel" = "mipsle";
-    "powerpc64le" = "ppc64le";
-    "riscv64" = "riscv64";
-    "s390x" = "s390x";
-    "x86_64" = "amd64";
-  }.${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
 
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
@@ -44,7 +26,12 @@ let
 
   isCross = stdenv.buildPlatform != stdenv.targetPlatform;
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs:
+let
+  goPlatform = makeGoPlatform { go = finalAttrs.finalPackage; };
+  skopeoTest = skopeo.override { inherit (goPlatform) buildGoModule; };
+in
+{
   pname = "go";
   version = "1.20.8";
 
@@ -89,32 +76,24 @@ stdenv.mkDerivation (finalAttrs: {
     ./go_no_vendor_checks-1.16.patch
   ];
 
-  GOOS = stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
-  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
-  # Go will nevertheless build a for host system that we will copy over in
-  # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
+  env = goPlatform.target.env // {
+    # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+    # Go will nevertheless build a for host system that we will copy over in
+    # the install phase.
+    GOHOSTOS = goPlatform.build.env.GOOS;
+    GOHOSTARCH = goPlatform.build.env.GOARCH;
 
-  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
-  # to be different from CC/CXX
-  CC_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}cc"
-    else
-      null;
-  CXX_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}c++"
-    else
-      null;
+    GOARM = goPlatform.host.env.GOARM or "";
+    GO386 = goPlatform.host.env.GO386 or "softfloat"; # from Arch: don't assume sse2 on i686
+    CGO_ENABLED = 1;
 
-  GOARM = toString (lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
-  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  CGO_ENABLED = 1;
-
-  GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
+    GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
+  } // lib.optionalAttrs (isCross) {
+    # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expects those
+    # to be different from CC/CXX.
+    CC_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}cc";
+    CXX_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}c++";
+  };
 
   buildPhase = ''
     runHook preBuild
@@ -144,13 +123,13 @@ stdenv.mkDerivation (finalAttrs: {
   '' + (if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then ''
     mv bin/*_*/* bin
     rmdir bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
+    ${lib.optionalString (!(finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS)) ''
+      rm -rf pkg/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH} pkg/tool/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH}
     ''}
   '' else lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
     rm -rf bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
+    ${lib.optionalString (!(finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS)) ''
+      rm -rf pkg/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH} pkg/tool/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH}
     ''}
   '');
 

--- a/pkgs/development/compilers/go/binary.nix
+++ b/pkgs/development/compilers/go/binary.nix
@@ -1,24 +1,11 @@
-{ lib, stdenv, fetchurl, version, hashes, autoPatchelfHook }:
+{ lib, stdenv, makeGoPlatform, fetchurl, version, hashes, autoPatchelfHook }:
+stdenv.mkDerivation (finalAttrs:
 let
-  toGoKernel = platform:
-    if platform.isDarwin then "darwin"
-    else platform.parsed.kernel.name;
-
-  toGoCPU = platform: {
-    "i686" = "386";
-    "x86_64" = "amd64";
-    "aarch64" = "arm64";
-    "armv6l" = "armv6l";
-    "armv7l" = "armv6l";
-    "powerpc64le" = "ppc64le";
-    "riscv64" = "riscv64";
-  }.${platform.parsed.cpu.name} or (throw "Unsupported CPU ${platform.parsed.cpu.name}");
-
-  toGoPlatform = platform: "${toGoKernel platform}-${toGoCPU platform}";
-
-  platform = toGoPlatform stdenv.hostPlatform;
+  goPlatform = makeGoPlatform { go = finalAttrs.finalPackage; };
+  inherit (goPlatform.host.env) GOOS GOARCH;
+  platform = "${GOOS}-${GOARCH}";
 in
-stdenv.mkDerivation rec {
+{
   name = "go-${version}-${platform}-bootstrap";
 
   src = fetchurl {
@@ -38,4 +25,4 @@ stdenv.mkDerivation rec {
     ln -s $out/share/go/bin/go $out/bin/go
     runHook postInstall
   '';
-}
+})

--- a/pkgs/development/tools/kind/default.nix
+++ b/pkgs/development/tools/kind/default.nix
@@ -19,7 +19,6 @@ buildGoModule rec {
   vendorHash = "sha256-J/sJd2LLMBr53Z3sGrWgnWA8Ry+XqqfCEObqFyUD96g=";
 
   CGO_ENABLED = 0;
-  GOFLAGS = [ "-trimpath" ];
   ldFlags = [ "-buildid=" "-w" ];
 
   doCheck = false;

--- a/pkgs/servers/monitoring/loki/promtail.nix
+++ b/pkgs/servers/monitoring/loki/promtail.nix
@@ -1,7 +1,6 @@
 { lib, grafana-loki }:
 
-grafana-loki.overrideAttrs (o: {
+grafana-loki.overrideAttrs (prev: {
   pname = "promtail";
   subPackages = ["clients/cmd/promtail"];
-  CGO_ENABLED = 1;
 })

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -17,8 +17,6 @@ import ./versions.nix ({ version, sha256, vendorHash ? throw "unsupported versio
     nativeBuildInputs = [ autoreconfHook pkg-config ];
     buildInputs = [ libiconv openssl pcre zlib ];
 
-    inherit (buildGoModule.go) GOOS GOARCH;
-
     # need to provide GO* env variables & patch for reproducibility
     postPatch = ''
       substituteInPlace src/go/Makefile.am \

--- a/pkgs/tools/security/slsa-verifier/default.nix
+++ b/pkgs/tools/security/slsa-verifier/default.nix
@@ -17,7 +17,6 @@ buildGoModule rec {
   vendorHash = "sha256-TwPbxoNu9PYAFEbUT5htyUY1RbkGow712ARJW6y496E=";
 
   CGO_ENABLED = 0;
-  GO111MODULE = "on";
 
   subPackages = [ "cli/slsa-verifier" ];
 

--- a/pkgs/tools/security/slsa-verifier/default.nix
+++ b/pkgs/tools/security/slsa-verifier/default.nix
@@ -18,7 +18,6 @@ buildGoModule rec {
 
   CGO_ENABLED = 0;
   GO111MODULE = "on";
-  GOFLAGS = "-trimpath";
 
   subPackages = [ "cli/slsa-verifier" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26059,54 +26059,49 @@ with pkgs;
 
   ### DEVELOPMENT / GO
 
+  makeGoPlatform = callPackage ../build-support/go/platform.nix {
+    # requires a newer Apple SDK
+    inherit (darwin.apple_sdk_11_0) callPackage;
+  };
+
   # the unversioned attributes should always point to the same go version
   go = go_1_20;
-  buildGoModule = buildGo120Module;
-  buildGoPackage = buildGo120Package;
+  goPlatform = goPlatform_1_20;
+  inherit (goPlatform)
+    buildGoModule
+    buildGoPackage;
 
   # requires a newer Apple SDK
   go_1_18 = darwin.apple_sdk_11_0.callPackage ../development/compilers/go/1.18.nix {
     inherit (darwin.apple_sdk_11_0.frameworks) Foundation Security;
   };
-  buildGo118Module = darwin.apple_sdk_11_0.callPackage ../build-support/go/module.nix {
-    go = buildPackages.go_1_18;
-  };
-  buildGo118Package = darwin.apple_sdk_11_0.callPackage ../build-support/go/package.nix{
-    go = buildPackages.go_1_18;
-  };
+  goPlatform_1_18 = makeGoPlatform { go = buildPackages.go_1_18; };
+  buildGo118Module = goPlatform_1_18.buildGoModule;
+  buildGo118Package = goPlatform_1_18.buildGoPackage;
 
   # requires a newer Apple SDK
   go_1_19 = darwin.apple_sdk_11_0.callPackage ../development/compilers/go/1.19.nix {
     inherit (darwin.apple_sdk_11_0.frameworks) Foundation Security;
   };
-  buildGo119Module = darwin.apple_sdk_11_0.callPackage ../build-support/go/module.nix {
-    go = buildPackages.go_1_19;
-  };
-  buildGo119Package = darwin.apple_sdk_11_0.callPackage ../build-support/go/package.nix {
-    go = buildPackages.go_1_19;
-  };
+  goPlatform_1_19 = makeGoPlatform { go = buildPackages.go_1_19; };
+  buildGo119Module = goPlatform_1_19.buildGoModule;
+  buildGo119Package = goPlatform_1_19.buildGoPackage;
 
   # requires a newer Apple SDK
   go_1_20 = darwin.apple_sdk_11_0.callPackage ../development/compilers/go/1.20.nix {
     inherit (darwin.apple_sdk_11_0.frameworks) Foundation Security;
   };
-  buildGo120Module = darwin.apple_sdk_11_0.callPackage ../build-support/go/module.nix {
-    go = buildPackages.go_1_20;
-  };
-  buildGo120Package = darwin.apple_sdk_11_0.callPackage ../build-support/go/package.nix {
-    go = buildPackages.go_1_20;
-  };
+  goPlatform_1_20 = makeGoPlatform { go = buildPackages.go_1_20; };
+  buildGo120Module = goPlatform_1_20.buildGoModule;
+  buildGo120Package = goPlatform_1_20.buildGoPackage;
 
   # requires a newer Apple SDK
   go_1_21 = darwin.apple_sdk_11_0.callPackage ../development/compilers/go/1.21.nix {
     inherit (darwin.apple_sdk_11_0.frameworks) Foundation Security;
   };
-  buildGo121Module = darwin.apple_sdk_11_0.callPackage ../build-support/go/module.nix {
-    go = buildPackages.go_1_21;
-  };
-  buildGo121Package = darwin.apple_sdk_11_0.callPackage ../build-support/go/package.nix {
-    go = buildPackages.go_1_21;
-  };
+  goPlatform_1_21 = makeGoPlatform { go = buildPackages.go_1_21; };
+  buildGo121Module = goPlatform_1_21.buildGoModule;
+  buildGo121Package = goPlatform_1_21.buildGoPackage;
 
   go2nix = callPackage ../development/tools/go2nix { };
 


### PR DESCRIPTION
## Description of changes

This change adds `go` attribute/argument for the platforms returned by `lib.systems.elaborate`, similar to `rustc`. This attribute is used for top-level `goPlatform` attributes that further elaborates platforms into GOOS/GOARCH and other Go-specific variables, potentially taking Go version being used into account. Go build infrastructure is updated to use `goPlatform` instead of using GOOS/GOARCH/etc exposed from the `go` package.

See also https://github.com/NixOS/nixpkgs/pull/256505#issuecomment-1731935611

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
