### PR TITLE
turso-cli: 0.82.0 -> 0.85.3

### DIFF
--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -5,16 +5,16 @@
 }:
 buildGo121Module rec {
   pname = "turso-cli";
-  version = "0.85.1";
+  version = "0.85.3";
 
   src = fetchFromGitHub {
     owner = "tursodatabase";
     repo = "turso-cli";
     rev = "v${version}";
-    hash = "sha256-3JyAvxIKDVifGNJ5uOiIcaCvZ3U8u1fdvT6Xmvksnzc=";
+    hash = "sha256-dJpHrqPyikkUnE4Un1fGOEJL49U5IiInYeSWmI04r18=";
   };
 
-  vendorHash = "sha256-OiLb+aLZfTLtxNWBJYyyrFXBGbsGKS5rjP+P6RQ94wE=";
+  vendorHash = "sha256-Hv4CacBrRX2YT3AkbNzyWrA9Ex6YMDPrPvezukwMkTE=";
 
   # Build with production code
   tags = ["prod"];

--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -20,7 +20,7 @@ buildGo121Module rec {
   tags = ["prod"];
   # Include version for `turso --version` reporting
   preBuild = ''
-    echo "v${version} (nix build)" > internal/cmd/version.txt
+    echo "v${version}" > internal/cmd/version.txt
   '';
 
   # Test_setDatabasesCache fails due to /homeless-shelter: read-only file system error.

--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -1,20 +1,27 @@
 {
   lib,
-  buildGoModule,
+  buildGo121Module,
   fetchFromGitHub,
 }:
-buildGoModule rec {
+buildGo121Module rec {
   pname = "turso-cli";
-  version = "0.82.0";
+  version = "0.85.1";
 
   src = fetchFromGitHub {
     owner = "tursodatabase";
     repo = "turso-cli";
     rev = "v${version}";
-    hash = "sha256-JFuD10EhR1/nmYPMnNsR/8PUR5ScvWyS+vhg7ZO5TpI=";
+    hash = "sha256-3JyAvxIKDVifGNJ5uOiIcaCvZ3U8u1fdvT6Xmvksnzc=";
   };
 
-  vendorHash = "sha256-Y/pg8+w6B1YQqaZ5wj8QZxiBHAG0Tf3Zec5WlVyA4eI=";
+  vendorHash = "sha256-OiLb+aLZfTLtxNWBJYyyrFXBGbsGKS5rjP+P6RQ94wE=";
+
+  # Build with production code
+  tags = ["prod"];
+  # Include version for `turso --version` reporting
+  preBuild = ''
+    echo "${version}" > internal/cmd/version.txt
+  '';
 
   # Test_setDatabasesCache fails due to /homeless-shelter: read-only file system error.
   doCheck = false;
@@ -22,6 +29,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "This is the command line interface (CLI) to Turso.";
     homepage = "https://turso.tech";
+    mainProgram = "turso";
     license = licenses.mit;
     maintainers = with maintainers; [ zestsystem kashw2 ];
   };

--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -20,7 +20,7 @@ buildGo121Module rec {
   tags = ["prod"];
   # Include version for `turso --version` reporting
   preBuild = ''
-    echo "${version}" > internal/cmd/version.txt
+    echo "v${version} (nix build)" > internal/cmd/version.txt
   '';
 
   # Test_setDatabasesCache fails due to /homeless-shelter: read-only file system error.


### PR DESCRIPTION
## Description of changes

### Version change

Turso CLI doesn't include a changelog, but the commits since the version here are there:
https://github.com/tursodatabase/turso-cli/compare/v0.82.0...v0.85.3

The major changes are:
- Support for database groups, allowing hundreds of isolated databases in a single location.
- Data branching.
- Point in time recovery.

### Other changes

- Added the build tag "prod" to mirror their release builds and not include development code
- Added a `preBuild` step to inform the build which version is being built (would be generated from the git tag)
  Previously `turso --version` would show `turso version dev`.  
  Now it shows `turso version v0.85.1 (nix build)`. I added the `(nix build)` at the end to avoid confusion with their distributed binaries.
- Added `meta.mainProgram` to allow `nix run nixpkgs#turso-cli` to work

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
