### PR TITLE
hashlink: add haxelib library to output

### DIFF
--- a/pkgs/development/interpreters/hashlink/default.nix
+++ b/pkgs/development/interpreters/hashlink/default.nix
@@ -44,6 +44,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ getconf ];
 
+  # append default installPhase with library install for haxe
+  postInstall = let
+    haxelibPath =
+      "$out/lib/haxe/hashlink/${lib.replaceStrings [ "." ] [ "," ] version}";
+  in ''
+    mkdir -p "${haxelibPath}"
+    echo -n "${version}" > "${haxelibPath}/../.current"
+    cp -r other/haxelib/* "${haxelibPath}"
+  '';
+
+
   postFixup = lib.optionalString stdenv.isDarwin ''
     install_name_tool -change libhl.dylib $out/lib/libhl.dylib $out/bin/hl
   '';

--- a/pkgs/development/interpreters/hashlink/default.nix
+++ b/pkgs/development/interpreters/hashlink/default.nix
@@ -46,14 +46,12 @@ stdenv.mkDerivation rec {
 
   # append default installPhase with library install for haxe
   postInstall = let
-    haxelibPath =
-      "$out/lib/haxe/hashlink/${lib.replaceStrings [ "." ] [ "," ] version}";
+    haxelibPath = "$out/lib/haxe/hashlink/${lib.replaceStrings [ "." ] [ "," ] version}";
   in ''
     mkdir -p "${haxelibPath}"
     echo -n "${version}" > "${haxelibPath}/../.current"
     cp -r other/haxelib/* "${haxelibPath}"
   '';
-
 
   postFixup = lib.optionalString stdenv.isDarwin ''
     install_name_tool -change libhl.dylib $out/lib/libhl.dylib $out/bin/hl


### PR DESCRIPTION
## Description of changes

This adds an output folder to `pkgs.hashlink`. hashlink haxelib library (located in `other/haxelib`) is necessary to use the HL/C pipeline, allowing native compilation (in C with GCC) of haxe code. The library is then detected by haxe (if in `lib/haxe/{name}/{versionWithCommas}/`) 
details about hashlink compilation can be found in the [haxe documentation](https://haxe.org/manual/target-hl-c-compilation.html)

Another way would be to do a separate package in haxePackages. but since it uses the same source I don't know if it's sane to not re-use.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
