### PR TITLE
linux-wallpaperengine: init at unstable-2023-09-23

### DIFF
--- a/pkgs/by-name/li/linux-wallpaperengine/package.nix
+++ b/pkgs/by-name/li/linux-wallpaperengine/package.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ffmpeg
+, freeglut
+, freeimage
+, glew
+, glfw
+, glm
+, libGL
+, libpulseaudio
+, libX11
+, libXau
+, libXdmcp
+, libXext
+, libXpm
+, libXrandr
+, libXxf86vm
+, lz4
+, mpv
+, pkg-config
+, SDL2
+, SDL2_mixer
+, zlib
+}:
+
+stdenv.mkDerivation {
+  pname = "linux-wallpaperengine";
+  version = "unstable-2023-09-23";
+
+  src = fetchFromGitHub {
+    owner = "Almamu";
+    repo = "linux-wallpaperengine";
+    # upstream lacks versioned releases
+    rev = "21c38d9fd1d3d89376c870cec5c5e5dc7086bc3c";
+    hash = "sha256-bZlMHlNKSydh9eGm5cFSEtv/RV9sA5ABs99uurblBZY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    ffmpeg
+    freeglut
+    freeimage
+    glew
+    glfw
+    glm
+    libGL
+    libpulseaudio
+    libX11
+    libXau
+    libXdmcp
+    libXext
+    libXrandr
+    libXpm
+    libXxf86vm
+    mpv
+    lz4
+    SDL2
+    SDL2_mixer.all
+    zlib
+  ];
+
+  meta = {
+    description = "Wallpaper Engine backgrounds for Linux";
+    homepage = "https://github.com/Almamu/linux-wallpaperengine";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "linux-wallpaperengine";
+    maintainers = with lib.maintainers; [ eclairevoyant ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Fixes #237762.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
