### PR TITLE
hypnotix: Add missing circles-flags

### DIFF
--- a/pkgs/applications/video/hypnotix/default.nix
+++ b/pkgs/applications/video/hypnotix/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , substituteAll
 , cinnamon
+, circle-flags
 , gettext
 , gobject-introspection
 , mpv
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace usr/lib/hypnotix/hypnotix.py \
       --replace __DEB_VERSION__ ${version} \
+      --replace /usr/share/circle-flags-svg ${circle-flags}/share/circle-flags-svg \
       --replace /usr/share/hypnotix $out/share/hypnotix
   '';
 

--- a/pkgs/by-name/ci/circle-flags/package.nix
+++ b/pkgs/by-name/ci/circle-flags/package.nix
@@ -1,0 +1,36 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, nix-update-script
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "circle-flags";
+  version = "2.7.0";
+
+  src = fetchFromGitHub {
+    owner = "HatScripts";
+    repo = "circle-flags";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-/+f5MDRW+tRH+jMtl3XuVPBShgy2PlD3NY+74mJa2Qk=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    mv flags $out/share/circle-flags-svg
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    homepage = "https://github.com/HatScripts/circle-flags";
+    description = "Collection of 400+ minimal circular SVG country and state flags";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bobby285271 ];
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

This fixes the log spam of "Couldn't find flag
/usr/share/circle-flags-svg/xx.svg" and adds missing
icons to the location list.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
