### PR TITLE
yajl: 2.1.0 -> unstable-2022-04-20

### DIFF
--- a/pkgs/development/libraries/yajl/cmake-shared-static-fix.patch
+++ b/pkgs/development/libraries/yajl/cmake-shared-static-fix.patch
@@ -1,0 +1,89 @@
+From 768be8b9f98e30a8bd2d51576be9dfcf2cb838ea Mon Sep 17 00:00:00 2001
+From: Kiskae <Kiskae@users.noreply.github.com>
+Date: Tue, 26 Sep 2023 20:53:00 +0200
+Subject: [PATCH] simplify compilation of static/shared with cmake
+
+Signed-off-by: Kiskae <Kiskae@users.noreply.github.com>
+---
+ CMakeLists.txt              | 2 ++
+ example/CMakeLists.txt      | 2 +-
+ perf/CMakeLists.txt         | 2 +-
+ src/CMakeLists.txt          | 7 ++-----
+ test/parsing/CMakeLists.txt | 2 +-
+ 5 files changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 471eee13..9af25203 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,6 +16,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+ 
+ PROJECT(YetAnotherJSONParser C)
+ 
++option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
++
+ SET (YAJL_MAJOR 2)
+ SET (YAJL_MINOR 1)
+ SET (YAJL_MICRO 1)
+diff --git a/example/CMakeLists.txt b/example/CMakeLists.txt
+index 0a7f6220..62ddf14c 100644
+--- a/example/CMakeLists.txt
++++ b/example/CMakeLists.txt
+@@ -20,4 +20,4 @@ LINK_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
+ 
+ ADD_EXECUTABLE(parse_config ${SRCS})
+ 
+-TARGET_LINK_LIBRARIES(parse_config yajl_s)
++TARGET_LINK_LIBRARIES(parse_config yajl)
+diff --git a/perf/CMakeLists.txt b/perf/CMakeLists.txt
+index b438d7a1..924a2681 100644
+--- a/perf/CMakeLists.txt
++++ b/perf/CMakeLists.txt
+@@ -20,4 +20,4 @@ LINK_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
+ 
+ ADD_EXECUTABLE(perftest ${SRCS})
+ 
+-TARGET_LINK_LIBRARIES(perftest yajl_s)
++TARGET_LINK_LIBRARIES(perftest yajl)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 789ddf99..78875032 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -35,9 +35,7 @@ SET (pkgconfigDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib/pkgconfig
+ # set the output path for libraries
+ SET(LIBRARY_OUTPUT_PATH ${libDir})
+ 
+-ADD_LIBRARY(yajl_s STATIC ${SRCS} ${HDRS} ${PUB_HDRS})
+-
+-ADD_LIBRARY(yajl SHARED ${SRCS} ${HDRS} ${PUB_HDRS})
++ADD_LIBRARY(yajl ${SRCS} ${HDRS} ${PUB_HDRS})
+ 
+ #### setup shared library version number
+ SET_TARGET_PROPERTIES(yajl PROPERTIES
+@@ -69,7 +67,7 @@ FOREACH (header ${PUB_HDRS})
+ 
+   EXEC_PROGRAM(${CMAKE_COMMAND} ARGS -E copy_if_different ${header} ${incDir})
+ 
+-  ADD_CUSTOM_COMMAND(TARGET yajl_s POST_BUILD
++  ADD_CUSTOM_COMMAND(TARGET yajl POST_BUILD
+       COMMAND ${CMAKE_COMMAND} -E copy_if_different ${header} ${incDir})
+ ENDFOREACH (header ${PUB_HDRS})
+ 
+@@ -81,7 +79,6 @@ INSTALL(TARGETS yajl
+         RUNTIME DESTINATION lib${LIB_SUFFIX}
+         LIBRARY DESTINATION lib${LIB_SUFFIX}
+         ARCHIVE DESTINATION lib${LIB_SUFFIX})
+-INSTALL(TARGETS yajl_s ARCHIVE DESTINATION lib${LIB_SUFFIX})
+ INSTALL(FILES ${PUB_HDRS} DESTINATION include/yajl)
+ INSTALL(FILES ${incDir}/yajl_version.h DESTINATION include/yajl)
+ INSTALL(FILES ${pkgconfigDir}/yajl.pc DESTINATION lib${LIB_SUFFIX}/pkgconfig)
+diff --git a/test/parsing/CMakeLists.txt b/test/parsing/CMakeLists.txt
+index c22a3887..f445920d 100644
+--- a/test/parsing/CMakeLists.txt
++++ b/test/parsing/CMakeLists.txt
+@@ -20,4 +20,4 @@ LINK_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/../../${YAJL_DIST_NAME}/lib)
+ 
+ ADD_EXECUTABLE(yajl_test ${SRCS})
+ 
+-TARGET_LINK_LIBRARIES(yajl_test yajl_s)
++TARGET_LINK_LIBRARIES(yajl_test yajl)

--- a/pkgs/development/libraries/yajl/default.nix
+++ b/pkgs/development/libraries/yajl/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, cmake, which, testers }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "yajl";
   version = "unstable-2022-04-20";
 
@@ -18,6 +18,13 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake ];
 
+  doCheck = true;
+  nativeCheckInputs = [ which ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
   meta = {
     description = "Yet Another JSON Library";
     longDescription = ''
@@ -26,7 +33,8 @@ stdenv.mkDerivation {
     '';
     homepage = "http://lloyd.github.com/yajl/";
     license = lib.licenses.isc;
+    pkgConfigModules = [ "yajl" ];
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = with lib.maintainers; [ maggesi ];
   };
-}
+})

--- a/pkgs/development/libraries/yajl/default.nix
+++ b/pkgs/development/libraries/yajl/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "yajl";
-  version = "2.1.0";
+  version = "unstable-2022-04-20";
 
   src = fetchFromGitHub {
-    owner = "lloyd";
+    owner = "containers";
     repo = "yajl";
-    rev = "refs/tags/${version}";
-    sha256 = "00yj06drb6izcxfxfqlhimlrb089kka0w0x8k27pyzyiq7qzcvml";
+    rev = "49923ccb2143e36850bcdeb781e2bcdf5ce22f15";
+    hash = "sha256-9bMPA5FpyBp8fvG/kkT/MnhYtdqg3QzOnmDFXKwJVW0=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/yajl/default.nix
+++ b/pkgs/development/libraries/yajl/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation {
     hash = "sha256-9bMPA5FpyBp8fvG/kkT/MnhYtdqg3QzOnmDFXKwJVW0=";
   };
 
+  patches = [
+    # https://github.com/containers/yajl/pull/1
+    ./cmake-shared-static-fix.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   meta = {


### PR DESCRIPTION
## Description of changes

1. Changes source to https://github.com/containers/yajl since the original source hasn't seen any updates since 2015
2. Add a patch that strips out the shared library cmake target inside `pkgsStatic`
Fixes #257241
3. Add `testers.testMetaPkgConfig`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
