### PR TITLE
stdenv: improve build phases output

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1547,13 +1547,15 @@ genericBuild() {
             configurePhase ${preBuildPhases[*]:-} buildPhase checkPhase \
             ${preInstallPhases[*]:-} installPhase ${preFixupPhases[*]:-} fixupPhase installCheckPhase \
             ${preDistPhases[*]:-} distPhase ${postPhases[*]:-}";
-        echo "phases: $phases" | tr -s ' '
     fi
 
     # The use of ${phases[*]} gives the correct behavior both with and
     # without structured attrs.  This relies on the fact that each
     # phase name is space-free, which it must be because it's the name
     # of either a shell variable or a shell function.
+
+    # Detect active phases
+    local activePhases=()
     for curPhase in ${phases[*]}; do
         if [[ "$curPhase" = unpackPhase && -n "${dontUnpack:-}" ]]; then continue; fi
         if [[ "$curPhase" = patchPhase && -n "${dontPatch:-}" ]]; then continue; fi
@@ -1569,6 +1571,13 @@ genericBuild() {
             echo "@nix { \"action\": \"setPhase\", \"phase\": \"$curPhase\" }" >&"$NIX_LOG_FD"
         fi
 
+        activePhases+=("$curPhase")
+    done
+
+    # Execute active phases
+    echo "phases: ${activePhases[*]}"
+
+    for curPhase in ${activePhases[*]}; do
         showPhaseHeader "$curPhase"
         dumpVars
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1508,17 +1508,7 @@ distPhase() {
 
 showPhaseHeader() {
     local phase="$1"
-    case "$phase" in
-        unpackPhase) echo "unpacking sources";;
-        patchPhase) echo "patching sources";;
-        configurePhase) echo "configuring";;
-        buildPhase) echo "building";;
-        checkPhase) echo "running tests";;
-        installPhase) echo "installing";;
-        fixupPhase) echo "post-installation fixup";;
-        installCheckPhase) echo "running install tests";;
-        *) echo "$phase";;
-    esac
+        echo "started phase: $phase"
 }
 
 
@@ -1526,13 +1516,12 @@ showPhaseFooter() {
     local phase="$1"
     local startTime="$2"
     local endTime="$3"
-    local delta=$(( endTime - startTime ))
-    (( delta < 30 )) && return
 
+    local delta=$(( endTime - startTime ))
     local H=$((delta/3600))
     local M=$((delta%3600/60))
     local S=$((delta%60))
-    echo -n "$phase completed in "
+    echo -n "finished phase: $phase in "
     (( H > 0 )) && echo -n "$H hours "
     (( M > 0 )) && echo -n "$M minutes "
     echo "$S seconds"
@@ -1558,6 +1547,7 @@ genericBuild() {
             configurePhase ${preBuildPhases[*]:-} buildPhase checkPhase \
             ${preInstallPhases[*]:-} installPhase ${preFixupPhases[*]:-} fixupPhase installCheckPhase \
             ${preDistPhases[*]:-} distPhase ${postPhases[*]:-}";
+        echo "phases: $phases" | tr -s ' '
     fi
 
     # The use of ${phases[*]} gives the correct behavior both with and


### PR DESCRIPTION
## Description of changes

In the current state, it is not possible to know which build phases and in which order where used for the build process. This information is very useful when working with packages, which are using customized phases (for example Python packages built using `buildPythonPackage`).

Also, it is not possible to know which line of the build output belongs to which phase.

This change will:

1. print list of build phases at the beginning of the build process

For example:
```
phases: unpackPhase patchPhase updateAutotoolsGnuConfigScriptsPhase configurePhase buildPhase checkPhase installPhase fixupPhase installCheckPhase distPhase
```


2. improve consistency of phase start and finish messages, by always printing them in the same format for all phases.

Message format: `started phase: <PHASE-NAME>`or `finished phase: <PHASE-NAME>`

For example:
```
started unpackPhase

unpacking source archive /nix/store/447hvnlzzi9myri1iq3bijxgx6v6b592-patchelf-0.15.0.tar.bz2
source root is patchelf-0.15.0
setting SOURCE_DATE_EPOCH to timestamp 1657949009 of file patchelf-0.15.0/patchelf.spec

finished unpackPhase
```

These small changes will improve readability of build process log and will allow better understanding of the build process. Knowing the list of phases and their execution order is needed for package development using `nix develop .#<PACKAGE>`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
