### PR TITLE
quartus-prime-lite: improvements & fixes

### DIFF
--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -89,7 +89,10 @@ in buildFHSEnvChroot rec {
   # (a similiar fix involving LD_PRELOADing tcmalloc did not solve the issue in my situation)
   # we use the name so that quartus can load the 64 bit verson and modelsim can load the 32 bit version
   # https://community.intel.com/t5/Intel-FPGA-Software-Installation/Running-Quartus-Prime-Standard-on-WSL-crashes-in-libudev-so/m-p/1189032
-  runScript = writeScript "${name}-wrapper" ''
-    exec env LD_PRELOAD=libudev.so.0 "$@"
+  profile = ''
+    export LD_PRELOAD=libudev.so.0
   '';
+
+  # Run the wrappers directly, instead of going via bash.
+  runScript = "";
 }

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -17,6 +17,11 @@ in buildFHSEnvChroot rec {
   name = "quartus-prime-lite"; # wrapped
 
   targetPkgs = pkgs: with pkgs; [
+    (runCommand "ld-lsb-compat" {} ''
+      mkdir -p "$out/lib"
+      ln -sr "${glibc}/lib/ld-linux-x86-64.so.2" "$out/lib/ld-lsb-x86-64.so.3"
+      ln -sr "${pkgsi686Linux.glibc}/lib/ld-linux.so.2" "$out/lib/ld-lsb.so.3"
+    '')
     # quartus requirements
     glib
     xorg.libICE

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -67,18 +67,18 @@ in buildFHSEnvChroot rec {
     ln -s ${desktopItem}/share/applications/* $out/share/applications
     ln -s ${unwrapped}/licenses/images/dc_quartus_panel_logo.png $out/share/icons/128x128/quartus.png
 
-    WRAPPER=$out/bin/${name}
-    EXECUTABLES="${lib.concatStringsSep " " (quartusExecutables ++ qsysExecutables ++ modelsimExecutables)}"
-    for executable in $EXECUTABLES; do
+    wrapper=$out/bin/${name}
+    executables="${lib.concatStringsSep " " (quartusExecutables ++ qsysExecutables ++ modelsimExecutables)}"
+    for executable in $executables; do
         mkdir -p "$(dirname "$out/$executable")"
         echo "#!${stdenv.shell}" >> $out/$executable
-        echo "$WRAPPER ${unwrapped}/$executable \"\$@\"" >> $out/$executable
+        echo "$wrapper ${unwrapped}/$executable \"\$@\"" >> $out/$executable
     done
 
     cd $out
-    chmod +x $EXECUTABLES
+    chmod +x $executables
     # link into $out/bin so executables become available on $PATH
-    ln --symbolic --relative --target-directory ./bin $EXECUTABLES
+    ln --symbolic --relative --target-directory ./bin $executables
   '';
 
   # LD_PRELOAD fixes issues in the licensing system that cause memory corruption and crashes when

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -56,8 +56,6 @@ in buildFHSEnv rec {
     libxcrypt-legacy
   ];
 
-  passthru = { inherit unwrapped; };
-
   extraInstallCommands = ''
     mkdir -p $out/share/applications $out/share/icons/128x128
     ln -s ${desktopItem}/share/applications/* $out/share/applications
@@ -99,4 +97,6 @@ in buildFHSEnv rec {
 
   # Run the wrappers directly, instead of going via bash.
   runScript = "";
+
+  passthru = { inherit unwrapped; };
 }

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildFHSEnv, callPackage, makeDesktopItem, writeScript
+{ lib, buildFHSEnv, callPackage, makeDesktopItem, writeScript, runtimeShell
 , runCommand, quartus-prime-lite
 , supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ]
 , unwrapped ? callPackage ./quartus.nix { inherit supportedDevices; }
@@ -77,7 +77,7 @@ in buildFHSEnv rec {
         wrapped="$out/$relname"
         progs_wrapped+=("$wrapped")
         mkdir -p "$(dirname "$wrapped")"
-        echo "#!${stdenv.shell}" >> "$wrapped"
+        echo "#!${runtimeShell}" >> "$wrapped"
         case "$relname" in
             modelsim_ase/*)
                 echo "export NIXPKGS_IS_MODELSIM_WRAPPER=1" >> "$wrapped"

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildFHSEnvChroot, callPackage, makeDesktopItem, writeScript
+{ stdenv, lib, buildFHSEnv, callPackage, makeDesktopItem, writeScript
 , supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ]
 , unwrapped ? callPackage ./quartus.nix { inherit supportedDevices; }
 }:
@@ -13,7 +13,7 @@ let
     categories = [ "Development" ];
   };
 # I think modelsim_ase/linux/vlm checksums itself, so use FHSUserEnv instead of `patchelf`
-in buildFHSEnvChroot rec {
+in buildFHSEnv rec {
   name = "quartus-prime-lite"; # wrapped
 
   targetPkgs = pkgs: with pkgs; [
@@ -31,6 +31,10 @@ in buildFHSEnvChroot rec {
     xorg.libXtst
     xorg.libXi
   ];
+
+  # Also support 32-bit executables.
+  multiArch = true;
+
   multiPkgs = pkgs: with pkgs; let
     # This seems ugly - can we override `libpng = libpng12` for all `pkgs`?
     freetype = pkgs.freetype.override { libpng = libpng12; };

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -64,7 +64,7 @@ in buildFHSEnvChroot rec {
       "${unwrapped}"/quartus/bin/quartus_{asm,cdb,cpf,drc,eda,fit,jbcc,jli,map,pgm,pow,sh,si,sim,sta,stp,tan}
       "${unwrapped}"/quartus/sopc_builder/bin/qsys-{generate,edit,script}
       # Should we install all executables?
-      "${unwrapped}"/modelsim_ase/bin/{vsim,vlog,vlib}
+      "${unwrapped}"/modelsim_ase/bin/{vsim,vlog,vlib,vcom,vdel,vmap}
       "${unwrapped}"/modelsim_ase/linuxaloem/lmutil
     )
 

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -65,6 +65,7 @@ in buildFHSEnvChroot rec {
       "${unwrapped}"/quartus/sopc_builder/bin/qsys-{generate,edit,script}
       # Should we install all executables?
       "${unwrapped}"/modelsim_ase/bin/{vsim,vlog,vlib}
+      "${unwrapped}"/modelsim_ase/linuxaloem/lmutil
     )
 
     wrapper=$out/bin/${name}

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -90,7 +90,7 @@ in buildFHSEnvChroot rec {
   # we use the name so that quartus can load the 64 bit verson and modelsim can load the 32 bit version
   # https://community.intel.com/t5/Intel-FPGA-Software-Installation/Running-Quartus-Prime-Standard-on-WSL-crashes-in-libudev-so/m-p/1189032
   profile = ''
-    export LD_PRELOAD=libudev.so.0
+    export LD_PRELOAD=''${LD_PRELOAD:+$LD_PRELOAD:}libudev.so.0
   '';
 
   # Run the wrappers directly, instead of going via bash.

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -1,4 +1,5 @@
 { stdenv, lib, buildFHSEnv, callPackage, makeDesktopItem, writeScript
+, runCommand, quartus-prime-lite
 , supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ]
 , unwrapped ? callPackage ./quartus.nix { inherit supportedDevices; }
 }:
@@ -110,5 +111,13 @@ in buildFHSEnv rec {
   # Run the wrappers directly, instead of going via bash.
   runScript = "";
 
-  passthru = { inherit unwrapped; };
+  passthru = {
+    inherit unwrapped;
+    tests = {
+      modelsimEncryptedModel = runCommand "quartus-prime-lite-test-modelsim-encrypted-model" {} ''
+        "${quartus-prime-lite}/bin/vlog" "${quartus-prime-lite.unwrapped}/modelsim_ase/altera/verilog/src/arriav_atoms_ncrypt.v"
+        touch "$out"
+      '';
+    };
+  };
 }

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -67,10 +67,10 @@ in buildFHSEnvChroot rec {
     ln -s ${desktopItem}/share/applications/* $out/share/applications
     ln -s ${unwrapped}/licenses/images/dc_quartus_panel_logo.png $out/share/icons/128x128/quartus.png
 
-    mkdir -p $out/quartus/bin $out/quartus/sopc_builder/bin $out/modelsim_ase/bin
     WRAPPER=$out/bin/${name}
     EXECUTABLES="${lib.concatStringsSep " " (quartusExecutables ++ qsysExecutables ++ modelsimExecutables)}"
     for executable in $EXECUTABLES; do
+        mkdir -p "$(dirname "$out/$executable")"
         echo "#!${stdenv.shell}" >> $out/$executable
         echo "$WRAPPER ${unwrapped}/$executable \"\$@\"" >> $out/$executable
     done

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -60,8 +60,7 @@ in buildFHSEnvChroot rec {
     ln -s ${unwrapped}/licenses/images/dc_quartus_panel_logo.png $out/share/icons/128x128/quartus.png
 
     progs_to_wrap=(
-      "${unwrapped}"/quartus/bin/quartus
-      "${unwrapped}"/quartus/bin/quartus_{asm,cdb,cpf,drc,eda,fit,jbcc,jli,map,pgm,pow,sh,si,sim,sta,stp,tan}
+      "${unwrapped}"/quartus/bin/*
       "${unwrapped}"/quartus/sopc_builder/bin/qsys-{generate,edit,script}
       # Should we install all executables?
       "${unwrapped}"/modelsim_ase/bin/{vsim,vlog,vlib,vcom,vdel,vmap}


### PR DESCRIPTION
## Description of changes

Best reviewed per commit:

- quartus-prime-lite: run mkdir as needed
- quartus-prime-lite: lower case local shell variables
- quartus-prime-lite: list progs to wrap in sh instead of Nix
- quartus-prime-lite: add /lib/ld-lsb*.so.3 dynamic loaders to FHS env
- quartus-prime-lite: add lmutil
- quartus-prime-lite: add vcom, vdel, vmap
- quartus-prime-lite: expose all of quartus/bin/*
- quartus-prime-lite: eliminate two unneeded execve syscalls
- quartus-prime-lite: don't overwrite LD_PRELOAD
- quartus-prime-lite: buildFHSEnvChroot -> buildFHSEnv

UPDATE: More commits:
- quartus-prime-lite: modelsim: fix compiling encrypted device models
- quartus-prime-lite: test building encrypted device model
- quartus-prime-lite: use runtimeShell in wrappers

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
