### PR TITLE
nftables: fix python module lookup for libnftables

### DIFF
--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -35,6 +35,13 @@ stdenv.mkDerivation rec {
       python3.pkgs.setuptools
     ];
 
+  patches = [ ./fix-py-libnftables.patch ];
+
+  postPatch = ''
+    substituteInPlace "py/src/nftables.py" \
+      --subst-var-by "out" "$out"
+  '';
+
   configureFlags = [
     "--with-json"
     (lib.withFeatureAs withCli "cli" "editline")

--- a/pkgs/os-specific/linux/nftables/fix-py-libnftables.patch
+++ b/pkgs/os-specific/linux/nftables/fix-py-libnftables.patch
@@ -1,0 +1,13 @@
+diff --git a/py/src/nftables.py b/py/src/nftables.py
+index f1e43ade..9adcd1be 100644
+--- a/py/src/nftables.py
++++ b/py/src/nftables.py
+@@ -69,7 +69,7 @@ class Nftables:
+ 
+     validator = None
+ 
+-    def __init__(self, sofile="libnftables.so.1"):
++    def __init__(self, sofile="@out@/lib/libnftables.so.1"):
+         """Instantiate a new Nftables class object.
+ 
+         Accepts a shared object file to open, by default standard search path


### PR DESCRIPTION
## Description of changes

The default parameter for Nftables class relies on Python looking via default search path, which will not work with Nix.

This commit hardcode the path into the module to handle software using this default parameter (eg. firewalld).

Splitted off #205380 in hopes of getting this in quickly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
