### PR TITLE
Revert "nixos/generic-extlinux-compatible: implement append secrets to initrd…"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -270,8 +270,6 @@ The module update takes care of the new config syntax and the data itself (user 
 
 - `services.nginx` gained a `defaultListen` option at server-level with support for PROXY protocol listeners, also `proxyProtocol` is now exposed in `services.nginx.virtualHosts.<name>.listen` option. It is now possible to run PROXY listeners and non-PROXY listeners at a server-level, see [#213510](https://github.com/NixOS/nixpkgs/pull/213510/) for more details.
 
-- `generic-extlinux-compatible` bootloader (and raspberry pi with uboot) supports appending secrets to the initramfs
-
 - `services.restic.backups` now adds wrapper scripts to your system path, which set the same environment variables as the service, so restic operations can easly be run from the command line. This behavior can be disabled by setting `createWrapper` to `false`, per backup configuration.
 
 - `services.prometheus.exporters` has a new exporter to monitor electrical power consumption based on PowercapRAPL sensor called [Scaphandre](https://github.com/hubblo-org/scaphandre), see [#239803](https://github.com/NixOS/nixpkgs/pull/239803) for more details.

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -70,33 +70,13 @@ copyToKernelsDir() {
 addEntry() {
     local path=$(readlink -f "$1")
     local tag="$2" # Generation number or 'default'
-    local current="$3" # whether this is the current/latest generation
 
     if ! test -e $path/kernel -a -e $path/initrd; then
         return
     fi
 
-    if test -e "$path/append-initrd-secrets"; then
-        local initrd="$target/nixos/$(basename "$path")-initramfs-with-secrets"
-        cp $(readlink -f "$path/initrd") "$initrd"
-        chmod 600 "${initrd}"
-        chown 0:0 "${initrd}"
-        filesCopied[$initrd]=1
-
-        "$path/append-initrd-secrets" "$initrd" || if test "${current}" = "1"; then
-            echo "failed to create initrd secrets for the current generation." >&2
-            echo "are your \`boot.initrd.secrets\` still in place?" >&2
-            exit 1
-        else
-            echo "warning: failed to create initrd secrets for \"$path\", an older generation" >&2
-            echo "note: this is normal after having removed or renamed a file in \`boot.initrd.secrets\`" >&2
-        fi
-    else
-        copyToKernelsDir "$path/initrd"; initrd=$result
-    fi
-
     copyToKernelsDir "$path/kernel"; kernel=$result
-
+    copyToKernelsDir "$path/initrd"; initrd=$result
     dtbDir=$(readlink -m "$path/dtbs")
     if [ -e "$dtbDir" ]; then
         copyToKernelsDir "$dtbDir"; dtbs=$result
@@ -150,20 +130,18 @@ MENU TITLE ------------------------------------------------------------
 TIMEOUT $timeout
 EOF
 
-addEntry $default default 1 >> $tmpFile
+addEntry $default default >> $tmpFile
 
 if [ "$numGenerations" -gt 0 ]; then
     # Add up to $numGenerations generations of the system profile to the menu,
     # in reverse (most recent to least recent) order.
-    current=1
     for generation in $(
             (cd /nix/var/nix/profiles && ls -d system-*-link) \
             | sed 's/system-\([0-9]\+\)-link/\1/' \
             | sort -n -r \
             | head -n $numGenerations); do
         link=/nix/var/nix/profiles/system-$generation-link
-        addEntry $link $generation $current
-        current=0
+        addEntry $link $generation
     done >> $tmpFile
 fi
 

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
@@ -142,7 +142,6 @@ in
         assertion = !pkgs.stdenv.hostPlatform.isAarch64 || cfg.version >= 3;
         message = "Only Raspberry Pi >= 3 supports aarch64.";
       };
-      boot.loader.supportsInitrdSecrets = cfg.uboot.enable;
 
       system.build.installBootLoader = builder;
       system.boot.loader.id = "raspberrypi";

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -610,13 +610,6 @@ in
             path the secret should have inside the initrd, the value
             is the path it should be copied from (or null for the same
             path inside and out).
-
-            The loader `generic-extlinux-compatible` supports this. Because
-            it is not well know how different implementations react to
-            concatenated cpio archives, this is disabled by default. It can be
-            enabled by setting {option}`boot.loader.supportsInitrdSecrets`
-            to true. If this works for you, please report your findings at
-            https://github.com/NixOS/nixpkgs/issues/247145 .
           '';
         example = literalExpression
           ''


### PR DESCRIPTION
Reverts NixOS/nixpkgs#240358

Was supposed to be opt-in for users of the `boot.loader.generic-extlinux-compatible`, however the change did not work as expected and the new code path was always entered because `$system/append-initrd-secrets` always exists.