### PR TITLE
pulumiPackages: fix cross-compilation

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/base.nix
+++ b/pkgs/tools/admin/pulumi-packages/base.nix
@@ -1,9 +1,11 @@
-{ buildGoModule
+{ lib
+, buildGoModule
+, buildPackages
 , fetchFromGitHub
 , python3Packages
 }:
 let
-  mkBasePackage =
+  mkBasePackage = buildGoModule:
     { pname
     , src
     , version
@@ -15,8 +17,6 @@ let
       inherit pname src vendorHash version;
 
       sourceRoot = "${src.name}/provider";
-
-      subPackages = [ "cmd/${cmd}" ];
 
       doCheck = false;
 
@@ -79,10 +79,12 @@ in
 , hash
 , vendorHash
 , cmdGen
+, cmdGenArgs ? "schema"
 , cmdRes
 , extraLdflags
 , meta
 , fetchSubmodules ? false
+, terraformBridge ? false
 , ...
 }@args:
 let
@@ -91,14 +93,17 @@ let
     inherit owner repo rev hash fetchSubmodules;
   };
 
-  pulumi-gen = mkBasePackage rec {
+  pulumi-gen = mkBasePackage buildPackages.buildGoModule {
     inherit src version vendorHash extraLdflags;
 
     cmd = cmdGen;
     pname = cmdGen;
+
+    subPackages = [ "cmd/${cmdGen}" ]
+      ++ lib.optionals terraformBridge [ "cmd/${cmdRes}/generate.go" ];
   };
 in
-mkBasePackage ({
+mkBasePackage buildGoModule ({
   inherit meta src version vendorHash extraLdflags;
 
   pname = repo;
@@ -109,15 +114,19 @@ mkBasePackage ({
 
   cmd = cmdRes;
 
+  subPackages = [
+    "cmd/${cmdRes}"
+  ];
+
   postConfigure = ''
     pushd ..
-
-    chmod +w sdk/
-    ${cmdGen} schema
-
+    chmod +w sdk
+    ${cmdGen} ${cmdGenArgs}
     popd
-
-    VERSION=v${version} go generate cmd/${cmdRes}/main.go
+  '' + lib.optionalString terraformBridge ''
+    pushd cmd/${cmdRes}
+    VERSION=v${version} generate
+    popd
   '';
 
   passthru.sdks.python = mkPythonPackage {

--- a/pkgs/tools/admin/pulumi-packages/pulumi-aws-native.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-aws-native.nix
@@ -9,22 +9,13 @@ mkPulumiPackage rec {
   hash = "sha256-v7jNPCrjtfi9KYD4RhiphMIpV23g/CBV/sKPBkMulu0=";
   vendorHash = "sha256-Yu9tNakwXWYdrjzI6/MFRzVBhJAEOjsmq9iBAQlR0AI=";
   cmdGen = "pulumi-gen-aws-native";
+  cmdGenArgs = "schema aws-cloudformation-schema ${version}";
   cmdRes = "pulumi-resource-aws-native";
   extraLdflags = [
     "-X github.com/pulumi/${repo}/provider/pkg/version.Version=v${version}"
   ];
-
   fetchSubmodules = true;
-  postConfigure = ''
-    pushd ..
-
-    ${cmdGen} schema aws-cloudformation-schema ${version}
-
-    popd
-  '';
-
   __darwinAllowLocalNetworking = true;
-
   meta = with lib; {
     description = "Native AWS Pulumi Provider";
     homepage = "https://github.com/pulumi/pulumi-aws-native";

--- a/pkgs/tools/admin/pulumi-packages/pulumi-command.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-command.nix
@@ -9,21 +9,12 @@ mkPulumiPackage rec {
   hash = "sha256-QrKtnpJGWoc5WwV6bnERrN3iBJpyoFKFwlqBtNNK7F8=";
   vendorHash = "sha256-HyzWPRYfjdjGGBByCc8N91qWhX2QBJoQMpudHWrkmFM=";
   cmdGen = "pulumi-gen-command";
+  cmdGenArgs = "provider/cmd/pulumi-resource-command/schema.json --version ${version}";
   cmdRes = "pulumi-resource-command";
   extraLdflags = [
     "-X github.com/pulumi/${repo}/provider/v4/pkg/version.Version=v${version}"
   ];
-
-  postConfigure = ''
-    pushd ..
-
-    ${cmdGen} provider/cmd/pulumi-resource-command/schema.json --version ${version}
-
-    popd
-  '';
-
   __darwinAllowLocalNetworking = true;
-
   meta = with lib; {
     description = "A Pulumi provider to execute commands and scripts either locally or remotely as part of the Pulumi resource model";
     homepage = "https://github.com/pulumi/pulumi-command";

--- a/pkgs/tools/admin/pulumi-packages/pulumi-random.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-random.nix
@@ -13,6 +13,7 @@ mkPulumiPackage rec {
   extraLdflags = [
     "-X github.com/pulumi/${repo}/provider/v4/pkg/version.Version=v${version}"
   ];
+  terraformBridge = true;
   __darwinAllowLocalNetworking = true;
   meta = with lib; {
     description = "A Pulumi provider that safely enables randomness for resources";


### PR DESCRIPTION
## Description of changes

pulumiPackages was using tfgen built for the host platform.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

