### PR TITLE
[exploratory] Module system `types.record`, `types.fix`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -84,7 +84,7 @@ let
       mapAttrs' mapAttrsToList concatMapAttrs mapAttrsRecursive mapAttrsRecursiveCond
       genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
-      recursiveUpdate matchAttrs overrideExisting showAttrPath getOutput getBin
+      recursiveUpdate removeAttrs matchAttrs overrideExisting showAttrPath getOutput getBin
       getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProductOfSets
       updateManyAttrsByPath;

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -64,6 +64,33 @@ checkConfigError() {
     fi
 }
 
+# record field
+checkConfigOutput '^"Alice"$' config.people.alice.name ./declare-record.nix ./define-record-alice.nix ./define-record-bob.nix
+checkConfigOutput '^2019$' config.people.bob.nixerSince ./declare-record.nix ./define-record-alice.nix ./define-record-bob.nix
+
+# record field type error
+checkConfigError 'A definition for option .people.mallory.nixerSince. is not of type .signed integer.. Definition values' config.people.mallory.nixerSince ./declare-record.nix ./define-record-mallory.nix
+checkConfigError 'define-record-mallory.nix.: "beginning of time"' config.people.mallory.nixerSince ./declare-record.nix ./define-record-mallory.nix
+
+# record field default
+checkConfigOutput '^true$' config.people.bob.isCool ./declare-record.nix ./define-record-alice.nix ./define-record-bob.nix
+
+# record field bad default definition
+checkConfigError 'In .the default value of option people.mallory.: "yeah"' config.people.mallory.isCool ./declare-record-bad-default.nix ./define-record-mallory.nix
+checkConfigError 'A definition for option .people.mallory.isCool. is not of type .boolean.. Definition values:' config.people.mallory.isCool ./declare-record-bad-default.nix ./define-record-mallory.nix
+
+# record field works in presence of wildcard
+checkConfigOutput '^2016$' config.people.alice.nixerSince ./declare-record-wildcard.nix ./define-record-alice-prefs.nix
+
+# record wildcard field
+checkConfigOutput '^true$' config.people.alice.mechKeyboard ./declare-record-wildcard.nix ./define-record-alice-prefs.nix
+
+
+# fix
+checkConfigOutput '"bobby"' config.people.lilbob.name ./fixpoint.nix
+
+if false; then
+
 # Shorthand meta attribute does not duplicate the config
 checkConfigOutput '^"one two"$' config.result ./shorthand-meta.nix
 
@@ -461,6 +488,8 @@ checkConfigOutput '^34|23$' options.submoduleLine34.declarationPositions.0.line 
 checkConfigOutput '^34|23$' options.submoduleLine34.declarationPositions.1.line ./declaration-positions.nix
 # nested options work
 checkConfigOutput '^30$' options.nested.nestedLine30.declarationPositions.0.line ./declaration-positions.nix
+
+fi
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules/declare-record-bad-default.nix
+++ b/lib/tests/modules/declare-record-bad-default.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+
+  person = types.record {
+    fields = {
+      nixerSince = mkOption {
+        type = types.int;
+      };
+      name = mkOption {
+        type = types.str;
+      };
+      isCool = mkOption {
+        type = types.bool;
+        default = "yeah";
+      };
+    };
+  };
+
+in {
+  options.people = mkOption {
+    type = types.attrsOf person;
+  };
+}

--- a/lib/tests/modules/declare-record-wildcard.nix
+++ b/lib/tests/modules/declare-record-wildcard.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+
+  person = types.record {
+    fields = {
+      nixerSince = mkOption {
+        type = types.int;
+      };
+      name = mkOption {
+        type = types.str;
+      };
+    };
+    wildcard = mkOption {
+      type = types.bool;
+    };
+  };
+
+in {
+  options.people = mkOption {
+    type = types.attrsOf person;
+  };
+}

--- a/lib/tests/modules/declare-record.nix
+++ b/lib/tests/modules/declare-record.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+
+  person = types.record {
+    fields = {
+      nixerSince = mkOption {
+        type = types.int;
+      };
+      name = mkOption {
+        type = types.str;
+      };
+      isCool = mkOption {
+        type = types.bool;
+        default = true;
+      };
+    };
+  };
+
+in {
+  options.people = mkOption {
+    type = types.attrsOf person;
+  };
+}

--- a/lib/tests/modules/define-record-alice-prefs.nix
+++ b/lib/tests/modules/define-record-alice-prefs.nix
@@ -1,0 +1,9 @@
+{ lib, ... }: {
+  people.alice = {
+    nixerSince = 2016;
+    name = "Alice";
+    hiRes = true;
+    mechKeyboard = true;
+    spiders = false;
+  };
+}

--- a/lib/tests/modules/define-record-alice.nix
+++ b/lib/tests/modules/define-record-alice.nix
@@ -1,0 +1,6 @@
+{
+  people.alice = {
+    nixerSince = 2016;
+    name = "Alice";
+  };
+}

--- a/lib/tests/modules/define-record-bob.nix
+++ b/lib/tests/modules/define-record-bob.nix
@@ -1,0 +1,6 @@
+{
+  people.bob = {
+    nixerSince = 2019;
+    name = "Bob";
+  };
+}

--- a/lib/tests/modules/define-record-mallory.nix
+++ b/lib/tests/modules/define-record-mallory.nix
@@ -1,0 +1,6 @@
+{
+  people.mallory = {
+    nixerSince = "beginning of time";
+    name = "Bobby";
+  };
+}

--- a/lib/tests/modules/fixpoint.nix
+++ b/lib/tests/modules/fixpoint.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+let
+  inherit (lib) types mkOption;
+
+  person = types.record {
+    fields = {
+      name = mkOption { type = lib.types.str; };
+      age = mkOption { type = lib.types.int; };
+    };
+  };
+
+  bobber = { value }: {
+    name = if value.age < 10 then "bobby" else "bob";
+  };
+in
+{
+  options = {
+    people = mkOption {
+      type = types.attrsOf (types.fix person);
+      default = {};
+    };
+  };
+  config = {
+    people.bob = lib.mkMerge [ { age = 23; } bobber ];
+    people.lilbob = lib.mkMerge [ { age = 3; } bobber ];
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -913,7 +913,9 @@ rec {
     # Augment the given type with an additional type check function.
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 
-  };
+  }
+  // import ./types/fix.nix { inherit lib; }
+  // import ./types/record.nix { inherit lib; };
 };
 
 in outer_types // outer_types.types

--- a/lib/types/fix.nix
+++ b/lib/types/fix.nix
@@ -1,0 +1,29 @@
+{ lib }:
+
+let
+  inherit (lib) toFunction mkOptionType
+    optionDescriptionPhrase isFunction mergeDefinitions defaultFunctor;
+
+  # TODO: should this be a type or a "property"? (i.e. one of `mkIf`, `mkMerge`, etc)
+  fix = t: mkOptionType {
+    name = "fixpoint of ${t.name}";
+    description = t.description;
+    descriptionClass = "composite";
+    check = v: isFunction v || t.check v;
+    merge = loc: defs:
+      let
+        # TODO: facilities elsewhere for wiring `options` and/or other "meta" info into this.
+        args = { value = r; };
+        r = (mergeDefinitions loc t (map (fn: { inherit (fn) file; value = toFunction fn.value args; }) defs)).mergedValue;
+      in r;
+    getSubOptions = prefix: t.getSubOptions prefix;
+    getSubModules = t.getSubModules;
+    substSubModules = m: fix (t.substSubModules m);
+    functor = defaultFunctor "fix" // { inherit t; };
+    nestedTypes.t = t;
+  };
+
+in
+{
+  inherit fix;
+}

--- a/lib/types/record.nix
+++ b/lib/types/record.nix
@@ -1,0 +1,86 @@
+{ lib }:
+
+let
+  inherit (lib)
+    mapAttrs zipAttrsWith removeAttrs attrNames showOption
+    mergeDefinitions mkOptionType isAttrs
+    ;
+
+  record = args@{ fields, wildcard ? null }:
+    let
+      fields =
+        mapAttrs
+          (name: value: 
+            if value._type or null != "option"
+            then throw "Record field `${lib.escapeNixIdentifier name}` must be declared with `mkOption`."
+            else if value?apply then throw "In field ${lib.escapeNixIdentifier name} records do not support options with `apply`"
+            else if value?readOnly then throw "In field ${lib.escapeNixIdentifier name} records do not support options with `readOnly`"
+            else value)
+          args.fields;
+      wildcard =
+        if args.wildcard or null == null
+        then null
+        else if args.wildcard._type or null != "option"
+        then throw "Record wildcard must be declared with `mkOption`."
+        else if args.wildcard?apply
+        then throw "Records do not support options with `apply`, but wildcard has `apply`."
+        else args.wildcard;
+    in
+    mkOptionType {
+      name = "record";
+      description = if wildcard == null then "record" else "open record of ${wildcard.description}";
+      descriptionClass = if wildcard == null then "noun" else "composite";
+      check = isAttrs;
+      merge = loc: defs:
+        let
+          data = zipAttrsWith
+            (name: values: values)
+            (map
+              (def: mapAttrs (_fieldName: fieldValue: { inherit (def) file; value = fieldValue; }) def.value)
+              defs);
+          requiredFieldValues =
+            mapAttrs
+              (fieldName: fieldOption:
+                builtins.addErrorContext ("while evaluating the field `${fieldName}' of option `${showOption loc}'") (
+                  (mergeDefinitions
+                    (loc ++ [fieldName])
+                    fieldOption.type
+                    (data.${fieldName} or [] ++
+                      (if fieldOption?default
+                      then [{ value = fieldOption.default; file = "the default value of option ${showOption loc}"; }]
+                      else []))
+                  ).mergedValue
+                )
+              )
+              fields;
+          extraData = removeAttrs data (attrNames fields);
+        in
+          if wildcard == null
+          then
+            if extraData == {}
+            then requiredFieldValues
+            else throw "A definition for option `${showOption loc}' has an unknown field."
+          else
+            requiredFieldValues //
+              mapAttrs
+                (fieldName: fieldDefs:
+                  builtins.addErrorContext ("while evaluating the wildcard field `${fieldName}' of option `${showOption loc}'") (
+                    (mergeDefinitions
+                      (loc ++ [fieldName])
+                      wildcard.type
+                      fieldDefs
+                    ).mergedValue
+                  )
+                )
+                extraData;
+      nestedTypes = fields // {
+        # potential collision with `_wildcard` field
+        _wildcard = wildcard;
+      };
+    };
+
+in
+# public
+{
+  inherit record;
+}


### PR DESCRIPTION
## Description of changes

An exploratory PR to help me and others understand the module system design space.

The `submodule` type (or `evalModules`) can be thought of as a combination of
- trees of options
- a fixpoint

Splitting these concepts out might
- make the module system easier to understand
- speed it up by removing unneeded features, such as fixpoints in submodules that are purely data
- lead to interesting insights

Observations so far:

- The submodule fixpoint is not a fixpoint of merely the `config`, but also `options`.
The option type interface is currently not conducive to the transfer of any kind of metadata. This also plagues solutions for built-in assertions and warnings.

- `record` and `fix` were easy to implement. I can't imagine implementing `submodule` in a remotely similar time frame.

This was written at [nix.camp :camping: ](https://nix.camp).

Could implement https://github.com/NixOS/nixpkgs/issues/158598 except not the `types.fix` part of module evaluation this PR was originally going for.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
