### PR TITLE
prettierd: 0.23.4 -> 0.25.1

### DIFF
--- a/pkgs/development/tools/prettierd/default.nix
+++ b/pkgs/development/tools/prettierd/default.nix
@@ -8,18 +8,18 @@
 }:
 mkYarnPackage rec {
   pname = "prettierd";
-  version = "0.23.4";
+  version = "0.25.1";
 
   src = fetchFromGitHub {
     owner = "fsouza";
     repo = "prettierd";
     rev = "v${version}";
-    hash = "sha256-GTukjkA/53N9ICdfCJr5HAqhdL5T0pth6zAk8Fu/cis=";
+    hash = "sha256-aoRfZ9SJazz0ir1fyHypn3aYqK9DJOLLVPMuFcOm/20=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = src + "/yarn.lock";
-    hash = "sha256-32wMwkVgO5DQuROWnujVGNeCAUq1D6jJurecsD2ROOU=";
+    hash = "sha256-HsWsRIONRNY9akZ2LXlWcPhH6N5qCKnesaDX1gQp+NU=";
   };
 
   packageJSON = ./package.json;

--- a/pkgs/development/tools/prettierd/package.json
+++ b/pkgs/development/tools/prettierd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsouza/prettierd",
-  "version": "0.23.4",
+  "version": "0.25.1",
   "description": "prettier, as a daemon",
   "bin": {
     "prettierd": "./bin/prettierd"
@@ -24,14 +24,13 @@
   },
   "homepage": "https://github.com/fsouza/prettierd",
   "devDependencies": {
-    "@types/node": "^20.2.5",
-    "@types/prettier": "^2.7.2",
-    "typescript": "^5.0.4"
+    "@types/node": "^20.6.3",
+    "@types/prettier": "^3.0.0",
+    "typescript": "^5.2.2"
   },
   "dependencies": {
-    "core_d": "^5.0.1",
-    "nanolru": "^1.0.0",
-    "prettier": "^2.8.8"
+    "core_d": "^6.0.0",
+    "prettier": "^3.0.3"
   },
   "files": [
     "bin",
@@ -40,7 +39,7 @@
     "README.md"
   ],
   "optionalDependencies": {
-    "@babel/parser": "^7.22.3",
-    "@typescript-eslint/typescript-estree": "^5.59.7"
+    "@babel/parser": "^7.22.16",
+    "@typescript-eslint/typescript-estree": "^6.7.2"
   }
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/fsouza/prettierd/compare/v0.23.4...v0.25.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
