### PR TITLE
mold: wrap so it can find system libraries

### DIFF
--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -9,6 +9,11 @@
 , testers
 , mold
 , nix-update-script
+, runCommandCC
+, mold-wrapped
+, hello
+, buildPackages
+, useMoldLinker
 }:
 
 stdenv.mkDerivation rec {
@@ -44,7 +49,47 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = mold; };
+    tests =
+      let
+        helloTest = name: helloMold:
+          let
+            command = "$READELF -p .comment ${lib.getExe helloMold}";
+            emulator = stdenv.hostPlatform.emulator buildPackages;
+          in
+          runCommandCC "mold-${name}-test" { passthru = { inherit helloMold; }; }
+            ''
+              echo "Testing running the 'hello' binary which should be linked with 'mold'" >&2
+              ${emulator} ${lib.getExe helloMold}
+
+              echo "Checking for mold in the '.comment' section" >&2
+              if output=$(${command} 2>&1); then
+                if grep -Fw -- "mold" - <<< "$output"; then
+                  touch $out
+                else
+                  echo "No mention of 'mold' detected in the '.comment' section" >&2
+                  echo "The command was:" >&2
+                  echo "${command}" >&2
+                  echo "The output was:" >&2
+                  echo "$output" >&2
+                  exit 1
+                fi
+              else
+                echo -n "${command}" >&2
+                echo " returned a non-zero exit code." >&2
+                echo "$output" >&2
+                exit 1
+              fi
+            ''
+        ;
+      in
+      {
+        version = testers.testVersion { package = mold; };
+        wrapped = helloTest "wrapped" (hello.overrideAttrs (previousAttrs: {
+          nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [ mold-wrapped ];
+          NIX_CFLAGS_LINK = toString (previousAttrs.NIX_CFLAGS_LINK or "") + " -fuse-ld=mold";
+        }));
+        adapter = helloTest "adapter" (hello.override (old: { stdenv = useMoldLinker old.stdenv; }));
+      };
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "A faster drop-in replacement for existing Unix linkers";
+    description = "A faster drop-in replacement for existing Unix linkers (unwrapped)";
     longDescription = ''
       mold is a faster drop-in replacement for existing Unix linkers. It is
       several times faster than the LLVM lld linker. mold is designed to

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -192,8 +192,8 @@ rec {
   useMoldLinker = stdenv: let
     bintools = stdenv.cc.bintools.override {
       extraBuildCommands = ''
-        wrap ld.mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.mold}/bin/ld.mold
-        wrap ld ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.mold}/bin/ld.mold
+        wrap ${stdenv.cc.bintools.targetPrefix}ld.mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.mold}/bin/ld.mold
+        wrap ${stdenv.cc.bintools.targetPrefix}ld ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.mold}/bin/ld.mold
       '';
     };
   in stdenv.override (old: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19647,6 +19647,13 @@ with pkgs;
 
   mold = callPackage ../development/tools/mold { };
 
+  mold-wrapped = wrapBintoolsWith {
+    bintools = mold;
+    extraBuildCommands = ''
+      wrap mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${mold}/bin/ld.mold
+    '';
+  };
+
   mommy = callPackage ../tools/misc/mommy { };
 
   moon = callPackage ../development/tools/build-managers/moon/default.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19650,7 +19650,8 @@ with pkgs;
   mold-wrapped = wrapBintoolsWith {
     bintools = mold;
     extraBuildCommands = ''
-      wrap mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${mold}/bin/ld.mold
+      wrap ${targetPackages.stdenv.cc.bintools.targetPrefix}ld.mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${mold}/bin/ld.mold
+      wrap ${targetPackages.stdenv.cc.bintools.targetPrefix}mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${mold}/bin/mold
     '';
   };
 


### PR DESCRIPTION
## Description of changes


Add a wrapped version as `mold` as `mold-wrapped`.

Currently `mold` mostly works, but the moment users start to need to link with system libraries, they hit issues.

github:

Re #242816

and on user forums, e.g.:

https://discourse.nixos.org/t/using-mold-as-linker-prevents-libraries-from-being-found


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
