### PR TITLE
pdf2djvu: 0.9.18.2 -> 0.9.19

### DIFF
--- a/pkgs/tools/typesetting/pdf2djvu/default.nix
+++ b/pkgs/tools/typesetting/pdf2djvu/default.nix
@@ -16,39 +16,15 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.18.2";
+  version = "0.9.19";
   pname = "pdf2djvu";
 
   src = fetchFromGitHub {
     owner = "jwilk";
     repo = "pdf2djvu";
     rev = version;
-    sha256 = "s6n7nDO15DZSJ1EOPoNvjdFv/QtOoGiUa2b/k3kzWe8=";
+    sha256 = "sha256-j4mYdmLZ56qTA1KbWBjBvyTyLaeuIITKYsALRIO7lj0=";
   };
-
-  patches = [
-    # Fix build with Poppler 22.03.
-    (fetchpatch {
-      url = "https://github.com/jwilk/pdf2djvu/commit/e170ad557d5f13daeeac047dfaa79347bbe5062f.patch";
-      sha256 = "OPK2UWVs+E2uOEaxPtLWmVL28yCxaeJKscY9ziAbS7E=";
-    })
-    (fetchpatch {
-      url = "https://github.com/jwilk/pdf2djvu/commit/956fedc7e0831126b9006efedad5519c14201c52.patch";
-      sha256 = "JF1xvvL2WyMu6GjdrPLlRC6eC6vGLbVurQcNy3AOOXA=";
-    })
-    (fetchpatch {
-      url = "https://github.com/jwilk/pdf2djvu/commit/dca43e8182174bc04e107eaefcafcfdfdf9bcd61.patch";
-      sha256 = "0JcfDaVZpuv6VfUJ2HuxRqgntZ/t8AzU0RG/E83BWGY=";
-    })
-    (fetchpatch {
-      url = "https://github.com/jwilk/pdf2djvu/commit/81b635e014ebd0240a8719cc39b6a1b759cc6a98.patch";
-      sha256 = "LBmT4eflLd23X7gg7IbqGe3PfTGldEGFLEKImV4nbB0=";
-      postFetch = ''
-        # The file was renamed after the release.
-        sed -i "s/main.cc/pdf2djvu.cc/g" "$out"
-      '';
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
@@ -77,7 +53,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # Required by Poppler
+  # Required by Poppler on darwin
   # https://github.com/jwilk/pdf2djvu/commit/373e065faf2f0d868a3700788d20a96e9528bb12
   CXXFLAGS = "-std=c++17";
 


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/jwilk/pdf2djvu/compare/0.9.18.2...0.9.19

Lots of patches could be removed. Here are the `branch_commits` endpoints of each referenced commit, indicating that they're merged into 0.9.19:

* https://github.com/jwilk-archive/pdf2djvu/branch_commits/956fedc7e0831126b9006efedad5519c14201c52
* https://github.com/jwilk-archive/pdf2djvu/branch_commits/dca43e8182174bc04e107eaefcafcfdfdf9bcd61
* https://github.com/jwilk-archive/pdf2djvu/branch_commits/81b635e014ebd0240a8719cc39b6a1b759cc6a98
* https://github.com/jwilk-archive/pdf2djvu/branch_commits/e170ad557d5f13daeeac047dfaa79347bbe5062f

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
