### PR TITLE
vcmi: 1.2.1 -> 1.3.2

### DIFF
--- a/pkgs/games/vcmi/default.nix
+++ b/pkgs/games/vcmi/default.nix
@@ -27,14 +27,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vcmi";
-  version = "1.2.1";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "vcmi";
     repo = "vcmi";
     rev = version;
     fetchSubmodules = true;
-    hash = "sha256-F1g3ric23jKetl5aBG5NRpT4LnGXhBKZmGp2hg6Io9s=";
+    hash = "sha256-dwTQRpu+IrKhuiiw/uYBt8i/BYlQ5XCy/jUhDAo6aa4=";
   };
 
   nativeBuildInputs = [
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DENABLE_LUA:BOOL=ON"
-    "-DENABLE_ERM:BOOL=ON"
+    "-DENABLE_ERM:BOOL=OFF"
     "-DENABLE_GITVERSION:BOOL=OFF"
     "-DENABLE_PCH:BOOL=OFF"
     "-DENABLE_TEST:BOOL=OFF"


### PR DESCRIPTION
!! First PR for nixpkgs, feedback very welcome !!

## Description of changes

Update vcmi to [1.3.2](https://github.com/vcmi/vcmi/releases/tag/1.3.2)

Disable building of ERM scripting as compilation fails.  Note that scripting is [disabled by default](https://github.com/vcmi/vcmi/pull/968) upstream.

(cc @azahi as maintainer.  Plus I see you updated previously to 1.2.1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Output of `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`

```
https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"                                                                                                               09/25/2023 08:28:51 PM
these 2 paths will be fetched (0.09 MiB download, 0.46 MiB unpacked):
  /nix/store/1m0a7ws3snpl112jaa33zg8npngkfwb8-nixpkgs-review-2.10.2
  /nix/store/rw6ls8q4yavfavbkchnp67lhvr35xrsk-python3.10-argcomplete-3.1.1
copying path '/nix/store/rw6ls8q4yavfavbkchnp67lhvr35xrsk-python3.10-argcomplete-3.1.1' from 'https://cache.nixos.org'...
copying path '/nix/store/1m0a7ws3snpl112jaa33zg8npngkfwb8-nixpkgs-review-2.10.2' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 85, done.
remote: Counting objects: 100% (83/83), done.
remote: Compressing objects: 100% (39/39), done.
remote: Total 85 (delta 52), reused 60 (delta 43), pack-reused 2
Unpacking objects: 100% (85/85), 107.91 KiB | 445.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   e4271725471..7e5e43ef91a  master     -> refs/nixpkgs-review/0
$ git worktree add /home/eduard/.cache/nixpkgs-review/rev-7aecbe2f5e9a058624a255dc7183678ec04aae78-1/nixpkgs 7e5e43ef91a3828f92f8dd149d9af6521d0c736b
Preparing worktree (detached HEAD 7e5e43ef91a)
Updating files: 100% (37277/37277), done.
HEAD is now at 7e5e43ef91a Merge pull request #257291 from domenkozar/cachix-1.6.1
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/eduard/.cache/nixpkgs-review/rev-7aecbe2f5e9a058624a255dc7183678ec04aae78-1/nixpkgs nixpkgs-overlays=/run/user/1000/tmp2vedz_hd -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff 7aecbe2f5e9a058624a255dc7183678ec04aae78
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/eduard/.cache/nixpkgs-review/rev-7aecbe2f5e9a058624a255dc7183678ec04aae78-1/nixpkgs nixpkgs-overlays=/run/user/1000/tmp2vedz_hd -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
1 package updated:
vcmi (1.2.1 → 1.3.2)

$ nix build --nix-path nixpkgs=/home/eduard/.cache/nixpkgs-review/rev-7aecbe2f5e9a058624a255dc7183678ec04aae78-1/nixpkgs nixpkgs-overlays=/run/user/1000/tmp2vedz_hd --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/eduard/.cache/nixpkgs-review/rev-7aecbe2f5e9a058624a255dc7183678ec04aae78-1/build.nix
1 package built:
vcmi

error: build log of '/nix/store/lz999vqwzczlwszdr6q8yf5d3ibxq3i0-vcmi-1.3.2.drv^*' is not available
$ /nix/store/ggza64x1frk77rcyzlpc3nwwp5v726vf-nix-2.17.0/bin/nix-shell /home/eduard/.cache/nixpkgs-review/rev-7aecbe2f5e9a058624a255dc7183678ec04aae78-1/shell.nix --nix-path nixpkgs=/home/eduard/.cache/nixpkgs-review/rev-7aecbe2f5e9a058624a255dc7183678ec04aae78-1/nixpkgs nixpkgs-overlays=/run/user/1000/tmp2vedz_hd
```

Screenshot of launcher:

![imagen](https://github.com/NixOS/nixpkgs/assets/666148/9ff6681b-bd2c-4c9c-b1db-b8e7f115e3e8)

