### PR TITLE
calibre: 6.26.0 -> 6.28.1

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -32,11 +32,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "calibre";
-  version = "6.26.0";
+  version = "6.28.1";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${finalAttrs.version}/calibre-${finalAttrs.version}.tar.xz";
-    hash = "sha256-7UUnDtTRf162xKMUuZoKh+y47oeUtrOsFHUTAvtOryM=";
+    hash = "sha256-ZoJN8weAXUQkxalRtVtEaychc30+l2kfzG9Tm5jZh9g=";
   };
 
   patches = [
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       name = "0007-Hardening-Qt-code.patch";
       url = "https://raw.githubusercontent.com/debian-calibre/calibre/debian/${finalAttrs.version}+ds-1/debian/patches/hardening/0007-Hardening-Qt-code.patch";
-      hash = "sha256-2V8H6ElvzS5yw1di+XZvMssuokUT5zP3aTzpDpMsMac=";
+      hash = "sha256-eTzwo8aAIJnZTIZ/8DqCQi3ZbKxycEdiv+UxRuxo12g=";
     })
   ]
   ++ lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;

--- a/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
+++ b/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
@@ -1,12 +1,12 @@
 diff --git a/src/calibre/ebooks/metadata/archive.py b/src/calibre/ebooks/metadata/archive.py
-index 938ab24..1e095f8 100644
+index 50b4750124..858e39eece 100644
 --- a/src/calibre/ebooks/metadata/archive.py
 +++ b/src/calibre/ebooks/metadata/archive.py
-@@ -44,7 +44,7 @@
+@@ -99,7 +99,7 @@ class ArchiveExtract(FileTypePlugin):
      description = _('Extract common e-book formats from archive files '
-         '(ZIP/RAR). Also try to autodetect if they are actually '
-         'CBZ/CBR files.')
--    file_types = {'zip', 'rar'}
-+    file_types = {'zip'}
+         '(ZIP/RAR/7z). Also try to autodetect if they are actually '
+         'CBZ/CBR/CB7 files.')
+-    file_types = {'zip', 'rar', '7z'}
++    file_types = {'zip', '7z'}
      supported_platforms = ['windows', 'osx', 'linux']
      on_import = True


### PR DESCRIPTION
## Description of changes
- https://github.com/kovidgoyal/calibre/releases/tag/v6.27.0
- https://github.com/kovidgoyal/calibre/releases/tag/v6.28.0

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).