### PR TITLE
libsForQt5.kdegraphics-thumbnailers: hardcode Ghostscript path

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -120,7 +120,7 @@ let
       kdebugsettings = callPackage ./kdebugsettings.nix {};
       kdeconnect-kde = callPackage ./kdeconnect-kde.nix {};
       kdegraphics-mobipocket = callPackage ./kdegraphics-mobipocket.nix {};
-      kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
+      kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers {};
       kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
       kdenlive = callPackage ./kdenlive {};
       kdepim-addons = callPackage ./kdepim-addons.nix {};

--- a/pkgs/applications/kde/kdegraphics-thumbnailers/default.nix
+++ b/pkgs/applications/kde/kdegraphics-thumbnailers/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, fetchpatch,
+  mkDerivation, lib, ghostscript, substituteAll,
   extra-cmake-modules, karchive, kio, libkexiv2, libkdcraw, kdegraphics-mobipocket
 }:
 
@@ -11,4 +11,13 @@ mkDerivation {
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ karchive kio libkexiv2 libkdcraw kdegraphics-mobipocket ];
+
+  patches = [
+    # Hardcode patches to Ghostscript so PDF thumbnails work OOTB.
+    # Intentionally not doing the same for dvips because TeX is big.
+    (substituteAll {
+      gs = "${ghostscript}/bin/gs";
+      src = ./gs-paths.patch;
+    })
+  ];
 }

--- a/pkgs/applications/kde/kdegraphics-thumbnailers/gs-paths.patch
+++ b/pkgs/applications/kde/kdegraphics-thumbnailers/gs-paths.patch
@@ -1,0 +1,22 @@
+diff --git a/ps/gscreator.cpp b/ps/gscreator.cpp
+index 5b84e49..cbb7c25 100644
+--- a/ps/gscreator.cpp
++++ b/ps/gscreator.cpp
+@@ -101,7 +101,7 @@ static const char *epsprolog =
+     "[ ] 0 setdash newpath false setoverprint false setstrokeadjust\n";
+ 
+ static const char * gsargs_ps[] = {
+-    "gs",
++    "@gs@",
+     "-sDEVICE=png16m",
+     "-sOutputFile=-",
+     "-dSAFER",
+@@ -120,7 +120,7 @@ static const char * gsargs_ps[] = {
+ };
+ 
+ static const char * gsargs_eps[] = {
+-    "gs",
++    "@gs@",
+     "-sDEVICE=png16m",
+     "-sOutputFile=-",
+     "-dSAFER",


### PR DESCRIPTION
Fixes #153983.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
