### PR TITLE
 python3.pkgs.django-postgresql-netfields: run tests & update

### DIFF
--- a/pkgs/development/python-modules/django-postgresql-netfields/default.nix
+++ b/pkgs/development/python-modules/django-postgresql-netfields/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "django-postgresql-netfields";
-  version = "1.3.0";
+  version = "1.3.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "jimfunk";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-I+X4yfadtiiZlW7QhfwVbK1qyWn/khH9fWXszCo9uro=";
+    hash = "sha256-76vGvxxfNZQBCCsTkkSgQZ8PpFspWxJQDj/xq9iOSTU=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/django-postgresql-netfields/default.nix
+++ b/pkgs/development/python-modules/django-postgresql-netfields/default.nix
@@ -1,13 +1,18 @@
-{ lib
+{ stdenv
+, lib
 , buildPythonPackage
 , django
 , netaddr
 , six
 , fetchFromGitHub
 , pythonOlder
+, djangorestframework
 # required for tests
-#, djangorestframework
-#, psycopg2
+, postgresql
+, postgresqlTestHook
+, psycopg2
+, pytestCheckHook
+, pytest-django
 }:
 
 buildPythonPackage rec {
@@ -30,23 +35,19 @@ buildPythonPackage rec {
     six
   ];
 
-  # tests need a postgres database
-  doCheck = false;
+  doCheck = !stdenv.isDarwin; # could not create shared memory segment: Operation not permitted
 
-  # keeping the dependencies below as comment for reference
-  # checkPhase = ''
-    # python manage.py test
-  # '';
+  nativeCheckInputs = [
+    djangorestframework
+    postgresql
+    postgresqlTestHook
+    psycopg2
+    pytestCheckHook
+    pytest-django
+  ];
 
-  # buildInputs = [
-    # djangorestframework
-    # psycopg2
-  # ];
-
-  # Requires psycopg2
-  # pythonImportsCheck = [
-  #   "netfields"
-  # ];
+  postgresqlTestUserOptions = "LOGIN SUPERUSER";
+  env.DJANGO_SETTINGS_MODULE = "testsettings";
 
   meta = with lib; {
     description = "Django PostgreSQL netfields implementation";


### PR DESCRIPTION
## Description of changes

https://github.com/jimfunk/django-postgresql-netfields/blob/v1.3.1/CHANGELOG
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
