### PR TITLE
inetutils: add patch for CVE-2023-40303

### DIFF
--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -51,9 +51,7 @@ stdenv.mkDerivation rec {
     "--disable-rexec"
   ] ++ lib.optional stdenv.isDarwin  "--disable-servers";
 
-  # Test fails with "UNIX socket name too long", probably because our
-  # $TMPDIR is too long.
-  doCheck = false;
+  doCheck = true;
 
   installFlags = [ "SUIDMODE=" ];
 

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, lib, fetchurl, ncurses, perl, help2man
+{ stdenv
+, lib
+, fetchurl
+, fetchpatch
+, ncurses
+, perl
+, help2man
 , apparmorRulesFromClosure
 , libxcrypt
 }:
@@ -17,6 +23,11 @@ stdenv.mkDerivation rec {
   patches = [
     # https://git.congatec.com/yocto/meta-openembedded/commit/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3
     ./inetutils-1_9-PATH_PROCNET_DEV.patch
+    (fetchpatch {
+      name = "CVE-2023-40303.patch";
+      url = "https://git.savannah.gnu.org/cgit/inetutils.git/patch/?id=e4e65c03f4c11292a3e40ef72ca3f194c8bffdd6";
+      hash = "sha256-I5skN537owfpFpAZr4vDKPHuERI6+oq5/hFW2RQeUxI=";
+    })
   ];
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2023-40303

No upstream release yet.

Built `pkgsStatic`, `pkgsMusl`, `pkgsCross.aarch64-multiplatform`, `pkgsi686Linux`, `pkgsLLVM` variants successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
