### PR TITLE
hid-tmff2: init at v0.81

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14427,6 +14427,12 @@
     githubId = 145816;
     name = "David McKay";
   };
+  rayslash = {
+    email = "stevemathewjoy@tutanota.cm";
+    github = "rayslash";
+    githubId = 45141270;
+    name = "Steve Mathew Joy";
+  };
   razvan = {
     email = "razvan.panda@gmail.com";
     github = "freeman42x";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14428,7 +14428,7 @@
     name = "David McKay";
   };
   rayslash = {
-    email = "stevemathewjoy@tutanota.cm";
+    email = "stevemathewjoy@tutanota.com";
     github = "rayslash";
     githubId = 45141270;
     name = "Steve Mathew Joy";

--- a/pkgs/os-specific/linux/hid-tmff2/default.nix
+++ b/pkgs/os-specific/linux/hid-tmff2/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation {
+  pname = "hid-tmff2";
+  # https://github.com/Kimplul/hid-tmff2/blob/ca168637fbfb085ebc9ade0c47fa0653dac5d25b/dkms/dkms-install.sh#L12
+  version = "0.81";
+
+  src = fetchFromGitHub {
+    owner = "Kimplul";
+    repo = "hid-tmff2";
+    rev = "ca168637fbfb085ebc9ade0c47fa0653dac5d25b";
+    hash = "sha256-Nm5m5xjwJGy+ia4nTkvPZynIxUj6MVGGbSNmIcIpziM=";
+    # For hid-tminit. Source: https://github.com/scarburato/hid-tminit
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installFlags = [
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
+
+  postPatch = "sed -i '/depmod -A/d' Makefile";
+
+  meta = with lib; {
+    description = "A linux kernel module for Thrustmaster T300RS, T248 and TX(experimental)";
+    homepage = "https://github.com/Kimplul/hid-tmff2";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.rayslash ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -583,6 +583,8 @@ in {
 
     hid-ite8291r3 = callPackage ../os-specific/linux/hid-ite8291r3 { };
 
+    hid-tmff2 = callPackage ../os-specific/linux/hid-tmff2 { };
+
   } // lib.optionalAttrs config.allowAliases {
     ati_drivers_x11 = throw "ati drivers are no longer supported by any kernel >=4.1"; # added 2021-05-18;
     hid-nintendo = throw "hid-nintendo was added in mainline kernel version 5.16"; # Added 2023-07-30


### PR DESCRIPTION
## Description

A linux kernel module for Thrustmaster T300RS, T248 and TX(experimental) wheels.
https://github.com/Kimplul/hid-tmff2/commit/ca168637fbfb085ebc9ade0c47fa0653dac5d25b

- Add myself ``rayslash`` as maintainer
- Add hid-tmff2 derivation

> **Note:** Until the updated ``hid-tminit`` is upstreamed, one might want to blacklist the kernel module ``hid-thrustmaster`` to use this module.
 
## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ]  aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandbox = true set in nix.conf? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))

- [x] Tested, as applicable:
  - [x] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [x] and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - [x] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - [x] made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages

- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in ./result/bin/)
- [ ] [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
    - [ ] (Package updates) Added a release notes entry if the change is major or breaking
    - [ ] (Module updates) Added a release notes entry if the change is significant
    - [ ] (Module addition) Added a release notes entry if adding a new NixOS module

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
