### PR TITLE
[RFC] fetchFromGitHub: normalize the revision to be consistent with fetchgit when fetchzip is used

### DIFF
--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -46,12 +46,18 @@ let
 
   gitRepoUrl = "${baseUrl}.git";
 
+  newRev =
+    if lib.hasPrefix "refs/" rev || builtins.match "^[0-9a-f]+$" rev != null then
+      rev
+    else
+      "refs/tags/${rev}";
+
   fetcherArgs = (if useFetchGit
     then {
       inherit rev deepClone fetchSubmodules sparseCheckout; url = gitRepoUrl;
     } // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
     else {
-      url = "${baseUrl}/archive/${rev}.tar.gz";
+      url = "${baseUrl}/archive/${newRev}.tar.gz";
 
       passthru = {
         inherit gitRepoUrl;


### PR DESCRIPTION
## Description of changes

When `fetchFromGitHub` uses the `fetchgit` backend, `nix-prefetch-git` [normalizes](https://github.com/NixOS/nixpkgs/blob/e35dcc04a3853da485a396bdd332217d0ac9054f/pkgs/build-support/fetchgit/nix-prefetch-git#L303-L313) the revision passed to it and appends `refs/tags` to it when it doesn't look like a commit hash.

This patch ports the behavior to the `fetchzip` backend, with the exception of handling `HEAD`, since we don't want to fetch `HEAD` with `fetchFromGitHub`, so we no longer need to append `refs/tags` to revisions to make sure they are not fetching a branch.

There are still valid tags like `20230924` and `b20` that won't be automatically appended `refs/tags`. Ideally this logic can be stricter about what are valid commit hashes e.g. based on the length, but there are [existing short hashes](https://github.com/search?q=repo%3Anixos%2Fnixpkgs+fetchFromGitHub+%2Frev+%3D+%22[0-9a-f]{1%2C39}%22%2F&type=code) used with `fetchFromGitHub` in nixpkgs which will be broken by a stricter logic, so I think it's safer to match the behavior of `fetchgit` almost exactly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->