### PR TITLE
opentoonz: Fix and 1.5 -> 1.7

### DIFF
--- a/pkgs/applications/graphics/opentoonz/default.nix
+++ b/pkgs/applications/graphics/opentoonz/default.nix
@@ -36,6 +36,7 @@ in stdenv.mkDerivation rec {
 
   cmakeDir = "../sources";
   cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
     "-DTIFF_INCLUDE_DIR=${libtiff.dev}/include"
     "-DTIFF_LIBRARY=${libtiff.out}/lib/libtiff.so"
   ];

--- a/pkgs/applications/graphics/opentoonz/source.nix
+++ b/pkgs/applications/graphics/opentoonz/source.nix
@@ -3,7 +3,7 @@
 
 { fetchFromGitHub, }: rec {
   versions = {
-    opentoonz = "1.5.0";
+    opentoonz = "1.6.0";
     libtiff = "4.0.3";  # The version in thirdparty/tiff-*
   };
 
@@ -11,6 +11,6 @@
     owner = "opentoonz";
     repo = "opentoonz";
     rev = "v${versions.opentoonz}";
-    sha256 = "1rw30ksw3zjph1cwxkfvqj0330v8wd4333gn0fdf3cln1w0549lk";
+    hash = "sha256-8QZyIMYDqvhQUW5etSjugQRBWhsN3w/QUGC0RfnqYDc=";
   };
 }

--- a/pkgs/applications/graphics/opentoonz/source.nix
+++ b/pkgs/applications/graphics/opentoonz/source.nix
@@ -3,7 +3,7 @@
 
 { fetchFromGitHub, }: rec {
   versions = {
-    opentoonz = "1.6.0";
+    opentoonz = "1.7.1";
     libtiff = "4.0.3";  # The version in thirdparty/tiff-*
   };
 
@@ -11,6 +11,6 @@
     owner = "opentoonz";
     repo = "opentoonz";
     rev = "v${versions.opentoonz}";
-    hash = "sha256-8QZyIMYDqvhQUW5etSjugQRBWhsN3w/QUGC0RfnqYDc=";
+    hash = "sha256-5iXOvh4QTv+G0fjEHU62u7QCee+jbvKhK0+fQXbdJis=";
   };
 }


### PR DESCRIPTION
## Description of changes

Fix and bring opentoonz current.

* Fix build after https://github.com/nixos/nixpkgs/pull/108496
* Changelogs:
    * https://github.com/opentoonz/opentoonz/releases/tag/v1.6.0
    * https://github.com/opentoonz/opentoonz/releases/tag/v1.7.0
    * https://github.com/opentoonz/opentoonz/releases/tag/v1.7.1



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
