### PR TITLE
openjdk17: 17.0.8 -> 17.0.8.1 (darwin)

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/17.nix
+++ b/pkgs/development/compilers/openjdk/darwin/17.nix
@@ -11,20 +11,20 @@ let
   dist = {
     x86_64-darwin = {
       arch = "x64";
-      zuluVersion = "17.44.15";
-      jdkVersion = "17.0.8";
+      zuluVersion = "17.44.53";
+      jdkVersion = "17.0.8.1";
       hash =
-        if enableJavaFX then "sha256-gmDku/AkWzO+eDRitezM9wCtTYDrUMtXyMulxqi9tNI="
-        else "sha256-Ci18gBkAv/UUIQw9KlnfibcQMXwQRGx6K7L/NBB7b7Q=";
+        if enableJavaFX then "sha256-9U0XYZRA+LZTQ7eHrT5SWhgcxv43ajC9n9Tj3qPPLWA="
+        else "sha256-ZART6K/o/+D7Tc60U1+1DbnCg8ZGZe67C6aLGeZfSx8=";
     };
 
     aarch64-darwin = {
       arch = "aarch64";
-      zuluVersion = "17.44.15";
-      jdkVersion = "17.0.8";
+      zuluVersion = "17.44.53";
+      jdkVersion = "17.0.8.1";
       hash =
-        if enableJavaFX then "sha256-mvyfqpnAoA05HJB9EBewW2MDuhQBOvp6svzyayV1irI="
-        else "sha256-8b81QY6DGXVOsTKM8QDzJnYjXV0ipCbYWaaz6oF2A6k=";
+        if enableJavaFX then "sha256-udYW3nOADclWqVcVtS9dgjSY0w6xf2nsBpLzPmQCYlI="
+        else "sha256-MUsEVo7Arps2ugPJy9Qq3J4SZfdGeJI7GSl9ZuuE3Mo=";
     };
   }."${stdenv.hostPlatform.system}";
 


### PR DESCRIPTION
## Description of changes

Updating JDK 17 on darwin to version 17.8.0.1, because 17.8.0 has a broken build (at least on aarch64). Reproducer:
```nix
{ pkgs ? import <nixpkgs> {} } :
  let 
    pkgs = import ../nixpkgs {};
    jre = pkgs.jre_minimal.override {
      modules = ["java.base" "java.se" "java.logging"];
      jdk = pkgs.jdk17;
    };
  in pkgs.mkShell {
    packages = [jre];
  }
```

results with: 
```
no configure script, doing nothing
building
Error: jdk.tools.jlink.plugin.PluginException: Duplicate resources: {lib/libj2gss.dylib=[java.security.jgss, java.security.sasl], bin/jrunscript=[java.sql, java.security.jgss, java.scripting, java.se, java.transaction.xa, java.xml.crypto, java.sql.rowset, java.xml, java.security.sasl], include/darwin/jawt_md.h=[java.rmi, java.sql, java.logging, java.transaction.xa, java.xml.crypto, java.management, java.sql.rowset, java.xml, java.instrument, java.security.jgss, java.desktop, java.naming, java.scripting, java.prefs, java.se, java.net.http, java.security.sasl, java.management.rmi], lib/libinstrument.dylib=[java.logging, java.instrument], man/man1/jrunscript.1=[java.sql, java.security.jgss, java.scripting, java.se, java.transaction.xa, java.xml.crypto, java.sql.rowset, java.xml, java.security.sasl], lib/libosxkrb5.dylib=[java.security.jgss, java.security.sasl], conf/logging.properties=[java.rmi, java.sql, java.logging, java.transaction.xa, java.xml.crypto, java.management, java.sql.rowset, java.xml, java.security.jgss, java.naming, java.scripting, java.prefs, java.se, java.net.http, java.security.sasl, java.management.rmi], lib/libj2pcsc.dylib=[java.sql, java.transaction.xa, java.xml.crypto, java.sql.rowset, java.xml], conf/sound.properties=[java.desktop, java.instrument], lib/libmanagement.dylib=[java.naming, java.management, java.net.http, java.management.rmi], lib/librmi.dylib=[java.rmi, java.scripting, java.se], include/jawt.h=[java.rmi, java.sql, java.logging, java.transaction.xa, java.xml.crypto, java.management, java.sql.rowset, java.xml, java.instrument, java.security.jgss, java.desktop, java.naming, java.scripting, java.prefs, java.se, java.net.http, java.security.sasl, java.management.rmi]}
error: builder for '/nix/store/7hwxm03mv9jj8a5lvhgf2k1crv2k9l2i-zulu17.44.15-ca-jdk-minimal-jre-17.0.8.drv' failed with exit code 1;
       last 6 log lines:
       > patching sources
       > updateAutotoolsGnuConfigScriptsPhase
       > configuring
       > no configure script, doing nothing
       > building
       > Error: jdk.tools.jlink.plugin.PluginException: Duplicate resources: {lib/libj2gss.dylib=[java.security.jgss, java.security.sasl], bin/jrunscript=[java.sql, java.security.jgss, java.scripting, java.se, java.transaction.xa, java.xml.crypto, java.sql.rowset, java.xml, java.security.sasl], include/darwin/jawt_md.h=[java.rmi, java.sql, java.logging, java.transaction.xa, java.xml.crypto, java.management, java.sql.rowset, java.xml, java.instrument, java.security.jgss, java.desktop, java.naming, java.scripting, java.prefs, java.se, java.net.http, java.security.sasl, java.management.rmi], lib/libinstrument.dylib=[java.logging, java.instrument], man/man1/jrunscript.1=[java.sql, java.security.jgss, java.scripting, java.se, java.transaction.xa, java.xml.crypto, java.sql.rowset, java.xml, java.security.sasl], lib/libosxkrb5.dylib=[java.security.jgss, java.security.sasl], conf/logging.properties=[java.rmi, java.sql, java.logging, java.transaction.xa, java.xml.crypto, java.management, java.sql.rowset, java.xml, java.security.jgss, java.naming, java.scripting, java.prefs, java.se, java.net.http, java.security.sasl, java.management.rmi], lib/libj2pcsc.dylib=[java.sql, java.transaction.xa, java.xml.crypto, java.sql.rowset, java.xml], conf/sound.properties=[java.desktop, java.instrument], lib/libmanagement.dylib=[java.naming, java.management, java.net.http, java.management.rmi], lib/librmi.dylib=[java.rmi, java.scripting, java.se], include/jawt.h=[java.rmi, java.sql, java.logging, java.transaction.xa, java.xml.crypto, java.management, java.sql.rowset, java.xml, java.instrument, java.security.jgss, java.desktop, java.naming, java.scripting, java.prefs, java.se, java.net.http, java.security.sasl, java.management.rmi]}
       For full logs, run 'nix log /nix/store/7hwxm03mv9jj8a5lvhgf2k1crv2k9l2i-zulu17.44.15-ca-jdk-minimal-jre-17.0.8.drv'.
```

on current master

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
