### PR TITLE
ocamlPackages.camomile: 1.0.2 → 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,34 +1,57 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, cppo }:
+{ stdenv, lib, darwin, fetchFromGitHub, buildDunePackage, ocaml, cppo
+, camlp-streams, dune-site
+, version ? if lib.versionAtLeast ocaml.version "4.08" then "2.0.0" else "1.0.2"
+}:
 
-buildDunePackage rec {
+let params =
+  {
+    "1.0.2" = lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+      "camomile 1 is not available for OCaml ${ocaml.version}" {
+      src = fetchFromGitHub {
+        owner = "yoriyuki";
+        repo = "camomile";
+        rev = version;
+        sha256 = "00i910qjv6bpk0nkafp5fg97isqas0bwjf7m6rz11rsxilpalzad";
+      };
+
+      nativeBuildInputs = [ cppo ];
+
+      configurePhase = ''
+        runHook preConfigure
+        ocaml configure.ml --share $out/share/camomile
+        runHook postConfigure
+      '';
+
+      postInstall = ''
+        echo "version = \"${version}\"" >> $out/lib/ocaml/${ocaml.version}/site-lib/camomile/META
+      '';
+
+    };
+
+    "2.0.0" = {
+      src = fetchFromGitHub {
+        owner = "ocaml-community";
+        repo = "camomile";
+        rev = "v${version}";
+        hash = "sha256-HklX+VPD0Ta3Knv++dBT2rhsDSlDRH90k4Cj1YtWIa8=";
+      };
+
+      nativeBuildInputs = lib.optional stdenv.isDarwin darwin.sigtool;
+
+      propagatedBuildInputs = [ camlp-streams dune-site ];
+    };
+  }
+; in
+
+
+buildDunePackage (params."${version}" // {
   pname = "camomile";
-  version = "1.0.2";
-
-  useDune2 = true;
-
-  src = fetchFromGitHub {
-    owner = "yoriyuki";
-    repo = pname;
-    rev = version;
-    sha256 = "00i910qjv6bpk0nkafp5fg97isqas0bwjf7m6rz11rsxilpalzad";
-  };
-
-  nativeBuildInputs = [ cppo ];
-
-  configurePhase = ''
-    runHook preConfigure
-    ocaml configure.ml --share $out/share/camomile
-    runHook postConfigure
-  '';
-
-  postInstall = ''
-    echo "version = \"${version}\"" >> $out/lib/ocaml/${ocaml.version}/site-lib/camomile/META
-  '';
+  inherit version;
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/ocaml-community/Camomile";
     maintainers = [ lib.maintainers.vbgl ];
     license = lib.licenses.lgpl21;
     description = "A Unicode library for OCaml";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/charInfo_width/default.nix
+++ b/pkgs/development/ocaml-modules/charInfo_width/default.nix
@@ -3,13 +3,15 @@
 buildDunePackage rec {
   pname = "charInfo_width";
   version = "1.1.0";
-  duneVersion = "3";
   src = fetchzip {
     url = "https://bitbucket.org/zandoye/charinfo_width/get/${version}.tar.bz2";
     sha256 = "19mnq9a1yr16srqs8n6hddahr4f9d2gbpmld62pvlw1ps7nfrp9w";
   };
 
-  propagatedBuildInputs = [ camomile result ];
+  propagatedBuildInputs = [
+    (camomile.override { version = "1.0.2"; })
+    result
+  ];
 
   meta = {
     homepage = "https://bitbucket.org/zandoye/charinfo_width/";

--- a/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
@@ -4,7 +4,10 @@ buildDunePackage {
   pname = "gettext-camomile";
   inherit (ocaml_gettext) src version;
 
-  propagatedBuildInputs = [ camomile ocaml_gettext ];
+  propagatedBuildInputs = [
+    (camomile.override { version = "1.0.2"; })
+    ocaml_gettext
+  ];
 
   doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ ounit fileutils ];

--- a/pkgs/development/tools/headache/default.nix
+++ b/pkgs/development/tools/headache/default.nix
@@ -13,9 +13,9 @@ buildDunePackage rec {
     sha256 = "sha256-BA7u09MKYMyspFX8AcAkDVA6UUG5DKAdbIDdt+b3Fc4=";
   };
 
-  duneVersion = "3";
-
-  propagatedBuildInputs = [ camomile ];
+  propagatedBuildInputs = [
+    (camomile.override { version = "1.0.2"; })
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/frama-c/${pname}";

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
     ocamlPackages.mm
     ocamlPackages.ocaml_pcre
     ocamlPackages.menhir ocamlPackages.menhirLib
-    ocamlPackages.camomile
+    (ocamlPackages.camomile.override { version = "1.0.2"; })
     ocamlPackages.ocurl
     ocamlPackages.uri
     ocamlPackages.sedlex

--- a/pkgs/tools/typesetting/soupault/default.nix
+++ b/pkgs/tools/typesetting/soupault/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitea
-, fetchpatch
 , ocamlPackages
 , soupault
 , testers
@@ -23,14 +22,6 @@ ocamlPackages.buildDunePackage {
     rev = version;
     sha256 = "nwXyOwDUbkMnyHPrvCvmToyONdbg5kJm2mt5rWrB6HA=";
   };
-
-  patches = lib.lists.optional
-    (lib.strings.versionAtLeast "2.0.0" ocamlPackages.camomile.version)
-    (fetchpatch {
-      name = "camomile-1_x";
-      url = "https://files.baturin.org/software/soupault/soupault-4.7.0-camomile-1.x.patch";
-      sha256 = "V7+OUjXqWtXwjUa35MlY9iyAlqOkst9Th7DgfDXkXZg=";
-    });
 
   buildInputs = with ocamlPackages; [
     base64


### PR DESCRIPTION
## Description of changes

https://github.com/ocaml-community/Camomile/blob/v2.0.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
