### PR TITLE
serial-unit-testing: init at 0.2.4

### DIFF
--- a/pkgs/by-name/se/serial-unit-testing/package.nix
+++ b/pkgs/by-name/se/serial-unit-testing/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, udev
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "serial-unit-testing";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "markatk";
+    repo = "serial-unit-testing";
+    rev = "v${version}";
+    hash = "sha256-SLwTwEQdwbus9RFskFjU8m4fS9Pnp8HsgnKkBvTqmSI=";
+  };
+
+  cargoHash = "sha256-PoV2v0p0L3CTtC9VMAx2Z/ZsSAIFi2gh2TtOp64S6ZQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    udev
+  ];
+
+  # tests require a serial port
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Automate testing of serial communication with any serial port device";
+    homepage = "https://github.com/markatk/serial-unit-testing";
+    changelog = "https://github.com/markatk/serial-unit-testing/blob/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rudolfvesely ];
+    mainProgram = "sut";
+  };
+}


### PR DESCRIPTION
Package "serial-unit-testing" is a cross-platform cli application and rust library. Using serial unit testing communication and testing with any serial port device can be done and most important automated. Release notes: https://github.com/markatk/serial-unit-testing/blob/v0.2.4/CHANGELOG.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable
  - Compiled and run against a serial port - fully functional.
  - Unit tests require an accessible serial port and therefore skipped by: `doCheck = false;`
- [x] Tested compilation of all packages that depend on this change:
  - No dependencies except what is in `nativeBuildInputs` and `buildInputs`
- [x] Tested basic functionality of all binary files: Yes
