### PR TITLE
openfec: 1.4.2 -> 1.4.2.9

### DIFF
--- a/pkgs/development/libraries/openfec/default.nix
+++ b/pkgs/development/libraries/openfec/default.nix
@@ -1,12 +1,17 @@
-{ stdenv, lib, fetchzip, cmake }:
+{ stdenv
+, lib
+, fetchzip
+, cmake
+, gitUpdater
+}:
 
 stdenv.mkDerivation rec {
   pname = "openfec";
-  version = "1.4.2";
+  version = "1.4.2.9";
 
   src = fetchzip {
-    url = "http://openfec.org/files/openfec_v1_4_2.tgz";
-    sha256 = "sha256:0c2lg8afr7lqpzrsi0g44a6h6s7nq4vz7yc9vm2k57ph2y6r86la";
+    url = "https://github.com/roc-streaming/openfec/archive/refs/tags/v${version}.tar.gz";
+    hash = "sha256-A/U9Nh8tspRoT3bYePJLUrNa9jxiL0r2Xaf64wWbmVA=";
   };
 
   outputs = [ "out" "dev" ];
@@ -32,6 +37,11 @@ stdenv.mkDerivation rec {
     '' + ''
       ln -s libopenfec${so} $out/lib/libopenfec${so}.1
     '';
+
+  passthru.updateScript = gitUpdater {
+    url = "https://github.com/roc-streaming/openfec.git";
+    rev-prefix = "v";
+  };
 
   meta = with lib; {
     description = "Application-level Forward Erasure Correction codes";


### PR DESCRIPTION
While at it added trivial updater.

Changes: https://github.com/roc-streaming/openfec/releases/tag/v1.4.2.9

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
