### PR TITLE
nixosTests.nfs4.{simple,kerberos}: use a nonzero fsid

### DIFF
--- a/nixos/tests/nfs/kerberos.nix
+++ b/nixos/tests/nfs/kerberos.nix
@@ -40,7 +40,7 @@ in
 
         virtualisation.fileSystems =
           { "/data" = {
-              device  = "server.nfs.test:/";
+              device  = "server.nfs.test:/data";
               fsType  = "nfs";
               options = [ "nfsvers=4" "sec=krb5p" "noauto" ];
             };
@@ -71,7 +71,7 @@ in
         services.nfs.server.createMountPoints = true;
         services.nfs.server.exports =
           ''
-            /data *(rw,no_root_squash,fsid=0,sec=krb5p)
+            /data *(rw,no_root_squash,fsid=1,sec=krb5p)
           '';
       };
   };

--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -6,8 +6,8 @@ let
     { pkgs, ... }:
     { virtualisation.fileSystems =
         { "/data" =
-           { # nfs4 exports the export with fsid=0 as a virtual root directory
-             device = if (version == 4) then "server:/" else "server:/data";
+           {
+             device = "server:/data";
              fsType = "nfs";
              options = [ "vers=${toString version}" ];
            };
@@ -32,7 +32,7 @@ in
         { services.nfs.server.enable = true;
           services.nfs.server.exports =
             ''
-              /data 192.168.1.0/255.255.255.0(rw,no_root_squash,no_subtree_check,fsid=0)
+              /data 192.168.1.0/255.255.255.0(rw,no_root_squash,no_subtree_check,fsid=1)
             '';
           services.nfs.server.createMountPoints = true;
           networking.firewall.enable = false; # FIXME: figure out what ports need to be allowed


### PR DESCRIPTION
## Description of changes

#256526, but only the nixos test changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
