### PR TITLE
tests.nixpkgs-check-by-name: Fix non-deterministic test failures

### DIFF
--- a/pkgs/test/nixpkgs-check-by-name/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/default.nix
@@ -26,10 +26,13 @@ let
         export NIX_STATE_DIR=$TEST_ROOT/var/nix
         export NIX_STORE_DIR=$TEST_ROOT/store
 
-        # cargo tests run in parallel by default, which would then run into
-        # https://github.com/NixOS/nix/issues/2706 unless the store is initialised first
+        # Ensure that even if tests run in parallel, we don't get an error
+        # We'd run into https://github.com/NixOS/nix/issues/2706 unless the store is initialised first
         nix-store --init
       '';
+      # The tests use the shared environment variables,
+      # so we cannot run them in parallel
+      dontUseCargoParallelTests = true;
       postCheck = ''
         cargo fmt --check
         cargo clippy -- -D warnings


### PR DESCRIPTION
## Description of changes
Fixes https://github.com/NixOS/nixpkgs/issues/256773 by not running tests in parallel.

This was an oversight in https://github.com/NixOS/nixpkgs/pull/254435, where I started setting an environment variable in the tests: https://github.com/NixOS/nixpkgs/blob/929f1197066e11c014dc9355ac013718d8c3e295/pkgs/test/nixpkgs-check-by-name/src/main.rs#L163

which is problematic because the [same process is used](https://doc.rust-lang.org/book/ch11-02-running-tests.html#running-tests-in-parallel-or-consecutively) to run the tests in parallel.

## Things done
- [x] Was able to reproduce the failure before by running the build a couple times
- [x] Am not able to reproduce the failure anymore