### PR TITLE
NetBox 3.6

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -119,6 +119,8 @@
   - A list of all extras (and the extras enabled by default) can be found at the [option's reference for `services.matrix-synapse.extras`](#opt-services.matrix-synapse.extras).
   - In some cases (e.g. for running synapse workers) it was necessary to re-use the `PYTHONPATH` of `matrix-synapse.service`'s environment to have all plugins available. This isn't necessary anymore, instead `config.services.matrix-synapse.package` can be used as it points to the wrapper with properly configured `extras` and also all plugins defined via [`services.matrix-synapse.plugins`](#opt-services.matrix-synapse.plugins) available. This is also the reason for why the option is read-only now, it's supposed to be set by the module only.
 
+- `netbox` was updated to 3.6. NixOS' `services.netbox.package` still defaults to 3.5 if `stateVersion` is earlier than 23.11. Please review upstream's breaking changes [for 3.6.0](https://github.com/netbox-community/netbox/releases/tag/v3.6.0) and upgrade NetBox by changing `services.netbox.package`. Database migrations will be run automatically.
+
 - `etcd` has been updated to 3.5, you will want to read the [3.3 to 3.4](https://etcd.io/docs/v3.5/upgrades/upgrade_3_4/) and [3.4 to 3.5](https://etcd.io/docs/v3.5/upgrades/upgrade_3_5/) upgrade guides
 
 - `gitlab` installations created or updated between versions \[15.11.0, 15.11.2] have an incorrect database schema. This will become a problem when upgrading to `gitlab` >=16.2.0. A workaround for affected users can be found in the [GitLab docs](https://docs.gitlab.com/ee/update/versions/gitlab_16_changes.html#undefined-column-error-upgrading-to-162-or-later).

--- a/nixos/modules/services/web-apps/netbox.nix
+++ b/nixos/modules/services/web-apps/netbox.nix
@@ -74,9 +74,18 @@ in {
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = if lib.versionAtLeast config.system.stateVersion "23.05" then pkgs.netbox_3_5 else pkgs.netbox_3_3;
+      default =
+        if lib.versionAtLeast config.system.stateVersion "23.11"
+        then pkgs.netbox_3_6
+        else if lib.versionAtLeast config.system.stateVersion "23.05"
+        then pkgs.netbox_3_5
+        else pkgs.netbox_3_3;
       defaultText = lib.literalExpression ''
-        if versionAtLeast config.system.stateVersion "23.05" then pkgs.netbox_3_5 else pkgs.netbox_3_3;
+        if lib.versionAtLeast config.system.stateVersion "23.11"
+        then pkgs.netbox_3_6
+        else if lib.versionAtLeast config.system.stateVersion "23.05"
+        then pkgs.netbox_3_5
+        else pkgs.netbox_3_3;
       '';
       description = lib.mdDoc ''
         NetBox package to use.

--- a/nixos/modules/services/web-apps/netbox.nix
+++ b/nixos/modules/services/web-apps/netbox.nix
@@ -74,9 +74,9 @@ in {
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = if lib.versionAtLeast config.system.stateVersion "23.05" then pkgs.netbox else pkgs.netbox_3_3;
+      default = if lib.versionAtLeast config.system.stateVersion "23.05" then pkgs.netbox_3_5 else pkgs.netbox_3_3;
       defaultText = lib.literalExpression ''
-        if versionAtLeast config.system.stateVersion "23.05" then pkgs.netbox else pkgs.netbox_3_3;
+        if versionAtLeast config.system.stateVersion "23.05" then pkgs.netbox_3_5 else pkgs.netbox_3_3;
       '';
       description = lib.mdDoc ''
         NetBox package to use.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -531,6 +531,7 @@ in {
   networking.scripted = handleTest ./networking.nix { networkd = false; };
   netbox_3_5 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_5; };
   netbox_3_3 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_3; };
+  netbox_3_6 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_6; };
   netbox-upgrade = handleTest ./web-apps/netbox-upgrade.nix {};
   # TODO: put in networking.nix after the test becomes more complete
   networkingProxy = handleTest ./networking-proxy.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -530,7 +530,6 @@ in {
   networking.networkd = handleTest ./networking.nix { networkd = true; };
   networking.scripted = handleTest ./networking.nix { networkd = false; };
   netbox_3_5 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_5; };
-  netbox_3_3 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_3; };
   netbox_3_6 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_6; };
   netbox-upgrade = handleTest ./web-apps/netbox-upgrade.nix {};
   # TODO: put in networking.nix after the test becomes more complete

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -529,7 +529,7 @@ in {
   netdata = handleTest ./netdata.nix {};
   networking.networkd = handleTest ./networking.nix { networkd = true; };
   networking.scripted = handleTest ./networking.nix { networkd = false; };
-  netbox = handleTest ./web-apps/netbox.nix { inherit (pkgs) netbox; };
+  netbox_3_5 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_5; };
   netbox_3_3 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_3; };
   netbox-upgrade = handleTest ./web-apps/netbox-upgrade.nix {};
   # TODO: put in networking.nix after the test becomes more complete

--- a/nixos/tests/web-apps/netbox-upgrade.nix
+++ b/nixos/tests/web-apps/netbox-upgrade.nix
@@ -1,6 +1,6 @@
 import ../make-test-python.nix ({ lib, pkgs, ... }: let
-  oldNetbox = pkgs.netbox_3_3;
-  newNetbox = pkgs.netbox_3_5;
+  oldNetbox = pkgs.netbox_3_5;
+  newNetbox = pkgs.netbox_3_6;
 in {
   name = "netbox-upgrade";
 
@@ -9,6 +9,7 @@ in {
   };
 
   nodes.machine = { config, ... }: {
+    virtualisation.memorySize = 2048;
     services.netbox = {
       enable = true;
       package = oldNetbox;

--- a/nixos/tests/web-apps/netbox-upgrade.nix
+++ b/nixos/tests/web-apps/netbox-upgrade.nix
@@ -1,10 +1,11 @@
 import ../make-test-python.nix ({ lib, pkgs, ... }: let
   oldNetbox = pkgs.netbox_3_3;
+  newNetbox = pkgs.netbox_3_5;
 in {
   name = "netbox-upgrade";
 
   meta = with lib.maintainers; {
-    maintainers = [ minijackson ];
+    maintainers = [ minijackson raitobezarius ];
   };
 
   nodes.machine = { config, ... }: {
@@ -32,7 +33,7 @@ in {
 
     networking.firewall.allowedTCPPorts = [ 80 ];
 
-    specialisation.upgrade.configuration.services.netbox.package = lib.mkForce pkgs.netbox;
+    specialisation.upgrade.configuration.services.netbox.package = lib.mkForce newNetbox;
   };
 
   testScript = { nodes, ... }:
@@ -43,7 +44,7 @@ in {
         (lib.concatStringsSep ".")
       ];
       oldApiVersion = apiVersion oldNetbox.version;
-      newApiVersion = apiVersion pkgs.netbox.version;
+      newApiVersion = apiVersion newNetbox.version;
     in
     ''
       start_all()

--- a/nixos/tests/web-apps/netbox.nix
+++ b/nixos/tests/web-apps/netbox.nix
@@ -16,6 +16,7 @@ in import ../make-test-python.nix ({ lib, pkgs, netbox, ... }: {
   };
 
   nodes.machine = { config, ... }: {
+    virtualisation.memorySize = 2048;
     services.netbox = {
       enable = true;
       package = netbox;

--- a/pkgs/servers/web-apps/netbox/default.nix
+++ b/pkgs/servers/web-apps/netbox/default.nix
@@ -1,31 +1,9 @@
-{ lib, nixosTests, callPackage, fetchpatch }:
+{ lib, nixosTests, callPackage, }:
 let
   generic = import ./generic.nix;
 in
 lib.fix (self: {
   netbox = self.netbox_3_6;
-
-  netbox_3_3 = callPackage generic {
-    version = "3.3.10";
-    hash = "sha256-MeOfTU5IxNDoUh7FyvwAQNRC/CE0R6p40WnlF+3RuxA=";
-    extraPatches = [
-      # Allow setting the STATIC_ROOT from within the configuration and setting a custom redis URL
-      ./config_3_3.patch
-      ./graphql-3_2_0.patch
-      # fix compatibility ith django 4.1
-      (fetchpatch {
-        url = "https://github.com/netbox-community/netbox/pull/10341/commits/ce6bf9e5c1bc08edc80f6ea1e55cf1318ae6e14b.patch";
-        sha256 = "sha256-aCPQp6k7Zwga29euASAd+f13hIcZnIUu3RPAzNPqgxc=";
-      })
-    ];
-
-    tests = {
-      netbox = nixosTests.netbox_3_3;
-      inherit (nixosTests) netbox-upgrade;
-    };
-    maintainers = with lib.maintainers; [ n0emis raitobezarius ];
-    eol = true;
-  };
 
   netbox_3_5 = callPackage generic {
     version = "3.5.9";

--- a/pkgs/servers/web-apps/netbox/default.nix
+++ b/pkgs/servers/web-apps/netbox/default.nix
@@ -3,7 +3,7 @@ let
   generic = import ./generic.nix;
 in
 lib.fix (self: {
-  netbox = self.netbox_3_5;
+  netbox = self.netbox_3_6;
 
   netbox_3_3 = callPackage generic {
     version = "3.3.10";
@@ -36,6 +36,22 @@ lib.fix (self: {
     ];
     tests = {
       netbox = nixosTests.netbox_3_5;
+      inherit (nixosTests) netbox-upgrade;
+    };
+
+    maintainers = with lib.maintainers; [ minijackson n0emis raitobezarius ];
+    eol = true;
+  };
+
+  netbox_3_6 = callPackage generic {
+    version = "3.6.2";
+    hash = "sha256-iKYzeiaJhF8T+qbft6fS1PjHyPxxQm86om9YpAGnvYE=";
+    extraPatches = [
+      # Allow setting the STATIC_ROOT from within the configuration and setting a custom redis URL
+      ./config.patch
+    ];
+    tests = {
+      netbox = nixosTests.netbox_3_6;
       inherit (nixosTests) netbox-upgrade;
     };
 

--- a/pkgs/servers/web-apps/netbox/default.nix
+++ b/pkgs/servers/web-apps/netbox/default.nix
@@ -22,8 +22,8 @@ lib.fix (self: {
   };
 
   netbox_3_6 = callPackage generic {
-    version = "3.6.2";
-    hash = "sha256-iKYzeiaJhF8T+qbft6fS1PjHyPxxQm86om9YpAGnvYE=";
+    version = "3.6.3";
+    hash = "sha256-8Xir2Gvwh2cllHu5qVAzumuH0lknMMtjd8BuFuuf9A0=";
     extraPatches = [
       # Allow setting the STATIC_ROOT from within the configuration and setting a custom redis URL
       ./config.patch

--- a/pkgs/servers/web-apps/netbox/default.nix
+++ b/pkgs/servers/web-apps/netbox/default.nix
@@ -2,7 +2,9 @@
 let
   generic = import ./generic.nix;
 in
-{
+lib.fix (self: {
+  netbox = self.netbox_3_5;
+
   netbox_3_3 = callPackage generic {
     version = "3.3.10";
     hash = "sha256-MeOfTU5IxNDoUh7FyvwAQNRC/CE0R6p40WnlF+3RuxA=";
@@ -25,7 +27,7 @@ in
     eol = true;
   };
 
-  netbox = callPackage generic {
+  netbox_3_5 = callPackage generic {
     version = "3.5.9";
     hash = "sha256-CJbcuCyTuihDXrObSGyJi2XF+zgWAwcJzjxtkX8pmKs=";
     extraPatches = [
@@ -33,9 +35,10 @@ in
       ./config.patch
     ];
     tests = {
-      inherit (nixosTests) netbox netbox-upgrade;
+      netbox = nixosTests.netbox_3_5;
+      inherit (nixosTests) netbox-upgrade;
     };
 
     maintainers = with lib.maintainers; [ minijackson n0emis raitobezarius ];
   };
-}
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1183,6 +1183,7 @@ mapAliases ({
   nccl_cudatoolkit_11 = throw "nccl_cudatoolkit_11 has been renamed to cudaPackages_11.nccl"; # Added 2022-04-04
 
   net_snmp = throw "'net_snmp' has been renamed to/replaced by 'net-snmp'"; # Converted to throw 2023-09-10
+  netbox_3_3 = throw "netbox 3.3 series has been removed as it was EOL"; # Added 2023-09-02
   nagiosPluginsOfficial = monitoring-plugins;
   navit = throw "navit has been removed from nixpkgs, due to being unmaintained"; # Added 2021-06-07
   ncat = throw "'ncat' has been renamed to/replaced by 'nmap'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11073,7 +11073,7 @@ with pkgs;
   netbootxyz-efi = callPackage ../tools/misc/netbootxyz-efi { };
 
   inherit (callPackage ../servers/web-apps/netbox { })
-    netbox netbox_3_3 netbox_3_5;
+    netbox netbox_3_3 netbox_3_5 netbox_3_6;
 
   netbox2netshot = callPackage ../tools/admin/netbox2netshot { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11073,7 +11073,7 @@ with pkgs;
   netbootxyz-efi = callPackage ../tools/misc/netbootxyz-efi { };
 
   inherit (callPackage ../servers/web-apps/netbox { })
-    netbox netbox_3_3 netbox_3_5 netbox_3_6;
+    netbox netbox_3_5 netbox_3_6;
 
   netbox2netshot = callPackage ../tools/admin/netbox2netshot { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11073,7 +11073,7 @@ with pkgs;
   netbootxyz-efi = callPackage ../tools/misc/netbootxyz-efi { };
 
   inherit (callPackage ../servers/web-apps/netbox { })
-    netbox_3_3 netbox;
+    netbox netbox_3_3 netbox_3_5;
 
   netbox2netshot = callPackage ../tools/admin/netbox2netshot { };
 


### PR DESCRIPTION
## Description of changes

Based on #252854

Introduces NetBox 3.6.2, marks NetBox 3.5.9 as EOL, removes NetBox 3.3.*

One thing that's different from #252854 is that the `netbox` attribute points to the latest version. This shouldn't have any bad consequence, since I've replaced any `netbox` usage in the NixOS modules & NixOS tests by `netbox_3_6`.

NetBox release notes:

- https://github.com/netbox-community/netbox/releases/tag/v3.6.0 (with breaking changes)
- https://github.com/netbox-community/netbox/releases/tag/v3.6.1
- https://github.com/netbox-community/netbox/releases/tag/v3.6.2
- https://github.com/netbox-community/netbox/releases/tag/v3.6.3
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


cc @n0emis & @RaitoBezarius

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>netbox (netbox_3_6)</li>
  </ul>
</details>
