### PR TITLE
clang-tools: add optional support for libcxx

### DIFF
--- a/pkgs/development/tools/clang-tools/default.nix
+++ b/pkgs/development/tools/clang-tools/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvmPackages }:
+{ lib, stdenv, llvmPackages, enableLibcxx ? false }:
+# enableLibcxx will use the c++ headers from clang instead of gcc.
+# This shouldn't have any effect on platforms that use clang as the default compiler already.
 
 let
   unwrapped = llvmPackages.clang-unwrapped;
@@ -9,7 +11,7 @@ in stdenv.mkDerivation {
   pname = "clang-tools";
   version = lib.getVersion unwrapped;
   dontUnpack = true;
-  clang = llvmPackages.clang;
+  clang = if enableLibcxx then llvmPackages.libcxxClang else llvmPackages.clang;
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Description of changes
`clang-tools` fails to see  LLVM's libcxx and instead uses GCC's c++ ibrary since that is what is present in `libcxx-cxxflags` for `llvmPackages.clang`. To solve this one can use `llvmPackages.libcxxClang`.

## Things done
Added a parameter to optionally use `libcxxClang` instead of `clang`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
