### PR TITLE
lexmark-aex: init at 1.0

### DIFF
--- a/pkgs/by-name/le/lexmark-aex/package.nix
+++ b/pkgs/by-name/le/lexmark-aex/package.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, cups
+, fetchurl
+, patchPpdFilesHook
+, autoPatchelfHook
+, dpkg
+, perl
+, avahi
+}:
+
+stdenv.mkDerivation {
+  pname = "lexmark-aex";
+  version = "1.0";
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  src = fetchurl {
+    url = "https://downloads.lexmark.com/downloads/drivers/Lexmark-AEX-PPD-Files-1.0-01242019.amd64.deb";
+    hash = "sha256-igrJEeFLArGbncOwk/WttnWfPjOokD0/IzpJ4VSOtHk=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    patchPpdFilesHook
+    dpkg
+  ];
+
+  buildInputs = [
+    # Needed for autoPatchelfHook.
+    avahi
+    cups
+    # Needed for patchShebangs.
+    perl
+  ];
+
+  # Needed for autoPatchelfHook.
+  runtimeDependencies = [ (lib.getLib cups) ];
+
+  ppdFileCommands = [ "CommandFileFilterG2" "rerouteprintoption" ];
+
+  installPhase = let
+    libdir =
+      if stdenv.system == "x86_64-linux"    then "lib64"
+      else if stdenv.system == "i686_linux" then "lib"
+      else throw "other platforms than i686_linux and x86_64-linux are not yet supported";
+  in ''
+    runHook preInstall
+
+    prefix=usr/local/Lexmark/ppd/Lexmark-AEX-PPD-Files/GlobalPPD_1.4
+
+    # Install raster image filter.
+    install -Dm755 "$prefix/rerouteprintoption" "$out/lib/cups/filter/rerouteprintoption"
+    patchShebangs "$out/lib/cups/filter/rerouteprintoption"
+
+    # Install additional binary filters.
+    for i in CommandFileFilterG2 LexHBPFilter; do
+      install -Dm755 "$prefix/${libdir}/$i" "$out/lib/cups/filter/$i"
+    done
+
+    # Install PPD.
+    install -Dm 0644 -t "$out/share/cups/model/Lexmark" "$prefix"/*.ppd
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "CUPS drivers for Lexmark B2200 and MB2200 Series printers";
+    homepage = "https://support.lexmark.com/en_xm/drivers-downloads.html";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = [ maintainers.tobim ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Proprietary printer driver for some Lexmark models.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
