### PR TITLE
libetpan: Fix CVE-2022-4121 and more patches

### DIFF
--- a/pkgs/development/libraries/libetpan/default.nix
+++ b/pkgs/development/libraries/libetpan/default.nix
@@ -10,22 +10,53 @@ stdenv.mkDerivation rec {
     owner = "dinhviethoa";
     repo = "libetpan";
     rev = version;
-    sha256 = "0g7an003simfdn7ihg9yjv7hl2czsmjsndjrp39i7cad8icixscn";
+    hash = "sha256-lukeWURNsRPTuFk2q2XVnwkKz5Y+PRiPba5GPQCw6jw=";
   };
 
   outputs = [ "out" "dev" ];
 
   patches = [
-    # The following two patches are fixing CVE-2020-15953, as reported in the
-    # issue tracker: https://github.com/dinhvh/libetpan/issues/386
-    # They might be removed for the next version bump.
+    # The following patches are security and/or reliability fixes.
+    # They all must be removed for the next version bump.
+
+    # Fix potential null pointer deference
+    # https://github.com/dinhvh/libetpan/pull/348
+    (fetchpatch {
+      name = "pr-348-null-pointer-deference.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/720e92e5752e562723a9730f8e604cb78f3a9163.patch";
+      hash = "sha256-/bA/ekeMhLE3OyREHIanlrb+uuSxwur+ZloeaX9AyyM=";
+    })
+
+    # Fix potential null pointer deference
+    # https://github.com/dinhvh/libetpan/pull/361
+    (fetchpatch {
+      name = "pr-361-null-pointer-deference.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/0cdefb017fcfd0fae56a151dc14c8439a38ecc44.patch";
+      hash = "sha256-qbWisOCPI91AIXzg3n7mceSVbBKHZXd8Z0z1u/SrIG8=";
+    })
+
+    # Fix potential null pointer deference
+    # https://github.com/dinhvh/libetpan/pull/363
+    (fetchpatch {
+      name = "pr-363-null-pointer-deference.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/68bde8b12b40a680c29d228f0b8fe4dfbf2d8d0b.patch";
+      hash = "sha256-dUbnh2RoeELk/usHeFsdGC+J198jcudx3rb6/3sUAX0=";
+    })
+
+    # Missing boundary fix
+    # https://github.com/dinhvh/libetpan/pull/384
+    (fetchpatch {
+      name = "pr-384-missing-boundary-fix.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/24c485495216c00076b29391591f46b61fcb3dac.patch";
+      hash = "sha256-6ry8EfiYgbMtQYtT7L662I1A7N7N6OOy9T2ECgR7+cI=";
+    })
 
     # CVE-2020-15953: Detect extra data after STARTTLS response and exit
     # https://github.com/dinhvh/libetpan/pull/387
     (fetchpatch {
       name = "cve-2020-15953-imap.patch";
       url = "https://github.com/dinhvh/libetpan/commit/1002a0121a8f5a9aee25357769807f2c519fa50b.patch";
-      sha256 = "1h9ds2z4jii40a0i3z6hsnzx1ldmd2jqidsxp2y2ksyp1ijcgabn";
+      hash = "sha256-dqnHZAzX6ym8uF23iKVotdHQv9XQ/BGBAiRGSb7QLcE=";
     })
 
     # CVE-2020-15953: Detect extra data after STARTTLS responses in SMTP and POP3 and exit
@@ -33,7 +64,23 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "cve-2020-15953-pop3-smtp.patch";
       url = "https://github.com/dinhvh/libetpan/commit/298460a2adaabd2f28f417a0f106cb3b68d27df9.patch";
-      sha256 = "0lq829djar7nb3fai3vdzirmks3w2lfagzqc809lx2lln6y213a0";
+      hash = "sha256-QI0gvLGUik4TQAz/pxwVfOhZc/xtj6jcWPZkJVsSCFM=";
+    })
+
+    # Fix buffer overwrite for empty string in remove_trailing_eol
+    # https://github.com/dinhvh/libetpan/pull/408
+    (fetchpatch {
+      name = "pr-408-fix-buffer-overwrite.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/078b924c7f49ac435b10b0f53a73f1bbc4717064.patch";
+      hash = "sha256-lBRS+bv/7IK7yat2p3mc0SRYn/wRB/spjE7ungj6DT0=";
+    })
+
+    # CVE-2022-4121: Fixed crash when st_info_list is NULL.
+    # https://github.com/dinhvh/libetpan/issues/420
+    (fetchpatch {
+      name = "cve-2022-4121.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/5c9eb6b6ba64c4eb927d7a902317410181aacbba.patch";
+      hash = "sha256-O+LUkI91oej7MFg4Pg6/xq1uhSanweH81VzPXBdiPh4=";
     })
   ];
 
@@ -45,9 +92,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Mail Framework for the C Language";
-    homepage = "http://www.etpan.org/libetpan.html";
+    homepage = "https://www.etpan.org/libetpan.html";
     license = licenses.bsd3;
     maintainers = with maintainers; [ oxzi ];
-    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

There are multiple security and reliability fixes on libetpan's master branch which weren't included into a new release yet. Next to the mentioned CVE-2022-4121, some other small security-related commits were selected.

As a bit of housekeeping, the sha256 field was replaced with hash for the fetchers and an https URL was chosen for the homepage.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
