### PR TITLE
Revert "sundials: 6.6.0 -> 6.6.1"

### DIFF
--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sundials";
-  version = "6.6.1";
+  version = "6.6.0";
 
   outputs = [ "out" "examples" ];
 
   src = fetchurl {
     url = "https://github.com/LLNL/sundials/releases/download/v${version}/sundials-${version}.tar.gz";
-    hash = "sha256-UWKw5tGdexQHiiFEHgeVzzjR2IOXO+NZAeAY+bswxUM=";
+    hash = "sha256-+QApuNqEbI+v9VMP0fpIRweRiNBAVU9VwdXR4EdD0p0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#254897 because the hash of the tarball changed.