### PR TITLE
nixos/tests/microsoft-edge: Reuse chromium tests to add tests for microsoft-edge

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -511,6 +511,7 @@ in {
   memcached = handleTest ./memcached.nix {};
   merecat = handleTest ./merecat.nix {};
   metabase = handleTest ./metabase.nix {};
+  microsoft-edge = (handleTestOn ["x86_64-linux"] ./microsoft-edge.nix {}).stable or {};
   mindustry = handleTest ./mindustry.nix {};
   minecraft = handleTest ./minecraft.nix {};
   minecraft-server = handleTest ./minecraft-server.nix {};

--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -119,7 +119,7 @@ mapAttrs (channel: chromiumPkg: makeTest {
             machine.wait_until_succeeds(
                 ru(
                     "${xdo "create_new_win-wait_for_window" ''
-                      search --onlyvisible --name "New Tab"
+                      search --onlyvisible --name "New [tT]ab"
                       windowfocus --sync
                       windowactivate --sync
                     ''}"
@@ -132,7 +132,7 @@ mapAttrs (channel: chromiumPkg: makeTest {
         machine.wait_until_succeeds(
             ru(
                 "${xdo "close_new_tab_win-select_main_window" ''
-                  search --onlyvisible --name "New Tab"
+                  search --onlyvisible --name "New [tT]ab"
                   windowfocus --sync
                   windowactivate --sync
                 ''}"
@@ -143,7 +143,7 @@ mapAttrs (channel: chromiumPkg: makeTest {
         machine.wait_until_fails(
             ru(
                 "${xdo "close_new_tab_win-wait_for_close" ''
-                  search --onlyvisible --name "New Tab"
+                  search --onlyvisible --name "New [tT]ab"
                 ''}"
             )
         )
@@ -152,7 +152,7 @@ mapAttrs (channel: chromiumPkg: makeTest {
     @contextmanager
     def test_new_win(description, url, window_name):
         create_new_win()
-        machine.wait_for_window("New Tab")
+        machine.wait_for_window("New [tT]ab")
         machine.send_chars(f"{url}\n")
         machine.wait_for_window(window_name)
         machine.screenshot(description)
@@ -194,7 +194,9 @@ mapAttrs (channel: chromiumPkg: makeTest {
 
     create_new_win()
     # Optional: Wait for the new tab page to fully load before taking the screenshot:
-    machine.wait_for_text("Web Store")
+
+    if not "${getName chromiumPkg.name}".startswith("microsoft-edge"):
+        machine.wait_for_text("Web Store")
     machine.screenshot("empty_windows")
     close_new_tab_win()
 
@@ -254,9 +256,9 @@ mapAttrs (channel: chromiumPkg: makeTest {
         # TODO: Fix copying all of the text to the clipboard
 
 
-    with test_new_win("version_info", "chrome://version", "About Version") as clipboard:
+    with test_new_win("version_info", "chrome://version", "About [vV]ersion") as clipboard:
         filters = [
-            r"${chromiumPkg.version} \(Official Build",
+            r"${chromiumPkg.version} \(Official [bB]uild",
         ]
         if not all(
             re.search(filter, clipboard) for filter in filters

--- a/nixos/tests/microsoft-edge.nix
+++ b/nixos/tests/microsoft-edge.nix
@@ -1,0 +1,38 @@
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? import ../.. { inherit system config; }
+, channelMap ? { # Maps "channels" to packages
+    stable        = pkgs.microsoft-edge;
+    beta          = pkgs.microsoft-edge-beta;
+    dev           = pkgs.microsoft-edge-dev;
+  }
+}:
+with import ../lib/testing-python.nix { inherit system pkgs; };
+
+let
+  user = "alice";
+in
+
+pkgs.lib.mapAttrs (channel: chromiumPkg: makeTest {
+  name = "microsoft-edge-${channel}";
+  meta = {
+    maintainers = with pkgs.lib.maintainers; [ rhysmdnz ];
+  };
+
+  nodes.machine = {
+    imports = [ ./common/user-account.nix ./common/x11.nix ];
+    virtualisation.memorySize = 2047;
+    test-support.displayManager.auto.user = user;
+    environment = {
+      systemPackages = [ chromiumPkg ];
+      variables."XAUTHORITY" = "/home/alice/.Xauthority";
+      etc."opt/edge/policies/managed/default.json".text = ''
+        {"HideFirstRunExperience":true}
+      '';
+    };
+  };
+
+  enableOCR = true;
+
+  testScript = (import ./chromium.nix { inherit system config pkgs channelMap; })."${channel}".testScript;
+}) channelMap

--- a/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
+++ b/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
@@ -4,6 +4,7 @@
 , fetchurl
 , lib
 , makeWrapper
+, nixosTests
 
 , binutils-unwrapped
 , xz
@@ -188,6 +189,9 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.updateScript = ./update.py;
+  passthru.tests = {
+    inherit (nixosTests) microsoft-edge;
+  };
 
   meta = with lib; {
     homepage = "https://www.microsoft.com/en-us/edge";


### PR DESCRIPTION
## Description of changes

Adds nixos tests for Microsoft edge

@aszlig @primeos this steps on your chromium tests a bunch with minor capitalisation changes, and reusing the test script. Would appreciate feedback on better ways to do this / make sure I'm not causing you to much future trouble.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
