### PR TITLE
midisheetmusic: fix tests, migrate to by-name, remove dependencies on dotnetPackages

### DIFF
--- a/pkgs/by-name/mi/midisheetmusic/package.nix
+++ b/pkgs/by-name/mi/midisheetmusic/package.nix
@@ -3,14 +3,33 @@
   stdenv,
   fetchurl,
   mono,
-  dotnetPackages,
+  mkNugetDeps,
   makeWrapper,
+  makeFontsConf,
   gtk2,
   cups,
   timidity,
 }:
 
 let
+  deps = mkNugetDeps {
+    name = "midisheetmusic-deps";
+    nugetDeps =
+      { fetchNuGet }:
+      [
+        (fetchNuGet {
+          pname = "NUnit.Console";
+          version = "3.0.1";
+          hash = "sha256-FkzpEk12msmUp5I05ZzlGiG+UInoYhBmar/vB5Gt4H8=";
+        })
+        (fetchNuGet {
+          pname = "NUnit";
+          version = "2.6.4";
+          hash = "sha256-Kkft3QO9T5WwsvyPRNGT2nut7RS7OWArDjIYxvwA8qU=";
+        })
+      ];
+  };
+
   version = "2.6";
 in
 stdenv.mkDerivation {
@@ -22,7 +41,6 @@ stdenv.mkDerivation {
     sha256 = "05c6zskj50g29f51lx8fvgzsi3f31z01zj6ssjjrgr7jfs7ak70p";
   };
 
-  nativeCheckInputs = (with dotnetPackages; [ NUnitConsole ]);
   nativeBuildInputs = [
     mono
     makeWrapper
@@ -31,25 +49,32 @@ stdenv.mkDerivation {
   buildPhase = ''
     for i in Classes/MidiPlayer.cs Classes/MidiSheetMusic.cs
     do
-      substituteInPlace $i --replace "/usr/bin/timidity" "${timidity}/bin/timidity"
+      substituteInPlace $i --replace-fail "/usr/bin/timidity" "${timidity}/bin/timidity"
     done
 
     ./build.sh
   '';
 
-  # include missing file with unit tests for building
-  # switch from mono nunit dll to standalone dll otherwise mono compiler barks
-  # run via nunit3 console, because mono nunit console wants access $HOME
+  doCheck = true;
+
   checkPhase = ''
+    # Resolves the warning "Fontconfig error: No writable cache directories"
+    export XDG_CACHE_HOME="$(mktemp -d)"
+
+    # Adds one file with tests that's missing from compiliation
+    # Makes sure NUnit framework from NuGet can be found
     substituteInPlace UnitTestDLL.csproj \
-      --replace "</Compile>" '</Compile><Compile Include="Classes\UnitTest.cs"/>' \
-      --replace nunit.framework.dll "${dotnetPackages.NUnit}/lib/dotnet/NUnit/nunit.framework.dll"
+      --replace-fail '</Compile>' '</Compile><Compile Include="Classes\UnitTest.cs"/>' \
+      --replace-fail 'nunit.framework.dll' '${deps}/share/nuget/packages/nunit/2.6.4/lib/nunit.framework.dll'
     ./build_unit_test.sh
-    nunit3-console bin/Debug/UnitTest.dll
+
+    # 2 tests are still failing, we exclude them for now
+    mono ${deps}/share/nuget/packages/nunit.console/3.0.1/tools/nunit3-console.exe bin/Debug/UnitTest.dll \
+      --where "test != 'MidiFileTest.TestChangeSoundTrack' && test != 'MidiFileTest.TestChangeSoundPerChannelTracks'"
   '';
 
-  # 2 tests of 47 are still failing
-  doCheck = false;
+  # This fixes tests that fail because of missing fonts
+  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
 
   installPhase = ''
     mkdir -p $out/share/applications $out/share/pixmaps $out/bin
@@ -69,12 +94,12 @@ stdenv.mkDerivation {
       --add-flags $out/bin/.MidiSheetMusic.exe
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Convert MIDI Files to Piano Sheet Music for two hands";
     mainProgram = "midisheetmusic.mono.exe";
     homepage = "http://midisheetmusic.com";
-    license = licenses.gpl2;
-    maintainers = [ ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.mdarocha ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

Helps with #234775
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
