### PR TITLE
python311Packages.pygitguardian: 1.10.0 -> 1.10.0

### DIFF
--- a/pkgs/development/python-modules/pygitguardian/default.nix
+++ b/pkgs/development/python-modules/pygitguardian/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "pygitguardian";
-  version = "1.9.0";
+  version = "1.10.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "GitGuardian";
     repo = "py-gitguardian";
     rev = "refs/tags/v${version}";
-    hash = "sha256-lDs2H5GUf3fhTSX+20dD0FNW2oirkgQQk5t7GKSnKe4=";
+    hash = "sha256-o5Hur51Dh4HWI7f4BpfEi40/inVAJgYF3xXZGPMyF8E=";
   };
 
   nativeBuildInputs = [
@@ -49,17 +49,21 @@ buildPythonPackage rec {
 
   disabledTests = [
     # Tests require an API key
-    "test_health_check"
-    "test_multi_content_scan"
+    "test_compute_sca_files"
     "test_content_scan_exceptions"
-    "test_multi_content_exceptions"
     "test_content_scan"
-    "test_extra_headers"
-    "test_multiscan_parameters"
-    "test_quota_overview"
-    "test_versions_from_headers"
     "test_create_honeytoken"
     "test_create_jwt"
+    "test_extra_headers"
+    "test_health_check"
+    "test_multi_content_exceptions"
+    "test_multi_content_scan"
+    "test_multiscan_parameters"
+    "test_quota_overview"
+    "test_sca_client_scan_diff"
+    "test_sca_scan_directory_invalid_tar"
+    "test_sca_scan_directory"
+    "test_versions_from_headers"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/GitGuardian/py-gitguardian/compare/refs/tags/v1.10.0...v1.10.0

Changelog: https://github.com/GitGuardian/py-gitguardian/blob/1.10.0/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
