### PR TITLE
glasgow: fix on Darwin and non-NixOS Linux

### DIFF
--- a/pkgs/tools/misc/glasgow/default.nix
+++ b/pkgs/tools/misc/glasgow/default.nix
@@ -58,7 +58,10 @@ python3.pkgs.buildPythonApplication rec {
 
   checkPhase = ''
     # tests attempt to cache bitstreams
+    # for linux:
     export XDG_CACHE_HOME=$TMPDIR
+    # for darwin:
+    export HOME=$TMPDIR
     ${python3.interpreter} -W ignore::DeprecationWarning test.py
   '';
 

--- a/pkgs/tools/misc/glasgow/default.nix
+++ b/pkgs/tools/misc/glasgow/default.nix
@@ -33,6 +33,7 @@ python3.pkgs.buildPythonApplication rec {
     crc
     fx2
     libusb1
+    packaging
     pyvcd
     setuptools
   ];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1. Attempts to fix Glasgow check phase on Darwin (AArch64/x86_64).

Failure log: https://hydra.nixos.org/build/236090691/nixlog/1

Setting HOME=/tmp should make `appdirs.user_cache_dir("GlasgowEmbedded", appauthor=False)` in `software/glasgow/target/hardware.py` return `/tmp/Library/Application Support` (via appdirs).

Haven't tested on Darwin as I don't have access to a machine with it, deferring to CI on this one.

2. Fixes runtime issue on non-NixOS Linux.

Failure log (Fedora + Nix):

```
q3k@xxx ~/Software/nixpkgs $ result/bin/glasgow list
Traceback (most recent call last):
  File "/nix/store/975r0wf3x8mgx5sh0vxf04ci0rdpifb9-glasgow-unstable-2023-09-20/bin/.glasgow-wrapped", line 6, in <module>
    from glasgow.cli import main
  File "/nix/store/975r0wf3x8mgx5sh0vxf04ci0rdpifb9-glasgow-unstable-2023-09-20/lib/python3.10/site-packages/glasgow/cli.py", line 25, in <module>
    from .support.plugin import PluginRequirementsUnmet
  File "/nix/store/975r0wf3x8mgx5sh0vxf04ci0rdpifb9-glasgow-unstable-2023-09-20/lib/python3.10/site-packages/glasgow/support/plugin.py", line 2, in <module>
    import packaging.requirements
ModuleNotFoundError: No module named 'packaging'
```

Ideally we would add a regression test for this, but I wasn't able to replicate this within checkPhase.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
