### PR TITLE
slurm: init at 0.4.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14457,6 +14457,12 @@
     githubId = 816465;
     name = "Redvers Davies";
   };
+  redxtech = {
+    email = "gabe@gabedunn.dev";
+    github = "redxtech";
+    githubId = 18155001;
+    name = "Gabe Dunn";
+  };
   reedrw = {
     email = "reedrw5601@gmail.com";
     github = "reedrw";

--- a/pkgs/by-name/sl/slurm/package.nix
+++ b/pkgs/by-name/sl/slurm/package.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ncurses6
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  pname = "slurm";
+  version = "0.4.4";
+  src = fetchFromGitHub {
+    owner = "mattthias";
+    repo = "slurm";
+    rev = "upstream/${version}";
+    hash = "sha256-w77SIXFctMwwNw9cQm0HQaEaMs/5NXQjn1LpvkpCCB8=";
+  };
+
+  buildInputs = [meson ncurses6 ninja];
+
+  buildPhase = ''
+    meson setup
+    meson compile
+  '';
+
+  installPhase = ''
+    meson install
+  '';
+
+  meta = with lib; {
+    description = "yet another network load monitor";
+    homepage = "https://github.com/mattthias/slurm";
+    license = licenses.gpl2Only;
+    platforms = with platforms; [ linux ];
+    maintainers = with lib.maintainers; [ redxtech ];
+  };
+}
+


### PR DESCRIPTION
## Description of changes

Adds the `slurm` package. [GitHub linked here](https://github.com/mattthias/slurm). This will resolve the [issue requesting it](https://github.com/NixOS/nixpkgs/issues/257288).

### `slurm`

> yet another network load monitor

slurm started as a FreeBSD port of the Linux ppp link monitor called pppstatus by Gabriel Montenegro. Hendrik Scholz ripped off the ppp dependent parts and the email checks to turn in into a generic network load monitor for *BSD, Linux, HP-UX and Solaris.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
