### PR TITLE
composefs: init at 0.9.0

### DIFF
--- a/pkgs/by-name/co/composefs/package.nix
+++ b/pkgs/by-name/co/composefs/package.nix
@@ -1,0 +1,89 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, autoreconfHook
+, pandoc
+, pkg-config
+, openssl
+, fuse3
+, yajl
+, libcap
+, libseccomp
+, python3
+, which
+, valgrind
+, erofs-utils
+, fsverity-utils
+, nix-update-script
+
+, fuseSupport ? lib.meta.availableOn stdenv.hostPlatform fuse3
+, yajlSupport ? lib.meta.availableOn stdenv.hostPlatform yajl && (!stdenv.hostPlatform.isStatic)
+, enableValgrindCheck ? false
+, installExperimentalTools ? false
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "composefs";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "composefs";
+    # rev = "v${finalAttrs.version}";
+    rev = "0c63ee0a5f51f6154ae6031649e8642e83f588db";
+    # hash = "sha256-oXc3vpqJ4PGoHCpYnSY/kqhSHw5CVRXNreNTAg4aCSs=";
+    hash = "sha256-I1YQvUjZ5dx+ioqQel4KUNzQiR4MZa5oXhGhEuInV1Q=";
+  };
+
+  strictDeps = true;
+  outputs = [ "out" "lib" "dev" ];
+
+  postPatch = ''
+    echo "libcomposefs_la_LDFLAGS = -release @VERSION@" >> libcomposefs/Makefile-lib.am
+  '' + lib.optionalString installExperimentalTools ''
+    sed -i "s/noinst_PROGRAMS +\?=/bin_PROGRAMS +=/g" tools/Makefile.am
+  '';
+
+  configureFlags = lib.optionals enableValgrindCheck [
+    (lib.enableFeature true "valgrind-test")
+    # valgrind is incompatible with seccomp
+    (lib.withFeatureAs true "seccomp" "no")
+  ];
+
+  nativeBuildInputs = [ autoreconfHook pandoc pkg-config ];
+  buildInputs = [ openssl ]
+    ++ lib.optional fuseSupport fuse3
+    ++ lib.optional yajlSupport yajl
+    ++ lib.filter (lib.meta.availableOn stdenv.hostPlatform) (
+    [
+      libcap
+      libseccomp
+    ]
+  );
+
+  # yajl is required to read the test json files
+  doCheck = yajlSupport;
+  nativeCheckInputs = [ python3 which ]
+    ++ lib.optional enableValgrindCheck valgrind
+    ++ lib.filter (lib.meta.availableOn stdenv.buildPlatform) [ erofs-utils fsverity-utils ];
+
+  preCheck = ''
+    patchShebangs --build tests/*dir tests/*.sh
+    substituteInPlace tests/*.sh \
+      --replace " /tmp" " $TMPDIR" \
+      --replace " /var/tmp" " $TMPDIR"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A file system for mounting container images";
+    homepage = "https://github.com/containers/composefs";
+    changelog = "https://github.com/containers/composefs/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [ gpl3Plus lgpl21Plus ];
+    maintainers = with lib.maintainers; [ kiskae ];
+    mainProgram = "mkcomposefs";
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description of changes

Added [composefs](https://github.com/containers/composefs) as a package. It is a file system implemented using `erofs`, `overlayfs`, loop devices and a content-addressible storage directory for file contents.

Support for `fs-verity` verification is currently depends on features from `overlay-next`.

Integration with `ostree` is currently "experimental": https://ostreedev.github.io/ostree/composefs/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
