### PR TITLE
treewide: fail when `nixpkgs.config` is set with explicit `pkgs`, remove all `nixpkgs.config` usages in in-tree modules

### DIFF
--- a/nixos/doc/manual/configuration/customizing-packages.section.md
+++ b/nixos/doc/manual/configuration/customizing-packages.section.md
@@ -1,11 +1,7 @@
 # Customising Packages {#sec-customising-packages}
 
 Some packages in Nixpkgs have options to enable or disable optional
-functionality or change other aspects of the package. For instance, the
-Firefox wrapper package (which provides Firefox with a set of plugins
-such as the Adobe Flash player) has an option to enable the Google Talk
-plugin. It can be set in `configuration.nix` as follows:
-`nixpkgs.config.firefox.enableGoogleTalkPlugin = true;`
+functionality or change other aspects of the package.
 
 ::: {.warning}
 Unfortunately, Nixpkgs currently lacks a way to query available
@@ -13,7 +9,7 @@ configuration options.
 :::
 
 ::: {.note}
-Alternatively, many packages come with extensions one might add.
+For example, many packages come with extensions one might add.
 Examples include:
 - [`passExtensions.pass-otp`](https://search.nixos.org/packages/query=passExtensions.pass-otp)
 - [`python310Packages.requests`](https://search.nixos.org/packages/query=python310Packages.requests)

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -230,6 +230,8 @@
 
 - The `services.mtr-exporter.target` has been removed in favor of `services.mtr-exporter.jobs` which allows specifying multiple targets.
 
+- Setting `nixpkgs.config` options while providing an external `pkgs` instance will now raise an error instead of silently ignoring the options. NixOS modules no longer set `nixpkgs.config` to accomodate this. This specifically affects `services.locate`, `services.xserver.displayManager.lightdm.greeters.tiny` and `programs.firefox` NixOS modules. No manual intervention should be required in most cases, however, configurations relying on those modules affecting packages outside the system environment should switch to explicit overlays.
+
 ## Other Notable Changes {#sec-release-23.11-notable-changes}
 
 - The Cinnamon module now enables XDG desktop integration by default. If you are experiencing collisions related to xdg-desktop-portal-gtk you can safely remove `xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];` from your NixOS configuration.

--- a/nixos/modules/hardware/video/amdgpu-pro.nix
+++ b/nixos/modules/hardware/video/amdgpu-pro.nix
@@ -20,9 +20,6 @@ in
 {
 
   config = mkIf enabled {
-
-    nixpkgs.config.xorg.abiCompat = "1.20";
-
     services.xserver.drivers = singleton
       { name = "amdgpu"; modules = [ package ]; display = true; };
 

--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -230,9 +230,7 @@ in
         plocate = (mkIf isPLocate (mkMerge [ common plocate ]));
       };
 
-    nixpkgs.config = { locate.dbfile = cfg.output; };
-
-    environment.systemPackages = [ cfg.locate ];
+    environment.systemPackages = [ (cfg.locate.override { dbfile = cfg.output; }) ];
 
     environment.variables = mkIf (!isMorPLocate) { LOCATE_PATH = cfg.output; };
 

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -383,6 +383,16 @@ in
           the legacy definitions.
         '';
       }
+      {
+        assertion = opt.pkgs.isDefined -> cfg.config == {};
+        message = ''
+          Your system configures nixpkgs with an externally created instance.
+          `nixpkgs.config` options should be passed when creating the instance instead.
+
+          Current value:
+          ${lib.generators.toPretty { multiline = true; } opt.config}
+        '';
+      }
     ];
   };
 

--- a/nixos/modules/programs/browserpass.nix
+++ b/nixos/modules/programs/browserpass.nix
@@ -27,6 +27,6 @@ with lib;
       "opt/brave/native-messaging-hosts/${appId}".source = source "hosts/chromium";
       "opt/brave/policies/managed/${appId}".source = source "policies/chromium";
     };
-    nixpkgs.config.firefox.enableBrowserpass = true;
+    programs.firefox.wrapperConfig.enableBrowserpass = true;
   };
 }

--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -36,6 +36,12 @@ in
       ];
     };
 
+    wrapperConfig = mkOption {
+      type = types.attrs;
+      default = {};
+      description = mdDoc "Arguments to pass to Firefox wrapper";
+    };
+
     policies = mkOption {
       type = policyFormat.type;
       default = { };
@@ -227,16 +233,22 @@ in
         ] ++ optionals nmh.passff [
           passff-host
         ];
+        cfg = let
+          # copy-pasted from the wrapper; TODO: figure out fix
+          applicationName = cfg.package.binaryName or (lib.getName cfg.package);
+
+          nixpkgsConfig = config.nixpkgs.config.${applicationName} or {};
+          optionConfig = cfg.wrapperConfig;
+          nmhConfig = {
+            enableBrowserpass = nmh.browserpass;
+            enableBukubrow = nmh.bukubrow;
+            enableTridactylNative = nmh.tridactyl;
+            enableUgetIntegrator = nmh.ugetIntegrator;
+            enableFXCastBridge = nmh.fxCast;
+          };
+        in nixpkgsConfig // optionConfig // nmhConfig;
       })
     ];
-
-    nixpkgs.config.firefox = {
-      enableBrowserpass = nmh.browserpass;
-      enableBukubrow = nmh.bukubrow;
-      enableTridactylNative = nmh.tridactyl;
-      enableUgetIntegrator = nmh.ugetIntegrator;
-      enableFXCastBridge = nmh.fxCast;
-    };
 
     environment.etc =
       let

--- a/nixos/modules/services/desktops/gnome/gnome-browser-connector.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-browser-connector.nix
@@ -42,6 +42,6 @@ in
 
     services.dbus.packages = [ pkgs.gnome-browser-connector ];
 
-    nixpkgs.config.firefox.enableGnomeExtensions = true;
+    programs.firefox.wrapperConfig.enableGnomeExtensions = true;
   };
 }

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -282,9 +282,6 @@ in
 
       # Override GSettings schemas
       environment.sessionVariables.NIX_GSETTINGS_OVERRIDES_DIR = "${nixos-gsettings-desktop-schemas}/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas";
-
-       # If gnome is installed, build vim for gtk3 too.
-      nixpkgs.config.vim.gui = "gtk3";
     })
 
     (mkIf flashbackEnabled {

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -379,7 +379,7 @@ in
       # Update the start menu for each user that is currently logged in
       system.userActivationScripts.plasmaSetup = activationScript;
 
-      nixpkgs.config.firefox.enablePlasmaBrowserIntegration = true;
+      programs.firefox.wrapperConfig.enablePlasmaBrowserIntegration = true;
     })
 
     (mkIf (cfg.kwinrc != {}) {

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/tiny.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/tiny.nix
@@ -61,7 +61,7 @@ in
 
     services.xserver.displayManager.lightdm.greeters.gtk.enable = false;
 
-    nixpkgs.config.lightdm-tiny-greeter.conf =
+    services.xserver.displayManager.lightdm.greeter =
     let
       configHeader = ''
         #include <gtk/gtk.h>
@@ -69,13 +69,11 @@ in
         static const char *pass_text = "${cfg.label.pass}";
         static const char *session = "${dmcfg.defaultSession}";
       '';
+      config = optionalString (cfg.extraConfig != "") (configHeader + cfg.extraConfig);
+      package = pkgs.lightdm-tiny-greeter.override { conf = config; };
     in
-      optionalString (cfg.extraConfig != "")
-        (configHeader + cfg.extraConfig);
-
-    services.xserver.displayManager.lightdm.greeter =
       mkDefault {
-        package = pkgs.lightdm-tiny-greeter.xgreeters;
+        package = package.xgreeters;
         name = "lightdm-tiny-greeter";
       };
 

--- a/pkgs/applications/display-managers/lightdm-tiny-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-tiny-greeter/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, linkFarm, lightdm-tiny-greeter, fetchFromGitHub
-, pkg-config, lightdm, gtk3, glib, wrapGAppsHook, conf ? "" }:
+, pkg-config, lightdm, gtk3, glib, wrapGAppsHook, config, conf ? config.lightdm-tiny-greeter.conf or "" }:
 
 stdenv.mkDerivation rec {
   pname = "lightdm-tiny-greeter";

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,5 +1,4 @@
-{ abiCompat ? null,
-  callPackage,
+{ callPackage,
   lib, stdenv, makeWrapper, fetchurl, fetchpatch, fetchFromGitLab, buildPackages,
   automake, autoconf, libiconv, libtool, intltool, gettext, python3, perl,
   freetype, tradcpp, fontconfig, meson, ninja, ed, fontforge,
@@ -738,24 +737,18 @@ self: super:
   });
 
   xorgserver = with xorg; super.xorgserver.overrideAttrs (attrs_passed:
-    # exchange attrs if abiCompat is set
     let
-      version = lib.getVersion attrs_passed;
-      attrs =
-        if (abiCompat == null || lib.hasPrefix abiCompat version) then
-          attrs_passed // {
-            buildInputs = attrs_passed.buildInputs ++
-              lib.optional (libdrm != null) libdrm.dev;
-            postPatch = ''
-              for i in dri3/*.c
-              do
-                sed -i -e "s|#include <drm_fourcc.h>|#include <libdrm/drm_fourcc.h>|" $i
-              done
-            '';
-            meta = attrs_passed.meta // { mainProgram = "X"; };
-          }
-        else throw "unsupported xorg abiCompat ${abiCompat} for ${attrs_passed.name}";
-
+      attrs = attrs_passed // {
+        buildInputs = attrs_passed.buildInputs ++
+          lib.optional (libdrm != null) libdrm.dev;
+        postPatch = ''
+          for i in dri3/*.c
+          do
+            sed -i -e "s|#include <drm_fourcc.h>|#include <libdrm/drm_fourcc.h>|" $i
+          done
+        '';
+        meta = attrs_passed.meta // { mainProgram = "X"; };
+      };
     in attrs //
     (let
       version = lib.getVersion attrs;

--- a/pkgs/tools/misc/mlocate/default.nix
+++ b/pkgs/tools/misc/mlocate/default.nix
@@ -1,8 +1,6 @@
-{ lib, stdenv, fetchurl, config }:
+{ lib, stdenv, fetchurl, config, dbfile ? config.locate.dbfile or "/var/cache/locatedb" }:
 
-let
-  dbfile = lib.attrByPath [ "locate" "dbfile" ] "/var/cache/locatedb" config;
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "mlocate";
   version = "0.26";
 

--- a/pkgs/tools/misc/plocate/default.nix
+++ b/pkgs/tools/misc/plocate/default.nix
@@ -8,10 +8,8 @@
 , systemd
 , liburing
 , zstd
+, dbfile ? config.locate.dbfile or "/var/cache/locatedb"
 }:
-let
-  dbfile = lib.attrByPath [ "locate" "dbfile" ] "/var/cache/locatedb" config;
-in
 stdenv.mkDerivation rec {
   pname = "plocate";
   version = "1.1.19";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35647,9 +35647,7 @@ with pkgs;
 
   lightdm-mobile-greeter = callPackage ../applications/display-managers/lightdm-mobile-greeter { };
 
-  lightdm-tiny-greeter = callPackage ../applications/display-managers/lightdm-tiny-greeter {
-    conf = config.lightdm-tiny-greeter.conf or "";
-  };
+  lightdm-tiny-greeter = callPackage ../applications/display-managers/lightdm-tiny-greeter { };
 
   ly = callPackage ../applications/display-managers/ly { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27692,7 +27692,6 @@ with pkgs;
       inherit (buildPackages.darwin) bootstrap_cmds;
       udev = if stdenv.isLinux then udev else null;
       libdrm = if stdenv.isLinux then libdrm else null;
-      abiCompat = config.xorg.abiCompat or null; # `config` because we have no `xorg.override`
     };
 
     generatedPackages = lib.callPackageWith __splicedPackages ../servers/x11/xorg/default.nix { };


### PR DESCRIPTION
## Description of changes

This gun has been pointed at too many feet now. Kill it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
