### PR TITLE
pulumiPackages.pulumi-yandex-unofficial: init at 0.98.0

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/base.nix
+++ b/pkgs/tools/admin/pulumi-packages/base.nix
@@ -10,9 +10,10 @@ let
     , vendorHash
     , cmd
     , extraLdflags
+    , env
     , ...
     }@args: buildGoModule (rec {
-      inherit pname src vendorHash version;
+      inherit pname src vendorHash version env;
 
       sourceRoot = "${src.name}/provider";
 
@@ -81,6 +82,7 @@ in
 , cmdGen
 , cmdRes
 , extraLdflags
+, env ? { }
 , meta
 , fetchSubmodules ? false
 , ...
@@ -92,14 +94,14 @@ let
   };
 
   pulumi-gen = mkBasePackage rec {
-    inherit src version vendorHash extraLdflags;
+    inherit src version vendorHash extraLdflags env;
 
     cmd = cmdGen;
     pname = cmdGen;
   };
 in
 mkBasePackage ({
-  inherit meta src version vendorHash extraLdflags;
+  inherit meta src version vendorHash extraLdflags env;
 
   pname = repo;
 

--- a/pkgs/tools/admin/pulumi-packages/default.nix
+++ b/pkgs/tools/admin/pulumi-packages/default.nix
@@ -11,4 +11,5 @@ in
   pulumi-language-nodejs = callPackage ./pulumi-language-nodejs.nix { };
   pulumi-language-python = callPackage ./pulumi-language-python.nix { };
   pulumi-random = callPackage' ./pulumi-random.nix { };
+  pulumi-yandex-unofficial = callPackage' ./pulumi-yandex-unofficial.nix { };
 }

--- a/pkgs/tools/admin/pulumi-packages/pulumi-yandex-unofficial.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-yandex-unofficial.nix
@@ -1,0 +1,27 @@
+{ lib
+, mkPulumiPackage
+}:
+# Note that we are not using https://github.com/pulumi/pulumi-yandex because
+# it has been archived in 2022.
+mkPulumiPackage rec {
+  owner = "Regrau";
+  repo = "pulumi-yandex";
+  version = "0.98.0";
+  rev = "v${version}";
+  hash = "sha256-Olwl4JNrJUiJaGha7ZT0Qb0+6hRKxOOy06eKMJfYf0I=";
+  vendorHash = "sha256-8mu0msSq59f5GZNo7YIGuNTYealGyEL9kwk0jCcSO68=";
+  cmdGen = "pulumi-tfgen-yandex";
+  cmdRes = "pulumi-resource-yandex";
+  extraLdflags = [
+    "-X github.com/regrau/${repo}/provider/pkg/version.Version=v${version}"
+  ];
+  __darwinAllowLocalNetworking = true;
+  env.GOWORK = "off";
+  meta = with lib; {
+    description = "Unofficial Yandex Cloud Resource Provider";
+    homepage = "https://github.com/Regrau/pulumi-yandex";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tie veehaitch trundle ];
+    mainProgram = cmdRes;
+  };
+}


### PR DESCRIPTION
## Description of changes

This one is a bit controversial since Pulumi dropped support for Yandex.Cloud in 2022, and Yandex does not have native Pulumi provider. However, @Regrau has been consistently updating a fork of the provider almost for a year now, so I think it’s OK to package it, albeit with `unofficial` suffix.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
