### PR TITLE
[23.05] erofs-utils: 1.6 -> 1.7

### DIFF
--- a/pkgs/tools/filesystems/erofs-utils/default.nix
+++ b/pkgs/tools/filesystems/erofs-utils/default.nix
@@ -1,20 +1,20 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, fuse, util-linux, lz4
+{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, fuse, util-linux, lz4, zlib
 , fuseSupport ? stdenv.isLinux
 }:
 
 stdenv.mkDerivation rec {
   pname = "erofs-utils";
-  version = "1.6";
+  version = "1.7";
   outputs = [ "out" "man" ];
 
   src = fetchurl {
     url =
       "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${version}.tar.gz";
-    sha256 = "sha256-2/Gtrv8buFMrKacsip4ZGTjJOJlGdw3HY9PFnm8yBXE=";
+    hash = "sha256-tutSm7Qj6y3XecnanCYyhVSItLkeI1U6Mc4j8Rycziw=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ util-linux lz4 ]
+  buildInputs = [ util-linux lz4 zlib ]
     ++ lib.optionals fuseSupport [ fuse ];
 
   configureFlags = lib.optionals fuseSupport [ "--enable-fuse" ];

--- a/pkgs/tools/filesystems/erofs-utils/default.nix
+++ b/pkgs/tools/filesystems/erofs-utils/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, fuse, libuuid, lz4 }:
+{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, fuse, util-linux, lz4
+, fuseSupport ? stdenv.isLinux
+}:
 
 stdenv.mkDerivation rec {
   pname = "erofs-utils";
@@ -12,14 +14,15 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ fuse libuuid lz4 ];
+  buildInputs = [ util-linux lz4 ]
+    ++ lib.optionals fuseSupport [ fuse ];
 
-  configureFlags = [ "--enable-fuse" ];
+  configureFlags = lib.optionals fuseSupport [ "--enable-fuse" ];
 
   meta = with lib; {
     description = "Userspace utilities for linux-erofs file system";
     license = with licenses; [ gpl2Plus ];
-    maintainers = with maintainers; [ ehmry ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ ehmry nikstur ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/erofs-utils/default.nix
+++ b/pkgs/tools/filesystems/erofs-utils/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     description = "Userspace utilities for linux-erofs file system";
     license = with licenses; [ gpl2Plus ];
     maintainers = with maintainers; [ ehmry nikstur ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7050,6 +7050,8 @@ with pkgs;
 
   ecmtools = callPackage ../tools/cd-dvd/ecm-tools { };
 
+  erofs-utils = callPackage ../tools/filesystems/erofs-utils { };
+
   e2tools = callPackage ../tools/filesystems/e2tools { };
 
   e2fsprogs = callPackage ../tools/filesystems/e2fsprogs { };
@@ -26730,8 +26732,6 @@ with pkgs;
   dsd = callPackage ../applications/radio/dsd { };
 
   dstat = callPackage ../os-specific/linux/dstat { };
-
-  erofs-utils = callPackage ../os-specific/linux/erofs-utils { };
 
   evdev-proto = callPackage ../os-specific/bsd/freebsd/evdev-proto { };
 


### PR DESCRIPTION
## Description of changes

Fixes CVE-2023-33552 and CVE-2023-33551.

Changelog:
https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/tree/ChangeLog?h=v1.7

Also cherry-picked d98a872d5877bd98c73438657d89a05abfc0595e because it brings no changes for Linux and it makes the backport of the new version easier.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
