### PR TITLE
atlauncher: 3.4.30.0 -> 3.4.34.0

### DIFF
--- a/pkgs/games/atlauncher/default.nix
+++ b/pkgs/games/atlauncher/default.nix
@@ -9,6 +9,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-gHUYZaxADchikoCmAfqFjVbMYhhiwg2BZKctmww1Mlw=";
   };
 
+  env.ICON = fetchurl {
+    url = "https://atlauncher.com/assets/images/logo.svg";
+    hash = "sha256-XoqpsgLmkpa2SdjZvPkgg6BUJulIBIeu6mBsJJCixfo=";
+  };
+
   dontUnpack = true;
 
   buildInputs = [ ];
@@ -30,6 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
         --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" ${
             lib.strings.optionalString withSteamRun ''--run "${steamrun} \\"''
           }
+
+      mkdir -p $out/share/icons/hicolor/scalable/apps
+      cp $ICON $out/share/icons/hicolor/scalable/apps/${finalAttrs.pname}.svg
+
       runHook postInstall
     '';
 
@@ -37,10 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     (makeDesktopItem {
       name = finalAttrs.pname;
       exec = "${finalAttrs.pname} --no-launcher-update true";
-      icon = fetchurl {
-        url = "https://avatars.githubusercontent.com/u/7068667";
-        hash = "sha256-YmEkxf4rZxN3jhiib0UtdUDDcn9lw7IMbiEucBL7b9o=";
-      };
+      icon = finalAttrs.pname;
       desktopName = "ATLauncher";
       categories = [ "Game" ];
     })

--- a/pkgs/games/atlauncher/default.nix
+++ b/pkgs/games/atlauncher/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "atlauncher";
-  version = "3.4.30.0";
+  version = "3.4.34.0";
 
   src = fetchurl {
     url = "https://github.com/ATLauncher/ATLauncher/releases/download/v${finalAttrs.version}/ATLauncher-${finalAttrs.version}.jar";
-    hash = "sha256-eSb+qH/ZoPpeOyIuoJsEpecG7uUyh0vkqZzNuxriRuI=";
+    hash = "sha256-gHUYZaxADchikoCmAfqFjVbMYhhiwg2BZKctmww1Mlw=";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
## Description of changes

1. Update the package
2. Fix icon that didn't show up

Changelog available [here](https://atlauncher.com/downloads)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
