### PR TITLE
slurm: init at 0.4.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11412,8 +11412,8 @@
   mikaelfangel = {
     email = "nixpkgs.bottle597@passfwd.com";
     github = "MikaelFangel";
-    githubID = "34864484";
-    name = "Mikael Fangel"
+    githubId = 34864484;
+    name = "Mikael Fangel";
   };
   mikefaille = {
     email = "michael@faille.io";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11409,6 +11409,12 @@
     githubId = 43088426;
     name = "Mihnea Stoian";
   };
+  mikaelfangel = {
+    email = "nixpkgs.bottle597@passfwd.com";
+    github = "MikaelFangel";
+    githubID = "34864484";
+    name = "Mikael Fangel"
+  };
   mikefaille = {
     email = "michael@faille.io";
     github = "mikefaille";

--- a/pkgs/by-name/sl/slurm-nm/package.nix
+++ b/pkgs/by-name/sl/slurm-nm/package.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, meson
+, ncurses
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  pname = "slurm";
+  version = "0.4.4";
+
+  src = fetchFromGitHub {
+    owner = "mattthias";
+    repo = "slurm";
+    rev = "upstream/${version}";
+    hash = "sha256-w77SIXFctMwwNw9cQm0HQaEaMs/5NXQjn1LpvkpCCB8=";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [ ncurses ];
+
+  meta = with lib; {
+    description = "A generic network load monitor";
+    homepage = "https://github.com/mattthias/slurm";
+    license = licenses.gpl2Plus;
+    platforms = with platforms; [ "x86_64-linux" ];
+    maintainers = with maintainers; [ mikaelfangel ];
+    mainProgram = "slurm";
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes #257288

Adds the package slurm as a generic network load monitor. The name of the package is slurm-cli as there already is a package named slurm.

URL: [https://github.com/mattthias/slurm](https://github.com/mattthias/slurm)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
