### PR TITLE
Update Discourse and Discourse plugins

### DIFF
--- a/pkgs/servers/web-apps/discourse/assets_esbuild_from_path.patch
+++ b/pkgs/servers/web-apps/discourse/assets_esbuild_from_path.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/discourse_js_processor.rb b/lib/discourse_js_processor.rb
+index 3fee4259af9..53cc3107f46 100644
+--- a/lib/discourse_js_processor.rb
++++ b/lib/discourse_js_processor.rb
+@@ -111,8 +111,6 @@ class DiscourseJsProcessor
+ 
+     def self.generate_js_processor
+       Discourse::Utils.execute_command(
+-        "yarn",
+-        "--silent",
+         "esbuild",
+         "--log-level=warning",
+         "--bundle",

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -13,6 +13,7 @@
 , gzip
 , gnutar
 , git
+, esbuild
 , cacert
 , util-linux
 , gawk
@@ -46,13 +47,13 @@
 }@args:
 
 let
-  version = "3.1.0";
+  version = "3.2.0.beta1";
 
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse";
     rev = "v${version}";
-    sha256 = "sha256-Iv7VSnK8nZDpmIwIRPedSWlftABKuMOQ4MXDGpjuWrY=";
+    sha256 = "sha256-HVjt5rsLSuyOaQxkbiTrsYsSXj3oSWjke98QVp+tEqk=";
   };
 
   ruby = ruby_3_2;
@@ -65,6 +66,7 @@ let
     gnutar
     git
     brotli
+    esbuild
 
     # Misc required system utils
     which
@@ -202,7 +204,7 @@ let
 
     yarnOfflineCache = fetchYarnDeps {
       yarnLock = src + "/app/assets/javascripts/yarn.lock";
-      sha256 = "0sclrv3303dgg3r08dwhd1yvi3pvlnvnikn300vjsh6c71fnzhnj";
+      sha256 = "070h66zp8kmsigbrkh5d3jzbzvllzhbx0fa2yzx5lbpgnjhih3p2";
     };
 
     nativeBuildInputs = runtimeDeps ++ [
@@ -215,6 +217,7 @@ let
       nodejs_18
       jq
       moreutils
+      esbuild
     ];
 
     outputs = [ "out" "javascripts" ];
@@ -238,6 +241,12 @@ let
       # hasn't been `patchShebangs`-ed yet. So instead we just use
       # `patch-package` from `nativeBuildInputs`.
       ./asserts_patch-package_from_path.patch
+
+      # `lib/discourse_js_processor.rb`
+      # tries to call `../node_modules/.bin/esbuild`, which
+      # hasn't been `patchShebangs`-ed yet. So instead we just use
+      # `esbuild` from `nativeBuildInputs`.
+      ./assets_esbuild_from_path.patch
     ];
 
     # We have to set up an environment that is close enough to
@@ -351,6 +360,12 @@ let
 
       # Make sure the notification email setting applies
       ./notification_email.patch
+
+      # `lib/discourse_js_processor.rb`
+      # tries to call `../node_modules/.bin/esbuild`, which
+      # hasn't been `patchShebangs`-ed yet. So instead we just use
+      # `esbuild` from `nativeBuildInputs`.
+      ./assets_esbuild_from_path.patch
     ];
 
     postPatch = ''

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-assign/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-assign/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-assign";
-    rev = "0cbf10b8055370445bd36536e51986bf48bdc57e";
-    sha256 = "sha256-7rJ2zQo1nCHwtVuLJUmdj66Ky2bi4Cpo+22H3DbO1uo=";
+    rev = "e9c7cb5c3f90109bc47223b0aa4054d681e9cc04";
+    sha256 = "sha256-w1h1dCSyOml+AT7lPKENYfawm6BU2De5CyBHrDnDcrM=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-docs";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-bbcode-color/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-bbcode-color/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-bbcode-color";
-    rev = "35aab2e9b92f8b01633d374ea999e7fd59d020d7";
-    sha256 = "sha256-DHckx921EeQysm1UPloCrt43BJetTnZKnTbJGk15NMs=";
+    rev = "79ed22b3a3352adbd20f7e2222b9dbdb9fbaf7fe";
+    sha256 = "sha256-AHgny9BW/ssmv0U2lwzVWgYKPsvWHD6kgU3mBMFX4Aw=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-bbcode-color";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/Gemfile.lock
@@ -22,4 +22,4 @@ DEPENDENCIES
   rrule (= 0.4.4)
 
 BUNDLED WITH
-   2.4.13
+   2.4.17

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/default.nix
@@ -6,8 +6,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-calendar";
-    rev = "afc2ee684de41601d6cecc46713d139760f176a6";
-    sha256 = "sha256-rTQWO+E/Jg4zjZDYDvBrDQsox5q4dHkdQjwnJxgv3dI=";
+    rev = "4d4fe40d09f7232b1348e1ff910b37b2cec0835d";
+    sha256 = "sha256-w1sqE3KxwrE8SWqZUtPVhjITOPFXwlj4iPyPZeSfvtI=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-calendar";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-chat-integration/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-chat-integration/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-chat-integration";
-    rev = "70fea6b66b68868aa4c00b45a169436deaa142a8";
-    sha256 = "sha256-K9MmP1F0B6Na2dTqgnsjMbTQFkF+nNKkI8aF3zPAodc=";
+    rev = "4f9ccb58cae8600dcb6db84f38f235283911e6e8";
+    sha256 = "sha256-Em9aAwAfUoqsOHLrqNhxUQXsO4Owydf9nhCHbBaqqpg=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-chat-integration";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-data-explorer/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-data-explorer/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-data-explorer";
-    rev = "e4f8d3924a18b303c2bb7da9472cf0c060060e4e";
-    sha256 = "sha256-K+GPszO3je6NmnhIRSqSEhylUK5oEByaS0bLfAGjvB4=";
+    rev = "06193f27ef15828479eea61ae4a80bf59806a535";
+    sha256 = "sha256-afjqgi2gzRpbZt5K9yXPy4BJ5qRv7A4ZkXHX85+Cv7s=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-data-explorer";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-docs/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-docs/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-docs";
-    rev = "a4b203274b88c5277d0b5b936de0bc0e0016726c";
-    sha256 = "sha256-R+VP/gsb2Oa6lPVMhRoGZzOBx5C7kRSxqwYpWE10GHw=";
+    rev = "89c7274b1a730edefd1b56c13b8c04305d4ef331";
+    sha256 = "sha256-j3zrGmoAvbSHFnbiUfetyfiQJebrtW3Iw5GvsRRq1kk=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-docs";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile.lock
@@ -3,7 +3,9 @@ GEM
   specs:
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
-    faraday (2.7.10)
+    base64 (0.1.1)
+    faraday (2.7.11)
+      base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
@@ -24,4 +26,4 @@ DEPENDENCIES
   sawyer (= 0.9.2)
 
 BUNDLED WITH
-   2.4.13
+   2.4.17

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/default.nix
@@ -6,8 +6,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-github";
-    rev = "8aa068d56ef010cecaabd50657e7753f4bbecc1f";
-    sha256 = "sha256-WzljuGvv6pki3ROkvhXZWQaq5D9JkCbWjdlkdRI8lHE=";
+    rev = "21fa5c97ca23b4c39aef5ab9c4f8ebb22f19a19b";
+    sha256 = "sha256-0Teu6nMJWAT9TCjZ0RWZKtfsUKAS1cga5DvALIvrUyY=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-github";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/gemset.nix
@@ -10,16 +10,26 @@
     };
     version = "2.8.5";
   };
-  faraday = {
-    dependencies = ["faraday-net_http" "ruby2_keywords"];
+  base64 = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "187clqhp9mv5mnqmjlfdp57svhsg1bggz84ak8v333j9skrnrgh9";
+      sha256 = "0cydk9p2cv25qysm0sn2pb97fcpz1isa7n3c8xm1gd99li8x6x8c";
       type = "gem";
     };
-    version = "2.7.10";
+    version = "0.1.1";
+  };
+  faraday = {
+    dependencies = ["base64" "faraday-net_http" "ruby2_keywords"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vn7jwss2v6jhnxvjsiwbs3irjwhbx9zxn4l6fhd4rkcfyxzdnw5";
+      type = "gem";
+    };
+    version = "2.7.11";
   };
   faraday-net_http = {
     groups = ["default"];

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-math/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-math/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-math";
-    rev = "529ad1fe6da924da378a60bec48c35657bb01a68";
-    sha256 = "sha256-zhtAy0tTVMzQfPilTwfyyzxgCJD4xazOITBuliFR5Gg=";
+    rev = "66d522cd8e4cf98547f083c4decdc64c688767de";
+    sha256 = "sha256-Zil6LWl6ACyP/ZkxNli1u9/3dlHFRETtmIov1BmQ3u4=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-math";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/default.nix
@@ -6,8 +6,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-openid-connect";
-    rev = "b1df541ad29f6f6098a1008b83393b2d400986ed";
-    sha256 = "sha256-afRd/9M0nQGkS14Q8BJhcJwMCkOku3Fr0uHxcRl44vQ=";
+    rev = "322bf50700840b327d9a52091fedbacc0bb1edfe";
+    sha256 = "sha256-8WMhlKHYVm2wHbkP7b8dhOosvwDNjHqTrEziQT1Bu/4=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-openid-connect";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/Gemfile.lock
@@ -13,4 +13,4 @@ DEPENDENCIES
   webrick (= 1.7.0)
 
 BUNDLED WITH
-   2.4.13
+   2.4.17

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/default.nix
@@ -6,8 +6,8 @@
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-prometheus";
-    rev = "8a7a46a80cc65aa0839bc5e3c3b6f8ef6544089f";
-    sha256 = "sha256-TL+pbP26LvRMKdy8CAuBEK+LZfAs8HfggMeUDaBu9hc=";
+    rev = "305610c90079556cdfa2aa09b567a6ca10d11de5";
+    sha256 = "sha256-dz+/2pbbhs8sxYMxe/wAjvdxoU4ihjN95A4ngP0KzQg=";
   };
 
   patches = [

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-reactions/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-reactions/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-reactions";
-    rev = "643f807a3a2195f08211064301f0350d9f51604f";
-    sha256 = "sha256-4FdiYUNysSuOJ664G3YvlUHx/J7MLUS3kVBdXT47oEw=";
+    rev = "f04f077e9f0392ca2373ca001044069d650ae6e5";
+    sha256 = "sha256-HuFXgfd5HO7qfVlf1RHxenlNL10YRF5OYya4Yt6eS14=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-reactions";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-saved-searches/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-saved-searches/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-saved-searches";
-    rev = "7c9bdcd68951e7cef16cafe3c4bfb583bb994d2a";
-    sha256 = "sha256-6RIN12ACDCeRcxmsC3FgeIPdvovI4arn7w/Dqil1yCI=";
+    rev = "1b90d26cc35bd049d0ab7ea3922f7db6ac7ec017";
+    sha256 = "sha256-d+zbm8UAZ/ow8o1Y5mWAyjg5JCvQ761jcGcO72tHEIs=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-saved-searches";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-solved/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-solved/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-solved";
-    rev = "b5d487d6a5bfe2571d936eec5911d02a5f3fcc32";
-    sha256 = "sha256-Tt7B9PcsV8E7B+m8GnJw+MBz9rGYtojKt6NjBFMQvOM=";
+    rev = "3b9ecc69c6a25b7671c42842b8a6f3872873f537";
+    sha256 = "sha256-gtG+v25jJ0DiYlU2vatreGj13yrb5WWRTvxlcDdAibw=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-solved";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-spoiler-alert/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-spoiler-alert/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-spoiler-alert";
-    rev = "65989714af08eda44196cca3a0afe85c9e9443f9";
-    sha256 = "sha256-R/vqNEDst50+Y7anckIvhy4viBOqBemIZMh4sPt7kRM=";
+    rev = "b57e79343acc15cb2c0a032a2deb29ad4b9d53cc";
+    sha256 = "sha256-Ypt6PYCZzArCv9KkCtw5rfT6++dDoUx5q9m/eMvP0Sc=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-spoiler-alert";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-voting/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-voting/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-voting";
-    rev = "6449fc15658d972e20086a3f1fae3dbac9cd9eeb";
-    sha256 = "sha256-f04LpVeodCVEB/t5Ic2dketp542Nrc0rZWbQ6hrC22g=";
+    rev = "83ab47f3186694039c6850ac3e230443e05d37c5";
+    sha256 = "sha256-2sSBLSSPddxXqvEukDn8tzLVOOWoPBA+C8N5jVccCjA=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-voting";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-yearly-review/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-yearly-review/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-yearly-review";
-    rev = "3246c6b378f9e69e664c575efc63c2ad83bcac2f";
-    sha256 = "sha256-usHHyfYP4YAQ94f7gvNSH7VBRRkdZMmsSi9QQM8tPfY=";
+    rev = "47014a8ecb96da8d45d0fe141a069010161b3087";
+    sha256 = "sha256-9OIgxRdQoYH19vb7GcTt8MxVM5N4JPzmMIsg7FQOjJs=";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-yearly-review";

--- a/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile
@@ -18,7 +18,7 @@ else
   # this allows us to include the bits of rails we use without pieces we do not.
   #
   # To issue a rails update bump the version number here
-  rails_version = "7.0.5.1"
+  rails_version = "7.0.7"
   gem "actionmailer", rails_version
   gem "actionpack", rails_version
   gem "actionview", rails_version
@@ -141,10 +141,10 @@ group :test do
   gem "fakeweb", require: false
   gem "minitest", require: false
   gem "simplecov", require: false
-  gem "selenium-webdriver", require: false
+  gem "selenium-webdriver", "~> 4.11", require: false
   gem "test-prof"
-  gem "webdrivers", require: false
   gem "rails-dom-testing", require: false
+  gem "minio_runner", require: false
 end
 
 group :test, :development do
@@ -257,6 +257,11 @@ if ENV["IMPORT"] == "1"
   gem "csv"
 
   gem "parallel", require: false
+end
+
+if ENV["GENERIC_IMPORT"] == "1"
+  gem "sqlite3"
+  gem "redcarpet"
 end
 
 gem "web-push"

--- a/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: 783a90554053002017510285bc736099b2749c22
+  revision: 68f76ce13e9892339f90c4928339dfd769cfa613
   specs:
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
@@ -17,47 +17,47 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (7.0.5.1)
-      actionpack (= 7.0.5.1)
-      actionview (= 7.0.5.1)
-      activejob (= 7.0.5.1)
-      activesupport (= 7.0.5.1)
+    actionmailer (7.0.7)
+      actionpack (= 7.0.7)
+      actionview (= 7.0.7)
+      activejob (= 7.0.7)
+      activesupport (= 7.0.7)
       mail (~> 2.5, >= 2.5.4)
       net-imap
       net-pop
       net-smtp
       rails-dom-testing (~> 2.0)
-    actionpack (7.0.5.1)
-      actionview (= 7.0.5.1)
-      activesupport (= 7.0.5.1)
+    actionpack (7.0.7)
+      actionview (= 7.0.7)
+      activesupport (= 7.0.7)
       rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.5.1)
-      activesupport (= 7.0.5.1)
+    actionview (7.0.7)
+      activesupport (= 7.0.7)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    actionview_precompiler (0.2.3)
+    actionview_precompiler (0.3.0)
       actionview (>= 6.0.a)
     active_model_serializers (0.8.4)
       activemodel (>= 3.0)
-    activejob (7.0.5.1)
-      activesupport (= 7.0.5.1)
+    activejob (7.0.7)
+      activesupport (= 7.0.7)
       globalid (>= 0.3.6)
-    activemodel (7.0.5.1)
-      activesupport (= 7.0.5.1)
-    activerecord (7.0.5.1)
-      activemodel (= 7.0.5.1)
-      activesupport (= 7.0.5.1)
-    activesupport (7.0.5.1)
+    activemodel (7.0.7)
+      activesupport (= 7.0.7)
+    activerecord (7.0.7)
+      activemodel (= 7.0.7)
+      activesupport (= 7.0.7)
+    activesupport (7.0.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
@@ -82,6 +82,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.1.1)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
@@ -109,7 +110,7 @@ GEM
     cgi (0.3.6)
     chunky_png (1.4.0)
     coderay (1.1.3)
-    colored2 (3.1.2)
+    colored2 (4.0.0)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     cose (1.3.0)
@@ -119,7 +120,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    css_parser (1.14.0)
+    css_parser (1.16.0)
       addressable
     dartsass-ruby (3.0.1)
       sass-embedded (~> 1.54)
@@ -144,8 +145,8 @@ GEM
     docile (1.4.0)
     email_reply_trimmer (0.1.13)
     erubi (1.12.0)
-    excon (0.100.0)
-    execjs (2.8.1)
+    excon (0.102.0)
+    execjs (2.9.0)
     exifr (1.4.0)
     fabrication (2.30.0)
     faker (2.23.0)
@@ -163,9 +164,9 @@ GEM
     ffi (1.15.5)
     fspath (3.1.2)
     gc_tracer (1.5.1)
-    globalid (1.1.0)
-      activesupport (>= 5.0)
-    google-protobuf (3.23.4)
+    globalid (1.2.1)
+      activesupport (>= 6.1)
+    google-protobuf (3.24.3)
     guess_html_encoding (0.0.11)
     hana (1.3.7)
     hashdiff (1.0.1)
@@ -188,7 +189,7 @@ GEM
     json (2.6.3)
     json-schema (3.0.0)
       addressable (>= 2.8)
-    json_schemer (1.0.3)
+    json_schemer (2.0.0)
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
@@ -222,19 +223,20 @@ GEM
     matrix (0.4.2)
     maxminddb (0.1.22)
     memory_profiler (1.0.1)
-    message_bus (4.3.7)
+    message_bus (4.3.8)
       rack (>= 1.1.3)
     method_source (1.0.0)
-    mini_mime (1.1.2)
+    mini_mime (1.1.5)
     mini_portile2 (2.8.4)
     mini_racer (0.8.0)
       libv8-node (~> 18.16.0.0)
     mini_scheduler (0.16.0)
       sidekiq (>= 4.2.3, < 7.0)
-    mini_sql (1.4.0)
+    mini_sql (1.5.0)
     mini_suffix (0.3.3)
       ffi (~> 1.9)
-    minitest (5.19.0)
+    minio_runner (0.1.1)
+    minitest (5.20.0)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.7.2)
@@ -253,7 +255,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.3)
+    nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -268,7 +270,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-    oj (3.15.1)
+    oj (3.16.1)
     omniauth (1.9.2)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -296,7 +298,7 @@ GEM
       openssl (> 2.0)
     optimist (3.1.0)
     parallel (1.23.0)
-    parallel_tests (4.2.1)
+    parallel_tests (4.2.2)
       parallel
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -313,17 +315,17 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (5.0.3)
-    puma (6.3.0)
+    puma (6.3.1)
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
-    rack-mini-profiler (3.1.0)
+    rack-mini-profiler (3.1.1)
       rack (>= 1.2.0)
-    rack-protection (3.0.6)
-      rack
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rails-dom-testing (2.1.1)
+    rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -337,9 +339,9 @@ GEM
     rails_multisite (5.0.0)
       activerecord (>= 6.0)
       railties (>= 6.0)
-    railties (7.0.5.1)
-      actionpack (= 7.0.5.1)
-      activesupport (= 7.0.5.1)
+    railties (7.0.7)
+      actionpack (= 7.0.7)
+      activesupport (= 7.0.7)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -363,7 +365,7 @@ GEM
       rack (>= 1.4)
     rexml (3.2.6)
     rinku (2.0.6)
-    rotp (6.2.2)
+    rotp (6.3.0)
     rouge (4.1.3)
     rqrcode (2.2.0)
       chunky_png (~> 1.0)
@@ -393,7 +395,7 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    rss (0.2.9)
+    rss (0.3.0)
       rexml
     rswag-specs (2.10.1)
       activesupport (>= 3.1, < 7.1)
@@ -402,7 +404,8 @@ GEM
       rspec-core (>= 2.14)
     rtlcss (0.2.1)
       mini_racer (>= 0.6.3)
-    rubocop (1.55.1)
+    rubocop (1.56.3)
+      base64 (~> 0.1.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -422,7 +425,7 @@ GEM
       rubocop-rspec (>= 2.0.0)
     rubocop-factory_bot (2.23.1)
       rubocop (~> 1.33)
-    rubocop-rspec (2.23.0)
+    rubocop-rspec (2.23.2)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
@@ -436,10 +439,10 @@ GEM
     sanitize (6.0.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sass-embedded (1.64.1)
+    sass-embedded (1.66.1)
       google-protobuf (~> 3.23)
       rake (>= 13.0.0)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.12.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -462,7 +465,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sshkey (2.0.0)
+    sshkey (3.0.0)
     stackprof (0.2.25)
     syntax_tree (6.1.1)
       prettier_print (>= 1.2.0)
@@ -491,11 +494,7 @@ GEM
       hkdf (~> 1.0)
       jwt (~> 2.0)
       openssl (~> 3.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
-    webmock (3.18.1)
+    webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -504,20 +503,20 @@ GEM
       nokogiri (~> 1.8)
     yaml-lint (0.1.2)
     yard (0.9.34)
-    zeitwerk (2.6.10)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionmailer (= 7.0.5.1)
-  actionpack (= 7.0.5.1)
-  actionview (= 7.0.5.1)
+  actionmailer (= 7.0.7)
+  actionpack (= 7.0.7)
+  actionview (= 7.0.7)
   actionview_precompiler
   active_model_serializers (~> 0.8.3)
-  activemodel (= 7.0.5.1)
-  activerecord (= 7.0.5.1)
-  activesupport (= 7.0.5.1)
+  activemodel (= 7.0.7)
+  activerecord (= 7.0.7)
+  activesupport (= 7.0.7)
   addressable
   annotate
   aws-sdk-s3
@@ -577,6 +576,7 @@ DEPENDENCIES
   mini_scheduler
   mini_sql
   mini_suffix
+  minio_runner
   minitest
   mocha
   multi_json
@@ -604,7 +604,7 @@ DEPENDENCIES
   rails-dom-testing
   rails_failover
   rails_multisite
-  railties (= 7.0.5.1)
+  railties (= 7.0.7)
   rake
   rb-fsevent
   rbtrace
@@ -625,7 +625,7 @@ DEPENDENCIES
   ruby-readability
   rubyzip
   sanitize
-  selenium-webdriver
+  selenium-webdriver (~> 4.11)
   shoulda-matchers!
   sidekiq
   simplecov
@@ -642,10 +642,9 @@ DEPENDENCIES
   unf
   unicorn
   web-push
-  webdrivers
   webmock
   yaml-lint
   yard
 
 BUNDLED WITH
-   2.4.13
+   2.4.17

--- a/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
@@ -5,10 +5,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1pz26qpdx1xncpy5h8k4afw0npnh6wn580yvwv2cf857zrzvr1pm";
+      sha256 = "15ni57icsw1ilz5srlasff4h31h2ckgmxbdd8jnbniscvz4x2sd0";
       type = "gem";
     };
-    version = "7.0.5.1";
+    version = "7.0.7";
   };
   actionpack = {
     dependencies = ["actionview" "activesupport" "rack" "rack-test" "rails-dom-testing" "rails-html-sanitizer"];
@@ -16,10 +16,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "003y7cdxwzdqx8hgw02kf1b5mp8qr8syx07f35sk3ghhqxp39ksy";
+      sha256 = "150sjsk12vzj9aswjy3cz124l8n8sn52bhd0wwly73rwc1a750sg";
       type = "gem";
     };
-    version = "7.0.5.1";
+    version = "7.0.7";
   };
   actionview = {
     dependencies = ["activesupport" "builder" "erubi" "rails-dom-testing" "rails-html-sanitizer"];
@@ -27,10 +27,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "11ihpqcvz3f38ka85zdjkdcvgdbcan81dbr0y9bi784jn1v5ggwa";
+      sha256 = "1nn21k5psxdv2fkwxs679lr0b8n1nzli2ks343cx4azn6snp8b8a";
       type = "gem";
     };
-    version = "7.0.5.1";
+    version = "7.0.7";
   };
   actionview_precompiler = {
     dependencies = ["actionview"];
@@ -38,10 +38,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "07dx8vkwig8han4zccs0chahcf9ibd4abzx9n56qah8zak5cyrhd";
+      sha256 = "07jyr2h87ha6k2y965rs4ywq142ddkfkhbmp0r44xg4wnffr8jbl";
       type = "gem";
     };
-    version = "0.2.3";
+    version = "0.3.0";
   };
   active_model_serializers = {
     dependencies = ["activemodel"];
@@ -60,10 +60,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "11wkxf16zdb9gsnc94x4hyj89wjks06gnk4fbl7gp5vkbl744n83";
+      sha256 = "0s5r5z9jm57jjabh8w2823rpjd1agn8z2rlqgyyn4s9pbbhgalzy";
       type = "gem";
     };
-    version = "7.0.5.1";
+    version = "7.0.7";
   };
   activemodel = {
     dependencies = ["activesupport"];
@@ -71,10 +71,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "12f89hxs4s26ggsg4bnz9qxlcsclcgx9gdsl8dni5jc0gk47h14y";
+      sha256 = "1rspbw4yxx9fh2wyl2wvgwadwapfyx7j9zlirpd4pmk31wkhl4hf";
       type = "gem";
     };
-    version = "7.0.5.1";
+    version = "7.0.7";
   };
   activerecord = {
     dependencies = ["activemodel" "activesupport"];
@@ -82,10 +82,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1sfdq2slmsc0ygncl36dq1lmjww1y3b42izrnn62cyisiag28796";
+      sha256 = "1ygg145wxlgm12b1x5r0rsk2aa6i2wjz7bgb21j8vmyqyfl272cy";
       type = "gem";
     };
-    version = "7.0.5.1";
+    version = "7.0.7";
   };
   activesupport = {
     dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo"];
@@ -93,10 +93,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0m1sa6djlm9cz6mz3lcbqqahvm6qj75dmq3phpn2ysyxnlz2hr0c";
+      sha256 = "1wzbnv3hns0yiwbgh1m3q5j0d7b0k52nlpwirhxyv3l0ycmljfr9";
       type = "gem";
     };
-    version = "7.0.5.1";
+    version = "7.0.7";
   };
   addressable = {
     dependencies = ["public_suffix"];
@@ -104,10 +104,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "15s8van7r2ad3dq6i03l3z4hqnvxcq75a3h72kxvf9an53sqma20";
+      sha256 = "05r1fwy487klqkya7vzia8hnklcxy4vr92m9dmni3prfwk6zpw33";
       type = "gem";
     };
-    version = "2.8.4";
+    version = "2.8.5";
   };
   annotate = {
     dependencies = ["activerecord" "rake"];
@@ -204,6 +204,16 @@
       type = "gem";
     };
     version = "1.5.0";
+  };
+  base64 = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cydk9p2cv25qysm0sn2pb97fcpz1isa7n3c8xm1gd99li8x6x8c";
+      type = "gem";
+    };
+    version = "0.1.1";
   };
   better_errors = {
     dependencies = ["erubi" "rack" "rouge"];
@@ -351,10 +361,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0jlbqa9q4mvrm73aw9mxh23ygzbjiqwisl32d8szfb5fxvbjng5i";
+      sha256 = "1zj06gjqwykgzxmbkp2hmg3wv5kv8zz5d77acxipzcgicdjgvfan";
       type = "gem";
     };
-    version = "3.1.2";
+    version = "4.0.0";
   };
   concurrent-ruby = {
     groups = ["default" "development" "test"];
@@ -424,10 +434,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "04q1vin8slr3k8mp76qz0wqgap6f9kdsbryvgfq9fljhrm463kpj";
+      sha256 = "18mii41bbl106rn940ah8v3xclj4yrxxa0bwlwp546244n9b83zp";
       type = "gem";
     };
-    version = "1.14.0";
+    version = "1.16.0";
   };
   dartsass-ruby = {
     dependencies = ["sass-embedded"];
@@ -572,20 +582,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "08r6qgbpkxxsihjmlspk3l1sr69q5hx35p1l4wp7rmkbzys89867";
+      sha256 = "0mbkyyadz9vw7mzixi9dks6i6iw033yn2hzwfvnfdvgqq6ywqs4g";
       type = "gem";
     };
-    version = "0.100.0";
+    version = "0.102.0";
   };
   execjs = {
     groups = ["assets" "default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "121h6af4i6wr3wxvv84y53jcyw2sk71j5wsncm6wq6yqrwcrk4vd";
+      sha256 = "1a4dhqclx0n4dc5riiff1nkwfinaf5an1dxjywmlwa9wm57r9q9p";
       type = "gem";
     };
-    version = "2.8.1";
+    version = "2.9.0";
   };
   exifr = {
     groups = ["default"];
@@ -746,20 +756,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0kqm5ndzaybpnpxqiqkc41k4ksyxl41ln8qqr6kb130cdxsf2dxk";
+      sha256 = "1sbw6b66r7cwdx3jhs46s4lr991969hvigkjpbdl7y3i31qpdgvh";
       type = "gem";
     };
-    version = "1.1.0";
+    version = "1.2.1";
   };
   google-protobuf = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1dq5lgkxhagqr8zjrwr10zi8rldbg2vhis2m5q86v5q9415ylfgj";
+      sha256 = "0pcl4x4cw3snl5xzs99lm82m9xkfs8vm1a8dfrc34pwb77mwrwv3";
       type = "gem";
     };
-    version = "3.23.4";
+    version = "3.24.3";
   };
   guess_html_encoding = {
     groups = ["default"];
@@ -920,10 +930,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1mbf7v8bzmxyk413y16drnww68bgyzknlqmaqvj785iakja7in7x";
+      sha256 = "0spgxaxvsl3qvyj9qb95gd5hvy2pnp98hbgp8nfw6s69yyw0xmgj";
       type = "gem";
     };
-    version = "1.0.3";
+    version = "2.0.0";
   };
   jwt = {
     groups = ["default"];
@@ -1122,10 +1132,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ppqgch8xxccpmccdx37lb00112ayqjb80zz5m3w3298vdzb1kn4";
+      sha256 = "15xqp7pnicjh2868fsc6fmxw8cw32bpiaqpc5bz8cwdib09ns3qk";
       type = "gem";
     };
-    version = "4.3.7";
+    version = "4.3.8";
   };
   method_source = {
     groups = ["default" "development" "test"];
@@ -1138,14 +1148,14 @@
     version = "1.0.0";
   };
   mini_mime = {
-    groups = ["default"];
+    groups = ["default" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0lbim375gw2dk6383qirz13hgdmxlan0vc5da2l072j3qw6fqjm5";
+      sha256 = "1vycif7pjzkr29mfk4dlqv3disc5dn0va04lkwajlpr1wkibg0c6";
       type = "gem";
     };
-    version = "1.1.2";
+    version = "1.1.5";
   };
   mini_portile2 = {
     groups = ["default" "development" "test"];
@@ -1184,10 +1194,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1dgwyyya821sfj4f92sljsxmmnak2yrzsbckvy82001zgq1n3b41";
+      sha256 = "0yrxjmwhfnvcwbj9vscyq0z67sq09zl8qhmzgakq2ywy4yvcpwgg";
       type = "gem";
     };
-    version = "1.4.0";
+    version = "1.5.0";
   };
   mini_suffix = {
     dependencies = ["ffi"];
@@ -1200,15 +1210,25 @@
     };
     version = "0.3.3";
   };
+  minio_runner = {
+    groups = ["test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11rwvbqichq5jipgbr5x6s609485ga7vxc32r3h9vx342gs6nrzy";
+      type = "gem";
+    };
+    version = "0.1.1";
+  };
   minitest = {
     groups = ["default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0jnpsbb2dbcs95p4is4431l2pw1l5pn7dfg3vkgb4ga464j0c5l6";
+      sha256 = "0bkmfi9mb49m0fkdhl2g38i3xxa02d411gg0m8x0gvbwfmmg5ym3";
       type = "gem";
     };
-    version = "5.19.0";
+    version = "5.20.0";
   };
   mocha = {
     dependencies = ["ruby2_keywords"];
@@ -1336,10 +1356,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1jw8a20a9k05fpz3q24im19b97idss3179z76yn5scc5b8lk2rl7";
+      sha256 = "0k9w2z0953mnjrsji74cshqqp08q7m1r6zhadw1w0g34xzjh3a74";
       type = "gem";
     };
-    version = "1.15.3";
+    version = "1.15.4";
   };
   oauth = {
     dependencies = ["oauth-tty" "snaky_hash" "version_gem"];
@@ -1379,10 +1399,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1vzcrsv6w5k90l75gy83dlfkv2z9pvnr82mz1nhnijmcg3rgqaz8";
+      sha256 = "0m4vsd6i093kmyz9gckvzpnws997laldaiaf86hg5lza1ir82x7n";
       type = "gem";
     };
-    version = "3.15.1";
+    version = "3.16.1";
   };
   omniauth = {
     dependencies = ["hashie" "rack"];
@@ -1512,10 +1532,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "04y02j0kyhfww41dnnjawn2gpp24smq0x21dvaa5z6pnq0fvmahv";
+      sha256 = "1pa50my9sgh4wh9jah1qxjd33wsp1ahv29vj2q1biz434p67vh5p";
       type = "gem";
     };
-    version = "4.2.1";
+    version = "4.2.2";
   };
   parser = {
     dependencies = ["ast" "racc"];
@@ -1607,10 +1627,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1v7fmv0n4bhdcwh60dgza44iqai5pg34f5pzm4vh4i5fwx7mpqxh";
+      sha256 = "1x4dwx2shx0p7lsms97r85r7ji7zv57bjy3i1kmcpxc8bxvrr67c";
       type = "gem";
     };
-    version = "6.3.0";
+    version = "6.3.1";
   };
   racc = {
     groups = ["default" "development" "test"];
@@ -1642,10 +1662,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "13dhpp1iljhqp9c8akmp6gjhx47qf83w12ns4bif26ldkignpam1";
+      sha256 = "18vj7q740f7ffj677i258abryj97w0a6g3d5859y0lgypm5big1v";
       type = "gem";
     };
-    version = "3.1.0";
+    version = "3.1.1";
   };
   rack-protection = {
     dependencies = ["rack"];
@@ -1653,10 +1673,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1kpm67az1wxlg76h620in2r7agfyhv177ps268j5ggsanzddzih8";
+      sha256 = "0xsz78hccgza144n37bfisdkzpr2c8m0xl6rnlzgxdbsm1zrkg7r";
       type = "gem";
     };
-    version = "3.0.6";
+    version = "3.1.0";
   };
   rack-test = {
     dependencies = ["rack"];
@@ -1675,10 +1695,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "17g05y7q7934z0ib4aph8h71c2qwjmlakkm7nb2ab45q0aqkfgjd";
+      sha256 = "0fx9dx1ag0s1lr6lfr34lbx5i1bvn3bhyf3w3mx6h7yz90p725g5";
       type = "gem";
     };
-    version = "2.1.1";
+    version = "2.2.0";
   };
   rails-html-sanitizer = {
     dependencies = ["loofah" "nokogiri"];
@@ -1719,10 +1739,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1z4lqqbd4i5izsg97mx5yf3gj7y5d07wgvad0jzjghjg12pf142i";
+      sha256 = "0in2b84qqmfnigx0li9bgi6l4knmgbj3a29fzm1zzb5jnv4r1gbr";
       type = "gem";
     };
-    version = "7.0.5.1";
+    version = "7.0.7";
   };
   rainbow = {
     groups = ["default" "development" "test"];
@@ -1873,10 +1893,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "10mmzc85y7andsich586ndykw678qn1ns2wpjxrg0sc0gr4w3pig";
+      sha256 = "0m48hv6wpmmm6cjr6q92q78h1i610riml19k5h1dil2yws3h1m3m";
       type = "gem";
     };
-    version = "6.2.2";
+    version = "6.3.0";
   };
   rouge = {
     groups = ["default" "development"];
@@ -1995,10 +2015,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1b1zx07kr64kkpm4lssd4r1a1qyr829ppmfl85i4adcvx9mqfid0";
+      sha256 = "1wv27axi39hhr0nmaffdl5bdjqiafcvp9xhfgnsgfczsblja50sn";
       type = "gem";
     };
-    version = "0.2.9";
+    version = "0.3.0";
   };
   rswag-specs = {
     dependencies = ["activesupport" "json-schema" "railties" "rspec-core"];
@@ -2023,15 +2043,15 @@
     version = "0.2.1";
   };
   rubocop = {
-    dependencies = ["json" "language_server-protocol" "parallel" "parser" "rainbow" "regexp_parser" "rexml" "rubocop-ast" "ruby-progressbar" "unicode-display_width"];
+    dependencies = ["base64" "json" "language_server-protocol" "parallel" "parser" "rainbow" "regexp_parser" "rexml" "rubocop-ast" "ruby-progressbar" "unicode-display_width"];
     groups = ["default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0s9p5qaqq68h5s3ys8xlk9swccma7arjif1w58987n6gicrsprrm";
+      sha256 = "1i3571gchdj3c28znr5kisj0fkppy57208g9j1kv23rhk3p5q5p2";
       type = "gem";
     };
-    version = "1.55.1";
+    version = "1.56.3";
   };
   rubocop-ast = {
     dependencies = ["parser"];
@@ -2083,10 +2103,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0l364y00bw1zcs3grdxcxpn48vfrjds2khsiaxjqq3r9grvbprfy";
+      sha256 = "0ylwy4afnxhbrvlaf8an9nrizj78axnzggiyfcp8v531cv8six5f";
       type = "gem";
     };
-    version = "2.23.0";
+    version = "2.23.2";
   };
   ruby-prof = {
     groups = ["development"];
@@ -2160,10 +2180,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "15k44qn8vk8ap8khkmpsiw40pywm9pkx4a5yhm8vfi2rgqci9k90";
+      sha256 = "038fzkbq5sw9lf947akhpsvdm14q6jfzl2yn87s8958h42sn0xjy";
       type = "gem";
     };
-    version = "1.64.1";
+    version = "1.66.1";
   };
   selenium-webdriver = {
     dependencies = ["rexml" "rubyzip" "websocket"];
@@ -2171,10 +2191,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0hwxxvx6j95ln82pjmrgyzg6qmf511dkcp5q79n6m5m8z4way8m3";
+      sha256 = "0jwll13m7bqph4lgl75m7vwd175k657znwa7qn9qkf5dcxdjkcjs";
       type = "gem";
     };
-    version = "4.10.0";
+    version = "4.12.0";
   };
   shoulda-matchers = {
     dependencies = ["activesupport"];
@@ -2182,8 +2202,8 @@
     platforms = [];
     source = {
       fetchSubmodules = false;
-      rev = "783a90554053002017510285bc736099b2749c22";
-      sha256 = "10rw7ksi462fxamap6kimdy7hpdgx8477r6zs1kgrbakx24dm3wx";
+      rev = "68f76ce13e9892339f90c4928339dfd769cfa613";
+      sha256 = "08kbcdfplmbdhgq0x6lk2lpwrlgijrfq6vhl5hkmxg9v9gpgbbrj";
       type = "git";
       url = "https://github.com/thoughtbot/shoulda-matchers.git";
     };
@@ -2282,10 +2302,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "03bkn55qsng484iqwz2lmm6rkimj01vsvhwk661s3lnmpkl65lbp";
+      sha256 = "1k8i5pzjhcnyf0bhcyn5iixpfp4pz0556rcxwpglh6p0sr8s6nv5";
       type = "gem";
     };
-    version = "2.0.0";
+    version = "3.0.0";
   };
   stackprof = {
     groups = ["default"];
@@ -2484,27 +2504,16 @@
     };
     version = "3.0.0";
   };
-  webdrivers = {
-    dependencies = ["nokogiri" "rubyzip" "selenium-webdriver"];
-    groups = ["test"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "19aaxhawzv7315rh285gd1fg6m6wbrn3w3kilyibci1wphgm7mfp";
-      type = "gem";
-    };
-    version = "5.3.1";
-  };
   webmock = {
     dependencies = ["addressable" "crack" "hashdiff"];
     groups = ["test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1myj44wvbbqvv18ragv3ihl0h61acgnfwrnj3lccdgp49bgmbjal";
+      sha256 = "0vfispr7wd2p1fs9ckn1qnby1yyp4i1dl7qz8n482iw977iyxrza";
       type = "gem";
     };
-    version = "3.18.1";
+    version = "3.19.1";
   };
   websocket = {
     groups = ["default" "test"];
@@ -2552,9 +2561,9 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "06vf6y5ai20ry3b1h9cl7vsdj6i5valq172zdxpnfhj5zvlp104j";
+      sha256 = "1mwdd445w63khz13hpv17m2br5xngyjl3jdj08xizjbm78i2zrxd";
       type = "gem";
     };
-    version = "2.6.10";
+    version = "2.6.11";
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates discourse to the latest available tag using the documented update process. Both https://meta.discourse.org/t/discourse-version-3-1/239039/2 (in parts since we went from the latest beta version to stable to 3.1.1 and then 3.2.0.beta1 in this PR) and https://meta.discourse.org/t/discourse-version-3-2/278584 are relevant.

Note that the 3.1 changes that came after the beta4 also included further security fixes. (I noticed "Don’t reuse CSP nonce between requests" for example to not be in 3.1.0.beta4 but in 3.1.1)

Noteworthy is the introduction of esbuild. This needed a new patch to work otherwise it cant find esbuild.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
