### PR TITLE
nixos/users-groups: add recursiveCreateHome

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -235,7 +235,10 @@ foreach my $u (@{$spec->{users}}) {
     # Ensure home directory incl. ownership and permissions.
     if ($u->{createHome} and !$is_dry) {
         make_path($u->{home}, { mode => oct($u->{homeMode}) }) if ! -e $u->{home};
-        chown $u->{uid}, $u->{gid}, $u->{home};
+        system("chown",
+                ($u->{recursiveCreateHome} ? "-R" : ()),
+                "$u->{uid}:$u->{gid}",
+                 $u->{home}) == 0 || warn "warning: unable to chown $u->{home}, $!";
         chmod oct($u->{homeMode}), $u->{home};
     }
 

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -219,6 +219,14 @@ let
         '';
       };
 
+      recursiveCreateHome = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Whether to recursivley ensure ownership of the users home direcotry
+        '';
+      };
+
       useDefaultShell = mkOption {
         type = types.bool;
         default = false;
@@ -454,7 +462,7 @@ let
     inherit (cfg) mutableUsers;
     users = mapAttrsToList (_: u:
       { inherit (u)
-          name uid group description home homeMode createHome isSystemUser
+          name uid group description home homeMode createHome recursiveCreateHome isSystemUser
           password hashedPasswordFile hashedPassword
           autoSubUidGidRange subUidRanges subGidRanges
           initialPassword initialHashedPassword expires;

--- a/nixos/tests/user-home-mode.nix
+++ b/nixos/tests/user-home-mode.nix
@@ -10,8 +10,13 @@ import ./make-test-python.nix ({ lib, ... }: {
     users.users.bob = {
       initialPassword = "pass2";
       isNormalUser = true;
+      recursiveCreateHome = true;
       homeMode = "750";
     };
+    boot.initrd.postMountCommands = ''
+      mkdir -p $targetRoot/home/bob/.config
+      touch $targetRoot/home/bob/.config/user-dirs.dirs
+    '';
   };
 
   testScript = ''
@@ -23,5 +28,7 @@ import ./make-test-python.nix ({ lib, ... }: {
     machine.send_chars("pass1\n")
     machine.succeed('[ "$(stat -c %a /home/alice)" == "700" ]')
     machine.succeed('[ "$(stat -c %a /home/bob)" == "750" ]')
+    machine.succeed('[ "$(stat -c %U:%G /home/bob/.config)" == "bob:users" ]')
+    machine.succeed('[ "$(stat -c %U:%G /home/bob/.config/user-dirs.dirs)" = "bob:users" ]')
   '';
 })


### PR DESCRIPTION
## Description of changes

This PR adds a option to make the files in the home recursively owned by the actual user/group this can be useful in cases where you have files in the home directory before the user exits. A example use case is described in https://github.com/nix-community/disko/pull/383 where otherwise files end up getting owned by the root user.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
