### PR TITLE
gbar: init at unstable-2023-09-21

### DIFF
--- a/pkgs/by-name/gb/gbar/package.nix
+++ b/pkgs/by-name/gb/gbar/package.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, cmake
+, pkg-config
+, libdbusmenu-gtk3
+, gtk-layer-shell
+, stb
+, wayland-protocols
+, wayland-scanner
+, bluez
+, gtk3
+, libpulseaudio
+, wayland
+}:
+
+stdenv.mkDerivation {
+  pname = "gbar";
+  version = "unstable-2023-09-21";
+
+  src = fetchFromGitHub {
+    owner = "scorpion-26";
+    repo = "gBar";
+    rev = "96485f408efe411f281fa27dceb6d86399ec7804";
+    hash = "sha256-4zPvo0JBQOV1qn2X2iI8/JWYEQjFf9sDEICIWSCeaWk=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    wayland-scanner
+    bluez
+    gtk3
+    gtk-layer-shell
+    libpulseaudio
+    stb
+    libdbusmenu-gtk3
+  ];
+
+  meta = with lib; {
+    description = "Blazingly fast status bar written with GTK";
+    homepage = "https://github.com/scorpion-26/gBar";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ocfox ];
+    mainProgram = "gBar";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes
close #252906
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
