### PR TITLE
livecaptions: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/applications/misc/livecaptions/default.nix
+++ b/pkgs/applications/misc/livecaptions/default.nix
@@ -72,5 +72,6 @@ in
       license = licenses.gpl3Plus;
       platforms = platforms.linux;
       maintainers = with maintainers; [Scrumplex];
+      mainProgram = "livecaptions";
     };
   })

--- a/pkgs/applications/misc/livecaptions/default.nix
+++ b/pkgs/applications/misc/livecaptions/default.nix
@@ -18,8 +18,8 @@
     name = "april-asr";
     owner = "abb128";
     repo = "april-asr";
-    rev = "c2f138c674cad58e2708ecaddc95cc72e7f85549";
-    hash = "sha256-hZe2iss3BGdzeTM5FCp9wp6LaDOjtGJrZS5vB5F6uLg=";
+    rev = "3308e68442664552de593957cad0fa443ea183dd";
+    hash = "sha256-/cOZ2EcZu/Br9v0ComxnOegcEtlC9e8FYt3XHfah7mE=";
   };
 
   aprilModel = fetchurl {
@@ -28,15 +28,15 @@
     hash = "sha256-d+uV0PpPdwijfoaMImUwHubELcsl5jymPuo9nLrbwfM=";
   };
 in
-  stdenv.mkDerivation rec {
+  stdenv.mkDerivation (finalAttrs: {
     pname = "livecaptions";
-    version = "0.4.0";
+    version = "0.4.1";
 
     src = fetchFromGitHub {
       owner = "abb128";
       repo = "LiveCaptions";
-      rev = "v${version}";
-      hash = "sha256-RepuvqNPHRGENupPG5ezadn6f7FxEUYFDi4+DpNanuA=";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-x8NetSooIBlOKzKUMvDkPFtpD6EVGYECnaqWurySUDU=";
     };
 
     nativeBuildInputs = [
@@ -73,4 +73,4 @@ in
       platforms = platforms.linux;
       maintainers = with maintainers; [Scrumplex];
     };
-  }
+  })


### PR DESCRIPTION
## Description of changes

https://github.com/abb128/LiveCaptions/compare/v0.4.0...v0.4.1

https://github.com/abb128/LiveCaptions/releases/tag/v0.4.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
