### PR TITLE
caprine-bin: 2.58.0 -> 2.58.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/caprine-bin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/caprine-bin/default.nix
@@ -1,7 +1,7 @@
 { lib, callPackage, stdenvNoCC }:
 let
   pname = "caprine";
-  version = "2.58.0";
+  version = "2.58.3";
   metaCommon = with lib; {
     description = "An elegant Facebook Messenger desktop app";
     homepage = "https://sindresorhus.com/caprine";
@@ -10,11 +10,11 @@ let
   };
   x86_64-appimage = callPackage ./build-from-appimage.nix {
     inherit pname version metaCommon;
-    sha256 = "7iK2RyA63okJLH2Xm97fFilJHzqFuP96xkUr2+ADbC4=";
+    sha256 = "sha256-w0nBQhHYzFLsNu0MxWhoju6fh4JpAKC7MWWVxwDkRYk=";
   };
   x86_64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
-    sha256 = "RqK+fJJAt9W+m7zg6ZYI6PEAOa3V1UxsptEpG1qjibg=";
+    sha256 = "sha256-6Mx2ZkT2hdnaSVt2hKMMV9xc7rYPFFbxcj6vb84ojYU=";
   };
 in
 (if stdenvNoCC.isDarwin then x86_64-dmg else x86_64-appimage).overrideAttrs (oldAttrs: {


### PR DESCRIPTION
## Description of changes

Bump to patch for CVE-2023-4863

Vulnerability details:
https://github.com/advisories/GHSA-j7hp-h8jx-5pp

Upstream release notes:
https://github.com/sindresorhus/caprine/releases/tag/v2.58.2
https://github.com/sindresorhus/caprine/releases/tag/v2.58.3

This PR needs to be backported to 23.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
