### PR TITLE
python3Packages.pythonImportsCheckHook: restrict to propagated build inputs

### DIFF
--- a/pkgs/applications/misc/raiseorlaunch/default.nix
+++ b/pkgs/applications/misc/raiseorlaunch/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
 
   # no tests
   doCheck = false;
-  pythonImportsCheck = [ "raiseorlaunch" ];
+  pythonImportsExtrasCheck = [ "raiseorlaunch" ];
 
   meta = with lib; {
     maintainers = with maintainers; [ winpat ];

--- a/pkgs/applications/radio/openwebrx/default.nix
+++ b/pkgs/applications/radio/openwebrx/default.nix
@@ -17,6 +17,10 @@ let
       sha256 = "1j80zclg1cl5clqd00qqa16prz7cyc32bvxqz2mh540cirygq24w";
     };
 
+    propagatedBuildInputs = [
+      setuptools # needed for 'pkg_resources'
+    ];
+
     pythonImportsCheck = [ "js8py" "test" ];
 
     meta = with lib; {

--- a/pkgs/applications/science/misc/nextinspace/default.nix
+++ b/pkgs/applications/science/misc/nextinspace/default.nix
@@ -31,7 +31,7 @@ python3.pkgs.buildPythonApplication rec {
     requests-mock
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "nextinspace"
   ];
 

--- a/pkgs/applications/version-management/datalad/default.nix
+++ b/pkgs/applications/version-management/datalad/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, installShellFiles, python3, git, git-annex }:
+{ lib, stdenv, fetchFromGitHub, installShellFiles, python3, git, git-annex, less }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "datalad";
@@ -69,13 +69,16 @@ python3.pkgs.buildPythonApplication rec {
     installShellCompletion --cmd datalad \
          --bash <($out/bin/datalad shell-completion) \
          --zsh  <($out/bin/datalad shell-completion)
-    wrapProgram $out/bin/datalad --prefix PYTHONPATH : "$PYTHONPATH"
+    wrapProgram $out/bin/datalad \
+      --prefix PYTHONPATH : "$program_PYTHONPATH" \
+      --prefix PATH : "${git}/bin:${less}/bin"
   '';
 
   # no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "datalad" ];
+  # needs git in PATH
+  pythonImportsExtrasCheck = [ "datalad" ];
 
   meta = with lib; {
     description = "Keep code, data, containers under control with git and git-annex";

--- a/pkgs/development/python-modules/aiokef/default.nix
+++ b/pkgs/development/python-modules/aiokef/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , pytestCheckHook
 , pythonOlder
+, setuptools
 , tenacity
 }:
 
@@ -26,6 +27,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
+    setuptools
     async-timeout
     tenacity
   ];

--- a/pkgs/development/python-modules/aiomisc-pytest/default.nix
+++ b/pkgs/development/python-modules/aiomisc-pytest/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     aiomisc
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "aiomisc_pytest"
   ];
 

--- a/pkgs/development/python-modules/aiosql/default.nix
+++ b/pkgs/development/python-modules/aiosql/default.nix
@@ -4,6 +4,7 @@
 , poetry-core
 , pytestCheckHook
 , sphinxHook
+, setuptools
 , sphinx-rtd-theme
 }:
 
@@ -27,6 +28,10 @@ buildPythonPackage rec {
     sphinxHook
     poetry-core
     sphinx-rtd-theme
+  ];
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
   ];
 
   pythonImportsCheck = [ "aiosql" ];

--- a/pkgs/development/python-modules/altgraph/default.nix
+++ b/pkgs/development/python-modules/altgraph/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -13,6 +14,10 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "ad33358114df7c9416cdb8fa1eaa5852166c505118717021c6a8c7c7abbd03dd";
   };
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+  ];
 
   pythonImportsCheck = [ "altgraph" ];
 

--- a/pkgs/development/python-modules/apispec-webframeworks/default.nix
+++ b/pkgs/development/python-modules/apispec-webframeworks/default.nix
@@ -1,4 +1,5 @@
 { lib
+, setuptools
 , apispec
 , bottle
 , buildPythonPackage
@@ -25,6 +26,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     apispec
   ] ++ apispec.optional-dependencies.yaml;
 

--- a/pkgs/development/python-modules/aresponses/default.nix
+++ b/pkgs/development/python-modules/aresponses/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "aresponses"
   ];
 
@@ -56,4 +56,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ makefu ];
   };
 }
-

--- a/pkgs/development/python-modules/asdf/default.nix
+++ b/pkgs/development/python-modules/asdf/default.nix
@@ -16,6 +16,7 @@
 , pythonOlder
 , pyyaml
 , semantic-version
+, setuptools
 , setuptools-scm
 }:
 
@@ -58,6 +59,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     asdf-standard
     asdf-transform-schemas
     jmespath

--- a/pkgs/development/python-modules/astropy-extension-helpers/default.nix
+++ b/pkgs/development/python-modules/astropy-extension-helpers/default.nix
@@ -6,6 +6,7 @@
 , pytestCheckHook
 , pythonOlder
 , pip
+, setuptools
 , setuptools-scm
 , wheel
 }:
@@ -35,6 +36,10 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     setuptools-scm
     wheel
+  ];
+
+  propagatedBuildInputs = [
+    setuptools
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/augmax/default.nix
+++ b/pkgs/development/python-modules/augmax/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   # jaxlib is necessary for the pythonImportsCheckPhase.
   nativeCheckInputs = [ jaxlib ];
 
-  pythonImportsCheck = [ "augmax" ];
+  pythonImportsExtrasCheck = [ "augmax" ];
 
   meta = with lib; {
     description = "Efficiently Composable Data Augmentation on the GPU with Jax";

--- a/pkgs/development/python-modules/authheaders/default.nix
+++ b/pkgs/development/python-modules/authheaders/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     authres
     dnspython
     dkimpy

--- a/pkgs/development/python-modules/bagit/default.nix
+++ b/pkgs/development/python-modules/bagit/default.nix
@@ -4,6 +4,7 @@
 , gettext
 , mock
 , pytestCheckHook
+, setuptools
 , setuptools-scm
 }:
 
@@ -21,6 +22,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [ gettext setuptools-scm ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  propagatedBuildInputs = [ setuptools ]; # needed for 'pkg_resources'
 
   nativeCheckInputs = [
     mock

--- a/pkgs/development/python-modules/betterproto/default.nix
+++ b/pkgs/development/python-modules/betterproto/default.nix
@@ -3,6 +3,7 @@
 , lib
 , pythonOlder
 , poetry-core
+, setuptools
 , grpclib
 , python-dateutil
 , black
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     grpclib
     python-dateutil
   ];

--- a/pkgs/development/python-modules/boschshcpy/default.nix
+++ b/pkgs/development/python-modules/boschshcpy/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, setuptools
 , cryptography
 , fetchFromGitHub
 , getmac
@@ -23,6 +24,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     cryptography
     getmac
     requests

--- a/pkgs/development/python-modules/boxx/default.nix
+++ b/pkgs/development/python-modules/boxx/default.nix
@@ -29,6 +29,11 @@ buildPythonPackage rec {
     hash = "sha256-7A5qFpISrjVrqQfKk6BPb7RhDWd9f90eF3bku+LsCcc=";
   };
 
+  postPatch = ''
+    substituteInPlace boxx/ylsys.py \
+      --replace "os.getenv('HOME')" "os.getenv('HOME', \"\")"
+  '';
+
   propagatedBuildInputs = [
     matplotlib
     scikit-image

--- a/pkgs/development/python-modules/bsuite/default.nix
+++ b/pkgs/development/python-modules/bsuite/default.nix
@@ -11,11 +11,13 @@
 , dm-env
 , plotnine
 , scikit-image
+, six
 , dm-tree
 , patsy
 , tensorflow-probability
 , dm-haiku
 , statsmodels
+, numpy
 , mizani
 , trfl
 , optax
@@ -34,19 +36,21 @@ let bsuite = buildPythonPackage rec {
     hash = "sha256-ak9McvXl7Nz5toUaPaRaJek9lurxiQiIW209GnZEjX0=";
   };
 
-  buildInputs = [
+  propagatedBuildInputs = [
     absl-py
     dm-env
     dm-tree
     frozendict
     gym
     matplotlib
+    numpy
     mizani
     pandas
     patsy
     plotnine
     scikit-image
     scipy
+    six
     statsmodels
     termcolor
   ];

--- a/pkgs/development/python-modules/canals/default.nix
+++ b/pkgs/development/python-modules/canals/default.nix
@@ -32,6 +32,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     networkx
+    requests # not actually optional as advertised, required to import "canals"
   ];
 
   passthru.optional-dependencies = {

--- a/pkgs/development/python-modules/certomancer/default.nix
+++ b/pkgs/development/python-modules/certomancer/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage rec {
     python-dateutil
     pyyaml
     tzlocal
+    cryptography # not actually optional, required for import of "certomancer"
   ];
 
   passthru.optional-dependencies = {

--- a/pkgs/development/python-modules/chainer/default.nix
+++ b/pkgs/development/python-modules/chainer/default.nix
@@ -10,6 +10,7 @@
 , protobuf
 , pytestCheckHook
 , pythonOlder
+, setuptools
 , six
 , typing-extensions
 }:
@@ -29,6 +30,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     filelock
     numpy
     protobuf

--- a/pkgs/development/python-modules/chameleon/default.nix
+++ b/pkgs/development/python-modules/chameleon/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -14,6 +15,8 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "0nf8x4w2vh1a31wdb86nnvlic9xmr23j3in1f6fq4z6mv2jkwa87";
   };
+
+  propagatedBuildInputs = [ setuptools ]; # needed for pkg_resources
 
   pythonImportsCheck = [ "chameleon" ];
 

--- a/pkgs/development/python-modules/check-manifest/default.nix
+++ b/pkgs/development/python-modules/check-manifest/default.nix
@@ -5,6 +5,7 @@
 , fetchPypi
 , git
 , pep517
+, setuptools
 , pytestCheckHook
 , tomli
 , pythonOlder
@@ -25,6 +26,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     build
     pep517
+    setuptools
   ] ++ lib.optionals (pythonOlder "3.11") [
     tomli
   ];

--- a/pkgs/development/python-modules/claripy/default.nix
+++ b/pkgs/development/python-modules/claripy/default.nix
@@ -30,6 +30,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     cachetools
     decorator
     future

--- a/pkgs/development/python-modules/clickhouse-connect/default.nix
+++ b/pkgs/development/python-modules/clickhouse-connect/default.nix
@@ -63,6 +63,9 @@ buildPythonPackage rec {
     "clickhouse_connect"
     "clickhouse_connect.driverc.buffer"
     "clickhouse_connect.driverc.dataconv"
+  ];
+  pythonImportsExtrasCheck = [
+    # requires numpy
     "clickhouse_connect.driverc.npconv"
   ];
 

--- a/pkgs/development/python-modules/clvm/default.nix
+++ b/pkgs/development/python-modules/clvm/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pythonOlder
 , blspy
+, setuptools
 , setuptools-scm
 , pytestCheckHook
 }:
@@ -27,6 +28,7 @@ buildPythonPackage rec {
   SETUPTOOLS_SCM_PRETEND_VERSION = "v${version}";
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     blspy
   ];
 

--- a/pkgs/development/python-modules/coinmetrics-api-client/default.nix
+++ b/pkgs/development/python-modules/coinmetrics-api-client/default.nix
@@ -55,6 +55,10 @@ buildPythonPackage rec {
   ] ++ passthru.optional-dependencies.pandas;
 
   pythonImportsCheck = [
+    "coinmetrics.data_exporter"
+  ];
+  pythonImportsExtrasCheck = [
+    # requires pandas
     "coinmetrics.api_client"
   ];
 

--- a/pkgs/development/python-modules/coredis/default.nix
+++ b/pkgs/development/python-modules/coredis/default.nix
@@ -3,6 +3,8 @@
 , buildPythonPackage
 , deprecated
 , fetchFromGitHub
+, typing-extensions
+, packaging
 , pympler
 , pytest-asyncio
 , pytestCheckHook
@@ -33,6 +35,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     async-timeout
     deprecated
+    typing-extensions
+    packaging
     pympler
     wrapt
   ];

--- a/pkgs/development/python-modules/cornice/default.nix
+++ b/pkgs/development/python-modules/cornice/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , pyramid
 , simplejson
 , six
@@ -16,7 +17,13 @@ buildPythonPackage rec {
     sha256 = "6edf6f206ff1c3d108d7a7b9ae640a2f4737cfc04f0914ccc4eefe511d3a8985";
   };
 
-  propagatedBuildInputs = [ pyramid simplejson six venusian ];
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+    pyramid
+    simplejson
+    six
+    venusian
+  ];
 
   # tests not packaged with pypi release
   doCheck = false;

--- a/pkgs/development/python-modules/correctionlib/default.nix
+++ b/pkgs/development/python-modules/correctionlib/default.nix
@@ -42,11 +42,10 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     cmake
-    numpy
-    scikit-build
     setuptools
     setuptools-scm
     wheel
+    scikit-build
     pybind11
   ];
 
@@ -55,6 +54,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    numpy
     pydantic
     rich
   ];

--- a/pkgs/development/python-modules/cppy/default.nix
+++ b/pkgs/development/python-modules/cppy/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , pythonOlder
 , pytestCheckHook
+, setuptools
 , setuptools-scm
 }:
 
@@ -18,6 +19,10 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    setuptools
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/dash/default.nix
+++ b/pkgs/development/python-modules/dash/default.nix
@@ -17,6 +17,7 @@
 , pythonOlder
 , pyyaml
 , redis
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -40,6 +41,7 @@ buildPythonPackage rec {
     flask
     flask-compress
     plotly
+    setuptools # needed for 'pkg_resources'
   ];
 
   passthru.optional-dependencies = {

--- a/pkgs/development/python-modules/dataclasses-serialization/default.nix
+++ b/pkgs/development/python-modules/dataclasses-serialization/default.nix
@@ -52,9 +52,11 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [
-    "dataclasses_serialization.bson"
     "dataclasses_serialization.json"
     "dataclasses_serialization.serializer_base"
+  ];
+  pythonImportsExtrasCheck = [
+    "dataclasses_serialization.bson"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/dingz/default.nix
+++ b/pkgs/development/python-modules/dingz/default.nix
@@ -3,6 +3,7 @@
 , async-timeout
 , buildPythonPackage
 , click
+, setuptools
 , fetchFromGitHub
 , pythonOlder
 }:
@@ -25,6 +26,7 @@ buildPythonPackage rec {
     aiohttp
     async-timeout
     click
+    setuptools # needed for 'pkg_resources'
   ];
 
   # Project has no tests

--- a/pkgs/development/python-modules/diofant/default.nix
+++ b/pkgs/development/python-modules/diofant/default.nix
@@ -8,6 +8,7 @@
 , numpy
 , pythonOlder
 , scipy
+, setuptools
 , setuptools-scm
 , wheel
 }:
@@ -39,6 +40,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     mpmath
+    numpy
+    scipy
+    setuptools # needed for 'pkg_resources'
   ];
 
   passthru.optional-dependencies = {

--- a/pkgs/development/python-modules/dj-static/default.nix
+++ b/pkgs/development/python-modules/dj-static/default.nix
@@ -17,11 +17,8 @@ buildPythonPackage rec {
     hash = "sha256-B6TydlezbDkmfFgJjdFniZIYo/JjzPvFj43co+HYCdc=";
   };
 
-  buildInputs = [
-    django
-  ];
-
   propagatedBuildInputs = [
+    django
     static3
   ];
 

--- a/pkgs/development/python-modules/django-formtools/default.nix
+++ b/pkgs/development/python-modules/django-formtools/default.nix
@@ -4,6 +4,7 @@
 , fetchPypi
 , python
 , pythonOlder
+, setuptools
 , setuptools-scm
 }:
 
@@ -24,6 +25,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     django
   ];
 

--- a/pkgs/development/python-modules/django-model-utils/default.nix
+++ b/pkgs/development/python-modules/django-model-utils/default.nix
@@ -7,6 +7,7 @@
 , pytest-django
 , pytestCheckHook
 , pythonOlder
+, setuptools
 , setuptools-scm
 }:
 
@@ -31,6 +32,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     django
   ];
 

--- a/pkgs/development/python-modules/django-polymorphic/default.nix
+++ b/pkgs/development/python-modules/django-polymorphic/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, python, django, dj-database-url }:
+{ lib, buildPythonPackage, fetchFromGitHub, python, setuptools, django, dj-database-url }:
 
 buildPythonPackage rec {
   pname = "django-polymorphic";
@@ -11,7 +11,10 @@ buildPythonPackage rec {
     hash = "sha256-JJY+FoMPSnWuSsNIas2JedGJpdm6RfPE3E1VIjGuXIc=";
   };
 
-  propagatedBuildInputs = [ django ];
+  propagatedBuildInputs = [
+    django
+    setuptools # needed for 'pkg_resources'
+  ];
 
   nativeCheckInputs = [ dj-database-url ];
 

--- a/pkgs/development/python-modules/django-prometheus/default.nix
+++ b/pkgs/development/python-modules/django-prometheus/default.nix
@@ -2,6 +2,8 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
+, setuptools
+, django
 , prometheus-client
 , pytest-django
 , pytestCheckHook
@@ -30,6 +32,8 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+    django
     prometheus-client
   ];
 

--- a/pkgs/development/python-modules/django-silk/default.nix
+++ b/pkgs/development/python-modules/django-silk/default.nix
@@ -1,4 +1,5 @@
 { lib
+, setuptools
 , autopep8
 , buildPythonPackage
 , django
@@ -56,6 +57,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     autopep8
     django
     gprof2dot

--- a/pkgs/development/python-modules/djangorestframework-simplejwt/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-simplejwt/default.nix
@@ -7,6 +7,7 @@
 , pyjwt
 , python-jose
 , pythonOlder
+, setuptools
 , setuptools-scm
 }:
 
@@ -28,6 +29,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     django
     djangorestframework
     pyjwt

--- a/pkgs/development/python-modules/dm-env/default.nix
+++ b/pkgs/development/python-modules/dm-env/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     hash = "sha256-pDbrHGVMOeDJhqUWzuIYvqcUC1EPzv9j+X60/P89k94=";
   };
 
-  buildInputs = [
+  propagatedBuildInputs = [
     absl-py
     dm-tree
     numpy

--- a/pkgs/development/python-modules/doc8/default.nix
+++ b/pkgs/development/python-modules/doc8/default.nix
@@ -12,6 +12,7 @@
 , setuptools-scm
 , stevedore
 , wheel
+, tomli
 }:
 
 buildPythonPackage rec {
@@ -50,6 +51,8 @@ buildPythonPackage rec {
     stevedore
     restructuredtext_lint
     pygments
+  ] ++ lib.optionals pythonOlder "3.11" [
+    tomli
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/dogtag-pki/default.nix
+++ b/pkgs/development/python-modules/dogtag-pki/default.nix
@@ -10,9 +10,8 @@ buildPythonPackage rec {
     sha256 = "sha256-rQSnQPNYr5SyeNbKoFAbnGb2X/8utrfWLa8gu93hy2w=";
   };
 
-  buildInputs = [ cryptography python-ldap ];
   pythonImportsCheck = [ "pki" ];
-  propagatedBuildInputs = [ requests six ];
+  propagatedBuildInputs = [ requests six cryptography python-ldap ];
 
   meta = with lib; {
     description = "An enterprise-class Certificate Authority";

--- a/pkgs/development/python-modules/dparse/default.nix
+++ b/pkgs/development/python-modules/dparse/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, toml
+, tomli
 , pyyaml
 , packaging
 , pytestCheckHook
@@ -21,9 +21,10 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    toml
     pyyaml
     packaging
+  ] ++ lib.optionals pythonOlder "3.11" [
+    tomli
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/drf-yasg/default.nix
+++ b/pkgs/development/python-modules/drf-yasg/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , inflection
 , ruamel-yaml
+, setuptools
 , setuptools-scm
 , six
 , coreapi
@@ -31,6 +32,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     six
     inflection
     ruamel-yaml

--- a/pkgs/development/python-modules/drms/default.nix
+++ b/pkgs/development/python-modules/drms/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , numpy
 , pandas
+, packaging
 , six
 , astropy
 , oldest-supported-numpy
@@ -34,6 +35,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     numpy
     pandas
+    packaging
     six
   ];
 

--- a/pkgs/development/python-modules/dvc-gs/default.nix
+++ b/pkgs/development/python-modules/dvc-gs/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , dvc-objects
+, packaging
 , fetchPypi
 , gcsfs
 , pythonRelaxDepsHook
@@ -21,7 +22,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm pythonRelaxDepsHook ];
 
-  propagatedBuildInputs = [ gcsfs dvc-objects ];
+  propagatedBuildInputs = [ gcsfs dvc-objects packaging ];
 
   # Network access is needed for tests
   doCheck = false;

--- a/pkgs/development/python-modules/dvc-http/default.nix
+++ b/pkgs/development/python-modules/dvc-http/default.nix
@@ -2,6 +2,7 @@
 , aiohttp-retry
 , buildPythonPackage
 , fetchFromGitHub
+, packaging
 , dvc-objects
 , fsspec
 , pythonOlder
@@ -30,6 +31,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    packaging
     dvc-objects
     fsspec
     aiohttp-retry

--- a/pkgs/development/python-modules/dvc-render/default.nix
+++ b/pkgs/development/python-modules/dvc-render/default.nix
@@ -33,6 +33,10 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
+  propagatedBuildInputs = [
+    flatten-dict # not optional as advertised, needed to import "dvc_render"
+  ];
+
   passthru.optional-dependencies = {
     table = [
       flatten-dict

--- a/pkgs/development/python-modules/dvc-s3/default.nix
+++ b/pkgs/development/python-modules/dvc-s3/default.nix
@@ -1,4 +1,5 @@
 { lib
+, packaging
 , aiobotocore
 , boto3
 , buildPythonPackage
@@ -30,7 +31,12 @@ buildPythonPackage rec {
   nativeBuildInputs = [ setuptools-scm pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
-    aiobotocore boto3 dvc-objects flatten-dict s3fs
+    packaging
+    aiobotocore
+    boto3
+    dvc-objects
+    flatten-dict
+    s3fs
   ];
 
   # Network access is needed for tests

--- a/pkgs/development/python-modules/dvc-ssh/default.nix
+++ b/pkgs/development/python-modules/dvc-ssh/default.nix
@@ -1,4 +1,5 @@
 { lib
+, packaging
 , bcrypt
 , buildPythonPackage
 , dvc-objects
@@ -23,7 +24,12 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm pythonRelaxDepsHook ];
 
-  propagatedBuildInputs = [ bcrypt dvc-objects sshfs ];
+  propagatedBuildInputs = [
+    packaging
+    bcrypt
+    dvc-objects
+    sshfs
+  ];
 
   # bcrypt is enabled for sshfs in nixpkgs
   postPatch = ''

--- a/pkgs/development/python-modules/elasticsearch8/default.nix
+++ b/pkgs/development/python-modules/elasticsearch8/default.nix
@@ -20,11 +20,8 @@ buildPythonPackage rec {
     hash = "sha256-Wb2l0FL7rm9Ck7HSWs9PmPyeShn9Hd9fCKnh/jWVy3o=";
   };
 
-  propagatedNativeBuildInputs = [
-    elastic-transport
-  ];
-
   propagatedBuildInputs = [
+    elastic-transport
     requests
   ];
 

--- a/pkgs/development/python-modules/elasticsearch8/default.nix
+++ b/pkgs/development/python-modules/elasticsearch8/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     hash = "sha256-Wb2l0FL7rm9Ck7HSWs9PmPyeShn9Hd9fCKnh/jWVy3o=";
   };
 
-  nativeBuildInputs = [
+  propagatedNativeBuildInputs = [
     elastic-transport
   ];
 

--- a/pkgs/development/python-modules/emborg/default.nix
+++ b/pkgs/development/python-modules/emborg/default.nix
@@ -43,10 +43,10 @@ buildPythonPackage rec {
     inform
     quantiphy
     requests
+    nestedtext
   ];
 
   nativeCheckInputs = [
-    nestedtext
     parametrize-from-file
     pytestCheckHook
     shlib

--- a/pkgs/development/python-modules/eth-utils/default.nix
+++ b/pkgs/development/python-modules/eth-utils/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
+, setuptools
 , eth-hash
 , eth-typing
 , cytoolz
@@ -24,6 +25,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     eth-hash
     eth-typing
   ] ++ lib.optional (!isPyPy) cytoolz

--- a/pkgs/development/python-modules/exdown/default.nix
+++ b/pkgs/development/python-modules/exdown/default.nix
@@ -6,6 +6,7 @@
 , setuptools
 , importlib-metadata
 , pytestCheckHook
+, pytest
 }:
 
 buildPythonPackage rec {
@@ -24,7 +25,9 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  propagatedBuildInputs = [
+    pytest
+  ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -23,6 +23,7 @@
 , phonenumbers
 
 # propagates
+, setuptools
 , blinker
 , email-validator
 , flask
@@ -63,6 +64,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     blinker
     email-validator
     flask

--- a/pkgs/development/python-modules/glean-parser/default.nix
+++ b/pkgs/development/python-modules/glean-parser/default.nix
@@ -9,6 +9,7 @@
 , pytestCheckHook
 , pythonOlder
 , pyyaml
+, setuptools
 , setuptools-scm
 , yamllint
 }:
@@ -37,6 +38,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     appdirs
     click
     diskcache

--- a/pkgs/development/python-modules/goocalendar/default.nix
+++ b/pkgs/development/python-modules/goocalendar/default.nix
@@ -39,7 +39,8 @@ buildPythonPackage rec {
   # No upstream tests available
   doCheck = false;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
+    # requires gtk namespace
     "goocalendar"
   ];
 

--- a/pkgs/development/python-modules/google-cloud-asset/default.nix
+++ b/pkgs/development/python-modules/google-cloud-asset/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , grpc-google-iam-v1
 , google-api-core
 , google-cloud-access-context-manager
@@ -29,6 +30,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     grpc-google-iam-v1
     google-api-core
     google-cloud-access-context-manager

--- a/pkgs/development/python-modules/google-cloud-automl/default.nix
+++ b/pkgs/development/python-modules/google-cloud-automl/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , google-api-core
 , google-cloud-storage
 , google-cloud-testutils
@@ -27,6 +28,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     google-api-core
     proto-plus
     protobuf

--- a/pkgs/development/python-modules/google-cloud-bigquery/default.nix
+++ b/pkgs/development/python-modules/google-cloud-bigquery/default.nix
@@ -10,6 +10,7 @@
 , google-cloud-storage
 , google-cloud-testutils
 , google-resumable-media
+, packaging
 , grpcio
 , ipython
 , mock
@@ -39,6 +40,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    packaging
     grpcio
     google-api-core
     google-cloud-core

--- a/pkgs/development/python-modules/google-cloud-dns/default.nix
+++ b/pkgs/development/python-modules/google-cloud-dns/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , google-api-core
 , google-cloud-core
 , mock
@@ -21,6 +22,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     google-api-core
     google-cloud-core
   ];

--- a/pkgs/development/python-modules/google-cloud-runtimeconfig/default.nix
+++ b/pkgs/development/python-modules/google-cloud-runtimeconfig/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , google-api-core
 , google-cloud-core
 , mock
@@ -21,6 +22,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     google-api-core
     google-cloud-core
   ];

--- a/pkgs/development/python-modules/google-cloud-translate/default.nix
+++ b/pkgs/development/python-modules/google-cloud-translate/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , google-api-core
 , google-cloud-core
 , google-cloud-testutils
@@ -25,6 +26,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     google-api-core
     google-cloud-core
     proto-plus

--- a/pkgs/development/python-modules/gpaw/default.nix
+++ b/pkgs/development/python-modules/gpaw/default.nix
@@ -114,7 +114,7 @@ in buildPythonPackage rec {
   '';
 
   doCheck = false; # Requires MPI runtime to work in the sandbox
-  pythonImportsCheck = [ "gpaw" ];
+  pythonImportsExtrasCheck = [ "gpaw" ];
 
   passthru = { inherit mpi; };
 

--- a/pkgs/development/python-modules/h5netcdf/default.nix
+++ b/pkgs/development/python-modules/h5netcdf/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , fetchpatch
 , h5py
+, packaging
 , pytestCheckHook
 , netcdf4
 , pythonOlder
@@ -29,6 +30,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     h5py
+    packaging
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/hs-dbus-signature/default.nix
+++ b/pkgs/development/python-modules/hs-dbus-signature/default.nix
@@ -14,9 +14,12 @@ buildPythonPackage rec {
     hash = "sha256-NNnTcSX+K8zU+sj1QBd13h7aEXN9VqltJMNWCuhgZ6I=";
   };
 
+  propagatedBuildInputs = [
+    hypothesis
+  ];
+
   nativeCheckInputs = [
     pytestCheckHook
-    hypothesis
   ];
 
   pythonImportsCheck = [ "hs_dbus_signature" ];

--- a/pkgs/development/python-modules/httmock/default.nix
+++ b/pkgs/development/python-modules/httmock/default.nix
@@ -16,8 +16,11 @@ buildPythonPackage rec {
     hash = "sha256-yid4vh1do0zqVzd1VV7gc+Du4VPrkeGFsDHqNbHL28I=";
   };
 
-  nativeCheckInputs = [
+  propagatedBuildInputs = [
     requests
+  ];
+
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/httpsig/default.nix
+++ b/pkgs/development/python-modules/httpsig/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , setuptools-scm
 , pycryptodome
 , requests
@@ -21,6 +22,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     pycryptodome
     requests
     six

--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -176,9 +176,8 @@ buildPythonPackage rec {
     rm -r "$IBIS_TEST_DATA_DIRECTORY"
   '';
 
-  pythonImportsCheck = [
-    "ibis"
-  ] ++ map (backend: "ibis.backends.${backend}") testBackends;
+  pythonImportsCheck = [ "ibis" ];
+  pythonImportsExtrasCheck = map (backend: "ibis.backends.${backend}") testBackends;
 
   passthru = {
     optional-dependencies = {

--- a/pkgs/development/python-modules/ics/default.nix
+++ b/pkgs/development/python-modules/ics/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, attrs
 , tatsu
 , arrow
 , pytestCheckHook
@@ -21,6 +22,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    attrs
     arrow
     tatsu
   ];

--- a/pkgs/development/python-modules/imageio-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/imageio-ffmpeg/default.nix
@@ -4,6 +4,7 @@
 , substituteAll
 , ffmpeg_4
 , python
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -27,6 +28,10 @@ buildPythonPackage rec {
   postPatch = ''
     sed -i '/setup_requires=\["pip>19"\]/d' setup.py
   '';
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+  ];
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/python-modules/isbnlib/default.nix
+++ b/pkgs/development/python-modules/isbnlib/default.nix
@@ -4,6 +4,7 @@
 , nose
 , coverage
 , pythonOlder
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -17,6 +18,10 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-lvkIZMd7AfVfoR5b/Kn9kJUB2YQvO8cQ1Oq4UZXZBTk=";
   };
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+  ];
 
   nativeCheckInputs = [
     nose

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -115,7 +115,7 @@ buildPythonPackage rec {
     "tests/lax_test.py"
   ];
 
-  pythonImportsCheck = [ "jax" ];
+  pythonImportsExtrasCheck = [ "jax" ]; # requires jaxlib
 
   meta = with lib; {
     description = "Differentiate, compile, and transform Numpy code";

--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -12,6 +12,7 @@
 , optax
 , scipy
 , scikit-learn
+, typing-extensions
 }:
 
 buildPythonPackage rec {
@@ -35,6 +36,7 @@ buildPythonPackage rec {
     matplotlib
     numpy
     scipy
+    typing-extensions
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/jeepney/default.nix
+++ b/pkgs/development/python-modules/jeepney/default.nix
@@ -54,6 +54,8 @@ buildPythonPackage rec {
     "jeepney.io.asyncio"
     "jeepney.io.blocking"
     "jeepney.io.threading"
+  ];
+  pythonImportsExtrasCheck = [
     "jeepney.io.trio"
   ];
 

--- a/pkgs/development/python-modules/jira/default.nix
+++ b/pkgs/development/python-modules/jira/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, packaging
+, typing-extensions
 , defusedxml
 , flaky
 , keyring
@@ -35,6 +37,8 @@ buildPythonPackage rec {
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   propagatedBuildInputs = [
+    packaging
+    typing-extensions
     defusedxml
     keyring
     requests-oauthlib

--- a/pkgs/development/python-modules/jmp/default.nix
+++ b/pkgs/development/python-modules/jmp/default.nix
@@ -22,8 +22,8 @@ buildPythonPackage rec {
     jax
   ];
 
-  pythonImportsCheck = [
-    "jmp"
+  pythonImportsExtrasCheck = [
+    "jmp" # requires jaxlib
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/json-home-client/default.nix
+++ b/pkgs/development/python-modules/json-home-client/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pythonOlder
 # build inputs
+, setuptools
 , typing-extensions
 , uri-template
 }:
@@ -25,6 +26,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     typing-extensions
     uri-template
   ];

--- a/pkgs/development/python-modules/jsonconversion/default.nix
+++ b/pkgs/development/python-modules/jsonconversion/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, numpy }:
+{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, numpy, setuptools }:
 
 buildPythonPackage rec {
   pname = "jsonconversion";
@@ -12,6 +12,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py --replace "'pytest-runner'" ""
   '';
+
+  propagatedBuildInputs = [ setuptools ]; # needed for 'pkg_resources'
 
   nativeCheckInputs = [ pytestCheckHook numpy ];
 

--- a/pkgs/development/python-modules/kajiki/default.nix
+++ b/pkgs/development/python-modules/kajiki/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , linetable
+, setuptools
 , pytestCheckHook
 , pythonOlder
 }:
@@ -22,6 +23,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     linetable
   ];
 

--- a/pkgs/development/python-modules/kbcstorage/default.nix
+++ b/pkgs/development/python-modules/kbcstorage/default.nix
@@ -7,6 +7,7 @@
 , setuptools-scm
 
 # propagates
+, setuptools
 , azure-storage-blob
 , boto3
 , requests
@@ -36,6 +37,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     azure-storage-blob
     boto3
     requests

--- a/pkgs/development/python-modules/lifelines/default.nix
+++ b/pkgs/development/python-modules/lifelines/default.nix
@@ -1,4 +1,5 @@
 { lib
+, setuptools
 , autograd
 , autograd-gamma
 , buildPythonPackage
@@ -33,6 +34,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed or 'pkg_resources'
     autograd
     autograd-gamma
     formulaic

--- a/pkgs/development/python-modules/lightning-utilities/default.nix
+++ b/pkgs/development/python-modules/lightning-utilities/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     packaging
     typing-extensions
   ];

--- a/pkgs/development/python-modules/linode-api/default.nix
+++ b/pkgs/development/python-modules/linode-api/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, setuptools
 , requests
 , pytestCheckHook
 , mock
@@ -20,7 +21,10 @@ buildPythonPackage rec {
     sha256 = "0lqi15vks4fxbki1l7n1bfzygjy3w17d9wchjxvp22ijmas44yai";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+    requests
+  ];
 
   nativeCheckInputs = [
     mock

--- a/pkgs/development/python-modules/liquidctl/default.nix
+++ b/pkgs/development/python-modules/liquidctl/default.nix
@@ -73,11 +73,11 @@ buildPythonPackage rec {
   ];
 
   postBuild = ''
-    # needed for pythonImportsCheck
+    # needed for pythonImportsExtrasCheck
     export XDG_RUNTIME_DIR=$TMPDIR
   '';
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "liquidctl"
   ];
 

--- a/pkgs/development/python-modules/mdformat-beautysh/default.nix
+++ b/pkgs/development/python-modules/mdformat-beautysh/default.nix
@@ -28,18 +28,15 @@ buildPythonPackage rec {
     poetry-core
   ];
 
-  buildInputs = [
-    mdformat
-    mdformat-gfm
-    mdit-py-plugins
-  ];
-
   propagatedBuildInputs = [
     beautysh
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
+    mdformat
+    mdformat-gfm
+    mdit-py-plugins
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/mdformat-footnote/default.nix
+++ b/pkgs/development/python-modules/mdformat-footnote/default.nix
@@ -27,13 +27,14 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     mdformat
     mdit-py-plugins
   ];
 
   pythonImportsCheck = [
     "mdformat_footnote"
+    "mdformat_footnote.plugin"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mdformat-frontmatter/default.nix
+++ b/pkgs/development/python-modules/mdformat-frontmatter/default.nix
@@ -28,17 +28,15 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     mdformat
     mdit-py-plugins
-  ];
-
-  propagatedBuildInputs = [
     ruamel-yaml
   ];
 
   pythonImportsCheck = [
     "mdformat_frontmatter"
+    "mdformat_frontmatter.plugin"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mdformat-gfm/default.nix
+++ b/pkgs/development/python-modules/mdformat-gfm/default.nix
@@ -30,13 +30,9 @@ buildPythonPackage rec {
     poetry-core
   ];
 
-  buildInputs = [
-    mdformat
-    markdown-it-py
-    mdit-py-plugins
-  ];
-
   propagatedBuildInputs = [
+    mdformat
+    mdit-py-plugins
     mdformat-tables
     linkify-it-py
   ];
@@ -47,6 +43,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "mdformat_gfm"
+    "mdformat_gfm.plugin"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mdformat-mkdocs/default.nix
+++ b/pkgs/development/python-modules/mdformat-mkdocs/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     mdformat
     mdformat-gfm
     mdit-py-plugins
@@ -34,6 +34,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "mdformat_mkdocs"
+    "mdformat_mkdocs.plugin"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mdformat-simple-breaks/default.nix
+++ b/pkgs/development/python-modules/mdformat-simple-breaks/default.nix
@@ -25,12 +25,13 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     mdformat
   ];
 
   pythonImportsCheck = [
     "mdformat_simple_breaks"
+    "mdformat_simple_breaks.plugin"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mdformat-tables/default.nix
+++ b/pkgs/development/python-modules/mdformat-tables/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     mdformat
   ];
 
@@ -36,6 +36,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "mdformat_tables"
+    "mdformat_tables.plugin"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mdformat-toc/default.nix
+++ b/pkgs/development/python-modules/mdformat-toc/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     poetry-core
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     mdformat
   ];
 
@@ -36,6 +36,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "mdformat_toc"
+    "mdformat_toc.plugin"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mkdocs-macros/default.nix
+++ b/pkgs/development/python-modules/mkdocs-macros/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     jinja2
     termcolor
     python-dateutil

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -1,4 +1,5 @@
 { lib
+, setuptools
 , alembic
 , buildPythonPackage
 , click
@@ -61,6 +62,7 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "pytz" "pyarrow" ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     alembic
     click
     cloudpickle

--- a/pkgs/development/python-modules/mock-services/default.nix
+++ b/pkgs/development/python-modules/mock-services/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
+, setuptools
 , attrs
 , funcsigs
 , requests-mock
@@ -28,6 +29,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     attrs
     funcsigs
     requests-mock

--- a/pkgs/development/python-modules/nbxmpp/default.nix
+++ b/pkgs/development/python-modules/nbxmpp/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    # required for pythonImportsCheck otherwise libsoup cannot be found
+    # required for pythonImportsExtrasCheck otherwise libsoup cannot be found
     gobject-introspection
     setuptools
   ];
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "nbxmpp"
   ];
 

--- a/pkgs/development/python-modules/nbxmpp/default.nix
+++ b/pkgs/development/python-modules/nbxmpp/default.nix
@@ -45,6 +45,8 @@ buildPythonPackage rec {
     packaging
     pygobject3
     pyopenssl
+    packaging
+    setuptools
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/nextcord/default.nix
+++ b/pkgs/development/python-modules/nextcord/default.nix
@@ -4,6 +4,7 @@
 , pythonOlder
 , fetchFromGitHub
 , substituteAll
+, setuptools
 , ffmpeg
 , libopus
 , aiohttp
@@ -38,6 +39,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     aiodns
     aiohttp
     brotli

--- a/pkgs/development/python-modules/notmuch2/default.nix
+++ b/pkgs/development/python-modules/notmuch2/default.nix
@@ -16,7 +16,10 @@ buildPythonPackage {
     cffi
   ];
   buildInputs = [
-    python notmuch cffi
+    python notmuch
+  ];
+  propagatedBuildInputs = [
+    cffi
   ];
 
   # since notmuch 0.35, this package expects _notmuch_config.py that is

--- a/pkgs/development/python-modules/objax/default.nix
+++ b/pkgs/development/python-modules/objax/default.nix
@@ -36,7 +36,8 @@ buildPythonPackage rec {
     tensorboard
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
+    # requires jaxlib
     "objax"
   ];
 

--- a/pkgs/development/python-modules/obspy/default.nix
+++ b/pkgs/development/python-modules/obspy/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , decorator
 , future
 , lxml
@@ -22,6 +23,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     decorator
     future
     lxml

--- a/pkgs/development/python-modules/onnxmltools/default.nix
+++ b/pkgs/development/python-modules/onnxmltools/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , numpy
 , onnx
 , skl2onnx
@@ -27,6 +28,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     numpy
     onnx
     skl2onnx

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage {
     opentelemetry-sdk
     opentelemetry-semantic-conventions
     wrapt
+    grpcio # not actually optional, required for pythonImportsCheck
   ];
 
   passthru.optional-dependencies = {
@@ -39,7 +40,6 @@ buildPythonPackage {
 
   nativeCheckInputs = [
     opentelemetry-test-utils
-    grpcio
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/parametrize-from-file/default.nix
+++ b/pkgs/development/python-modules/parametrize-from-file/default.nix
@@ -4,6 +4,7 @@
 , fetchpatch
 , flit-core
 , pytestCheckHook
+, pytest
 , coveralls
 , numpy
 , decopatch
@@ -43,6 +44,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     flit-core
+    pytest
   ];
 
   nativeCheckInputs = [
@@ -59,7 +61,7 @@ buildPythonPackage rec {
     toml
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "parametrize_from_file"
   ];
 

--- a/pkgs/development/python-modules/phx-class-registry/default.nix
+++ b/pkgs/development/python-modules/phx-class-registry/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pytestCheckHook
 , pythonOlder
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -16,6 +17,10 @@ buildPythonPackage rec {
     rev = "refs/tags/${version}";
     hash = "sha256-kSEHgzBgnAq5rMv2HbmGl+9CUzsmzUzPQWr+5q8mcsA=";
   };
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/ppscore/default.nix
+++ b/pkgs/development/python-modules/ppscore/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , pandas
 , pytestCheckHook
 , pythonOlder
@@ -22,6 +23,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     pandas
     scikit-learn
   ];

--- a/pkgs/development/python-modules/psd-tools/default.nix
+++ b/pkgs/development/python-modules/psd-tools/default.nix
@@ -6,6 +6,7 @@
 , pillow
 , scikit-image
 , aggdraw
+, attrs
 , pytestCheckHook
 , ipython
 , cython
@@ -31,6 +32,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     aggdraw
+    attrs
     docopt
     ipython
     pillow

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -158,6 +158,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "psycopg"
     "psycopg_c"
+  ];
+  pythonImportsExtrasCheck = [
     "psycopg_pool"
   ];
 

--- a/pkgs/development/python-modules/pulumi-aws/default.nix
+++ b/pkgs/development/python-modules/pulumi-aws/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
+, setuptools
 , parver
 , pulumi
 , pythonOlder
@@ -27,6 +28,7 @@ buildPythonPackage rec {
   sourceRoot = "${src.name}/sdk/python";
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     parver
     pulumi
     semver

--- a/pkgs/development/python-modules/pyTelegramBotAPI/default.nix
+++ b/pkgs/development/python-modules/pyTelegramBotAPI/default.nix
@@ -30,6 +30,10 @@ buildPythonPackage rec {
     hash = "sha256-R52j4JnoM0nlZvlcDox2Wz3WjTEstNaqbg8SPiPHD4c=";
   };
 
+  propagatedBuildInputs = [
+    requests
+  ];
+
   passthru.optional-dependencies = {
     json = [
       ujson
@@ -65,7 +69,6 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-    requests
   ] ++ passthru.optional-dependencies.watchdog
   ++ passthru.optional-dependencies.aiohttp;
 

--- a/pkgs/development/python-modules/pyamg/default.nix
+++ b/pkgs/development/python-modules/pyamg/default.nix
@@ -6,6 +6,7 @@
 , pytest
 , python
 , pybind11
+, setuptools
 , setuptools-scm
 , pythonOlder
 }:
@@ -27,6 +28,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     numpy
     scipy
     pytest

--- a/pkgs/development/python-modules/pybigwig/default.nix
+++ b/pkgs/development/python-modules/pybigwig/default.nix
@@ -25,8 +25,11 @@ buildPythonPackage rec {
     zlib
   ];
 
-  nativeCheckInputs = [
+  propagatedBuildInputs = [
     numpy
+  ];
+
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/pybotvac/default.nix
+++ b/pkgs/development/python-modules/pybotvac/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, setuptools
 , requests
 , requests-oauthlib
 , voluptuous
@@ -20,6 +21,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     requests
     requests-oauthlib
     voluptuous

--- a/pkgs/development/python-modules/pybtex-docutils/default.nix
+++ b/pkgs/development/python-modules/pybtex-docutils/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-On69+StZPgDowcU4qpogvKXZLYQjESRxWsyWTVHZPGs=";
   };
 
-  buildInputs = [
+  propagatedBuildInputs = [
     docutils
     pybtex
   ];

--- a/pkgs/development/python-modules/pyfaidx/default.nix
+++ b/pkgs/development/python-modules/pyfaidx/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     six
   ];
 

--- a/pkgs/development/python-modules/pygit2/default.nix
+++ b/pkgs/development/python-modules/pygit2/default.nix
@@ -54,11 +54,11 @@ buildPythonPackage rec {
     "test/test_submodule.py"
   ];
 
-  # Tests require certificates
+  # Tests and import check require certificates
   # https://github.com/NixOS/nixpkgs/pull/72544#issuecomment-582674047
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pygit2"
   ];
 

--- a/pkgs/development/python-modules/pygmt/default.nix
+++ b/pkgs/development/python-modules/pygmt/default.nix
@@ -61,7 +61,8 @@ buildPythonPackage rec {
     export HOME=$TMP
   '';
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
+    # requires $HOME
     "pygmt"
   ];
 

--- a/pkgs/development/python-modules/pygtkspellcheck/default.nix
+++ b/pkgs/development/python-modules/pygtkspellcheck/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pyenchant pygobject3 gtk3 ];
 
   doCheck = false; # there are no tests
-  pythonImportsCheck = [ "gtkspellcheck" ];
+  pythonImportsExtrasCheck = [ "gtkspellcheck" ]; # requires gtk namespace
 
   meta = with lib; {
     homepage = "https://github.com/koehlma/pygtkspellcheck";

--- a/pkgs/development/python-modules/pyjnius/default.nix
+++ b/pkgs/development/python-modules/pyjnius/default.nix
@@ -28,7 +28,8 @@ buildPythonPackage rec {
     setuptools # needed for 'pkg_resources'
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
+    # needs jdk
     "jnius"
   ];
 

--- a/pkgs/development/python-modules/pyjnius/default.nix
+++ b/pkgs/development/python-modules/pyjnius/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, setuptools
 , cython
 , fetchPypi
 , jdk
@@ -21,6 +22,10 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     jdk
     cython
+  ];
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pykakasi/default.nix
+++ b/pkgs/development/python-modules/pykakasi/default.nix
@@ -3,6 +3,7 @@
 , deprecated
 , fetchFromGitHub
 , importlib-metadata
+, setuptools
 , jaconv
 , py-cpuinfo
 , pytest-benchmark
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     jaconv
     deprecated
   ] ++ lib.optionals (pythonOlder "3.8") [

--- a/pkgs/development/python-modules/pylxd/default.nix
+++ b/pkgs/development/python-modules/pylxd/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , cryptography
 , python-dateutil
 , requests
@@ -24,6 +25,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     cryptography
     python-dateutil
     requests

--- a/pkgs/development/python-modules/pymatting/default.nix
+++ b/pkgs/development/python-modules/pymatting/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     scipy
   ];
 
-  pythonImportsCheck = [ "pymatting" ];
+  pythonImportsExtrasCheck = [ "pymatting" ]; # AoT compilation in first import requires gcc
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -52,4 +52,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ blaggacao ];
   };
 }
-

--- a/pkgs/development/python-modules/pymilvus/default.nix
+++ b/pkgs/development/python-modules/pymilvus/default.nix
@@ -13,6 +13,7 @@
 , pythonRelaxDepsHook
 , scikit-learn
 , setuptools-scm
+, setuptools
 , ujson
 , wheel
 }:
@@ -45,6 +46,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     environs
     grpcio
     mmh3

--- a/pkgs/development/python-modules/pyocd/default.nix
+++ b/pkgs/development/python-modules/pyocd/default.nix
@@ -56,7 +56,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "pyocd" ];
+  # FIXME: requires cffi via cmsis-pack-manager, but buildPythonPath does not consider propagatedNativeBuildInputs
+  pythonImportsExtrasCheck = [ "pyocd" ];
 
   postPatch = ''
     substituteInPlace setup.cfg \

--- a/pkgs/development/python-modules/pyowm/default.nix
+++ b/pkgs/development/python-modules/pyowm/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , geojson
 , pysocks
 , pythonOlder
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     geojson
     pysocks
     requests

--- a/pkgs/development/python-modules/pyownet/default.nix
+++ b/pkgs/development/python-modules/pyownet/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -17,6 +18,10 @@ buildPythonPackage rec {
   postPatch = ''
     sed -i '/use_2to3/d' setup.py
   '';
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+  ];
 
   # tests access network
   doCheck = false;

--- a/pkgs/development/python-modules/pypiserver/default.nix
+++ b/pkgs/development/python-modules/pypiserver/default.nix
@@ -28,12 +28,12 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    setuptools
     setuptools-git
     wheel
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     pip
   ];
 

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -68,8 +68,6 @@ buildPythonPackage rec {
     export MAKEFLAGS+="''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
   '';
 
-  outputs = [ "out" "dev" ];
-
   dontWrapQtApps = true;
 
   nativeBuildInputs = with libsForQt5; [

--- a/pkgs/development/python-modules/pyquil/default.nix
+++ b/pkgs/development/python-modules/pyquil/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, packaging
 , deprecated
 , fetchFromGitHub
 , importlib-metadata
@@ -52,6 +53,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    packaging
     deprecated
     lark
     networkx

--- a/pkgs/development/python-modules/pyramid-jinja2/default.nix
+++ b/pkgs/development/python-modules/pyramid-jinja2/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , webtest
+, setuptools
 , markupsafe
 , jinja2
 , pytestCheckHook
@@ -24,6 +25,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     markupsafe
     jinja2
     pyramid

--- a/pkgs/development/python-modules/pyramid_exclog/default.nix
+++ b/pkgs/development/python-modules/pyramid_exclog/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , pyramid
 }:
 
@@ -13,7 +14,10 @@ buildPythonPackage rec {
     hash = "sha256-Tl2rYH/GifNfB9w4nG9UIqAQz0O6kujCED/4iZnPKDw=";
   };
 
-  propagatedBuildInputs = [ pyramid ];
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+    pyramid
+  ];
 
   pythonImportsCheck = [ "pyramid_exclog" ];
 

--- a/pkgs/development/python-modules/pysiaalarm/default.nix
+++ b/pkgs/development/python-modules/pysiaalarm/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
+, setuptools
 , dataclasses-json
 , pycryptodome
 , setuptools-scm
@@ -34,6 +35,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     dataclasses-json
     pycryptodome
     pytz

--- a/pkgs/development/python-modules/pysnow/default.nix
+++ b/pkgs/development/python-modules/pysnow/default.nix
@@ -10,6 +10,7 @@
 , pytz
 , pytestCheckHook
 , requests-oauthlib
+, six
 }:
 
 buildPythonPackage rec {
@@ -35,6 +36,7 @@ buildPythonPackage rec {
     python-magic
     pytz
     requests-oauthlib
+    six
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , cython
+, setuptools
 , decorator
 , fetchPypi
 , numpy
@@ -30,6 +31,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     decorator
     numpy
     scipy

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, setuptools
 , fetchFromGitHub
 , cython
 , versioneer
@@ -49,6 +50,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools
     cons
     etuples
     filelock

--- a/pkgs/development/python-modules/pytest-aio/default.nix
+++ b/pkgs/development/python-modules/pytest-aio/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     trio-asyncio
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_aio"
   ];
 

--- a/pkgs/development/python-modules/pytest-annotate/default.nix
+++ b/pkgs/development/python-modules/pytest-annotate/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   # Module has no tests
   doCheck = false;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_annotate"
   ];
 

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -80,7 +80,7 @@ buildPythonPackage rec {
     "tests/test_adhoc_result.py"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_ansible"
   ];
 

--- a/pkgs/development/python-modules/pytest-arraydiff/default.nix
+++ b/pkgs/development/python-modules/pytest-arraydiff/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   # The tests requires astropy, which itself requires pytest-arraydiff
   doCheck = false;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_arraydiff"
   ];
 

--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   doCheck = false;
   passthru.tests.pytest = callPackage ./tests.nix {};
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_asyncio"
   ];
 

--- a/pkgs/development/python-modules/pytest-base-url/default.nix
+++ b/pkgs/development/python-modules/pytest-base-url/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     "tests"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_base_url"
   ];
 

--- a/pkgs/development/python-modules/pytest-bdd/default.nix
+++ b/pkgs/development/python-modules/pytest-bdd/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     export PATH=$PATH:$out/bin
   '';
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_bdd"
   ];
 

--- a/pkgs/development/python-modules/pytest-benchmark/default.nix
+++ b/pkgs/development/python-modules/pytest-benchmark/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     py-cpuinfo
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_benchmark"
   ];
 

--- a/pkgs/development/python-modules/pytest-black/default.nix
+++ b/pkgs/development/python-modules/pytest-black/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   # does not contain tests
   doCheck = false;
-  pythonImportsCheck = [ "pytest_black" ];
+  pythonImportsExtrasCheck = [ "pytest_black" ];
 
   meta = with lib; {
     description = "A pytest plugin to enable format checking with black";

--- a/pkgs/development/python-modules/pytest-cases/default.nix
+++ b/pkgs/development/python-modules/pytest-cases/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   # makefun, pytest-*) have circular dependencies.
   doCheck = false;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_cases"
   ];
 

--- a/pkgs/development/python-modules/pytest-cid/default.nix
+++ b/pkgs/development/python-modules/pytest-cid/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytest-cov
   ];
 
-  pythonImportsCheck = [ "pytest_cid" ];
+  pythonImportsExtrasCheck = [ "pytest_cid" ];
 
   meta = with lib; {
     homepage = "https://github.com/ntninja/pytest-cid";

--- a/pkgs/development/python-modules/pytest-console-scripts/default.nix
+++ b/pkgs/development/python-modules/pytest-console-scripts/default.nix
@@ -3,6 +3,7 @@
 , mock
 , fetchPypi
 , pytestCheckHook
+, pytest
 , python
 , pythonOlder
 , setuptools-scm
@@ -27,6 +28,10 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
+  buildInputs = [
+    pytest
+  ];
+
   propagatedBuildInputs = [
     setuptools
   ];
@@ -42,7 +47,7 @@ buildPythonPackage rec {
       --replace "#!/usr/bin/env python" "#!${python.interpreter}"
   '';
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_console_scripts"
   ];
 

--- a/pkgs/development/python-modules/pytest-cov/default.nix
+++ b/pkgs/development/python-modules/pytest-cov/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     py.test tests
   '';
 
-  pythonImportsCheck = [ "pytest_cov" ];
+  pythonImportsExtrasCheck = [ "pytest_cov" ];
 
   meta = with lib; {
     description = "Plugin for coverage reporting with support for both centralised and distributed testing, including subprocesses and multiprocessing";

--- a/pkgs/development/python-modules/pytest-datadir/default.nix
+++ b/pkgs/development/python-modules/pytest-datadir/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
   nativeBuildInputs = [ setuptools-scm ];
   nativeCheckInputs = [ pytestCheckHook ];
-  pythonImportsCheck = [ "pytest_datadir" ];
+  pythonImportsExtrasCheck = [ "pytest_datadir" ];
 
   meta = with lib; {
     description = "Pytest plugin for manipulating test data directories and files";

--- a/pkgs/development/python-modules/pytest-datafiles/default.nix
+++ b/pkgs/development/python-modules/pytest-datafiles/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_datafiles"
   ];
 

--- a/pkgs/development/python-modules/pytest-emoji/default.nix
+++ b/pkgs/development/python-modules/pytest-emoji/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_emoji"
   ];
 

--- a/pkgs/development/python-modules/pytest-error-for-skips/default.nix
+++ b/pkgs/development/python-modules/pytest-error-for-skips/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "pytest_error_for_skips" ];
+  pythonImportsExtrasCheck = [ "pytest_error_for_skips" ];
 
   meta = with lib; {
     description = "Pytest plugin to treat skipped tests a test failures";

--- a/pkgs/development/python-modules/pytest-examples/default.nix
+++ b/pkgs/development/python-modules/pytest-examples/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_examples"
   ];
 

--- a/pkgs/development/python-modules/pytest-factoryboy/default.nix
+++ b/pkgs/development/python-modules/pytest-factoryboy/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_factoryboy"
   ];
 

--- a/pkgs/development/python-modules/pytest-flakes/default.nix
+++ b/pkgs/development/python-modules/pytest-flakes/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   # no longer passes
   doCheck = false;
-  pythonImportsCheck = [ "pytest_flakes" ];
+  pythonImportsExtrasCheck = [ "pytest_flakes" ];
   # disable one test case that looks broken
   checkPhase = ''
     py.test test_flakes.py -k 'not test_syntax_error'

--- a/pkgs/development/python-modules/pytest-flask/default.nix
+++ b/pkgs/development/python-modules/pytest-flask/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_flask"
   ];
 

--- a/pkgs/development/python-modules/pytest-freezer/default.nix
+++ b/pkgs/development/python-modules/pytest-freezer/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_freezer"
   ];
 

--- a/pkgs/development/python-modules/pytest-golden/default.nix
+++ b/pkgs/development/python-modules/pytest-golden/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_golden"
   ];
 

--- a/pkgs/development/python-modules/pytest-helpers-namespace/default.nix
+++ b/pkgs/development/python-modules/pytest-helpers-namespace/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "pytest_helpers_namespace" ];
+  pythonImportsExtrasCheck = [ "pytest_helpers_namespace" ];
 
   meta = with lib; {
     homepage = "https://github.com/saltstack/pytest-helpers-namespace";

--- a/pkgs/development/python-modules/pytest-httpbin/default.nix
+++ b/pkgs/development/python-modules/pytest-httpbin/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_httpbin"
   ];
 

--- a/pkgs/development/python-modules/pytest-httpserver/default.nix
+++ b/pkgs/development/python-modules/pytest-httpserver/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     "test_wait_raise_assertion_false" # racy
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_httpserver"
   ];
 

--- a/pkgs/development/python-modules/pytest-httpx/default.nix
+++ b/pkgs/development/python-modules/pytest-httpx/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , httpx
+, setuptools
 , pytest
 , pytest-asyncio
 , pytestCheckHook
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     httpx
   ];
 
@@ -44,7 +46,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_httpx"
   ];
 

--- a/pkgs/development/python-modules/pytest-image-diff/default.nix
+++ b/pkgs/development/python-modules/pytest-image-diff/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     imgdiff
   ];
 
-  pythonImportsCheck = [ "pytest_image_diff" ];
+  pythonImportsExtrasCheck = [ "pytest_image_diff" ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/pytest-instafail/default.nix
+++ b/pkgs/development/python-modules/pytest-instafail/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_instafail"
   ];
 

--- a/pkgs/development/python-modules/pytest-isort/default.nix
+++ b/pkgs/development/python-modules/pytest-isort/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_isort"
   ];
 

--- a/pkgs/development/python-modules/pytest-json-report/default.nix
+++ b/pkgs/development/python-modules/pytest-json-report/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     "test_bug_31"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_jsonreport"
   ];
 

--- a/pkgs/development/python-modules/pytest-localserver/default.nix
+++ b/pkgs/development/python-modules/pytest-localserver/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   # all tests access network: does not work in sandbox
   doCheck = false;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_localserver"
   ];
 

--- a/pkgs/development/python-modules/pytest-logdog/default.nix
+++ b/pkgs/development/python-modules/pytest-logdog/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_logdog"
   ];
 

--- a/pkgs/development/python-modules/pytest-md-report/default.nix
+++ b/pkgs/development/python-modules/pytest-md-report/default.nix
@@ -21,17 +21,19 @@ buildPythonPackage rec {
     hash = "sha256-4946iE+VYaPndJtQLQE7Q7VSs4aXxrg3wL4p84oT5to=";
   };
 
+  buildInputs = [
+    pytest
+  ];
+
   propagatedBuildInputs = [
     pytablewriter
     tcolorpy
     typepy
   ];
 
-  buildInputs = [ pytest ];
-
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "pytest_md_report" ];
+  pythonImportsExtrasCheck = [ "pytest_md_report" ];
 
   meta = with lib; {
     description = "A pytest plugin to make a test results report with Markdown table format";

--- a/pkgs/development/python-modules/pytest-mock/default.nix
+++ b/pkgs/development/python-modules/pytest-mock/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "pytest_mock" ];
+  pythonImportsExtrasCheck = [ "pytest_mock" ];
 
   meta = with lib; {
     description = "Thin wrapper around the mock package for easier use with pytest";

--- a/pkgs/development/python-modules/pytest-mockservers/default.nix
+++ b/pkgs/development/python-modules/pytest-mockservers/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_mockservers"
   ];
 

--- a/pkgs/development/python-modules/pytest-mypy-plugins/default.nix
+++ b/pkgs/development/python-modules/pytest-mypy-plugins/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     export PATH="$PATH:$out/bin";
   '';
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_mypy_plugins"
   ];
 

--- a/pkgs/development/python-modules/pytest-mypy/default.nix
+++ b/pkgs/development/python-modules/pytest-mypy/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , filelock
+, attrs
 , pytest
 , mypy
 , setuptools-scm
@@ -20,11 +21,11 @@ buildPythonPackage rec {
 
   buildInputs = [ pytest ];
 
-  propagatedBuildInputs = [ mypy filelock ];
+  propagatedBuildInputs = [ attrs mypy filelock ];
 
   # does not contain tests
   doCheck = false;
-  pythonImportsCheck = [ "pytest_mypy" ];
+  pythonImportsExtrasCheck = [ "pytest_mypy" ];
 
   meta = with lib; {
     description = "Mypy static type checker plugin for Pytest";

--- a/pkgs/development/python-modules/pytest-param-files/default.nix
+++ b/pkgs/development/python-modules/pytest-param-files/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     pytest
   ];
 
-  pythonImportsCheck = [ "pytest_param_files" ];
+  pythonImportsExtrasCheck = [ "pytest_param_files" ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/pytest-playwright/default.nix
+++ b/pkgs/development/python-modules/pytest-playwright/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     export PLAYWRIGHT_BROWSERS_PATH=${playwright-driver.browsers}
   '';
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_playwright"
   ];
 

--- a/pkgs/development/python-modules/pytest-pudb/default.nix
+++ b/pkgs/development/python-modules/pytest-pudb/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "pytest_pudb" ];
+  pythonImportsExtrasCheck = [ "pytest_pudb" ];
 
   meta = with lib; {
     description = "Pytest PuDB debugger integration";

--- a/pkgs/development/python-modules/pytest-pylint/default.nix
+++ b/pkgs/development/python-modules/pytest-pylint/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_pylint"
   ];
 

--- a/pkgs/development/python-modules/pytest-pytestrail/default.nix
+++ b/pkgs/development/python-modules/pytest-pytestrail/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   # all tests require network accesss
   doCheck = false;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_pytestrail"
   ];
 

--- a/pkgs/development/python-modules/pytest-qt/default.nix
+++ b/pkgs/development/python-modules/pytest-qt/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pyqt5
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytestqt"
   ];
 

--- a/pkgs/development/python-modules/pytest-raises/default.nix
+++ b/pkgs/development/python-modules/pytest-raises/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_raises"
   ];
 

--- a/pkgs/development/python-modules/pytest-randomly/default.nix
+++ b/pkgs/development/python-modules/pytest-randomly/default.nix
@@ -5,6 +5,7 @@
 , fetchFromGitHub
 , importlib-metadata
 , numpy
+, pytest
 , pytest-xdist
 , pytestCheckHook
 , pythonOlder
@@ -29,6 +30,10 @@ buildPythonPackage rec {
     setuptools
   ];
 
+  buildInputs = [
+    pytest
+  ];
+
   propagatedBuildInputs = lib.optionals (pythonOlder "3.10") [
     importlib-metadata
   ];
@@ -47,7 +52,7 @@ buildPythonPackage rec {
     "no:randomly"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_randomly"
   ];
 

--- a/pkgs/development/python-modules/pytest-recording/default.nix
+++ b/pkgs/development/python-modules/pytest-recording/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     "tests"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_recording"
   ];
 

--- a/pkgs/development/python-modules/pytest-regressions/default.nix
+++ b/pkgs/development/python-modules/pytest-regressions/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     matplotlib
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_regressions"
     "pytest_regressions.plugin"
   ];

--- a/pkgs/development/python-modules/pytest-relaxed/default.nix
+++ b/pkgs/development/python-modules/pytest-relaxed/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     "tests"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_relaxed"
   ];
 

--- a/pkgs/development/python-modules/pytest-remotedata/default.nix
+++ b/pkgs/development/python-modules/pytest-remotedata/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     "tests/test_strict_check.py"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_remotedata"
   ];
 

--- a/pkgs/development/python-modules/pytest-resource-path/default.nix
+++ b/pkgs/development/python-modules/pytest-resource-path/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_resource_path"
   ];
 

--- a/pkgs/development/python-modules/pytest-services/default.nix
+++ b/pkgs/development/python-modules/pytest-services/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   # no tests in PyPI tarball
   doCheck = false;
 
-  pythonImportsCheck = [ "pytest_services" ];
+  pythonImportsExtrasCheck = [ "pytest_services" ];
 
   meta = with lib; {
     description = "Services plugin for pytest testing framework";

--- a/pkgs/development/python-modules/pytest-snapshot/default.nix
+++ b/pkgs/development/python-modules/pytest-snapshot/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_snapshot"
   ];
 

--- a/pkgs/development/python-modules/pytest-socket/default.nix
+++ b/pkgs/development/python-modules/pytest-socket/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   # pytest-socket require network for majority of tests
   doCheck = false;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_socket"
   ];
 

--- a/pkgs/development/python-modules/pytest-subtests/default.nix
+++ b/pkgs/development/python-modules/pytest-subtests/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , pytestCheckHook
 , pythonOlder
+, pytest
 , setuptools
 , setuptools-scm
 }:
@@ -19,6 +20,10 @@ buildPythonPackage rec {
     hash = "sha256-UYZciEV1RfUftyARlC8KPGkB7p4ky/ttG53BNIuvvjc=";
   };
 
+  buildInputs = [
+    pytest
+  ];
+
   nativeBuildInputs = [
     setuptools
     setuptools-scm
@@ -28,7 +33,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_subtests"
   ];
 

--- a/pkgs/development/python-modules/pytest-tap/default.nix
+++ b/pkgs/development/python-modules/pytest-tap/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     "test_unittest_expected_failure"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_tap"
   ];
 

--- a/pkgs/development/python-modules/pytest-test-utils/default.nix
+++ b/pkgs/development/python-modules/pytest-test-utils/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_test_utils"
   ];
 

--- a/pkgs/development/python-modules/pytest-testmon/default.nix
+++ b/pkgs/development/python-modules/pytest-testmon/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   # The project does not include tests since version 1.3.0
   doCheck = false;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "testmon"
   ];
 

--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     "-ra"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_timeout"
   ];
 

--- a/pkgs/development/python-modules/pytest-trio/default.nix
+++ b/pkgs/development/python-modules/pytest-trio/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     PYTHONPATH=$PWD:$PYTHONPATH pytest
   '';
 
-  pythonImportsCheck = [ "pytest_trio" ];
+  pythonImportsExtrasCheck = [ "pytest_trio" ];
 
   meta = with lib; {
     description = "Pytest plugin for trio";

--- a/pkgs/development/python-modules/pytest-twisted/default.nix
+++ b/pkgs/development/python-modules/pytest-twisted/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     twisted
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_twisted"
   ];
 

--- a/pkgs/development/python-modules/pytest-unordered/default.nix
+++ b/pkgs/development/python-modules/pytest-unordered/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_unordered"
   ];
 

--- a/pkgs/development/python-modules/pytest-vcr/default.nix
+++ b/pkgs/development/python-modules/pytest-vcr/default.nix
@@ -20,12 +20,12 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     vcrpy
-   ];
+  ];
 
   # Tests are using an obsolete attribute 'config'
   # https://github.com/ktosiek/pytest-vcr/issues/43
   doCheck = false;
-  pythonImportsCheck = [ "pytest_vcr" ];
+  pythonImportsExtrasCheck = [ "pytest_vcr" ];
 
   meta = with lib; {
     description = "Integration VCR.py into pytest";

--- a/pkgs/development/python-modules/pytest-voluptuous/default.nix
+++ b/pkgs/development/python-modules/pytest-voluptuous/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     six
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
     "pytest_voluptuous"
   ];
 

--- a/pkgs/development/python-modules/pytest-watch/default.nix
+++ b/pkgs/development/python-modules/pytest-watch/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   # No Tests
   doCheck = false;
-  pythonImportsCheck = [ "pytest_watch" ];
+  pythonImportsExtrasCheck = [ "pytest_watch" ];
 
   meta = with lib; {
     homepage = "https://github.com/joeyespo/pytest-watch";

--- a/pkgs/development/python-modules/pytest-xprocess/default.nix
+++ b/pkgs/development/python-modules/pytest-xprocess/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
 , psutil
 , py
@@ -16,6 +17,14 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-WZ7iW5OOjyWeGNnFtNY4SIT4pqKMpR7tMtDZUmvc93w=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "remove-py-dep.patch";
+      url = "https://github.com/pytest-dev/pytest-xprocess/commit/125ddccd46645cf259fdb499ec45d66d5acc3230.patch";
+      hash = "sha256-hb3Lg3Kvnb+kBPZ2MQU9lWKfh1RaVsgkZbMrTOFX6vA=";
+    })
+  ];
 
   postPatch = ''
     # Remove test QoL package from install_requires
@@ -38,6 +47,10 @@ buildPythonPackage rec {
 
   # There's no tests in repo
   doCheck = false;
+
+  pythonImportsExtrasCheck = [
+    "xprocess"
+  ];
 
   meta = with lib; {
     description = "Pytest external process plugin";

--- a/pkgs/development/python-modules/python-velbus/default.nix
+++ b/pkgs/development/python-modules/python-velbus/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , pyserial
 , pythonOlder
 }:
@@ -18,6 +19,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     pyserial
   ];
 

--- a/pkgs/development/python-modules/pywbem/default.nix
+++ b/pkgs/development/python-modules/pywbem/default.nix
@@ -41,6 +41,7 @@ buildPythonPackage rec {
     pbr
     ply
     pyyaml
+    requests
     six
     yamlloader
   ];
@@ -53,7 +54,6 @@ buildPythonPackage rec {
     lxml
     pytest
     pytz
-    requests
     requests-mock
     testfixtures
   ];

--- a/pkgs/development/python-modules/pyworld/default.nix
+++ b/pkgs/development/python-modules/pyworld/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , numpy
 , cython
 }:
@@ -19,6 +20,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     numpy
   ];
 

--- a/pkgs/development/python-modules/pyyaml-include/default.nix
+++ b/pkgs/development/python-modules/pyyaml-include/default.nix
@@ -16,10 +16,13 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pyyaml
     setuptools-scm
     setuptools-scm-git-archive
     toml
+  ];
+
+  propagatedBuildInputs = [
+    pyyaml
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/qreactor/default.nix
+++ b/pkgs/development/python-modules/qreactor/default.nix
@@ -8,8 +8,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "qreactor-unstable";
-  version = "2018-09-29";
+  pname = "qreactor";
+  version = "unstable-2018-09-29";
 
   src = fetchFromGitHub {
     owner = "frmdstryr";

--- a/pkgs/development/python-modules/qreactor/default.nix
+++ b/pkgs/development/python-modules/qreactor/default.nix
@@ -28,7 +28,8 @@ buildPythonPackage rec {
     pyqt5
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
+    # requires Qt bindings
     "qreactor"
   ];
 

--- a/pkgs/development/python-modules/remi/default.nix
+++ b/pkgs/development/python-modules/remi/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
+, setuptools
 , matplotlib
 , python-snap7
 , opencv4
@@ -18,6 +19,10 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-VQn+Uzp6oGSit8ot0e8B0C2N41Q8+J+o91skyVN1gDA=";
   };
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
+  ];
 
   preCheck = ''
     # for some reason, REMI already deal with these using try blocks, but they fail

--- a/pkgs/development/python-modules/robotframework-pythonlibcore/default.nix
+++ b/pkgs/development/python-modules/robotframework-pythonlibcore/default.nix
@@ -22,10 +22,13 @@ buildPythonPackage rec {
     hash = "sha256-RJTn1zSVJYgbh93Idr77uHl02u0wpj6p6llSJfQVTQk=";
   };
 
+  propagatedBuildInputs = [
+    robotframework
+  ];
+
   nativeCheckInputs = [
     pytest-mockito
     pytestCheckHook
-    robotframework
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/setupmeta/default.nix
+++ b/pkgs/development/python-modules/setupmeta/default.nix
@@ -8,6 +8,7 @@
 , pytestCheckHook
 , pythonOlder
 , setuptools-scm
+, setuptools
 , six
 , wheel
 }:
@@ -33,6 +34,10 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     setuptools-scm
     wheel
+  ];
+
+  propagatedBuildInputs = [
+    setuptools
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/setuptools-scm-git-archive/default.nix
+++ b/pkgs/development/python-modules/setuptools-scm-git-archive/default.nix
@@ -12,6 +12,8 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
+  propagatedBuildInputs = [ setuptools-scm ];
+
   nativeCheckInputs = [ pytestCheckHook ];
 
   pytestFlagsArray = [

--- a/pkgs/development/python-modules/shap/default.nix
+++ b/pkgs/development/python-modules/shap/default.nix
@@ -5,6 +5,7 @@
 , pythonOlder
 , writeText
 , catboost
+, packaging
 , cloudpickle
 , ipython
 , lightgbm
@@ -50,6 +51,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    packaging
     cloudpickle
     numba
     numpy
@@ -133,13 +135,16 @@ buildPythonPackage rec {
     "shap"
     "shap.explainers"
     "shap.explainers.other"
-    "shap.plots"
-    "shap.plots.colors"
-    "shap.benchmark"
     "shap.maskers"
     "shap.utils"
     "shap.actions"
     "shap.models"
+  ];
+  pythonImportsExtrasCheck = [
+    # requires matplotlib
+    "shap.plots"
+    "shap.plots.colors"
+    "shap.benchmark"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/sievelib/default.nix
+++ b/pkgs/development/python-modules/sievelib/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , mock
 , pytestCheckHook
+, setuptools
 , setuptools-scm
 }:
 
@@ -18,6 +19,10 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/sigrok/default.nix
+++ b/pkgs/development/python-modules/sigrok/default.nix
@@ -4,6 +4,7 @@
 , toPythonModule
 , python
 , autoreconfHook
+, wrapPython
 , pythonImportsCheckHook
 , pythonCatchConflictsHook
 , swig
@@ -31,6 +32,7 @@ toPythonModule ((libsigrok.override {
     swig
     numpy
   ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+    wrapPython
     pythonImportsCheckHook
     pythonCatchConflictsHook
   ];
@@ -51,7 +53,7 @@ toPythonModule ((libsigrok.override {
     export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
   '';
 
-  pythonImportsCheck = [ "sigrok" "sigrok.core" ];
+  pythonImportsExtrasCheck = [ "sigrok" "sigrok.core" ];
 
   meta = orig.meta // {
     description = "Python bindings for libsigrok";

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -25,7 +25,12 @@ buildPythonPackage rec {
     wheel
   ];
 
-  propagatedBuildInputs = [ packaging ply toml ];
+  propagatedBuildInputs = [
+    packaging
+    ply
+    setuptools
+    toml
+  ];
 
   # There aren't tests
   doCheck = false;

--- a/pkgs/development/python-modules/slowapi/default.nix
+++ b/pkgs/development/python-modules/slowapi/default.nix
@@ -45,6 +45,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     limits
     redis
+    starlette
   ];
 
   nativeCheckInputs = [
@@ -52,7 +53,6 @@ buildPythonPackage rec {
     hiro
     mock
     pytestCheckHook
-    starlette
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/soxr/default.nix
+++ b/pkgs/development/python-modules/soxr/default.nix
@@ -41,6 +41,10 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
+  propagatedBuildInputs = [
+    numpy
+  ];
+
   pythonImportsCheck = [
     "soxr"
   ];

--- a/pkgs/development/python-modules/spdx-tools/default.nix
+++ b/pkgs/development/python-modules/spdx-tools/default.nix
@@ -38,6 +38,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     beartype
     click
     license-expression

--- a/pkgs/development/python-modules/sphinxcontrib-jquery/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-jquery/default.nix
@@ -18,6 +18,10 @@ buildPythonPackage rec {
     hash = "sha256-argG+jMUqLiWo4lKWAmHmUxotHl+ddJuJZ/zcUl9u5Q=";
   };
 
+  propagatedBuildInputs = [
+    sphinx
+  ];
+
   nativeBuildInputs = [
     flit-core
   ];
@@ -28,7 +32,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    sphinx
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/sphinxcontrib-programoutput/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-programoutput/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, docutils
 , sphinx
 , sphinxcontrib-serializinghtml
 }:
@@ -16,6 +17,10 @@ buildPythonPackage rec {
 
   buildInputs = [
     sphinx
+  ];
+
+  propagatedBuildInputs = [
+    docutils
   ];
 
   # fails to import sphinxcontrib.serializinghtml

--- a/pkgs/development/python-modules/sphinxcontrib-programoutput/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-programoutput/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   # fails to import sphinxcontrib.serializinghtml
   doCheck = false;
 
-  pythonImportsCheck = [ "sphinxcontrib.programoutput" ];
+  pythonImportsExtrasCheck = [ "sphinxcontrib.programoutput" ];
 
   meta = with lib; {
     description = "Sphinx extension to include program output";

--- a/pkgs/development/python-modules/swagger-spec-validator/default.nix
+++ b/pkgs/development/python-modules/swagger-spec-validator/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pyyaml, jsonschema, six, pytestCheckHook, mock }:
+{ lib, buildPythonPackage, fetchFromGitHub, pyyaml, jsonschema, setuptools, six, pytestCheckHook, mock }:
 
 buildPythonPackage rec {
   pname = "swagger-spec-validator";
@@ -12,6 +12,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     pyyaml
     jsonschema
     six

--- a/pkgs/development/python-modules/syrupy/default.nix
+++ b/pkgs/development/python-modules/syrupy/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
-  pythonImportsCheck = [ "syrupy" ];
+  pythonImportsExtrasCheck = [ "syrupy" ];
 
   meta = with lib; {
     changelog = "https://github.com/tophat/syrupy/releases/tag/v${version}";

--- a/pkgs/development/python-modules/telepath/default.nix
+++ b/pkgs/development/python-modules/telepath/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "sha256-kfEAYCXbK0HTf1Gut/APkpw2krMa6C6mU/dJ0dsqzS0=";
   };
 
-  checkInputs = [ django ];
+  propagatedBuildInputs = [ django ];
 
   checkPhase = ''
     ${python.interpreter} -m django test --settings=telepath.test_settings

--- a/pkgs/development/python-modules/tensorboardx/default.nix
+++ b/pkgs/development/python-modules/tensorboardx/default.nix
@@ -29,7 +29,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    protobuf
     setuptools-scm
   ];
 
@@ -39,6 +38,7 @@ buildPythonPackage rec {
   env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   propagatedBuildInputs = [
+    protobuf
     crc32c
     numpy
   ];

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , Accelerate
+, packaging
 , blis
 , buildPythonPackage
 , catalogue
@@ -49,6 +50,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    packaging
     blis
     catalogue
     confection

--- a/pkgs/development/python-modules/tiler/default.nix
+++ b/pkgs/development/python-modules/tiler/default.nix
@@ -30,12 +30,12 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    setuptools
     setuptools-scm
     wheel
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     numpy
     tqdm
   ];

--- a/pkgs/development/python-modules/torchmetrics/default.nix
+++ b/pkgs/development/python-modules/torchmetrics/default.nix
@@ -62,7 +62,8 @@ buildPythonPackage {
     "tests/bases/test_collections.py"
   ];
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
+    # requires torch
     "torchmetrics"
   ];
 
@@ -75,4 +76,3 @@ buildPythonPackage {
     ];
   };
 }
-

--- a/pkgs/development/python-modules/tracerite/default.nix
+++ b/pkgs/development/python-modules/tracerite/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , setuptools-scm
 , html5tagger
 , python
@@ -25,6 +26,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     html5tagger
   ];
 

--- a/pkgs/development/python-modules/ukkonen/default.nix
+++ b/pkgs/development/python-modules/ukkonen/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     sha256 = "jG6VP/P5sadrdrmneH36/ExSld9blyMAAG963QS9+p0=";
   };
 
-  nativeBuildInputs = [
+  propagatedBuildInputs = [
     cffi
   ];
 

--- a/pkgs/development/python-modules/upass/default.nix
+++ b/pkgs/development/python-modules/upass/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , pyperclip
 , urwid
 }:
@@ -18,6 +19,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    setuptools # needed for 'pkg_resources'
     pyperclip
     urwid
   ];

--- a/pkgs/development/python-modules/vispy/default.nix
+++ b/pkgs/development/python-modules/vispy/default.nix
@@ -4,6 +4,7 @@
 , substituteAll
 , fetchPypi
 , cython
+, packaging
 , fontconfig
 , freetype-py
 , hsluv
@@ -46,6 +47,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    packaging
     fontconfig
     freetype-py
     hsluv

--- a/pkgs/development/python-modules/w1thermsensor/default.nix
+++ b/pkgs/development/python-modules/w1thermsensor/default.nix
@@ -51,7 +51,9 @@ buildPythonPackage rec {
   # https://github.com/timofurrer/w1thermsensor/issues/116
   doCheck = pythonOlder "3.11";
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
+    # runs 'modprobe w1-gpio' and 'modprobe w1-therm' on import
+    # and thus requires W1THERMSENSOR_NO_KERNEL_MODULE
     "w1thermsensor"
   ];
 

--- a/pkgs/development/python-modules/webtest-aiohttp/default.nix
+++ b/pkgs/development/python-modules/webtest-aiohttp/default.nix
@@ -33,10 +33,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     webtest
+    aiohttp
   ];
 
   nativeCheckInputs = [
-    aiohttp
     pytest-aiohttp
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/ziamath/default.nix
+++ b/pkgs/development/python-modules/ziamath/default.nix
@@ -24,12 +24,12 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     ziafont
+    latex2mathml
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     nbval
-    latex2mathml
   ];
 
   pytestFlagsArray = [ "--nbval-lax" ];

--- a/pkgs/development/tools/continuous-integration/buildbot/pkg.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/pkg.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k, buildbot }:
+{ lib, buildPythonPackage, fetchPypi, isPy3k, buildbot, setuptools }:
 
 buildPythonPackage rec {
   pname = "buildbot-pkg";
@@ -17,6 +17,8 @@ buildPythonPackage rec {
 
   # No tests
   doCheck = false;
+
+  propagatedBuildInputs = [ setuptools ]; # needed for 'pkg_resources'
 
   pythonImportsCheck = [ "buildbot_pkg" ];
 

--- a/pkgs/servers/matrix-synapse/plugins/ldap3.nix
+++ b/pkgs/servers/matrix-synapse/plugins/ldap3.nix
@@ -31,11 +31,13 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
+  buildInputs = [  matrix-synapse-unwrapped ];
+
   propagatedBuildInputs = [ service-identity ldap3 twisted ];
 
-  nativeCheckInputs = [ ldaptor matrix-synapse-unwrapped pytestCheckHook ];
+  nativeCheckInputs = [ ldaptor pytestCheckHook ];
 
-  pythonImportsCheck = [ "ldap_auth_provider" ];
+  pythonImportsExtrasCheck = [ "ldap_auth_provider" ]; # requires 'synapse'
 
   meta = with lib; {
     description = "LDAP3 auth provider for Synapse";

--- a/pkgs/servers/matrix-synapse/plugins/mjolnir-antispam.nix
+++ b/pkgs/servers/matrix-synapse/plugins/mjolnir-antispam.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   buildInputs = [ matrix-synapse-unwrapped ];
 
   doCheck = false; # no tests
-  pythonImportsCheck = [ "mjolnir" ];
+  pythonImportsExtrasCheck = [ "mjolnir" ]; # requires 'twisted' from synapse
 
   meta = with lib; {
     description = "AntiSpam / Banlist plugin to be used with mjolnir";

--- a/pkgs/servers/matrix-synapse/plugins/s3-storage-provider.nix
+++ b/pkgs/servers/matrix-synapse/plugins/s3-storage-provider.nix
@@ -46,7 +46,8 @@ buildPythonPackage rec {
   # Tests need network access
   doCheck = false;
 
-  pythonImportsCheck = [
+  pythonImportsExtrasCheck = [
+    # requires 'synapse'
     "s3_storage_provider"
   ];
 

--- a/pkgs/servers/matrix-synapse/plugins/shared-secret-auth.nix
+++ b/pkgs/servers/matrix-synapse/plugins/shared-secret-auth.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   };
 
   doCheck = false;
-  pythonImportsCheck = [ "shared_secret_authenticator" ];
+  pythonImportsExtrasCheck = [ "shared_secret_authenticator" ]; # requires 'synapse'
 
   buildInputs = [ matrix-synapse-unwrapped ];
   propagatedBuildInputs = [ twisted ];

--- a/pkgs/servers/monitoring/alerta/default.nix
+++ b/pkgs/servers/monitoring/alerta/default.nix
@@ -13,6 +13,7 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with python3.pkgs; [
+    setuptools # needed for 'pkg_resources'
     bcrypt
     blinker
     cryptography

--- a/pkgs/tools/security/ec2stepshell/default.nix
+++ b/pkgs/tools/security/ec2stepshell/default.nix
@@ -26,6 +26,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
+    setuptools # needed for 'pkg_resources'
     boto3
     colorama
     pyfiglet

--- a/pkgs/tools/text/invoice2data/default.nix
+++ b/pkgs/tools/text/invoice2data/default.nix
@@ -34,6 +34,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
+    setuptools # needed for 'pkg_resources'
     dateparser
     pdfminer-six
     pillow


### PR DESCRIPTION
## Description of changes

Too often do i pull a python package, only for it to error on import due to `pkg_resources` from `setuptools` missing. This PR stops the problem during build, by ensuring that `pythonImportsCheck` only knows about the propagated build inputs. I also add a `pythonImportsExtrasCheck` escape hatch for packages which require the old behavior.

My computers have been running hot for a few weeks now trying to test this. Perhaps it is time I either merge it into staging/python-develop or ask for some hydra assistance.

The first commit detail the major change, and is *currently with `FIXME`s and debugging code in them*. The following commits fix all the packages that break.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A motivational photo, showcasing the diff of between the old and new `PATH` and `PYTHONPATH` entries in `pythonImportCheck`: 
![image](https://github.com/NixOS/nixpkgs/assets/140964/497e7cf5-1b62-4f46-b378-2db092e20c34)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
