### PR TITLE
openai-whisper: 20230314 -> 20230918

### DIFF
--- a/pkgs/development/python-modules/openai-whisper/default.nix
+++ b/pkgs/development/python-modules/openai-whisper/default.nix
@@ -5,7 +5,7 @@
 , cudaSupport ? false
 
 # runtime
-, ffmpeg
+, ffmpeg-headless
 
 # propagates
 , numpy
@@ -14,7 +14,6 @@
 , tqdm
 , more-itertools
 , transformers
-, ffmpeg-python
 , numba
 , openai-triton
 , scipy
@@ -26,20 +25,20 @@
 
 buildPythonPackage rec {
   pname = "whisper";
-  version = "20230314";
+  version = "20230918";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-qQCELjRFeRCT1k1CBc3netRtFvt+an/EbkrgnmiX/mc=";
+    hash = "sha256-wBAanFVEIIzTcoX40P9eI26UdEu0SC/xuife/zi2Xho=";
   };
 
   patches = [
     (substituteAll {
       src = ./ffmpeg-path.patch;
-      inherit ffmpeg;
+      ffmpeg = ffmpeg-headless;
     })
   ];
 
@@ -48,7 +47,6 @@ buildPythonPackage rec {
     tqdm
     more-itertools
     transformers
-    ffmpeg-python
     numba
     scipy
     tiktoken
@@ -61,7 +59,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "tiktoken==0.3.1" "tiktoken>=0.3.1"
+      --replace "tiktoken==0.3.3" "tiktoken>=0.3.3"
   ''
   # openai-triton is only needed for CUDA support.
   # triton needs CUDA to be build.
@@ -80,7 +78,6 @@ buildPythonPackage rec {
 
   disabledTests = [
     # requires network access to download models
-    "test_tokenizer"
     "test_transcribe"
     # requires NVIDIA drivers
     "test_dtw_cuda_equivalence"

--- a/pkgs/development/python-modules/openai-whisper/ffmpeg-path.patch
+++ b/pkgs/development/python-modules/openai-whisper/ffmpeg-path.patch
@@ -1,13 +1,13 @@
 diff --git a/whisper/audio.py b/whisper/audio.py
-index a6074e8..da18350 100644
+index 4f5b6e0..bfe7924 100644
 --- a/whisper/audio.py
 +++ b/whisper/audio.py
-@@ -41,7 +41,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
-         out, _ = (
-             ffmpeg.input(file, threads=0)
-             .output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=sr)
--            .run(cmd=["ffmpeg", "-nostdin"], capture_stdout=True, capture_stderr=True)
-+            .run(cmd=["@ffmpeg@/bin/ffmpeg", "-nostdin"], capture_stdout=True, capture_stderr=True)
-         )
-     except ffmpeg.Error as e:
-         raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
+@@ -44,7 +44,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
+     # and resampling as necessary.  Requires the ffmpeg CLI in PATH.
+     # fmt: off
+     cmd = [
+-        "ffmpeg",
++        "@ffmpeg@/bin/ffmpeg",
+         "-nostdin",
+         "-threads", "0",
+         "-i", file,


### PR DESCRIPTION
## Description of changes

Changelog:
https://github.com/openai/whisper/blob/v20230918/CHANGELOG.md

Relevant changes for us:
instead of using `ffmpeg-python`, the project now calls `ffmpeg` directly.

I only tested the CPU version. The CUDA build should be ready in ~12 hours.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
