### PR TITLE
composefs: init at 1.0.0

### DIFF
--- a/pkgs/by-name/co/composefs/package.nix
+++ b/pkgs/by-name/co/composefs/package.nix
@@ -1,0 +1,101 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, autoreconfHook
+, pandoc
+, pkg-config
+, openssl
+, fuse3
+, yajl
+, libcap
+, libseccomp
+, python3
+, which
+, valgrind
+, erofs-utils
+, fsverity-utils
+, nix-update-script
+, testers
+
+, fuseSupport ? lib.meta.availableOn stdenv.hostPlatform fuse3
+, yajlSupport ? lib.meta.availableOn stdenv.hostPlatform yajl
+, enableValgrindCheck ? false
+, installExperimentalTools ? false
+}:
+# https://github.com/containers/composefs/issues/204
+assert installExperimentalTools -> (!stdenv.hostPlatform.isMusl);
+stdenv.mkDerivation (finalAttrs: {
+  pname = "composefs";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "composefs";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-OjayMhLc3otqQjHsbLN8nm9D9yGOifBcrSLixjnJmvE=";
+  };
+
+  strictDeps = true;
+  outputs = [ "out" "lib" "dev" ];
+
+  postPatch = lib.optionalString installExperimentalTools ''
+    sed -i "s/noinst_PROGRAMS +\?=/bin_PROGRAMS +=/g" tools/Makefile.am
+  '';
+
+  configureFlags = lib.optionals enableValgrindCheck [
+    (lib.enableFeature true "valgrind-test")
+  ];
+
+  nativeBuildInputs = [ autoreconfHook pandoc pkg-config ];
+  buildInputs = [ openssl ]
+    ++ lib.optional fuseSupport fuse3
+    ++ lib.optional yajlSupport yajl
+    ++ lib.filter (lib.meta.availableOn stdenv.hostPlatform) (
+    [
+      libcap
+      libseccomp
+    ]
+  );
+
+  # yajl is required to read the test json files
+  doCheck = true;
+  nativeCheckInputs = [ python3 which ]
+    ++ lib.optional enableValgrindCheck valgrind
+    ++ lib.optional fuseSupport fuse3
+    ++ lib.filter (lib.meta.availableOn stdenv.buildPlatform) [ erofs-utils fsverity-utils ];
+
+  preCheck = ''
+    patchShebangs --build tests/*dir tests/*.sh
+    substituteInPlace tests/*.sh \
+      --replace " /tmp" " $TMPDIR" \
+      --replace " /var/tmp" " $TMPDIR"
+  '' + lib.optionalString (stdenv.hostPlatform.isMusl || !yajlSupport) ''
+    # test relies on `composefs-from-json` tool
+    # MUSL: https://github.com/containers/composefs/issues/204
+    substituteInPlace tests/Makefile \
+      --replace " check-checksums" ""
+  '' + lib.optionalString (stdenv.hostPlatform.isMusl || enableValgrindCheck) ''
+    # seccomp sandbox breaks these tests
+    # MUSL: https://github.com/containers/composefs/issues/206
+    substituteInPlace tests/test-checksums.sh \
+      --replace "composefs-from-json" "composefs-from-json --no-sandbox"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "A file system for mounting container images";
+    homepage = "https://github.com/containers/composefs";
+    changelog = "https://github.com/containers/composefs/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [ gpl3Plus lgpl21Plus ];
+    maintainers = with lib.maintainers; [ kiskae ];
+    mainProgram = "mkcomposefs";
+    pkgConfigModules = [ "composefs" ];
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Clean PR based on #256892

## Description of changes

This is the first stable release of composefs. Starting now, we
guarantee a stable library ABI and a binary stable file format. The
later means that any image build from an identical lcfs_node tree and
identical write options, will produce a file that is binary identical
to a later run even with a different version. The same is true for
an mkcomposefs run with the same options.

Major changes since 0.1.4:

* Added a soversion to libcomposefs

* All required overlayfs xattr changes are now upstream and the
  corresponding image generation changes have been made in
  composefs. This includes support for escaping overlayfs xattrs and
  whiteouts for nested overlayfs mounts.

* fs-verity built-in signature support was dropped in favour of
  userspace signatures.

* The erofs iamges now uses the new bloom filter for faster xattr
   lookups. This is backward compatible and old erofs version still
   work (sans the speedup).

* Files can now be inlined in the erofs image to avoid overhead of
  using redirections for small files.

* There is a new API to regenerate a lcfs_node tree from a composefs
  image file.

* There is a new composefs-info tool that lets you dump info about
  images, including what objects it refers to and which ones are
  missing from a given basedir.

* Various fixes, cleanups and new tests

Signed-off-by: Alexander Larsson <alexl@redhat.com>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
