### PR TITLE
hackneyed: 0.8.2 -> 0.9.1

### DIFF
--- a/pkgs/data/icons/hackneyed/default.nix
+++ b/pkgs/data/icons/hackneyed/default.nix
@@ -1,28 +1,40 @@
-{ lib, fetchzip, stdenvNoCC, fetchFromGitLab, xcursorgen, imagemagick6, inkscape }:
+{ lib, stdenvNoCC, fetchFromGitLab, imagemagick, inkscape, xcursorgen }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "hackneyed";
-  version = "0.8.2";
+  version = "0.9.1";
 
   src = fetchFromGitLab {
     owner = "Enthymeme";
     repo = "hackneyed-x11-cursors";
     rev = version;
-    sha256 = "sha256-Wtrw/EzxCj4cAyfdBp0OJE4+c6FouW7+b6nFTLxdXNY=";
+    hash = "sha256-+7QtHgBuhJtQejiHeZ+QoedJo24LqSY51XRVLv9Ho2g=";
   };
 
-  buildInputs = [ imagemagick6 inkscape xcursorgen ];
+  nativeBuildInputs = [ imagemagick inkscape xcursorgen ];
 
   postPatch = ''
     patchShebangs *.sh
-    substituteInPlace make-png.sh \
-      --replace /usr/bin/inkscape ${inkscape}/bin/inkscape
   '';
 
   enableParallelBuilding = true;
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [
+    "INKSCAPE=inkscape"
+    "INSTALL=install"
+    "PREFIX=$(out)"
+    "VERBOSE=1"
+    "XCURSORGEN=xcursorgen"
+  ];
+
   buildFlags = [ "theme" "theme.left" ];
+
+  # The Makefile declares a dependency on the value of $(INKSCAPE) for some reason;
+  # it's unnecessary for building though.
+  prePatch = ''
+    substituteInPlace GNUmakefile \
+        --replace 'inkscape-version: $(INKSCAPE)' 'inkscape-version:'
+  '';
 
   meta = with lib; {
     homepage = "https://gitlab.com/Enthymeme/hackneyed-x11-cursors";


### PR DESCRIPTION
## Description of changes

https://gitlab.com/Enthymeme/hackneyed-x11-cursors/-/tags/0.9.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
