### PR TITLE
turtlevcs: init at 0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2642,6 +2642,15 @@
     githubId = 37375448;
     name = "Buildit";
   };
+  burniintree = {
+    name = "Lars Mühmel";
+    email = "larsmuehmel@web.de";
+    github = "BurNiinTRee";
+    githubId = 7968493;
+    keys = [{
+      fingerprint = "2BC4 CCAD FA56 133A 551C  F38C 4106 FBAD F456 6EAC";
+    }];
+  };
   bwlang = {
     email = "brad@langhorst.com";
     github = "bwlang";

--- a/pkgs/by-name/tu/turtle/package.nix
+++ b/pkgs/by-name/tu/turtle/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, fetchFromGitLab
+, cacert
+, gobject-introspection
+, gtk4
+, glib
+, libadwaita
+, meld
+, python3
+, wrapGAppsHook4
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "turtle";
+  version = "0.6";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "philippun1";
+    repo = pname;
+    rev = version;
+    hash = "sha256-ShZlGZeIjsMOLrdPsl6WphGZcWPrhTQHv2b7HFVm4do=";
+  };
+  format = "setuptools";
+  nativeBuildInputs = [
+    wrapGAppsHook4
+    gobject-introspection
+  ];
+  buildInputs = [
+    libadwaita
+    gtk4
+    glib
+  ];
+  nativeCheckInputs = [
+    cacert
+  ];
+
+  postInstall = ''
+    install -Dm644 -t $out/share/nautilus-python/extensions $src/plugins/turtle_nautilus.py
+  '';
+
+  # this runs after the wrapPythonScipts function, hence $program_PYTHONPATH is already populated.
+  # the turtle_nautilus.py plugin imports turtlevcs, hence we have to patch it
+  postFixup = ''
+    patchPythonScript "$out/share/nautilus-python/extensions/turtle_nautilus.py"
+  '';
+
+  propagatedBuildInputs =
+    (with python3.pkgs; [
+      pygit2
+      pygobject3
+    ])
+    ++ [
+      meld
+    ];
+
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    # It can't find pygit2 without also adding $PYTHONPATH to the wrapper
+    makeWrapperArgs+=( --prefix PYTHONPATH : $out/${python3.sitePackages}:$PYTHONPATH )
+  '';
+
+  # breaks gobject-introspection
+  strictDeps = false;
+
+  meta = with lib; {
+    description = "A graphical interface for version control intended to run on gnome and nautilus";
+    homepage = "https://gitlab.gnome.org/philippun1/turtle";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ burniintree ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Closes #252317

Adds a [turtle](https://gitlab.gnome.org/philippun1/turtle) package.
The nautilus plugin requires `gnome.nautilus-python` to be installed separately.

The package is a bit weird, since `turtle_cli` subcommands are implemented through subprocesses
of either `$PYTHON` or `sys.executable`. This doesn't work well with `buildPythonApplication`s hooks
for setting up python dependencies.

I'm not very familiar with neither python packaging in general, nor nixpkgs' infrastructure for it,
so there might be better ways of achieving this.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
