### PR TITLE
go: move common implementation to generic.nix

### DIFF
--- a/pkgs/development/compilers/go/1.18.nix
+++ b/pkgs/development/compilers/go/1.18.nix
@@ -1,74 +1,30 @@
-{ lib
-, stdenv
+{ stdenv
+, callPackage
 , fetchpatch
-, fetchurl
-, tzdata
 , substituteAll
+, tzdata
 , iana-etc
+, mailcap
+, buildPackages
+, buildGo118Module
 , Security
 , Foundation
 , xcbuild
-, mailcap
-, buildPackages
-, pkgsBuildTarget
-, threadsCross
-, testers
-, skopeo
-, buildGo118Module
 }:
 
 let
-  useGccGoBootstrap = stdenv.buildPlatform.isMusl || stdenv.buildPlatform.isRiscV;
-  goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap116.nix { };
-
-  skopeoTest = skopeo.override { buildGoModule = buildGo118Module; };
-
-  goarch = platform: {
-    "aarch64" = "arm64";
-    "arm" = "arm";
-    "armv5tel" = "arm";
-    "armv6l" = "arm";
-    "armv7l" = "arm";
-    "i686" = "386";
-    "mips" = "mips";
-    "mips64el" = "mips64le";
-    "mipsel" = "mipsle";
-    "powerpc64le" = "ppc64le";
-    "riscv64" = "riscv64";
-    "s390x" = "s390x";
-    "x86_64" = "amd64";
-  }.${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
-
-  # We need a target compiler which is still runnable at build time,
-  # to handle the cross-building case where build != host == target
-  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
-
-  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
-in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "go";
-  version = "1.18.10";
-
-  src = fetchurl {
-    url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    sha256 = "sha256-nO3MpYhF3wyUdK4AJ0xEqVyd+u+xMvxZkhwox8EG+OY=";
+  buildGo = callPackage ./generic.nix {
+    buildGoModule = buildGo118Module;
+    inherit Security Foundation xcbuild;
   };
 
-  strictDeps = true;
-  buildInputs = [ ]
-    ++ lib.optionals stdenv.isLinux [ stdenv.cc.libc.out ]
-    ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
-
-  depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [ Foundation Security xcbuild ];
-
-  depsBuildTarget = lib.optional isCross targetCC;
-
-  depsTargetTarget = lib.optional stdenv.targetPlatform.isWindows threadsCross.package;
-
-  postPatch = ''
-    patchShebangs .
-  '';
-
+  useGccGoBootstrap = stdenv.buildPlatform.isMusl || stdenv.buildPlatform.isRiscV;
+  goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap116.nix { };
+in
+buildGo {
+  inherit useGccGoBootstrap goBootstrap;
+  version = "1.18.10";
+  hash = "sha256-nO3MpYhF3wyUdK4AJ0xEqVyd+u+xMvxZkhwox8EG+OY=";
   patches = [
     (substituteAll {
       src = ./iana-etc-1.17.patch;
@@ -92,105 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     # runtime: support riscv64 SV57 mode
     (fetchpatch {
       url = "https://github.com/golang/go/commit/1e3c19f3fee12e5e2b7802a54908a4d4d03960da.patch";
-      sha256 = "sha256-mk/9gXwQEcAkiRemF6GiNU0c0fhDR29/YcKgQR7ONTA=";
+      hash = "sha256-mk/9gXwQEcAkiRemF6GiNU0c0fhDR29/YcKgQR7ONTA=";
     })
   ];
-
-  GOOS = stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
-  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
-  # Go will nevertheless build a for host system that we will copy over in
-  # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
-
-  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
-  # to be different from CC/CXX
-  CC_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}cc"
-    else
-      null;
-  CXX_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}c++"
-    else
-      null;
-
-  GOARM = toString (lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
-  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  CGO_ENABLED = 1;
-
-  GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
-
-  buildPhase = ''
-    runHook preBuild
-    export GOCACHE=$TMPDIR/go-cache
-    # this is compiled into the binary
-    export GOROOT_FINAL=$out/share/go
-
-    export PATH=$(pwd)/bin:$PATH
-
-    ${lib.optionalString isCross ''
-    # Independent from host/target, CC should produce code for the building system.
-    # We only set it when cross-compiling.
-    export CC=${buildPackages.stdenv.cc}/bin/cc
-    ''}
-    ulimit -a
-
-    pushd src
-    ./make.bash
-    popd
-    runHook postBuild
-  '';
-
-  preInstall = ''
-    rm -r pkg/obj
-    # Contains the wrong perl shebang when cross compiling,
-    # since it is not used for anything we can deleted as well.
-    rm src/regexp/syntax/make_perl_groups.pl
-  '' + (if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then ''
-    mv bin/*_*/* bin
-    rmdir bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
-    ''}
-  '' else lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
-    rm -rf bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
-    ''}
-  '');
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $GOROOT_FINAL
-    cp -a bin pkg src lib misc api doc $GOROOT_FINAL
-    mkdir -p $out/bin
-    ln -s $GOROOT_FINAL/bin/* $out/bin
-    runHook postInstall
-  '';
-
-  disallowedReferences = [ goBootstrap ];
-
-  passthru = {
-    inherit goBootstrap skopeoTest;
-    tests = {
-      skopeo = testers.testVersion { package = skopeoTest; };
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "go version";
-        version = "go${finalAttrs.version}";
-      };
-    };
-  };
-
-  meta = with lib; {
-    changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor finalAttrs.version}";
-    description = "The Go Programming language";
-    homepage = "https://go.dev/";
-    license = licenses.bsd3;
-    maintainers = teams.golang.members;
-    platforms = platforms.darwin ++ platforms.linux;
-  };
-})
+}

--- a/pkgs/development/compilers/go/1.19.nix
+++ b/pkgs/development/compilers/go/1.19.nix
@@ -1,74 +1,30 @@
-{ lib
-, stdenv
+{ stdenv
+, callPackage
 , fetchpatch
-, fetchurl
-, tzdata
 , substituteAll
+, tzdata
 , iana-etc
+, mailcap
+, buildPackages
+, buildGo119Module
 , Security
 , Foundation
 , xcbuild
-, mailcap
-, buildPackages
-, pkgsBuildTarget
-, threadsCross
-, testers
-, skopeo
-, buildGo119Module
 }:
 
 let
-  useGccGoBootstrap = stdenv.buildPlatform.isMusl || stdenv.buildPlatform.isRiscV;
-  goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap116.nix { };
-
-  skopeoTest = skopeo.override { buildGoModule = buildGo119Module; };
-
-  goarch = platform: {
-    "aarch64" = "arm64";
-    "arm" = "arm";
-    "armv5tel" = "arm";
-    "armv6l" = "arm";
-    "armv7l" = "arm";
-    "i686" = "386";
-    "mips" = "mips";
-    "mips64el" = "mips64le";
-    "mipsel" = "mipsle";
-    "powerpc64le" = "ppc64le";
-    "riscv64" = "riscv64";
-    "s390x" = "s390x";
-    "x86_64" = "amd64";
-  }.${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
-
-  # We need a target compiler which is still runnable at build time,
-  # to handle the cross-building case where build != host == target
-  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
-
-  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
-in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "go";
-  version = "1.19.13";
-
-  src = fetchurl {
-    url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-zPNrU/sAJKAXNTw92yLB8AvHqAc8aqx5BC2iTuNENNM=";
+  buildGo = callPackage ./generic.nix {
+    buildGoModule = buildGo119Module;
+    inherit Security Foundation xcbuild;
   };
 
-  strictDeps = true;
-  buildInputs = [ ]
-    ++ lib.optionals stdenv.isLinux [ stdenv.cc.libc.out ]
-    ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
-
-  depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [ Foundation Security xcbuild ];
-
-  depsBuildTarget = lib.optional isCross targetCC;
-
-  depsTargetTarget = lib.optional stdenv.targetPlatform.isWindows threadsCross.package;
-
-  postPatch = ''
-    patchShebangs .
-  '';
-
+  useGccGoBootstrap = stdenv.buildPlatform.isMusl || stdenv.buildPlatform.isRiscV;
+  goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap116.nix { };
+in
+buildGo {
+  inherit useGccGoBootstrap goBootstrap;
+  version = "1.19.13";
+  hash = "sha256-zPNrU/sAJKAXNTw92yLB8AvHqAc8aqx5BC2iTuNENNM=";
   patches = [
     (substituteAll {
       src = ./iana-etc-1.17.patch;
@@ -92,105 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     # runtime: support riscv64 SV57 mode
     (fetchpatch {
       url = "https://github.com/golang/go/commit/1e3c19f3fee12e5e2b7802a54908a4d4d03960da.patch";
-      sha256 = "sha256-mk/9gXwQEcAkiRemF6GiNU0c0fhDR29/YcKgQR7ONTA=";
+      hash = "sha256-mk/9gXwQEcAkiRemF6GiNU0c0fhDR29/YcKgQR7ONTA=";
     })
   ];
-
-  GOOS = stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
-  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
-  # Go will nevertheless build a for host system that we will copy over in
-  # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
-
-  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
-  # to be different from CC/CXX
-  CC_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}cc"
-    else
-      null;
-  CXX_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}c++"
-    else
-      null;
-
-  GOARM = toString (lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
-  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  CGO_ENABLED = 1;
-
-  GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
-
-  buildPhase = ''
-    runHook preBuild
-    export GOCACHE=$TMPDIR/go-cache
-    # this is compiled into the binary
-    export GOROOT_FINAL=$out/share/go
-
-    export PATH=$(pwd)/bin:$PATH
-
-    ${lib.optionalString isCross ''
-    # Independent from host/target, CC should produce code for the building system.
-    # We only set it when cross-compiling.
-    export CC=${buildPackages.stdenv.cc}/bin/cc
-    ''}
-    ulimit -a
-
-    pushd src
-    ./make.bash
-    popd
-    runHook postBuild
-  '';
-
-  preInstall = ''
-    rm -r pkg/obj
-    # Contains the wrong perl shebang when cross compiling,
-    # since it is not used for anything we can deleted as well.
-    rm src/regexp/syntax/make_perl_groups.pl
-  '' + (if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then ''
-    mv bin/*_*/* bin
-    rmdir bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
-    ''}
-  '' else lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
-    rm -rf bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
-    ''}
-  '');
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $GOROOT_FINAL
-    cp -a bin pkg src lib misc api doc $GOROOT_FINAL
-    mkdir -p $out/bin
-    ln -s $GOROOT_FINAL/bin/* $out/bin
-    runHook postInstall
-  '';
-
-  disallowedReferences = [ goBootstrap ];
-
-  passthru = {
-    inherit goBootstrap skopeoTest;
-    tests = {
-      skopeo = testers.testVersion { package = skopeoTest; };
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "go version";
-        version = "go${finalAttrs.version}";
-      };
-    };
-  };
-
-  meta = with lib; {
-    changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor finalAttrs.version}";
-    description = "The Go Programming language";
-    homepage = "https://go.dev/";
-    license = licenses.bsd3;
-    maintainers = teams.golang.members;
-    platforms = platforms.darwin ++ platforms.linux;
-  };
-})
+}

--- a/pkgs/development/compilers/go/1.20.nix
+++ b/pkgs/development/compilers/go/1.20.nix
@@ -1,73 +1,29 @@
-{ lib
-, stdenv
-, fetchurl
-, tzdata
+{ stdenv
+, callPackage
 , substituteAll
+, tzdata
 , iana-etc
+, mailcap
+, buildPackages
+, buildGo120Module
 , Security
 , Foundation
 , xcbuild
-, mailcap
-, buildPackages
-, pkgsBuildTarget
-, threadsCross
-, testers
-, skopeo
-, buildGo120Module
 }:
 
 let
-  useGccGoBootstrap = stdenv.buildPlatform.isMusl || stdenv.buildPlatform.isRiscV;
-  goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap117.nix { };
-
-  skopeoTest = skopeo.override { buildGoModule = buildGo120Module; };
-
-  goarch = platform: {
-    "aarch64" = "arm64";
-    "arm" = "arm";
-    "armv5tel" = "arm";
-    "armv6l" = "arm";
-    "armv7l" = "arm";
-    "i686" = "386";
-    "mips" = "mips";
-    "mips64el" = "mips64le";
-    "mipsel" = "mipsle";
-    "powerpc64le" = "ppc64le";
-    "riscv64" = "riscv64";
-    "s390x" = "s390x";
-    "x86_64" = "amd64";
-  }.${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
-
-  # We need a target compiler which is still runnable at build time,
-  # to handle the cross-building case where build != host == target
-  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
-
-  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
-in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "go";
-  version = "1.20.8";
-
-  src = fetchurl {
-    url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-ONcXFPpSeflyQEUZVtjkfjwbal3ny4QTeUnWK13TGC4=";
+  buildGo = callPackage ./generic.nix {
+    buildGoModule = buildGo120Module;
+    inherit Security Foundation xcbuild;
   };
 
-  strictDeps = true;
-  buildInputs = [ ]
-    ++ lib.optionals stdenv.isLinux [ stdenv.cc.libc.out ]
-    ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
-
-  depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [ Foundation Security xcbuild ];
-
-  depsBuildTarget = lib.optional isCross targetCC;
-
-  depsTargetTarget = lib.optional stdenv.targetPlatform.isWindows threadsCross.package;
-
-  postPatch = ''
-    patchShebangs .
-  '';
-
+  useGccGoBootstrap = stdenv.buildPlatform.isMusl || stdenv.buildPlatform.isRiscV;
+  goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap117.nix { };
+in
+buildGo {
+  inherit useGccGoBootstrap goBootstrap;
+  version = "1.20.8";
+  hash = "sha256-ONcXFPpSeflyQEUZVtjkfjwbal3ny4QTeUnWK13TGC4=";
   patches = [
     (substituteAll {
       src = ./iana-etc-1.17.patch;
@@ -88,101 +44,4 @@ stdenv.mkDerivation (finalAttrs: {
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.16.patch
   ];
-
-  GOOS = stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
-  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
-  # Go will nevertheless build a for host system that we will copy over in
-  # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
-
-  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
-  # to be different from CC/CXX
-  CC_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}cc"
-    else
-      null;
-  CXX_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}c++"
-    else
-      null;
-
-  GOARM = toString (lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
-  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  CGO_ENABLED = 1;
-
-  GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
-
-  buildPhase = ''
-    runHook preBuild
-    export GOCACHE=$TMPDIR/go-cache
-    # this is compiled into the binary
-    export GOROOT_FINAL=$out/share/go
-
-    export PATH=$(pwd)/bin:$PATH
-
-    ${lib.optionalString isCross ''
-    # Independent from host/target, CC should produce code for the building system.
-    # We only set it when cross-compiling.
-    export CC=${buildPackages.stdenv.cc}/bin/cc
-    ''}
-    ulimit -a
-
-    pushd src
-    ./make.bash
-    popd
-    runHook postBuild
-  '';
-
-  preInstall = ''
-    # Contains the wrong perl shebang when cross compiling,
-    # since it is not used for anything we can deleted as well.
-    rm src/regexp/syntax/make_perl_groups.pl
-  '' + (if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then ''
-    mv bin/*_*/* bin
-    rmdir bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
-    ''}
-  '' else lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
-    rm -rf bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
-    ''}
-  '');
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $GOROOT_FINAL
-    cp -a bin pkg src lib misc api doc $GOROOT_FINAL
-    mkdir -p $out/bin
-    ln -s $GOROOT_FINAL/bin/* $out/bin
-    runHook postInstall
-  '';
-
-  disallowedReferences = [ goBootstrap ];
-
-  passthru = {
-    inherit goBootstrap skopeoTest;
-    tests = {
-      skopeo = testers.testVersion { package = skopeoTest; };
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "go version";
-        version = "go${finalAttrs.version}";
-      };
-    };
-  };
-
-  meta = with lib; {
-    changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor finalAttrs.version}";
-    description = "The Go Programming language";
-    homepage = "https://go.dev/";
-    license = licenses.bsd3;
-    maintainers = teams.golang.members;
-    platforms = platforms.darwin ++ platforms.linux;
-  };
-})
+}

--- a/pkgs/development/compilers/go/1.21.nix
+++ b/pkgs/development/compilers/go/1.21.nix
@@ -1,73 +1,29 @@
-{ lib
-, stdenv
-, fetchurl
-, tzdata
+{ stdenv
+, callPackage
 , substituteAll
+, tzdata
 , iana-etc
+, mailcap
+, buildPackages
+, buildGo121Module
 , Security
 , Foundation
 , xcbuild
-, mailcap
-, buildPackages
-, pkgsBuildTarget
-, threadsCross
-, testers
-, skopeo
-, buildGo121Module
 }:
 
 let
-  useGccGoBootstrap = stdenv.buildPlatform.isMusl;
-  goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap121.nix { };
-
-  skopeoTest = skopeo.override { buildGoModule = buildGo121Module; };
-
-  goarch = platform: {
-    "aarch64" = "arm64";
-    "arm" = "arm";
-    "armv5tel" = "arm";
-    "armv6l" = "arm";
-    "armv7l" = "arm";
-    "i686" = "386";
-    "mips" = "mips";
-    "mips64el" = "mips64le";
-    "mipsel" = "mipsle";
-    "powerpc64le" = "ppc64le";
-    "riscv64" = "riscv64";
-    "s390x" = "s390x";
-    "x86_64" = "amd64";
-  }.${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
-
-  # We need a target compiler which is still runnable at build time,
-  # to handle the cross-building case where build != host == target
-  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
-
-  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
-in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "go";
-  version = "1.21.1";
-
-  src = fetchurl {
-    url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-v6Nr916aHpy725q8+dFwfkeb06B4gKiuNWTK7lcRy5k=";
+  buildGo = callPackage ./generic.nix {
+    buildGoModule = buildGo121Module;
+    inherit Security Foundation xcbuild;
   };
 
-  strictDeps = true;
-  buildInputs = [ ]
-    ++ lib.optionals stdenv.isLinux [ stdenv.cc.libc.out ]
-    ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
-
-  depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [ Foundation Security xcbuild ];
-
-  depsBuildTarget = lib.optional isCross targetCC;
-
-  depsTargetTarget = lib.optional stdenv.targetPlatform.isWindows threadsCross.package;
-
-  postPatch = ''
-    patchShebangs .
-  '';
-
+  useGccGoBootstrap = stdenv.buildPlatform.isMusl;
+  goBootstrap = if useGccGoBootstrap then buildPackages.gccgo12 else buildPackages.callPackage ./bootstrap121.nix { };
+in
+buildGo {
+  inherit useGccGoBootstrap goBootstrap;
+  version = "1.21.1";
+  hash = "sha256-v6Nr916aHpy725q8+dFwfkeb06B4gKiuNWTK7lcRy5k=";
   patches = [
     (substituteAll {
       src = ./iana-etc-1.17.patch;
@@ -88,101 +44,4 @@ stdenv.mkDerivation (finalAttrs: {
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.21.patch
   ];
-
-  GOOS = stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
-  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
-  # Go will nevertheless build a for host system that we will copy over in
-  # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
-
-  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
-  # to be different from CC/CXX
-  CC_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}cc"
-    else
-      null;
-  CXX_FOR_TARGET =
-    if isCross then
-      "${targetCC}/bin/${targetCC.targetPrefix}c++"
-    else
-      null;
-
-  GOARM = toString (lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
-  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  CGO_ENABLED = 1;
-
-  GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
-
-  buildPhase = ''
-    runHook preBuild
-    export GOCACHE=$TMPDIR/go-cache
-    # this is compiled into the binary
-    export GOROOT_FINAL=$out/share/go
-
-    export PATH=$(pwd)/bin:$PATH
-
-    ${lib.optionalString isCross ''
-    # Independent from host/target, CC should produce code for the building system.
-    # We only set it when cross-compiling.
-    export CC=${buildPackages.stdenv.cc}/bin/cc
-    ''}
-    ulimit -a
-
-    pushd src
-    ./make.bash
-    popd
-    runHook postBuild
-  '';
-
-  preInstall = ''
-    # Contains the wrong perl shebang when cross compiling,
-    # since it is not used for anything we can deleted as well.
-    rm src/regexp/syntax/make_perl_groups.pl
-  '' + (if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then ''
-    mv bin/*_*/* bin
-    rmdir bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
-    ''}
-  '' else lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
-    rm -rf bin/*_*
-    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
-      rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
-    ''}
-  '');
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $GOROOT_FINAL
-    cp -a bin pkg src lib misc api doc go.env $GOROOT_FINAL
-    mkdir -p $out/bin
-    ln -s $GOROOT_FINAL/bin/* $out/bin
-    runHook postInstall
-  '';
-
-  disallowedReferences = [ goBootstrap ];
-
-  passthru = {
-    inherit goBootstrap skopeoTest;
-    tests = {
-      skopeo = testers.testVersion { package = skopeoTest; };
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "go version";
-        version = "go${finalAttrs.version}";
-      };
-    };
-  };
-
-  meta = with lib; {
-    changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor finalAttrs.version}";
-    description = "The Go Programming language";
-    homepage = "https://go.dev/";
-    license = licenses.bsd3;
-    maintainers = teams.golang.members;
-    platforms = platforms.darwin ++ platforms.linux;
-  };
-})
+}

--- a/pkgs/development/compilers/go/generic.nix
+++ b/pkgs/development/compilers/go/generic.nix
@@ -1,0 +1,166 @@
+{ lib
+, stdenv
+, fetchurl
+, Security
+, Foundation
+, xcbuild
+, buildPackages
+, pkgsBuildTarget
+, threadsCross
+, testers
+, skopeo
+, buildGoModule
+}:
+
+{ useGccGoBootstrap, goBootstrap, version, hash, patches }:
+
+let
+  skopeoTest = skopeo.override { inherit buildGoModule; };
+
+  goarch = platform: {
+    "aarch64" = "arm64";
+    "arm" = "arm";
+    "armv5tel" = "arm";
+    "armv6l" = "arm";
+    "armv7l" = "arm";
+    "i686" = "386";
+    "mips" = "mips";
+    "mips64el" = "mips64le";
+    "mipsel" = "mipsle";
+    "powerpc64le" = "ppc64le";
+    "riscv64" = "riscv64";
+    "s390x" = "s390x";
+    "x86_64" = "amd64";
+  }.${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
+
+  # We need a target compiler which is still runnable at build time,
+  # to handle the cross-building case where build != host == target
+  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
+
+  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "go";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
+    inherit hash;
+  };
+
+  strictDeps = true;
+  buildInputs = [ ]
+    ++ lib.optionals stdenv.isLinux [ stdenv.cc.libc.out ]
+    ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+  depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [ Foundation Security xcbuild ];
+
+  depsBuildTarget = lib.optional isCross targetCC;
+
+  depsTargetTarget = lib.optional stdenv.targetPlatform.isWindows threadsCross.package;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  inherit patches;
+
+  GOOS = stdenv.targetPlatform.parsed.kernel.name;
+  GOARCH = goarch stdenv.targetPlatform;
+  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+  # Go will nevertheless build a for host system that we will copy over in
+  # the install phase.
+  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
+  GOHOSTARCH = goarch stdenv.buildPlatform;
+
+  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+  # to be different from CC/CXX
+  CC_FOR_TARGET =
+    if isCross then
+      "${targetCC}/bin/${targetCC.targetPrefix}cc"
+    else
+      null;
+  CXX_FOR_TARGET =
+    if isCross then
+      "${targetCC}/bin/${targetCC.targetPrefix}c++"
+    else
+      null;
+
+  GOARM = toString (lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
+  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
+  CGO_ENABLED = 1;
+
+  GOROOT_BOOTSTRAP = if useGccGoBootstrap then goBootstrap else "${goBootstrap}/share/go";
+
+  buildPhase = ''
+    runHook preBuild
+    export GOCACHE=$TMPDIR/go-cache
+    # this is compiled into the binary
+    export GOROOT_FINAL=$out/share/go
+
+    export PATH=$(pwd)/bin:$PATH
+
+    ${lib.optionalString isCross ''
+    # Independent from host/target, CC should produce code for the building system.
+    # We only set it when cross-compiling.
+    export CC=${buildPackages.stdenv.cc}/bin/cc
+    ''}
+    ulimit -a
+
+    pushd src
+    ./make.bash
+    popd
+    runHook postBuild
+  '';
+
+  preInstall = lib.optionalString (lib.versionOlder finalAttrs.version "1.20") ''
+    rm -r pkg/obj
+  '' + ''
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  '' + (if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then ''
+    mv bin/*_*/* bin
+    rmdir bin/*_*
+    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
+      rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
+    ''}
+  '' else lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
+    rm -rf bin/*_*
+    ${lib.optionalString (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS)) ''
+      rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
+    ''}
+  '');
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $GOROOT_FINAL
+    cp -a bin pkg src lib misc api doc${lib.optionalString (lib.versionAtLeast finalAttrs.version "1.21") " go.env"} $GOROOT_FINAL
+    mkdir -p $out/bin
+    ln -s $GOROOT_FINAL/bin/* $out/bin
+    runHook postInstall
+  '';
+
+  disallowedReferences = [ goBootstrap ];
+
+  passthru = {
+    inherit goBootstrap skopeoTest;
+    tests = {
+      skopeo = testers.testVersion { package = skopeoTest; };
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "go version";
+        version = "go${finalAttrs.version}";
+      };
+    };
+  };
+
+  meta = with lib; {
+    changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor finalAttrs.version}";
+    description = "The Go Programming language";
+    homepage = "https://go.dev/";
+    license = licenses.bsd3;
+    maintainers = teams.golang.members;
+    platforms = platforms.darwin ++ platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

This change moves implementation common to all Go versions to generic.nix to avoid duplication. This should also make future changes easier since we don’t have to manually update each individual Go package while keeping in mind all the small differences there were between them.

This is based on and inspired by Node.js package implementation.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
