### PR TITLE
babashka: use upstream version of Clojure tools

### DIFF
--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -13,6 +13,7 @@
 , nativeImageBuildArgs ? [
     (lib.optionalString stdenv.isDarwin "-H:-CheckToolchain")
     "-H:Name=${executable}"
+    "-march=compatibility"
     "--verbose"
   ]
   # Extra arguments to be passed to the native-image

--- a/pkgs/development/interpreters/babashka/clojure-tools.nix
+++ b/pkgs/development/interpreters/babashka/clojure-tools.nix
@@ -1,0 +1,15 @@
+# This file tracks the Clojure tools version required by babashka.
+# See https://github.com/borkdude/deps.clj#deps_clj_tools_version for background.
+# The `updateScript` provided in default.nix takes care of keeping it in sync, as well.
+{ clojure
+, fetchurl
+}:
+clojure.overrideAttrs (previousAttrs: {
+  pname = "babashka-clojure-tools";
+  version = "1.11.1.1403";
+
+  src = fetchurl {
+    url = previousAttrs.src.url;
+    hash = "sha256-bVNHEEzpPanPF8pfDP51d13bxv9gZGzqczNmFQOk6zI=";
+  };
+})

--- a/pkgs/development/interpreters/babashka/default.nix
+++ b/pkgs/development/interpreters/babashka/default.nix
@@ -6,94 +6,109 @@
 , writeScript
 }:
 
-buildGraalvmNativeImage rec {
-  pname = "babashka-unwrapped";
-  version = "1.3.184";
+let
+  babashka-unwrapped = buildGraalvmNativeImage rec {
+    pname = "babashka-unwrapped";
+    version = "1.3.184";
 
-  src = fetchurl {
-    url = "https://github.com/babashka/babashka/releases/download/v${version}/babashka-${version}-standalone.jar";
-    sha256 = "sha256-O3pLELYmuuB+Bf1vHTWQ+u7Ymi3qYiMRpCwvEq+GeBQ=";
-  };
+    src = fetchurl {
+      url = "https://github.com/babashka/babashka/releases/download/v${version}/babashka-${version}-standalone.jar";
+      sha256 = "sha256-O3pLELYmuuB+Bf1vHTWQ+u7Ymi3qYiMRpCwvEq+GeBQ=";
+    };
 
-  graalvmDrv = graalvmCEPackages.graalvm-ce;
+    graalvmDrv = graalvmCEPackages.graalvm-ce;
 
-  executable = "bb";
+    executable = "bb";
 
-  nativeBuildInputs = [ removeReferencesTo ];
+    nativeBuildInputs = [ removeReferencesTo ];
 
-  extraNativeImageBuildArgs = [
-    "-H:+ReportExceptionStackTraces"
-    "--no-fallback"
-    "--native-image-info"
-    "--enable-preview"
-  ];
-
-  doInstallCheck = true;
-
-  installCheckPhase = ''
-    $out/bin/bb --version | grep '${version}'
-    $out/bin/bb '(+ 1 2)' | grep '3'
-    $out/bin/bb '(vec (dedupe *input*))' <<< '[1 1 1 1 2]' | grep '[1 2]'
-  '';
-
-  # As of v1.2.174, this will remove references to ${graalvmDrv}/conf/chronology,
-  # not sure the implications of this but this file is not available in
-  # graalvm-ce anyway.
-  postInstall = ''
-    remove-references-to -t ${graalvmDrv} $out/bin/${executable}
-  '';
-
-  passthru.updateScript = writeScript "update-babashka" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl common-updater-scripts jq
-
-    set -euo pipefail
-
-    readonly latest_version="$(curl \
-      ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
-      -s "https://api.github.com/repos/babashka/babashka/releases/latest" \
-      | jq -r '.tag_name')"
-
-    # v0.6.2 -> 0.6.2
-    update-source-version babashka "''${latest_version/v/}"
-  '';
-
-  meta = with lib; {
-    description = "A Clojure babushka for the grey areas of Bash";
-    longDescription = ''
-      The main idea behind babashka is to leverage Clojure in places where you
-      would be using bash otherwise.
-
-      As one user described it:
-
-          I’m quite at home in Bash most of the time, but there’s a substantial
-          grey area of things that are too complicated to be simple in bash, but
-          too simple to be worth writing a clj/s script for. Babashka really
-          seems to hit the sweet spot for those cases.
-
-      Goals:
-
-      - Low latency Clojure scripting alternative to JVM Clojure.
-      - Easy installation: grab the self-contained binary and run. No JVM needed.
-      - Familiarity and portability:
-        - Scripts should be compatible with JVM Clojure as much as possible
-        - Scripts should be platform-independent as much as possible. Babashka
-          offers support for linux, macOS and Windows.
-      - Allow interop with commonly used classes like java.io.File and System
-      - Multi-threading support (pmap, future, core.async)
-      - Batteries included (tools.cli, cheshire, ...)
-      - Library support via popular tools like the clojure CLI
-    '';
-    homepage = "https://github.com/babashka/babashka";
-    changelog = "https://github.com/babashka/babashka/blob/v${version}/CHANGELOG.md";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.epl10;
-    maintainers = with maintainers; [
-      bandresen
-      bhougland
-      DerGuteMoritz
-      jlesquembre
-      thiagokokada
+    extraNativeImageBuildArgs = [
+      "-H:+ReportExceptionStackTraces"
+      "--no-fallback"
+      "--native-image-info"
+      "--enable-preview"
     ];
+
+    doInstallCheck = true;
+
+    installCheckPhase = ''
+      $out/bin/bb --version | grep '${version}'
+      $out/bin/bb '(+ 1 2)' | grep '3'
+      $out/bin/bb '(vec (dedupe *input*))' <<< '[1 1 1 1 2]' | grep '[1 2]'
+    '';
+
+    # As of v1.2.174, this will remove references to ${graalvmDrv}/conf/chronology,
+    # not sure the implications of this but this file is not available in
+    # graalvm-ce anyway.
+    postInstall = ''
+      remove-references-to -t ${graalvmDrv} $out/bin/${executable}
+    '';
+
+    passthru.updateScript = writeScript "update-babashka" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl common-updater-scripts jq libarchive
+
+      set -euo pipefail
+      shopt -s inherit_errexit
+
+      latest_version="$(curl \
+        ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+        -fsL "https://api.github.com/repos/babashka/babashka/releases/latest" \
+        | jq -r '.tag_name')"
+
+      if [ "$(update-source-version babashka-unwrapped "''${latest_version/v/}" --print-changes)" = "[]" ]; then
+        # no need to update babashka.clojure-tools when babashka-unwrapped wasn't updated
+        exit 0
+      fi
+
+      clojure_tools_version=$(curl \
+        -fsL \
+        "https://github.com/babashka/babashka/releases/download/''${latest_version}/babashka-''${latest_version/v/}-standalone.jar" \
+        | bsdtar -qxOf - borkdude/deps.clj \
+        | ${babashka-unwrapped}/bin/bb -I -o -e "(or (some->> *input* (filter #(= '(def version) (take 2 %))) first last last last) (throw (ex-info \"Couldn't find expected '(def version ...)' form in 'borkdude/deps.clj'.\" {})))")
+
+      update-source-version babashka.clojure-tools "$clojure_tools_version" \
+        --file="pkgs/development/interpreters/babashka/clojure-tools.nix"
+    '';
+
+    meta = with lib; {
+      description = "A Clojure babushka for the grey areas of Bash";
+      longDescription = ''
+        The main idea behind babashka is to leverage Clojure in places where you
+        would be using bash otherwise.
+
+        As one user described it:
+
+            I’m quite at home in Bash most of the time, but there’s a substantial
+            grey area of things that are too complicated to be simple in bash, but
+            too simple to be worth writing a clj/s script for. Babashka really
+            seems to hit the sweet spot for those cases.
+
+        Goals:
+
+        - Low latency Clojure scripting alternative to JVM Clojure.
+        - Easy installation: grab the self-contained binary and run. No JVM needed.
+        - Familiarity and portability:
+          - Scripts should be compatible with JVM Clojure as much as possible
+          - Scripts should be platform-independent as much as possible. Babashka
+            offers support for linux, macOS and Windows.
+        - Allow interop with commonly used classes like java.io.File and System
+        - Multi-threading support (pmap, future, core.async)
+        - Batteries included (tools.cli, cheshire, ...)
+        - Library support via popular tools like the clojure CLI
+      '';
+      homepage = "https://github.com/babashka/babashka";
+      changelog = "https://github.com/babashka/babashka/blob/v${version}/CHANGELOG.md";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
+      license = licenses.epl10;
+      maintainers = with maintainers; [
+        bandresen
+        bhougland
+        DerGuteMoritz
+        jlesquembre
+        thiagokokada
+      ];
+    };
   };
-}
+in
+babashka-unwrapped


### PR DESCRIPTION
## Description of changes

As recommended by @borkdude[1], we should use the Clojure tools version included in a particular upstream release since the code might not always work with more recent versions.

[1]  https://github.com/borkdude/deps.clj/issues/113#issuecomment-1735805109

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NixOS/nixpkgs/257473)
<!-- Reviewable:end -->
