### PR TITLE
actiona: init at 3.10.2

### DIFF
--- a/pkgs/applications/misc/actiona/default.nix
+++ b/pkgs/applications/misc/actiona/default.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  wrapQtAppsHook,
+
+  bluez,
+  libnotify,
+  libXdmcp,
+  libXtst,
+  opencv,
+  qtbase,
+  qtmultimedia,
+  qtscript,
+  qttools,
+  qtx11extras,
+  qtxmlpatterns,
+
+  # Running with TTS support causes the program to freeze for a few seconds every time at startup,
+  # so it is disabled by default
+  textToSpeechSupport ? false,
+  qtspeech,
+}:
+
+let
+  # For some reason qtscript wants to use the same version of qtbase as itself
+  # This override makes it think that they are the same version
+  qtscript' = qtscript.overrideAttrs (oldAttrs: {
+    inherit (qtbase) version;
+    postPatch = ''
+      substituteInPlace .qmake.conf \
+          --replace-fail ${oldAttrs.version} ${qtbase.version}
+    '';
+  });
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "actiona";
+  version = "3.10.2";
+
+  src = fetchFromGitHub {
+    owner = "Jmgr";
+    repo = "actiona";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-4RKCNEniBBx0kDwdHVZOqXYeGCsH8g6SfVc8JdDV0hI=";
+    fetchSubmodules = true;
+  };
+
+  patches =
+    [
+      # Sets the proper search location for the `.so` files and the translations
+      ./fix-paths.patch
+    ]
+    ++ lib.optionals (!textToSpeechSupport) [
+      # Removes TTS support
+      ./disable-tts.patch
+    ];
+
+  postPatch = ''
+    substituteInPlace gui/src/mainwindow.cpp executer/src/executer.cpp tools/src/languages.cpp \
+        --subst-var out
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    bluez
+    libnotify
+    libXdmcp
+    libXtst
+    opencv
+    qtbase
+    qtmultimedia
+    qtscript'
+    qttools
+    qtx11extras
+    qtxmlpatterns
+  ] ++ lib.optionals textToSpeechSupport [ qtspeech ];
+
+  # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
+  cmakeFlags = [ (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true) ];
+
+  # udev is used by the system-actionpack
+  env.NIX_LDFLAGS = "-ludev";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 {execution,actiontools,tools}/*.so -t $out/lib
+    install -Dm755 actions/actionpack*.so -t $out/lib/actions
+    install -Dm755 actiona actexec -t $out/bin
+    install -Dm644 translations/*.qm -t $out/share/actiona/translations
+    install -Dm644 $src/actiona.desktop -t $out/share/applications
+    install -Dm644 $src/gui/icons/actiona.png -t $out/share/icons/hicolor/48x48/apps
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A cross-platform automation tool";
+    homepage = "https://github.com/Jmgr/actiona";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "actiona";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/applications/misc/actiona/disable-tts.patch
+++ b/pkgs/applications/misc/actiona/disable-tts.patch
@@ -1,0 +1,54 @@
+diff --git a/actions/system/CMakeLists.txt b/actions/system/CMakeLists.txt
+index ca861145..3e3d3d3b 100644
+--- a/actions/system/CMakeLists.txt
++++ b/actions/system/CMakeLists.txt
+@@ -66,8 +66,6 @@ set(HEADERS
+     ${HEADERS_PREFIX}/actions/playsoundinstance.hpp
+     ${HEADERS_PREFIX}/actions/systemdefinition.hpp
+     ${HEADERS_PREFIX}/actions/systeminstance.hpp
+-    ${HEADERS_PREFIX}/actions/texttospeechdefinition.hpp
+-    ${HEADERS_PREFIX}/actions/texttospeechinstance.hpp
+     ${HEADERS_PREFIX}/code/mediaplaylist.hpp
+     ${HEADERS_PREFIX}/code/notify.hpp
+     ${HEADERS_PREFIX}/code/process.hpp
+@@ -131,7 +129,6 @@ find_package(Qt5 ${ACT_MINIMUM_QT_VERSION} COMPONENTS
+     DBus
+     Multimedia
+     MultimediaWidgets
+-    TextToSpeech
+ REQUIRED)
+ 
+ target_include_directories(${PROJECT}
+@@ -153,7 +150,6 @@ target_link_libraries(${PROJECT}
+     Qt5::DBus
+     Qt5::Multimedia
+     Qt5::MultimediaWidgets
+-    Qt5::TextToSpeech
+     ${LIBNOTIFY_LIBRARIES}
+     ${BLUEZ_LIBRARIES}
+     ${UDEV_LIBRARIES}
+diff --git a/actions/system/src/actionpacksystem.hpp b/actions/system/src/actionpacksystem.hpp
+index c5768415..27a899d6 100644
+--- a/actions/system/src/actionpacksystem.hpp
++++ b/actions/system/src/actionpacksystem.hpp
+@@ -31,10 +31,6 @@
+ #include "actions/playsounddefinition.hpp"
+ #include "actions/findimagedefinition.hpp"
+ 
+-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+-#include "actions/texttospeechdefinition.hpp"
+-#endif
+-
+ #include "code/system.hpp"
+ #include "code/mediaplaylist.hpp"
+ #include "code/notify.hpp"
+@@ -67,9 +63,6 @@ public:
+ 		addActionDefinition(new Actions::DetachedCommandDefinition(this));
+ 		addActionDefinition(new Actions::PlaySoundDefinition(this));
+ 		addActionDefinition(new Actions::FindImageDefinition(this));
+-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+-        addActionDefinition(new Actions::TextToSpeechDefinition(this));
+-#endif
+ 	}
+ 
+ 	QString id() const override							{ return QStringLiteral("system"); }

--- a/pkgs/applications/misc/actiona/fix-paths.patch
+++ b/pkgs/applications/misc/actiona/fix-paths.patch
@@ -1,0 +1,39 @@
+diff --git a/executer/src/executer.cpp b/executer/src/executer.cpp
+index da848dad..5bd7e986 100644
+--- a/executer/src/executer.cpp
++++ b/executer/src/executer.cpp
+@@ -45,7 +45,7 @@ bool Executer::start(QIODevice *device, const QString &filename)
+ 	QSettings settings;
+ 	QString locale = settings.value(QStringLiteral("gui/locale"), QLocale::system().name()).toString();
+ 
+-    mActionFactory->loadActionPacks(QApplication::applicationDirPath() + QStringLiteral("/actions"), locale);
++    mActionFactory->loadActionPacks(QStringLiteral("@out@/lib/actions"), locale);
+ #ifndef Q_OS_WIN
+ 	if(mActionFactory->actionPackCount() == 0)
+ 		mActionFactory->loadActionPacks(QStringLiteral("actiona/actions/"), locale);
+diff --git a/gui/src/mainwindow.cpp b/gui/src/mainwindow.cpp
+index 6052648e..3c802d93 100644
+--- a/gui/src/mainwindow.cpp
++++ b/gui/src/mainwindow.cpp
+@@ -322,7 +322,7 @@ void MainWindow::postInit()
+ 	if(mSplashScreen)
+ 		mSplashScreen->showMessage(tr("Loading actions..."));
+ 
+-    mActionFactory->loadActionPacks(QApplication::applicationDirPath() + QStringLiteral("/actions"), mUsedLocale);
++    mActionFactory->loadActionPacks(QStringLiteral("@out@/lib/actions"), mUsedLocale);
+ #ifndef Q_OS_WIN
+ 	if(mActionFactory->actionPackCount() == 0)
+ 		mActionFactory->loadActionPacks(QStringLiteral("actiona/actions/"), mUsedLocale);
+diff --git a/tools/src/languages.cpp b/tools/src/languages.cpp
+index 4926936e..18e9aabb 100644
+--- a/tools/src/languages.cpp
++++ b/tools/src/languages.cpp
+@@ -79,7 +79,7 @@ namespace Tools
+     void Languages::installTranslator(const QString &componentName, const QString &locale)
+     {
+         auto translator = new QTranslator(QCoreApplication::instance());
+-		if(!translator->load(QStringLiteral("%1/translations/%2_%3").arg(QCoreApplication::applicationDirPath()).arg(componentName).arg(locale)))
++		if(!translator->load(QStringLiteral("@out@/share/actiona/translations/%1_%2").arg(componentName).arg(locale)))
+         {
+             auto path = QStringLiteral("%1/translations/%2_%3").arg(QDir::currentPath()).arg(componentName).arg(locale);
+             if(!translator->load(path))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18026,6 +18026,8 @@ with pkgs;
 
   abuild = callPackage ../development/tools/abuild { };
 
+  actiona = libsForQt5.callPackage ../applications/misc/actiona { };
+
   actionlint = callPackage ../development/tools/analysis/actionlint { };
 
   adreaper = callPackage ../tools/security/adreaper { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/72766

This PR adds 1 package: `actiona`

I added a feature-flag to enable/disable text-to-speech.
I set it to off by default because the program has horrible load times, when enabled, I don't really know why.

The package seems to work. Some detaching scripts do have some issues, but I think that's not specific to Nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
