### PR TITLE
mecab: add support for the UTF-8 charset + refactor

### DIFF
--- a/pkgs/tools/text/mecab/base.nix
+++ b/pkgs/tools/text/mecab/base.nix
@@ -1,16 +1,13 @@
 { fetchurl }:
 
-{
-    version = "0.996";
+finalAttrs: {
+  version = "0.996";
 
-    src = fetchurl {
-      url = "https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE";
-      name = "mecab-0.996.tar.gz";
-      sha256 = "0ncwlqxl1hdn1x4v4kr2sn1sbbcgnhdphp0lcvk74nqkhdbk4wz0";
-    };
+  src = fetchurl {
+    url = "https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE";
+    name = "mecab-${finalAttrs.version}.tar.gz";
+    hash = "sha256-4HMyV4MTW3LmZhRceBu0j62lg9UiT7JJD7bBQDumnFk=";
+  };
 
-    buildPhase = ''
-      make
-      make check
-    '';
+  doCheck = true;
 }

--- a/pkgs/tools/text/mecab/base.nix
+++ b/pkgs/tools/text/mecab/base.nix
@@ -9,5 +9,9 @@ finalAttrs: {
     hash = "sha256-4HMyV4MTW3LmZhRceBu0j62lg9UiT7JJD7bBQDumnFk=";
   };
 
+  configureFlags = [
+    "--with-charset=utf8"
+  ];
+
   doCheck = true;
 }

--- a/pkgs/tools/text/mecab/default.nix
+++ b/pkgs/tools/text/mecab/default.nix
@@ -3,19 +3,19 @@
 let
   mecab-base = import ./base.nix { inherit fetchurl; };
 in
-stdenv.mkDerivation (mecab-base // {
-    pname = "mecab";
-    version = mecab-base.version;
+stdenv.mkDerivation (finalAttrs: ((mecab-base finalAttrs) // {
+  pname = "mecab";
 
-    postInstall = ''
-      sed -i 's|^dicdir = .*$|dicdir = ${mecab-ipadic}|' "$out/etc/mecabrc"
-    '';
+  postInstall = ''
+    sed -i 's|^dicdir = .*$|dicdir = ${mecab-ipadic}|' "$out/etc/mecabrc"
+  '';
 
-    meta = with lib; {
-      description = "Japanese morphological analysis system";
-      homepage = "http://taku910.github.io/mecab/";
-      license = licenses.bsd3;
-      platforms = platforms.unix;
-      maintainers = with maintainers; [ auntie ];
-    };
-})
+  meta = with lib; {
+    description = "Japanese morphological analysis system";
+    homepage = "http://taku910.github.io/mecab";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    mainProgram = "mecab";
+    maintainers = with maintainers; [ auntie paveloom ];
+  };
+}))

--- a/pkgs/tools/text/mecab/ipadic.nix
+++ b/pkgs/tools/text/mecab/ipadic.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ mecab-nodic ];
 
-  configurePhase = ''
-    ./configure --with-dicdir="$out"
-  '';
+  configureFlags = [
+    "--with-charset=utf8"
+    "--with-dicdir=${placeholder "out"}"
+  ];
 })

--- a/pkgs/tools/text/mecab/ipadic.nix
+++ b/pkgs/tools/text/mecab/ipadic.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, mecab-nodic }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mecab-ipadic";
   version = "2.7.0-20070801";
 
   src = fetchurl {
     url = "https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7MWVlSDBCSXZMTXM";
-    name = "mecab-ipadic-2.7.0-20070801.tar.gz";
-    sha256 = "08rmkvj0f0x6jq0axrjw2y5nam0mavv6x77dp9v4al0wi1ym4bxn";
+    name = "mecab-ipadic-${finalAttrs.version}.tar.gz";
+    hash = "sha256-ti9SfYgcUEV2uu2cbvZWFVRlixdc5q4AlqYDB+SeNSM=";
   };
 
   buildInputs = [ mecab-nodic ];
@@ -15,4 +15,4 @@ stdenv.mkDerivation {
   configurePhase = ''
     ./configure --with-dicdir="$out"
   '';
-}
+})

--- a/pkgs/tools/text/mecab/nodic.nix
+++ b/pkgs/tools/text/mecab/nodic.nix
@@ -3,7 +3,6 @@
 let
   mecab-base = import ./base.nix { inherit fetchurl; };
 in
-stdenv.mkDerivation (mecab-base // {
-    pname = "mecab-nodic";
-    version = mecab-base.version;
-})
+stdenv.mkDerivation (finalAttrs: ((mecab-base finalAttrs) // {
+  pname = "mecab-nodic";
+}))


### PR DESCRIPTION
## Description of changes

Make the output readable on most systems:

```
./result/bin/mecab
今日もしないとね。
今日    名詞,副詞可能,*,*,*,*,今日,キョウ,キョー
も      助詞,係助詞,*,*,*,*,も,モ,モ
し      動詞,自立,*,*,サ変・スル,未然形,する,シ,シ
ない    助動詞,*,*,*,特殊・ナイ,基本形,ない,ナイ,ナイ
と      助詞,接続助詞,*,*,*,*,と,ト,ト
ね      助詞,終助詞,*,*,*,*,ね,ネ,ネ
。      記号,句点,*,*,*,*,。,。,。
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
