### PR TITLE
Set pipefail and nounset in nixos-install.sh

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -1,7 +1,7 @@
 #! @runtimeShell@
 # shellcheck shell=bash
 
-set -e
+set -euo pipefail
 shopt -s nullglob
 
 export PATH=@path@:$PATH


### PR DESCRIPTION
Makes nixos-install.sh exit if there is an error when we resolve the flake (e.g., if flake.nix contains an error).  Also prevents `$flake` from being empty when this happens, which would cause the non-flake branch to be incorrectly taken when we build the system configuration.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes an issue that happens when flake.nix contains and error and nixos-install is run.  Because https://github.com/NixOS/nixpkgs/blob/0a017f947fc9a060bfdd79a8e885f1d54fd8a592/nixos/modules/installer/tools/nixos-install.sh#L129 is a pipeline, previously, in that case, `flake` would get set to the empty string without causing nixos-install to exit.  Then https://github.com/NixOS/nixpkgs/blob/0a017f947fc9a060bfdd79a8e885f1d54fd8a592/nixos/modules/installer/tools/nixos-install.sh#L166 would incorrectly take the non-flake branch.

Note that `set -o pipefail` is the essential part of this fix.  Since there are no other pipelines in the script, this shouldn't change any other behaviors of the script.

The `set -u` is not essential, but seemed a good-to-add while changing this part of the script.  However, I am not really setup to be able to set whether that breaks

-u

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
