### PR TITLE
zutty: init at 0.14

### DIFF
--- a/pkgs/by-name/zu/zutty/package.nix
+++ b/pkgs/by-name/zu/zutty/package.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, freetype
+, wafHook
+, python3
+, libXmu
+, glew-egl
+, ucs-fonts
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zutty";
+  version = "0.14";
+
+  src = fetchFromGitHub {
+    owner = "tomscii";
+    repo = "zutty";
+    rev = finalAttrs.version;
+    hash = "sha256-b/q7hIi/U/GkKo+MIFX2wWnHZAy5rQGXNul3I1pxo1Q=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/options.h \
+      --replace /usr/share/fonts ${ucs-fonts}/share/fonts
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    wafHook
+    python3
+  ];
+
+  buildInputs = [
+    freetype
+    libXmu
+    glew-egl
+  ];
+
+  meta = {
+    homepage = "https://tomscii.sig7.se/zutty/";
+    description = "X terminal emulator rendering through OpenGL ES Compute Shaders";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.quag ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

https://tomscii.sig7.se/zutty/
https://github.com/tomscii/zutty

## Issue: Hard coding fontpath to ucs-fonts
Note: I've set the fonts directory to be [ucs-fonts](https://www.cl.cam.ac.uk/~mgk25/ucs-fonts.html)--the fonts that Zutty was designed for. Zutty does not support searching for fonts using fontconfig and the author has rejected suggestions to support nix/guix or fontconfig instead scanning a hard coded fonts path, or relying on Xresources or command line options. An alternative approach would be to have override-able options for setting the font package and font name. I welcome other suggestions or advice.

From the zutty's author:
> The author of Zutty prefers the so-called [misc-fixed](https://www.cl.cam.ac.uk/~mgk25/ucs-fonts.html) fonts. These are upgraded, extended versions of the bitmap fonts originally designed for the X Window System, created in the '80s in an era of much inferior computer displays. Their availability is universal; you probably have them installed already. These fonts are highly optimized for readability at low resolutions.
https://tomscii.sig7.se/zutty/doc/USAGE.html#Recommended%20fonts

> I see a downside in adding a dependency on fontconfig.
> The problem is due to the idiosyncrasy of nix/guix -- hardly any other platform resembling unix is going to have this issue.
https://github.com/tomscii/zutty/issues/28#issuecomment-840747494

> Closing because Zutty already has appropriate facilities allowing the user to set up where it should look for fonts.
https://github.com/tomscii/zutty/issues/66#issuecomment-1033503585

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
