### PR TITLE
rss-bridge: 2022-06-14 -> 2023-09-24

### DIFF
--- a/pkgs/servers/web-apps/rss-bridge/default.nix
+++ b/pkgs/servers/web-apps/rss-bridge/default.nix
@@ -2,20 +2,22 @@
 
 stdenv.mkDerivation rec {
   pname = "rss-bridge";
-  version = "2022-06-14";
+  version = "2023-09-24";
 
   src = fetchFromGitHub {
     owner = "RSS-Bridge";
     repo = "rss-bridge";
     rev = version;
-    sha256 = "sha256-yH+m65CIZokZSbnv1zfpKC/Qr/mPPC6dG49Zn62X0l4=";
+    sha256 = "sha256-N1pbveOgJrB1M+WelKD07Jmv9Vz5NqT+IJf//L8UEnU=";
   };
 
   postPatch = ''
-    substituteInPlace lib/rssbridge.php \
-      --replace "define('PATH_CACHE', PATH_ROOT . 'cache/');" "define('PATH_CACHE', getenv('RSSBRIDGE_DATA') . '/cache/');" \
-      --replace "define('FILE_CONFIG', PATH_ROOT . 'config.ini.php');" "define('FILE_CONFIG', getenv('RSSBRIDGE_DATA') . '/config.ini.php');" \
-      --replace "define('WHITELIST', PATH_ROOT . 'whitelist.txt');" "define('WHITELIST', getenv('RSSBRIDGE_DATA') . '/whitelist.txt');"
+    substituteInPlace lib/RssBridge.php \
+        --replace "__DIR__ . '/../config.ini.php'" "getenv('RSSBRIDGE_DATA') . '/config.ini.php'"
+    substituteInPlace lib/bootstrap.php \
+        --replace "const PATH_CACHE = __DIR__ . '/../cache/';" "define('PATH_CACHE', getenv('RSSBRIDGE_DATA') . '/cache/');"
+    substituteInPlace lib/Configuration.php \
+        --replace "__DIR__ . '/../whitelist.txt'" "getenv('RSSBRIDGE_DATA') . '/whitelist.txt'"
   '';
 
   installPhase = ''

--- a/pkgs/servers/web-apps/rss-bridge/default.nix
+++ b/pkgs/servers/web-apps/rss-bridge/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "The RSS feed for websites missing it";
     homepage = "https://github.com/RSS-Bridge/rss-bridge";
     license = licenses.unlicense;
-    maintainers = with maintainers; [ dawidsowa ];
+    maintainers = with maintainers; [ dawidsowa mynacol ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/web-apps/rss-bridge/default.nix
+++ b/pkgs/servers/web-apps/rss-bridge/default.nix
@@ -11,14 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-N1pbveOgJrB1M+WelKD07Jmv9Vz5NqT+IJf//L8UEnU=";
   };
 
-  postPatch = ''
-    substituteInPlace lib/RssBridge.php \
-        --replace "__DIR__ . '/../config.ini.php'" "getenv('RSSBRIDGE_DATA') . '/config.ini.php'"
-    substituteInPlace lib/bootstrap.php \
-        --replace "const PATH_CACHE = __DIR__ . '/../cache/';" "define('PATH_CACHE', getenv('RSSBRIDGE_DATA') . '/cache/');"
-    substituteInPlace lib/Configuration.php \
-        --replace "__DIR__ . '/../whitelist.txt'" "getenv('RSSBRIDGE_DATA') . '/whitelist.txt'"
-  '';
+  patches = [
+    ./paths.patch
+  ];
 
   installPhase = ''
     mkdir $out/

--- a/pkgs/servers/web-apps/rss-bridge/paths.patch
+++ b/pkgs/servers/web-apps/rss-bridge/paths.patch
@@ -1,0 +1,43 @@
+diff --git a/lib/Configuration.php b/lib/Configuration.php
+index c38d7cc9..d95e5174 100644
+--- a/lib/Configuration.php
++++ b/lib/Configuration.php
+@@ -104,8 +104,8 @@ final class Configuration
+             }
+         }
+ 
+-        if (file_exists(__DIR__ . '/../whitelist.txt')) {
+-            $enabledBridges = trim(file_get_contents(__DIR__ . '/../whitelist.txt'));
++        if (file_exists(getenv('RSSBRIDGE_DATA') . '/whitelist.txt')) {
++            $enabledBridges = trim(file_get_contents(getenv('RSSBRIDGE_DATA') . '/whitelist.txt'));
+             if ($enabledBridges === '*') {
+                 self::setConfig('system', 'enabled_bridges', ['*']);
+             } else {
+diff --git a/lib/RssBridge.php b/lib/RssBridge.php
+index 6ba952eb..a0bbaf03 100644
+--- a/lib/RssBridge.php
++++ b/lib/RssBridge.php
+@@ -11,8 +11,8 @@ final class RssBridge
+         Configuration::verifyInstallation();
+ 
+         $customConfig = [];
+-        if (file_exists(__DIR__ . '/../config.ini.php')) {
+-            $customConfig = parse_ini_file(__DIR__ . '/../config.ini.php', true, INI_SCANNER_TYPED);
++        if (file_exists(getenv('RSSBRIDGE_DATA') . '/config.ini.php')) {
++            $customConfig = parse_ini_file(getenv('RSSBRIDGE_DATA') . '/config.ini.php', true, INI_SCANNER_TYPED);
+         }
+         Configuration::loadConfiguration($customConfig, getenv());
+ 
+diff --git a/lib/bootstrap.php b/lib/bootstrap.php
+index dc1c0f04..194a3f8f 100644
+--- a/lib/bootstrap.php
++++ b/lib/bootstrap.php
+@@ -27,7 +27,7 @@ const PATH_LIB_CACHES = __DIR__ . '/../caches/';
+ const PATH_LIB_ACTIONS = __DIR__ . '/../actions/';
+ 
+ /** Path to the cache folder */
+-const PATH_CACHE = __DIR__ . '/../cache/';
++define('PATH_CACHE', getenv('RSSBRIDGE_DATA') . '/cache/');
+ 
+ /** URL to the RSS-Bridge repository */
+ const REPOSITORY = 'https://github.com/RSS-Bridge/rss-bridge/';


### PR DESCRIPTION
## Description of changes

Update to the latest release: https://github.com/RSS-Bridge/rss-bridge/releases/tag/2023-09-24

The source code substitutions have to be adopted to continue working. The PATH_CACHE const has to use `define` instead, as const forbids using functions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@dawidsowa 