### PR TITLE
tor-browser: 12.5.6 -> 13.0

### DIFF
--- a/pkgs/applications/networking/browsers/mullvad-browser/default.nix
+++ b/pkgs/applications/networking/browsers/mullvad-browser/default.nix
@@ -232,7 +232,7 @@ stdenv.mkDerivation rec {
     updateScript = callPackage ../tor-browser/update.nix {
       inherit pname version meta;
       baseUrl = "https://cdn.mullvad.net/browser/";
-      prefix = "mullvad-browser-";
+      name = "mullvad-browser";
     };
   };
 

--- a/pkgs/applications/networking/browsers/tor-browser/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser/default.nix
@@ -34,8 +34,6 @@
 , mediaSupport ? true
 , ffmpeg
 
-, gmp
-
 # Wrapper runtime
 , coreutils
 , glibcLocales
@@ -88,33 +86,27 @@ lib.warnIf (useHardenedMalloc != null)
     ffmpeg
   ];
 
-  # Library search path for the fte transport
-  fteLibPath = lib.makeLibraryPath [ stdenv.cc.cc gmp ];
-
-  # Upstream source
-  version = "12.5.6";
-
-  lang = "ALL";
+  version = "13.0";
 
   sources = {
     x86_64-linux = fetchurl {
       urls = [
-        "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
-        "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
-        "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
-        "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
+        "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
+        "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
+        "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
+        "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-lZlGhyGDT9Vxox3ghfFSIZd3sazNyL23k0UtipaIGR8=";
+      hash = "sha256-zdmPbmJo5FDoOjob+9TDCvCgKgLHvLi3bOMhcZg8DVM=";
     };
 
     i686-linux = fetchurl {
       urls = [
-        "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
-        "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
-        "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
-        "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
+        "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
+        "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
+        "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
+        "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
       ];
-      hash = "sha256-3Z3S6P3wkZeC/lhgO7XDdDDQ6cpyOX+e3SBuh47aMl8=";
+      hash = "sha256-Hlvx2C4DF/wcHo9ES+g9UUgNFGDokW5OAX3FeOvR+fY=";
     };
   };
 
@@ -343,15 +335,11 @@ stdenv.mkDerivation rec {
     # chance that TBB would continue using old font files.
     rm -rf "\$HOME/.cache/fontconfig"
 
-    # Workaround a bug in 12.0.X that Tor directories are not cleaned up and tor gets confused where its socket is
-    rm -rf \$XDG_RUNTIME_DIR/Tor*
-
     # Manually specify data paths (by default TB attempts to create these in the store)
     {
       echo "user_pref(\"extensions.torlauncher.toronionauthdir_path\", \"\$HOME/TorBrowser/Data/Tor/onion-auth\");"
       echo "user_pref(\"extensions.torlauncher.torrc_path\", \"\$HOME/TorBrowser/Data/Tor/torrc\");"
       echo "user_pref(\"extensions.torlauncher.tordatadir_path\", \"\$HOME/TorBrowser/Data/Tor\");"
-      echo "user_pref(\"network.proxy.socks\", \"file://\$XDG_RUNTIME_DIR/Tor/socks.socket\");"
     } >> "\$HOME/TorBrowser/Data/Browser/profile.default/prefs.js"
 
     # Lift-off

--- a/pkgs/applications/networking/browsers/tor-browser/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser/default.nix
@@ -99,8 +99,8 @@ lib.warnIf (useHardenedMalloc != null)
   sources = {
     x86_64-linux = fetchurl {
       urls = [
-        "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
+        "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
@@ -109,8 +109,8 @@ lib.warnIf (useHardenedMalloc != null)
 
     i686-linux = fetchurl {
       urls = [
-        "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
+        "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];

--- a/pkgs/applications/networking/browsers/tor-browser/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser/default.nix
@@ -467,7 +467,7 @@ stdenv.mkDerivation rec {
     # MPL2.0+, GPL+, &c.  While it's not entirely clear whether
     # the compound is "libre" in a strict sense (some components place certain
     # restrictions on redistribution), it's free enough for our purposes.
-    license = licenses.free;
+    license = with licenses; [ mpl20 lgpl21Plus lgpl3Plus free ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/applications/networking/browsers/tor-browser/update.nix
+++ b/pkgs/applications/networking/browsers/tor-browser/update.nix
@@ -13,13 +13,16 @@
 , version
 , meta
 , baseUrl ? "https://dist.torproject.org/torbrowser/"
-# prefix used to match published archive
-, prefix ? "tor-browser-"
-# suffix used to match published archive
-, suffix ? "_ALL.tar.xz"
+# name used to match published archive
+, name ? "tor-browser"
+, prerelease ? false
 }:
 
-writeShellScript "update-${pname}" ''
+let
+  versionMatch = if prerelease
+    then ''[0-9]+(\.[0-9]+)*.*''
+    else ''[0-9]+(\.[0-9]+)*'';
+in writeShellScript "update-${pname}" ''
   PATH="${lib.makeBinPath [ coreutils curl gnugrep gnused gnupg nix common-updater-scripts ]}"
   set -euo pipefail
 
@@ -27,7 +30,7 @@ writeShellScript "update-${pname}" ''
 
   url=${baseUrl}
   version=$(curl -s $url \
-            | sed -rne 's,^.*href="([0-9]+(\.[0-9]+)*)/".*,\1,p' \
+            | sed -rne 's,^.*href="(${versionMatch})/".*,\1,p' \
             | sort --version-sort | tail -1)
 
   if [[ "${version}" = "$version" ]]; then
@@ -47,13 +50,13 @@ writeShellScript "update-${pname}" ''
   gpgv --keyring=$HOME/tor.keyring $HOME/shasums.asc $HOME/shasums
 
   declare -A platforms=(
-    ['x86_64-linux']='linux64'
-    ['i686-linux']='linux32'
+    ['x86_64-linux']='linux-x86_64'
+    ['i686-linux']='linux-i686'
   )
 
   for platform in ${lib.escapeShellArgs meta.platforms}; do
     arch="''${platforms[$platform]}"
-    sha256=$(cat "$HOME/shasums" | grep "${prefix}""$arch-$version""${suffix}" | cut -d" " -f1)
+    sha256=$(grep "${name}-$arch-$version.tar.xz" "$HOME/shasums" | cut -d" " -f1)
     hash=$(nix hash to-sri --type sha256 "$sha256")
 
     update-source-version "${pname}" "0" "sha256-${lib.fakeSha256}" --source-key="sources.$platform"


### PR DESCRIPTION
## Description of changes
https://blog.torproject.org/new-release-tor-browser-130/

Equivalent Mullvad Browser PR: #256935.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).