### PR TITLE
gallia: 1.1.4 -> 1.3.0

### DIFF
--- a/pkgs/tools/security/gallia/default.nix
+++ b/pkgs/tools/security/gallia/default.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gallia";
-  version = "1.1.4";
+  version = "1.3.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "Fraunhofer-AISEC";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-McHzHK404kDB992T2f84dZHDxujpPIz4qglYMmv3kTw=";
+    hash = "sha256-ofGAeTPEvzFTswDSR2xdlF5qxE41xsNeOB0G4xbHJYo=";
   };
 
   pythonRelaxDeps = [
@@ -34,7 +34,9 @@ python3.pkgs.buildPythonApplication rec {
     argcomplete
     can
     construct
+    exitcode
     msgspec
+    platformdirs
     pydantic
     pygit2
     tabulate


### PR DESCRIPTION
No idea why the tests fail, is this a bug in `nixpkgs` or is something else broken? Tests upstream are just fine.

```
error: builder for '/nix/store/j4091gl6lpcvfvgkjw2mrf3h7mj4r5jm-gallia-1.3.0.drv' failed with exit code 2;
       last 10 log lines:
       > -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
       > =========================== short test summary info ============================
       > ERROR src/gallia/commands/primitive/uds/test_xcp.py
       > ERROR tests/test_config.py
       > ERROR tests/test_helpers.py
       > ERROR tests/test_target_uris.py
       > ERROR tests/test_transports.py
       > !!!!!!!!!!!!!!!!!!! Interrupted: 5 errors during collection !!!!!!!!!!!!!!!!!!!!
       > ========================= 1 warning, 5 errors in 0.38s =========================
       > /nix/store/vr6wwdxkmyy44sg0gwxi10b8fc5zhwz0-stdenv-linux/setup: line 1596: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/j4091gl6lpcvfvgkjw2mrf3h7mj4r5jm-gallia-1.3.0.drv'.
```