### PR TITLE
nvim: patch liblpeg to work with clang on darwin

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -7,6 +7,7 @@
 , buildPackages
 , treesitter-parsers ? import ./treesitter-parsers.nix { inherit fetchurl; }
 , CoreServices
+, fixDarwinDylibNames
 , glibcLocales ? null, procps ? null
 
 # now defaults to false because some tests can be flaky (clipboard etc), see
@@ -16,8 +17,29 @@
 }:
 
 let
+  nvim-lpeg-dylib = luapkgs: if stdenv.isDarwin
+    then (luapkgs.lpeg.overrideAttrs (oa: {
+      preConfigure = ''
+        # neovim wants clang .dylib
+        sed -i makefile -e "s/CC = gcc/CC = clang/"
+        sed -i makefile -e "s/-bundle/-dynamiclib/"
+      '';
+      preBuild = ''
+        # there seems to be implicit calls to Makefile from luarocks, we need to
+        # add a stage to build our dylib
+        make macosx
+        mkdir -p $out/lib
+        mv lpeg.so $out/lib/lpeg.dylib
+      '';
+      nativeBuildInputs =
+        oa.nativeBuildInputs
+        ++ (
+          lib.optional stdenv.isDarwin fixDarwinDylibNames
+        );
+    }))
+    else luapkgs.lpeg;
   requiredLuaPkgs = ps: (with ps; [
-    lpeg
+    (nvim-lpeg-dylib ps)
     luabitop
     mpack
   ] ++ lib.optionals doCheck [
@@ -40,10 +62,11 @@ let
             deterministicStringIds = true;
             self = deterministicLuajit;
           };
-        in deterministicLuajit.withPackages(ps: [ ps.mpack ps.lpeg ])
+        in deterministicLuajit.withPackages(ps: [ ps.mpack (nvim-lpeg-dylib ps) ])
       else lua.luaOnBuild;
 
   pyEnv = python3.withPackages(ps: with ps; [ pynvim msgpack ]);
+
 in
   stdenv.mkDerivation rec {
     pname = "neovim-unwrapped";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a better-scoped change to patch broken interaction of neovim-lpeg on darwin. 

closes https://github.com/NixOS/nixpkgs/pull/257003
fixes https://github.com/NixOS/nixpkgs/issues/229275

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
```
% ❯ nix build .#neovim
warning: Git tree '/Users/htran/local_repos/neovim-nightly-overlay' is dirty

% ❯ nix run nixpkgs#jq -- -e '.nodes."neovim-flake".locked.rev' <flake.lock 
"3387dc4a463c80a01702cdd069dde3d505a4e805"

% ❯ result/bin/nvim --version
NVIM v0.10.0-dev-3387dc4
Build type: Release
LuaJIT 2.1.1693350652
Run "nvim -V1 -v" for more info
```
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

A quick way to test this change is to use nightly neovim, `nix build .#neovim` works regardless, only nightly is affected due to the new introduction of lpeg onto neovim post 0.9.2.

There are couple ways to do this. Assuming you use nix flakes, if you use `neovim-nightly-overlay`

```nix
inputs = {
  # neovim-nightly-overlay.url = ...;
  neovim-nightly-overlay.inputs.nixpkgs.follows = "github:pegasust/nixpkgs/nvim-patch-liblpeg";
};
# ...
```
Or, for convenience, I've created a fork for testing

```nix
inputs = {
  neovim-nightly-overlay.url = "github:pegasust/neovim-darwin-overlay/neovim-fix";
};
```

If you have `neovim` cloned locally, you could also test by overriding nixpkgs to follow this PR branch

There's probably another way to just use non-flake nix to test for this that uses `fetchFromGithub`, but I'm a bit rusty on that.