### PR TITLE
mattermost-desktop: 5.3.1 -> 5.5.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -2,29 +2,30 @@
 , stdenv
 , fetchurl
 , atomEnv
+, electron_26
 , systemd
 , pulseaudio
 , libxshmfence
 , libnotify
 , libappindicator-gtk3
-, wrapGAppsHook
+, makeWrapper
 , autoPatchelfHook
 }:
 
 let
 
   pname = "mattermost-desktop";
-  version = "5.3.1";
+  version = "5.5.0";
 
   srcs = {
     "x86_64-linux" = {
       url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-x64.tar.gz";
-      hash = "sha256-rw+SYCFmN2W4t5iIWEpV9VHxcvwTLOckMV58WRa5dZE=";
+      hash = "sha256-htjKGO16Qs1RVE4U47DdN8bNpUH4JD/LkMOeoIRmLPI=";
     };
 
     "aarch64-linux" = {
       url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-arm64.tar.gz";
-      hash = "sha256-FEIldkb3FbUfVAYRkjs7oPRJDHdsIGDW5iaC2Qz1dpc=";
+      hash = "sha256-LQhMSIrWDZTXBnJfLKph5e6txHGvQSqEu+P1j1zOiTg=";
     };
   };
 
@@ -37,11 +38,7 @@ stdenv.mkDerivation {
 
   src = fetchurl (srcs."${system}" or (throw "Unsupported system ${system}"));
 
-  dontBuild = true;
-  dontConfigure = true;
-  dontStrip = true;
-
-  nativeBuildInputs = [ wrapGAppsHook autoPatchelfHook ];
+  nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
 
   buildInputs = atomEnv.packages ++ [
     libxshmfence
@@ -63,20 +60,18 @@ stdenv.mkDerivation {
     find . -type f \( -name '*.so.*' -o -name '*.s[oh]' \) -print0 | xargs -0 chmod +x
     chmod +x mattermost-desktop chrome-sandbox
 
-    mkdir -p $out/share/mattermost-desktop
-    cp -R . $out/share/mattermost-desktop
+    mkdir -p $out/bin $out/share/applications $out/share/${pname}/
+    cp -r app_icon.png create_desktop_file.sh locales/ resources/* $out/share/${pname}/
 
-    mkdir -p "$out/bin"
-    ln -s $out/share/mattermost-desktop/mattermost-desktop $out/bin/mattermost-desktop
-
-    patchShebangs $out/share/mattermost-desktop/create_desktop_file.sh
-    $out/share/mattermost-desktop/create_desktop_file.sh
-    rm $out/share/mattermost-desktop/create_desktop_file.sh
-    mkdir -p $out/share/applications
-    chmod -x Mattermost.desktop
+    patchShebangs $out/share/${pname}/create_desktop_file.sh
+    $out/share/${pname}/create_desktop_file.sh
+    rm $out/share/${pname}/create_desktop_file.sh
     mv Mattermost.desktop $out/share/applications/Mattermost.desktop
     substituteInPlace $out/share/applications/Mattermost.desktop \
       --replace /share/mattermost-desktop/mattermost-desktop /bin/mattermost-desktop
+
+    makeWrapper ${electron_26}/bin/electron $out/bin/${pname} \
+      --add-flags $out/share/${pname}/app.asar
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

Update to latest release (https://github.com/NixOS/nixpkgs/issues/254798), change build to use our electron-build

![mattermost55](https://github.com/NixOS/nixpkgs/assets/17243347/a37a5201-cbeb-48f2-81d0-3588d7f2972f)

// cc @delroth 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
