### PR TITLE
python3.django-redis: 5.2.0 -> 5.3.0

### DIFF
--- a/pkgs/development/python-modules/django-redis/default.nix
+++ b/pkgs/development/python-modules/django-redis/default.nix
@@ -20,7 +20,7 @@
 
 let
   pname = "django-redis";
-  version = "5.2.0";
+  version = "5.3.0";
 in
 buildPythonPackage {
   inherit pname version;
@@ -31,7 +31,7 @@ buildPythonPackage {
     owner = "jazzband";
     repo = "django-redis";
     rev = version;
-    hash = "sha256-e8wCgfxBT+WKFY4H83CTMirTpQym3QAoeWnXbRCDO90=";
+    hash = "sha256-eX9rUUvpkRrkZ82YalWn8s9DTw6nsbGzi1A6ibRoQGw=";
   };
 
   postPatch = ''
@@ -67,11 +67,6 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = lib.optionals (pythonAtLeast "3.11") [
-    # DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
-    "-W" "ignore::DeprecationWarning"
-  ];
-
   disabledTests = [
     # ModuleNotFoundError: No module named 'test_cache_options'
     "test_custom_key_function"
@@ -79,7 +74,7 @@ buildPythonPackage {
     "test_delete_pattern_calls_get_client_given_no_client"
     "test_delete_pattern_calls_make_pattern"
     "test_delete_pattern_calls_scan_iter_with_count_if_itersize_given"
-    "test_delete_pattern_calls_scan_iter_with_count_if_itersize_given"
+    "test_delete_pattern_calls_pipeline_delete_and_execute"
     "test_delete_pattern_calls_scan_iter"
     "test_delete_pattern_calls_delete_for_given_keys"
   ];
@@ -87,6 +82,7 @@ buildPythonPackage {
   meta = with lib; {
     description = "Full featured redis cache backend for Django";
     homepage = "https://github.com/jazzband/django-redis";
+    changelog = "https://github.com/jazzband/django-redis/releases/tag/${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ hexa ];
   };


### PR DESCRIPTION
## Description of changes

https://github.com/jazzband/django-redis/releases/tag/5.3.0


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
