### PR TITLE
jdupes: 1.21.0 -> 1.27.3

### DIFF
--- a/pkgs/development/libraries/libjodycode/default.nix
+++ b/pkgs/development/libraries/libjodycode/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchFromGitea
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libjodycode";
+  version = "3.1";
+
+  outputs = [ "out" "man" "dev" ];
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "jbruchon";
+    repo = "libjodycode";
+    rev = "v${version}";
+    hash = "sha256-uhWQh5YwLwYRm34nY5HvcEepqlTSDt9s3PSoD403kQM=";
+  };
+
+  env.PREFIX = placeholder "out";
+
+  meta = with lib; {
+    description = "Shared code used by several utilities written by Jody Bruchon";
+    homepage = "https://github.com/jbruchon/libjodycode";
+    changelog = "https://github.com/jbruchon/libjodycode/blob/${src.rev}/CHANGES.txt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/tools/misc/jdupes/default.nix
+++ b/pkgs/tools/misc/jdupes/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/jbruchon/jdupes";
     license = licenses.mit;
-    maintainers = with maintainers; [ romildo ];
+    maintainers = with maintainers; [ ];
     mainProgram = "jdupes";
   };
 }

--- a/pkgs/tools/misc/jdupes/default.nix
+++ b/pkgs/tools/misc/jdupes/default.nix
@@ -1,37 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch }:
+{ lib, stdenv, fetchFromGitea, libjodycode }:
 
 stdenv.mkDerivation rec {
   pname = "jdupes";
-  version = "1.21.0";
+  version = "1.27.3";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "jbruchon";
     repo  = "jdupes";
     rev   = "v${version}";
-    sha256 = "sha256-nDyRaV49bLVHlyqKJ7hf6OBWOLCfmHrTeHryK091c3w=";
+    hash = "sha256-hR5nl8G7TYVm4ol/jgo7iOb4dLr2MovgjKSXCD2UwMg=";
     # Unicode file names lead to different checksums on HFS+ vs. other
     # filesystems because of unicode normalisation. The testdir
     # directories have such files and will be removed.
     postFetch = "rm -r $out/testdir";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "darwin-stack-size.patch";
-      url = "https://github.com/jbruchon/jdupes/commit/8f5b06109b44a9e4316f9445da3044590a6c63e2.patch";
-      sha256 = "0saq92v0mm5g979chr062psvwp3i3z23mgqrcliq4m07lvwc7i3s";
-    })
-    (fetchpatch {
-      name = "linux-header-ioctl.patch";
-      url = "https://github.com/jbruchon/jdupes/commit/0d4d98f51c99999d2c6dbbb89d554af551b5b69b.patch";
-      sha256 = "sha256-lyuZeRp0Laa8I9nDl1HGdlKa59OvGRQJnRg2fTWv7mQ=";
-    })
-    (fetchpatch {
-      name = "darwin-apfs-comp.patch";
-      url = "https://github.com/jbruchon/jdupes/commit/517b7035945eacd82323392b13bc17b044bcc89d.patch";
-      sha256 = "sha256-lvOab6tyEyKUtik3JBdIs5SHpVjcQEDfN7n2bfUszBw=";
-    })
-  ];
+  buildInputs = [ libjodycode ];
 
   dontConfigure = true;
 
@@ -49,7 +34,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # broken Makefile, the above also removes tests
 
   postInstall = ''
-    install -Dm444 -t $out/share/doc/jdupes CHANGES LICENSE README.md
+    install -Dm444 -t $out/share/doc/jdupes CHANGES.txt LICENSE.txt README.md
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22288,6 +22288,8 @@ with pkgs;
 
   libjson = callPackage ../development/libraries/libjson { };
 
+  libjodycode = callPackage ../development/libraries/libjodycode { };
+
   libb64 = callPackage ../development/libraries/libb64 { };
 
   judy = callPackage ../development/libraries/judy { };


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/jbruchon/jdupes/compare/v1.21.0...v1.27.3

Bye bye patches. As noted in #212217 i made sure to target staging.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
