### PR TITLE
python3Packages.pyqtdarktheme: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/pyqtdarktheme/add-missing-argument-to-the-proxy-style-initializer.patch
+++ b/pkgs/development/python-modules/pyqtdarktheme/add-missing-argument-to-the-proxy-style-initializer.patch
@@ -1,0 +1,25 @@
+From 816afb6a3a6a340ae2a2a06dc054dd8e65ff9d8f Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <paveloom@riseup.net>
+Date: Mon, 30 Oct 2023 20:42:31 +0300
+Subject: [PATCH] Add missing argument to the `proxy_style` initializer.
+
+---
+ qdarktheme/_proxy_style.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qdarktheme/_proxy_style.py b/qdarktheme/_proxy_style.py
+index b1fb358..f04f01e 100644
+--- a/qdarktheme/_proxy_style.py
++++ b/qdarktheme/_proxy_style.py
+@@ -14,7 +14,7 @@ class QDarkThemeStyle(QProxyStyle):
+
+     def __init__(self):
+         """Initialize style proxy."""
+-        super().__init__()
++        super().__init__(None)
+
+     def standardIcon(  # noqa: N802
+         self, standard_icon: QStyle.StandardPixmap, option: QStyleOption | None, widget
+--
+2.42.0
+

--- a/pkgs/development/python-modules/pyqtdarktheme/default.nix
+++ b/pkgs/development/python-modules/pyqtdarktheme/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+
+, darkdetect
+, poetry-core
+
+, pyqt5
+, pytest-mock
+, pytest-qt
+, pytestCheckHook
+, qt5
+}:
+
+buildPythonPackage rec {
+  pname = "pyqtdarktheme";
+  version = "2.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "5yutan5";
+    repo = "PyQtDarkTheme";
+    rev = "v${version}";
+    hash = "sha256-jK+wnIyPE8Bav0pzbvVisYYCzdRshYw1S2t0H3Pro5M=";
+  };
+
+  patches = [
+    ./add-missing-argument-to-the-proxy-style-initializer.patch
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    darkdetect
+  ];
+
+  nativeCheckInputs = [
+    pyqt5
+    pytest-mock
+    pytest-qt
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "qdarktheme"
+  ];
+
+  prePatch = ''
+    sed -i 's#darkdetect = ".*"#darkdetect = "*"#' pyproject.toml
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    export QT_PLUGIN_PATH="${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}"
+    export QT_QPA_PLATFORM_PLUGIN_PATH="${qt5.qtbase.bin}/lib/qt-${qt5.qtbase.version}/plugins";
+    export QT_QPA_PLATFORM=offscreen
+  '';
+
+  meta = with lib; {
+    description = "A flat dark theme for PySide and PyQt";
+    homepage = "https://pyqtdarktheme.readthedocs.io/en/stable";
+    license = licenses.mit;
+    maintainers = with maintainers; [ paveloom ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11042,6 +11042,8 @@ self: super: with self; {
       setuptools sip;
   };
 
+  pyqtdarktheme = callPackage ../development/python-modules/pyqtdarktheme { };
+
   pyqtdatavisualization = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtdatavisualization {
     inherit (self) buildPythonPackage pyqt5 pyqt-builder python pythonOlder
       setuptools sip;


### PR DESCRIPTION
## Description of changes

https://github.com/5yutan5/PyQtDarkTheme

Depends on https://github.com/NixOS/nixpkgs/pull/257434.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
