### PR TITLE
slack: 4.34.115 -> 4.34.120

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -45,14 +45,14 @@ let
 
   pname = "slack";
 
-  x86_64-darwin-version = "4.34.115";
-  x86_64-darwin-sha256 = "1l2swrjxm47xyb8skwzy7clmr3qdckx9xs1x204jbrz1xk7yd7l5";
+  x86_64-darwin-version = "4.34.119";
+  x86_64-darwin-sha256 = "17ssha6a8iyvan3k7mbg2cdyy1y7gmlwrh4dlkgcc63bqqxsavy1";
 
-  x86_64-linux-version = "4.34.115";
-  x86_64-linux-sha256 = "0gyyjyvrvn13i5308fg34z6b3yzr7vmmh1148a9xh79ngq2pqv47";
+  x86_64-linux-version = "4.34.120";
+  x86_64-linux-sha256 = "0wldnj6hyzqxyc9p365gb46pyqq0im1ayl12mrc8xkrikx9phb7y";
 
-  aarch64-darwin-version = "4.34.115";
-  aarch64-darwin-sha256 = "09qcz57yxjfw8sdqbvmkd25hs4c7frmpf6v94hr4d1szy1rfv11k";
+  aarch64-darwin-version = "4.34.119";
+  aarch64-darwin-sha256 = "0xa39l4ynjmzq6811vprxxz8znwckmxcss9aa7v68cja8vj033vj";
 
   version = {
     x86_64-darwin = x86_64-darwin-version;


### PR DESCRIPTION
## Description of changes

Includes not further specified security-update (https://slack.com/intl/de-de/release-notes/linux) with following specification:

> This release includes security improvements. Updating is recommended. | Some security improvements. Upgrading will provide users with security benefits.

Might need a Backport to 23.05 also. // cc @delroth

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
