### PR TITLE
[23.05] libarchive: apply security fixes from 3.7.1 and 3.7.2

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -43,6 +43,19 @@ assert xarSupport -> libxml2 != null;
 
   outputs = [ "out" "lib" "dev" ];
 
+  patches = [
+    (fetchpatch {
+      name = "security-fixes-pax-writer.patch";
+      url = "https://github.com/libarchive/libarchive/commit/1b4e0d0f9d445ba3e4d0c7db7ce0b30300572fe8.patch";
+      hash = "sha256-Ei0FMBu0SKZhJdOzHni/gyi8VTmF2cC0K4gEJDSPXpU=";
+    })
+    (fetchpatch {
+      name = "security-fixes-cpio-list_item_verbose.patch";
+      url = "https://github.com/libarchive/libarchive/commit/ee312cfd05c1d1d38f3a5dd10872b97cbc11902c.patch";
+      hash = "sha256-n1cZBgRmcNCx+PzGub5KE/TMY1oPXihMTVjkdF9Ws3k=";
+    })
+  ];
+
   postPatch = let
     skipTestPaths = [
       # test won't work in nix sandbox
@@ -122,7 +135,7 @@ assert xarSupport -> libxml2 != null;
 })).overrideAttrs(previousAttrs:
   assert previousAttrs.version == "3.6.2";
   lib.optionalAttrs stdenv.hostPlatform.isStatic {
-    patches = [
+    patches = previousAttrs.patches ++ [
       # fixes static linking; upstream in releases after 3.6.2
       # https://github.com/libarchive/libarchive/pull/1825 merged upstream
       (fetchpatch {


### PR DESCRIPTION
## Description of changes

No CVE ID seems to have been assigned to this.

https://github.com/libarchive/libarchive/commit/ee312cfd05c1d1d38f3a5dd10872b97cbc11902c
https://github.com/libarchive/libarchive/commit/1b4e0d0f9d445ba3e4d0c7db7ce0b30300572fe8
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
