### PR TITLE
cairo: 1.16.0 -> 1.18.0

### DIFF
--- a/pkgs/applications/audio/industrializer/default.nix
+++ b/pkgs/applications/audio/industrializer/default.nix
@@ -6,6 +6,7 @@
 , automake
 , gnome2
 , gtk2
+, libGL
 , libjack2
 , libtool
 , libxml2
@@ -27,6 +28,7 @@ stdenv.mkDerivation rec {
     audiofile
     gnome2.gtkglext
     gtk2
+    libGL
     libjack2
     libtool
     libxml2

--- a/pkgs/applications/audio/kapitonov-plugins-pack/default.nix
+++ b/pkgs/applications/audio/kapitonov-plugins-pack/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, faust, meson, ninja, pkg-config
-, boost, cairo, fftw, ladspa-sdk, libxcb, lv2, xcbutilwm
+, boost, cairo, fftw, ladspa-sdk, libxcb, lv2, xcbutilwm, xorg
 , zita-convolver, zita-resampler
  }:
 
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     libxcb
     lv2
     xcbutilwm
+    xorg.xcbutil
     zita-convolver
     zita-resampler
   ];

--- a/pkgs/applications/audio/stone-phaser/default.nix
+++ b/pkgs/applications/audio/stone-phaser/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, xorg, cairo, lv2, libjack2, mesa, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, xorg, cairo, libGL, lv2, libjack2, mesa, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "stone-phaser";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    xorg.libX11 cairo lv2 libjack2 mesa
+    xorg.libX11 cairo libGL lv2 libjack2 mesa
   ];
 
   postPatch = ''

--- a/pkgs/applications/audio/string-machine/default.nix
+++ b/pkgs/applications/audio/string-machine/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, boost, cairo, lv2, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, boost, cairo, libGL, lv2, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "string-machine";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
-    boost cairo lv2
+    boost cairo libGL lv2
   ];
 
   makeFlags = [

--- a/pkgs/applications/graphics/fbida/default.nix
+++ b/pkgs/applications/graphics/fbida/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, libGL
 , libjpeg
 , libexif
 , giflib
@@ -17,6 +18,7 @@
 , sane-backends
 , libXpm
 , libepoxy
+, pixman
 , poppler
 , mesa
 , lirc
@@ -42,6 +44,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config which ];
   buildInputs = [
+    libGL
     libexif
     libjpeg
     libpng
@@ -56,6 +59,7 @@ stdenv.mkDerivation rec {
     libdrm
     libXpm
     libepoxy
+    pixman
     poppler
     lirc
     mesa

--- a/pkgs/applications/misc/mission-center/default.nix
+++ b/pkgs/applications/misc/mission-center/default.nix
@@ -23,6 +23,7 @@
 , glib
 , graphene
 , gtk4
+, libGL
 , libadwaita
 , libdrm
 , mesa
@@ -92,6 +93,7 @@ stdenv.mkDerivation rec {
     glib
     graphene
     gtk4
+    libGL
     libadwaita
     libdrm
     mesa

--- a/pkgs/applications/science/chemistry/gwyddion/default.nix
+++ b/pkgs/applications/science/chemistry/gwyddion/default.nix
@@ -12,7 +12,7 @@
   zlibSupport ? true, zlib,
   libuniqueSupport ? true, libunique,
   libpngSupport ? true, libpng,
-  openglSupport ? !stdenv.isDarwin
+  openglSupport ? !stdenv.isDarwin, libGL
 }:
 
 let
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = with lib;
     [ gtk2 fftw ] ++
-    optional openglSupport gnome2.gtkglext ++
+    optionals openglSupport [ gnome2.gtkglext libGL ] ++
     optional openexrSupport openexr ++
     optional libXmuSupport xorg.libXmu ++
     optional fitsSupport cfitsio ++

--- a/pkgs/applications/video/clapper/default.nix
+++ b/pkgs/applications/video/clapper/default.nix
@@ -17,6 +17,7 @@
 , gjs
 , gtk4
 , gst_all_1
+, libGL
 , libadwaita
 , appstream-glib
 , libsoup
@@ -55,6 +56,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-plugins-ugly
     gtk4
+    libGL
     libadwaita
     libsoup
     wayland

--- a/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
@@ -10,6 +10,7 @@
 , git
 , hyprland-protocols
 , jq
+, libGL
 , libdrm
 , libexecinfo
 , libinput
@@ -82,6 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
       cairo
       git
       hyprland-protocols
+      libGL
       libdrm
       libinput
       libxkbcommon

--- a/pkgs/applications/window-managers/hyprwm/hyprpaper/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprpaper/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , cmake
 , file
+, libGL
 , libjpeg
 , mesa
 , pango
@@ -31,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     file
+    libGL
     libjpeg
     mesa
     pango

--- a/pkgs/applications/window-managers/hyprwm/hyprpicker/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprpicker/default.nix
@@ -6,6 +6,7 @@
 , ninja
 , cairo
 , fribidi
+, libGL
 , libdatrie
 , libjpeg
 , libselinux
@@ -43,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     cairo
     fribidi
+    libGL
     libdatrie
     libjpeg
     libselinux

--- a/pkgs/applications/window-managers/i3/lock-blur.nix
+++ b/pkgs/applications/window-managers/i3/lock-blur.nix
@@ -1,4 +1,4 @@
-{ i3lock-color, lib, stdenv, fetchFromGitHub, fetchpatch }:
+{ i3lock-color, lib, stdenv, fetchFromGitHub, fetchpatch, libGL }:
 
 i3lock-color.overrideAttrs (oldAttrs : rec {
   pname = "i3lock-blur";
@@ -20,6 +20,8 @@ i3lock-color.overrideAttrs (oldAttrs : rec {
       sha256 = "sha256-0hXUr+ZEB1tpI3xw80/hGzKyeGuna4CQmEvK6t0VBqU=";
     })
   ];
+
+  buildInputs = oldAttrs.buildInputs ++ [ libGL ];
 
   meta = with lib; {
     description = "An improved screenlocker based upon XCB and PAM with background blurring filter";

--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libxcb,
   xcbutilkeysyms , xcbutilimage, pam, libX11, libev, cairo, libxkbcommon,
-  libxkbfile, libjpeg_turbo, xcbutilxrm
+  libxkbfile, libjpeg_turbo, xcbutilxrm, xorg
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ libxcb xcbutilkeysyms xcbutilimage pam libX11
-    libev cairo libxkbcommon libxkbfile libjpeg_turbo xcbutilxrm ];
+    libev cairo libxkbcommon libxkbfile libjpeg_turbo xcbutilxrm xorg.xcbutil ];
 
   makeFlags = [ "all" ];
   preInstall = ''

--- a/pkgs/applications/window-managers/i3/lock.nix
+++ b/pkgs/applications/window-managers/i3/lock.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, meson, ninja, pkg-config, libxcb, xcbutilkeysyms, xcbutilimage,
-  xcbutilxrm, pam, libX11, libev, cairo, libxkbcommon, libxkbfile }:
+  xcbutilxrm, pam, libX11, libev, cairo, libxkbcommon, libxkbfile, xorg }:
 
 stdenv.mkDerivation rec {
   pname = "i3lock";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkg-config ];
   buildInputs = [ libxcb xcbutilkeysyms xcbutilimage xcbutilxrm
-    pam libX11 libev cairo libxkbcommon libxkbfile ];
+    pam libX11 libev cairo libxkbcommon libxkbfile xorg.xcbutil ];
 
   meta = with lib; {
     description = "A simple screen locker like slock";

--- a/pkgs/applications/window-managers/i3/wmfocus.nix
+++ b/pkgs/applications/window-managers/i3/wmfocus.nix
@@ -1,5 +1,5 @@
 { lib, fetchFromGitHub, rustPlatform
-, xorg, python3, pkg-config, cairo, libxkbcommon }:
+, xorg, python3, pkg-config, cairo, expat, libxkbcommon }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wmfocus";
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-4eoV/viI7Q7I7mIqcHVAyPf/y2RWaWX0B+mLZWMEbcI=";
 
   nativeBuildInputs = [ python3 pkg-config ];
-  buildInputs = [ cairo libxkbcommon xorg.xcbutilkeysyms ];
+  buildInputs = [ cairo expat libxkbcommon xorg.xcbutilkeysyms ];
 
   # For now, this is the only available featureset. This is also why the file is
   # in the i3 folder, even though it might be useful for more than just i3

--- a/pkgs/applications/window-managers/jay/default.nix
+++ b/pkgs/applications/window-managers/jay/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, libGL
 , libinput
 , libxkbcommon
 , mesa
@@ -22,6 +23,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-zSq6YBlm6gJXGlF9xZ8gWSTMewdNqrJzwP58a0x8QIU=";
 
   buildInputs = [
+    libGL
     libxkbcommon
     mesa
     pango

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, substituteAll, swaybg
 , meson, ninja, pkg-config, wayland-scanner, scdoc
-, wayland, libxkbcommon, pcre2, json_c, libevdev
+, libGL, wayland, libxkbcommon, pcre2, json_c, libevdev
 , pango, cairo, libinput, gdk-pixbuf, librsvg
 , wlroots, wayland-protocols, libdrm
 , nixosTests
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    wayland libxkbcommon pcre2 json_c libevdev
+    libGL wayland libxkbcommon pcre2 json_c libevdev
     pango cairo libinput gdk-pixbuf librsvg
     wayland-protocols libdrm
     (wlroots.override { inherit (finalAttrs) enableXWayland; })

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -8,6 +8,7 @@
 , wf-config
 , cairo
 , doctest
+, libGL
 , libdrm
 , libexecinfo
 , libevdev
@@ -44,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     wf-config
+    libGL
     libdrm
     libexecinfo
     libevdev

--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch2
 , meson, ninja, pkg-config, python3, wayland-scanner
-, cairo, libdrm, libevdev, libinput, libxkbcommon, mesa, seatd, wayland
+, cairo, libGL, libdrm, libevdev, libinput, libxkbcommon, mesa, seatd, wayland
 , wayland-protocols, xcbutilcursor
 
 , demoSupport ? true
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ meson ninja pkg-config python3 wayland-scanner ];
   buildInputs = [
-    cairo libdrm libevdev libinput libxkbcommon mesa seatd wayland
+    cairo libGL libdrm libevdev libinput libxkbcommon mesa seatd wayland
     wayland-protocols
   ] ++ lib.optional hdrSupport libdisplay-info
     ++ lib.optional jpegSupport libjpeg

--- a/pkgs/by-name/ce/celluloid/package.nix
+++ b/pkgs/by-name/ce/celluloid/package.nix
@@ -5,6 +5,7 @@
 , desktop-file-utils
 , glib
 , gtk4
+, libGL
 , libepoxy
 , libadwaita
 , meson
@@ -40,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     glib
     gtk4
+    libGL
     libadwaita
     libepoxy
     mpv

--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, fetchzip
 , autoconf, automake, autoreconfHook, clang, dos2unix, file, perl
 , pkg-config
-, alsa-lib, coreutils, freetype, glib, glibc, gnugrep, libpulseaudio, libtool
-, libuuid, openssl, pango, xorg
+, alsa-lib, coreutils, freetype, glib, glibc, gnugrep, libGL, libpulseaudio
+, libtool, libuuid, openssl, pango, xorg
 , squeakImageHash ? null, squeakSourcesHash ? null, squeakSourcesVersion ? null
 , squeakVersion ? null, squeakVmCommitHash ? null, squeakVmCommitHashHash ? null
 , squeakVmVersion ? null
@@ -88,6 +88,7 @@ in stdenv.mkDerivation {
     glib
     glibc
     gnugrep
+    libGL
     libpulseaudio
     libtool
     libuuid

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -1,12 +1,8 @@
-{ config, lib, stdenv, fetchurl, fetchpatch, pkg-config, libiconv
-, libintl, expat, zlib, libpng, pixman, fontconfig, freetype
-, x11Support? !stdenv.isDarwin, libXext, libXrender
+{ lib, stdenv, fetchurl, fetchpatch, gtk-doc, meson, ninja, pkg-config, python3
+, docbook_xsl, fontconfig, freetype, libpng, pixman, zlib
+, x11Support? !stdenv.isDarwin || true, libXext, libXrender
 , gobjectSupport ? true, glib
-, xcbSupport ? x11Support, libxcb, xcbutil # no longer experimental since 1.12
-, libGLSupported ? lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms
-, glSupport ? x11Support && config.cairo.gl or (libGLSupported && stdenv.isLinux)
-, libGL # libGLU libGL is no longer a big dependency
-, pdfSupport ? true
+, xcbSupport ? x11Support, libxcb
 , darwin
 , testers
 }:
@@ -17,82 +13,27 @@ in stdenv.mkDerivation (finalAttrs: let
   inherit (finalAttrs) pname version;
 in {
   pname = "cairo";
-  version = "1.16.0";
+  version = "1.18.0";
 
   src = fetchurl {
     url = "https://cairographics.org/${if lib.mod (builtins.fromJSON (lib.versions.minor version)) 2 == 0 then "releases" else "snapshots"}/${pname}-${version}.tar.xz";
-    sha256 = "0c930mk5xr2bshbdljv005j3j8zr47gqmkry3q6qgvqky6rjjysy";
+    hash = "sha256-JDoHNrl4oz3uKfnMp1IXM7eKZbVBggb+970cPUzxC2Q=";
   };
-
-  patches = [
-    # Fixes CVE-2018-19876; see Nixpkgs issue #55384
-    # CVE information: https://nvd.nist.gov/vuln/detail/CVE-2018-19876
-    # Upstream PR: https://gitlab.freedesktop.org/cairo/cairo/merge_requests/5
-    #
-    # This patch is the merged commit from the above PR.
-    (fetchpatch {
-      name   = "CVE-2018-19876.patch";
-      url    = "https://gitlab.freedesktop.org/cairo/cairo/-/commit/6edf572ebb27b00d3c371ba5ae267e39d27d5b6d.patch";
-      hash = "sha256-wZ51BZWlXByFY3/CTn7el2A9aYkwL1FygJ2zqnN+UIQ=";
-    })
-
-    # Fix PDF output.
-    # https://gitlab.freedesktop.org/cairo/cairo/issues/342
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/cairo/cairo/-/commit/5e34c5a9640e49dcc29e6b954c4187cfc838dbd1.patch";
-      hash = "sha256-yCwsDUY7efVvOZkA6a0bPS+RrVc8Yk9bfPwWHeOjq5o=";
-    })
-
-    # Fixes CVE-2020-35492; see https://github.com/NixOS/nixpkgs/issues/120364.
-    # CVE information: https://nvd.nist.gov/vuln/detail/CVE-2020-35492
-    # Upstream PR: https://gitlab.freedesktop.org/cairo/cairo/merge_requests/85
-    (fetchpatch {
-      name = "CVE-2020-35492.patch";
-      includes = [ "src/cairo-image-compositor.c" ];
-      url = "https://gitlab.freedesktop.org/cairo/cairo/-/commit/78266cc8c0f7a595cfe8f3b694bfb9bcc3700b38.patch";
-      hash = "sha256-cXKzLMENx4/BHXLZg3Kfkx3esCnaNaB7WvjNfL77FhE=";
-    })
-
-    # Workaround https://gitlab.freedesktop.org/cairo/cairo/-/issues/121
-    ./skip-configure-stderr-check.patch
-
-    # Fixes cairo crash on macOS Big Sur
-    # Upstream PR: https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/cairo/cairo/-/commit/e22d7212acb454daccc088619ee147af03883974.diff";
-      hash = "sha256-8G98nsPz3MLEWPDX9F0jKgXC4hC4NNdFQLSpmW3ay2s=";
-    })
-
-    # Fix clang build failures on newer LLVM versions
-    # Upstream PR: https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/119
-    (fetchpatch {
-      name = "fix-types.patch";
-      url = "https://gitlab.freedesktop.org/cairo/cairo/-/commit/38e486b34d435130f2fb38c429e6016c3c82cd53.patch";
-      hash = "sha256-vmluOJSuTRiQHmbBBVCxOIkZ0O0ZEo0J4mgrUPn0SIo=";
-    })
-
-    # Fix unexpected color addition on grayscale images (usually text).
-    # Upstream fix: https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/114
-    # Can be removed after 1.18 release
-    (fetchpatch {
-      name = "fix-grayscale-anialias.patch";
-      url = "https://gitlab.freedesktop.org/cairo/cairo/-/commit/4f4d89506f58a64b4829b1bb239bab9e46d63727.diff";
-      hash = "sha256-mbTg67e7APfdELsuMAgXdY3xokWbGtHF7VDD5UyYqKM=";
-    })
-
-  ];
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev"; # very small
   separateDebugInfo = true;
 
   nativeBuildInputs = [
+    gtk-doc
+    meson
+    ninja
     pkg-config
+    python3
   ];
 
   buildInputs = [
-    libiconv
-    libintl
+    docbook_xsl
   ] ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     CoreGraphics
     CoreText
@@ -100,49 +41,53 @@ in {
     Carbon
   ]);
 
-  propagatedBuildInputs = [ fontconfig expat freetype pixman zlib libpng ]
+  propagatedBuildInputs = [ fontconfig freetype pixman libpng zlib ]
     ++ optionals x11Support [ libXext libXrender ]
-    ++ optionals xcbSupport [ libxcb xcbutil ]
+    ++ optionals xcbSupport [ libxcb ]
     ++ optional gobjectSupport glib
-    ++ optional glSupport libGL
     ; # TODO: maybe liblzo but what would it be for here?
 
-  configureFlags = [
-    "--enable-tee"
-  ] ++ (if stdenv.isDarwin then [
-    "--disable-dependency-tracking"
-    "--enable-quartz"
-    "--enable-quartz-font"
-    "--enable-quartz-image"
-    "--enable-ft"
-  ] else (optional xcbSupport "--enable-xcb"
-    ++ optional glSupport "--enable-gl"
-    ++ optional pdfSupport "--enable-pdf"
-  )) ++ optional (!x11Support) "--disable-xlib";
+  mesonFlags = [
+    "-Dgtk_doc=true"
 
-  preConfigure =
-  # On FreeBSD, `-ldl' doesn't exist.
-    lib.optionalString stdenv.isFreeBSD
-       '' for i in "util/"*"/Makefile.in" boilerplate/Makefile.in
-          do
-            cat "$i" | sed -es/-ldl//g > t
-            mv t "$i"
-          done
-       ''
-    +
-    ''
-    # Work around broken `Requires.private' that prevents Freetype
-    # `-I' flags to be propagated.
-    sed -i "src/cairo.pc.in" \
-        -es'|^Cflags:\(.*\)$|Cflags: \1 -I${freetype.dev}/include/freetype2 -I${freetype.dev}/include|g'
-    substituteInPlace configure --replace strings $STRINGS
-    '';
+    # error: #error config.h must be included before this header
+    "-Dsymbol-lookup=disabled"
+
+    # Only used in tests, causes a dependency cycle
+    "-Dspectre=disabled"
+
+    (lib.mesonEnable "glib" gobjectSupport)
+    (lib.mesonEnable "tests" finalAttrs.doCheck)
+    (lib.mesonEnable "xlib" x11Support)
+    (lib.mesonEnable "xcb" xcbSupport)
+  # ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+  #   "--cross-file=${builtins.toFile "cross-file.conf" ''
+  #     [properties]
+  #     ipc_rmid_deferred_release = ${
+  #       {
+  #         linux = "true";
+  #         freebsd = "true";
+  #         netbsd = "false";
+  #       }.${stdenv.hostPlatform.parsed.kernel.name} or
+  #         throw "Unknown value for ipc_rmid_deferred_release"
+  #     }
+  #   ''}"
+  ];
+
+  preConfigure = ''
+    patchShebangs version.py
+  '';
 
   enableParallelBuilding = true;
 
   doCheck = false; # fails
 
-  postInstall = lib.optionalString stdenv.isDarwin glib.flattenInclude;
+  postInstall = ''
+    # Work around broken `Requires.private' that prevents Freetype
+    # `-I' flags to be propagated.
+    sed -i "$out/lib/pkgconfig/cairo.pc" \
+        -es'|^Cflags:\(.*\)$|Cflags: \1 -I${freetype.dev}/include/freetype2 -I${freetype.dev}/include|g'
+  '' + lib.optionalString stdenv.isDarwin glib.flattenInclude;
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
@@ -151,9 +96,8 @@ in {
     longDescription = ''
       Cairo is a 2D graphics library with support for multiple output
       devices.  Currently supported output targets include the X
-      Window System, Quartz, Win32, image buffers, PostScript, PDF,
-      and SVG file output.  Experimental backends include OpenGL
-      (through glitz), XCB, BeOS, OS/2, and DirectFB.
+      Window System, XCB, Quartz, Win32, image buffers, PostScript,
+      PDF, and SVG file output.
 
       Cairo is designed to produce consistent output on all output
       media while taking advantage of display hardware acceleration
@@ -162,10 +106,10 @@ in {
     homepage = "http://cairographics.org/";
     license = with licenses; [ lgpl2Plus mpl10 ];
     pkgConfigModules = [
+      "cairo-pdf"
       "cairo-ps"
       "cairo-svg"
-    ] ++ lib.optional gobjectSupport "cairo-gobject"
-      ++ lib.optional pdfSupport "cairo-pdf";
+    ] ++ lib.optional gobjectSupport "cairo-gobject";
     platforms = platforms.all;
   };
 })

--- a/pkgs/development/libraries/cogl/default.nix
+++ b/pkgs/development/libraries/cogl/default.nix
@@ -53,6 +53,9 @@ stdenv.mkDerivation rec {
     "--enable-wayland-egl-server"
     "--enable-gles1"
     "--enable-gles2"
+    # Force linking against libGL.
+    # Otherwise, it tries to load it from the runtime library path.
+    "LIBS=-lGL"
   ] ++ lib.optionals stdenv.isDarwin [
     "--disable-glx"
     "--without-x"

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -10,6 +10,7 @@
 , orc
 , bzip2
 , gettext
+, libGL
 , libv4l
 , libdv
 , libavc1394
@@ -129,6 +130,7 @@ stdenv.mkDerivation rec {
   ]) ++ lib.optionals stdenv.isDarwin [
     Cocoa
   ] ++ lib.optionals stdenv.isLinux [
+    libGL
     libv4l
     libpulseaudio
     libavc1394

--- a/pkgs/development/libraries/wxSVG/default.nix
+++ b/pkgs/development/libraries/wxSVG/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchurl
 , cairo
+, expat
 , ffmpeg
 , libexif
 , pango
@@ -28,6 +29,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cairo
+    expat
     ffmpeg
     libexif
     pango

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -22,7 +22,7 @@
 , pkg-config , ncurses, xapian, gpgme, util-linux, tzdata, icu, libffi
 , cmake, libssh2, openssl, openssl_1_1, libmysqlclient, git, perl, pcre, pcre2, gecode_3, curl
 , msgpack, libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, buildRubyGem
-, cairo, re2, rake, gobject-introspection, gdk-pixbuf, zeromq, czmq, graphicsmagick, libcxx
+, cairo, expat, re2, rake, gobject-introspection, gdk-pixbuf, zeromq, czmq, graphicsmagick, libcxx
 , file, libvirt, glib, vips, taglib, libopus, linux-pam, libidn, protobuf, fribidi, harfbuzz
 , bison, flex, pango, python3, patchelf, binutils, freetds, wrapGAppsHook, atk
 , bundler, libsass, dart-sass, libexif, libselinux, libsepol, shared-mime-info, libthai, libdatrie
@@ -76,7 +76,7 @@ in
   cairo-gobject = attrs: {
     nativeBuildInputs = [ pkg-config ]
       ++ lib.optionals stdenv.isDarwin [ DarwinTools ];
-    buildInputs = [ cairo pcre2 xorg.libpthreadstubs xorg.libXdmcp ];
+    buildInputs = [ cairo expat pcre2 xorg.libpthreadstubs xorg.libXdmcp ];
   };
 
   charlock_holmes = attrs: {

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -8,6 +8,7 @@
 , extra-cmake-modules
 , cairo
 , pango
+, expat
 , fribidi
 , fmt
 , wayland
@@ -29,6 +30,7 @@
 , libdatrie
 , xcbutilkeysyms
 , pcre
+, xcbutil
 , xcbutilwm
 , xcb-imdkit
 , libxkbfile
@@ -63,6 +65,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    expat
     fmt
     isocodes
     cairo
@@ -84,6 +87,7 @@ stdenv.mkDerivation rec {
     libXdmcp
     libxkbcommon
     pcre
+    xcbutil
     xcbutilwm
     xcbutilkeysyms
     xcb-imdkit


### PR DESCRIPTION
## Hydra comparisons

- [1800235](https://hydra.nixos.org/eval/1800235?compare=1799588&full=0) (complete)

## Description of changes

 - libiconv and expat are no longer used.
 - libintl and xcbutil no longer appear to be used.
 - The GL backend has been removed.
 - We can no longer disable PDF support, since something always propagates zlib.
 - Not sure whether the Requires.private is still needed, so I've left it.

Fixes #256519.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
