### PR TITLE
[Backport release-23.05] librewolf-unwrapped: 116.0.2-1 -> 117.0.1-1

### DIFF
--- a/pkgs/applications/networking/browsers/librewolf/librewolf.nix
+++ b/pkgs/applications/networking/browsers/librewolf/librewolf.nix
@@ -29,9 +29,9 @@ rec {
     sed -i '/MOZ_NORMANDY/ s/True/False/' browser/moz.configure
   '';
 
-  extraPrefsFiles = [ "${source}/submodules/settings/librewolf.cfg" ];
+  extraPrefsFiles = [ "${src.settings}/librewolf.cfg" ];
 
-  extraPoliciesFiles = [ "${source}/submodules/settings/distribution/policies.json" ];
+  extraPoliciesFiles = [ "${src.settings}/distribution/policies.json" ];
 
   extraPassthru = {
     librewolf = { inherit src extraPatches; };

--- a/pkgs/applications/networking/browsers/librewolf/src.json
+++ b/pkgs/applications/networking/browsers/librewolf/src.json
@@ -1,11 +1,15 @@
 {
-  "packageVersion": "116.0.2-1",
+  "packageVersion": "117.0.1-1",
   "source": {
-    "rev": "116.0.2-1",
-    "sha256": "08q50yjb8q168zb2y4iajjqd9ygbpywwr9i4vfn67wchqlsc1mrp"
+    "rev": "117.0.1-1",
+    "sha256": "06j85b6v54vxj99hgrlibpsg6f8w8cqj912vz7gwyfa17pawax9z"
+  },
+  "settings": {
+    "rev": "9c862f06f970d69e00c1035e0d4774fb44fd84a6",
+    "sha256": "0ay58wrhfn0b56748phpn0ahz11ls9y8d2fd1z4zrj6dv398vlmb"
   },
   "firefox": {
-    "version": "116.0.2",
-    "sha512": "2c0ae18672fe22c75002744831130e13da764f83726951e5b58cfe74f7f473e22634ce08ebc11a98bac5baec0a4ac099a3a350a8b756af9c5bea6d5f4432da6d"
+    "version": "117.0.1",
+    "sha512": "1583b0ad3b3b17c59bfbfb3e416074766327d0b926ef4f6c6b1e3b2d7cf6a18dec592b7d17fab9493ba1506f3540a02277096d28616dd29b6e7b9e93905f2071"
   }
 }

--- a/pkgs/applications/networking/browsers/librewolf/src.nix
+++ b/pkgs/applications/networking/browsers/librewolf/src.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, fetchFromGitLab }:
+{ lib, fetchurl, fetchFromGitLab, fetchFromGitea }:
 let src = lib.importJSON ./src.json;
 in
 {
@@ -8,6 +8,12 @@ in
     repo = "browser/source";
     fetchSubmodules = true;
     inherit (src.source) rev sha256;
+  };
+  settings = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "librewolf";
+    repo = "settings";
+    inherit (src.settings) rev sha256;
   };
   firefox = fetchurl {
     url =

--- a/pkgs/applications/networking/browsers/librewolf/update.nix
+++ b/pkgs/applications/networking/browsers/librewolf/update.nix
@@ -57,9 +57,18 @@ writeScript "update-librewolf" ''
   ffHash=$(grep '\.source\.tar\.xz$' "$HOME"/shasums | grep '^[^ ]*' -o)
   echo "ffHash=$ffHash"
 
+  # upstream does not specify settings rev, so just get the latest. see https://github.com/NixOS/nixpkgs/issues/252276
+  settingsRev=$(curl 'https://codeberg.org/api/v1/repos/librewolf/settings/commits?sha=master&limit=1' | jq -r .[0].sha)
+  echo "settingsRev=$settingsRev"
+  repoUrl=https://codeberg.org/librewolf/settings
+  nix-prefetch-git $repoUrl --quiet --rev $settingsRev > $prefetchOut
+  settingsSha256=$(jq -r .sha256 < $prefetchOut)
+
   jq ".source.rev = \"$latestTag\"" $srcJson | sponge $srcJson
   jq ".source.sha256 = \"$srcHash\"" $srcJson | sponge $srcJson
   jq ".firefox.version = \"$ffVersion\"" $srcJson | sponge $srcJson
   jq ".firefox.sha512 = \"$ffHash\"" $srcJson | sponge $srcJson
   jq ".packageVersion = \"$lwVersion\"" $srcJson | sponge $srcJson
+  jq ".settings.rev = \"$settingsRev\"" $srcJson | sponge $srcJson
+  jq ".settings.sha256 = \"$settingsSha256\"" $srcJson | sponge $srcJson
 ''


### PR DESCRIPTION
## Description of changes
- Backport of #257348

(cherry picked from commit b73f61061c77481ad5ee84eded5551b4d00961f0)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
