### PR TITLE
libreoffice-fresh: 7.5.4.1 -> 7.6.2.1

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , fetchurl
-, fetchpatch
 , lib
 , substituteAll
 , pam
@@ -221,12 +220,6 @@ in
   # for 7.4.
   patches = lib.optionals (lib.versionAtLeast version "7.5") [
     ./0001-Strip-away-BUILDCONFIG.patch
-  ] ++ [
-    (fetchpatch {
-      name = "fix-curl-8.2.patch";
-      url = "https://github.com/LibreOffice/core/commit/2a68dc02bd19a717d3c86873206fabed1098f228.diff";
-      hash = "sha256-C+kts+oaLR3+GbnX/wrFguF7SzgerNataxP0SPxhyY8=";
-    })
   ];
 
   # libreoffice tries to reference the BUILDCONFIG (e.g. PKG_CONFIG_PATH)

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -467,6 +467,7 @@ in
     "--without-system-libqxp"
     "--without-system-dragonbox"
     "--without-system-libfixmath"
+    "--without-system-frozen"
     # https://github.com/NixOS/nixpkgs/commit/5c5362427a3fa9aefccfca9e531492a8735d4e6f
     # https://github.com/NixOS/nixpkgs/issues/212556, but we need mdds 2.1 for libreoffice 7.6+
     "--without-system-mdds"

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -66,7 +66,6 @@
 , libcdr
 , lcms
 , unixODBC
-, mdds
 , sane-backends
 , mythes
 , libexttextcat
@@ -468,8 +467,9 @@ in
     "--without-system-libqxp"
     "--without-system-dragonbox"
     "--without-system-libfixmath"
-    "--with-system-mdds"
     # https://github.com/NixOS/nixpkgs/commit/5c5362427a3fa9aefccfca9e531492a8735d4e6f
+    # https://github.com/NixOS/nixpkgs/issues/212556, but we need mdds 2.1 for libreoffice 7.6+
+    "--without-system-mdds"
     "--without-system-orcus"
     "--without-system-xmlsec"
     "--without-system-cuckoo"
@@ -565,7 +565,6 @@ in
     libxshmfence
     libxslt
     libzmf
-    mdds
     mythes
     ncurses
     neon

--- a/pkgs/applications/office/libreoffice/src-fresh/download.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/download.nix
@@ -7,11 +7,11 @@
     md5name = "e763a9dc21c3d2667402d66e202e3f8ef4db51b34b79ef41f56cacb86dcd6eed-libabw-0.1.3.tar.xz";
   }
   {
-    name = "boost_1_80_0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/boost_1_80_0.tar.xz";
-    sha256 = "322e567e98c466c0aa0e380ed8c647552fe4af48998648428f1b5f0c8eff4666";
+    name = "boost_1_82_0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/boost_1_82_0.tar.xz";
+    sha256 = "e48ab6953fbd68ba47234bea5173e62427e9f6a7894e152305142895cfe955de";
     md5 = "";
-    md5name = "322e567e98c466c0aa0e380ed8c647552fe4af48998648428f1b5f0c8eff4666-boost_1_80_0.tar.xz";
+    md5name = "e48ab6953fbd68ba47234bea5173e62427e9f6a7894e152305142895cfe955de-boost_1_82_0.tar.xz";
   }
   {
     name = "box2d-2.4.1.tar.gz";
@@ -98,11 +98,11 @@
     md5name = "89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7-cppunit-1.15.1.tar.gz";
   }
   {
-    name = "curl-8.0.1.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/curl-8.0.1.tar.xz";
-    sha256 = "0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0";
+    name = "curl-8.2.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/curl-8.2.1.tar.xz";
+    sha256 = "dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894";
     md5 = "";
-    md5name = "0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0-curl-8.0.1.tar.xz";
+    md5name = "dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894-curl-8.2.1.tar.xz";
   }
   {
     name = "libe-book-0.1.3.tar.xz";
@@ -154,11 +154,11 @@
     md5name = "acb85cedafa10ce106b1823fb236b1b3e5d942a5741e8f8435cc8ccfec0afe76-Firebird-3.0.7.33374-0.tar.bz2";
   }
   {
-    name = "fontconfig-2.13.94.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/fontconfig-2.13.94.tar.xz";
-    sha256 = "a5f052cb73fd479ffb7b697980510903b563bbb55b8f7a2b001fcfb94026003c";
+    name = "fontconfig-2.14.2.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/fontconfig-2.14.2.tar.xz";
+    sha256 = "dba695b57bce15023d2ceedef82062c2b925e51f5d4cc4aef736cf13f60a468b";
     md5 = "";
-    md5name = "a5f052cb73fd479ffb7b697980510903b563bbb55b8f7a2b001fcfb94026003c-fontconfig-2.13.94.tar.xz";
+    md5name = "dba695b57bce15023d2ceedef82062c2b925e51f5d4cc4aef736cf13f60a468b-fontconfig-2.14.2.tar.xz";
   }
   {
     name = "crosextrafonts-20130214.tar.gz";
@@ -208,13 +208,6 @@
     sha256 = "54adcb2bc8cac0927a647fbd9362f45eff48130ce6e2379dc3867643019e08c5";
     md5 = "e7a384790b13c29113e22e596ade9687";
     md5name = "e7a384790b13c29113e22e596ade9687-LinLibertineG-20120116.zip";
-  }
-  {
-    name = "source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
-    sha256 = "e7bc9a1fec787a529e49f5a26b93dcdcf41506449dfc70f92cdef6d17eb6fb61";
-    md5 = "edc4d741888bc0d38e32dbaa17149596";
-    md5name = "edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
   }
   {
     name = "noto-fonts-20171024.tar.gz";
@@ -273,11 +266,18 @@
     md5name = "0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac-libfreehand-0.1.2.tar.xz";
   }
   {
-    name = "freetype-2.12.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/freetype-2.12.0.tar.xz";
-    sha256 = "ef5c336aacc1a079ff9262d6308d6c2a066dd4d2a905301c4adda9b354399033";
+    name = "freetype-2.13.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/freetype-2.13.0.tar.xz";
+    sha256 = "5ee23abd047636c24b2d43c6625dcafc66661d1aca64dec9e0d05df29592624c";
     md5 = "";
-    md5name = "ef5c336aacc1a079ff9262d6308d6c2a066dd4d2a905301c4adda9b354399033-freetype-2.12.0.tar.xz";
+    md5name = "5ee23abd047636c24b2d43c6625dcafc66661d1aca64dec9e0d05df29592624c-freetype-2.13.0.tar.xz";
+  }
+  {
+    name = "frozen-1.1.1.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/frozen-1.1.1.tar.gz";
+    sha256 = "f7c7075750e8fceeac081e9ef01944f221b36d9725beac8681cbd2838d26be45";
+    md5 = "";
+    md5name = "f7c7075750e8fceeac081e9ef01944f221b36d9725beac8681cbd2838d26be45-frozen-1.1.1.tar.gz";
   }
   {
     name = "glm-0.9.9.8.zip";
@@ -301,11 +301,11 @@
     md5name = "b8e892d8627c41888ff121e921455b9e2d26836978f2359173d19825da62b8fc-graphite2-minimal-1.3.14.tgz";
   }
   {
-    name = "harfbuzz-7.1.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/harfbuzz-7.1.0.tar.xz";
-    sha256 = "f135a61cd464c9ed6bc9823764c188f276c3850a8dc904628de2a87966b7077b";
+    name = "harfbuzz-8.0.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/harfbuzz-8.0.0.tar.xz";
+    sha256 = "1f98b5e3d06a344fe667d7e8210094ced458791499839bddde98c167ce6a7c79";
     md5 = "";
-    md5name = "f135a61cd464c9ed6bc9823764c188f276c3850a8dc904628de2a87966b7077b-harfbuzz-7.1.0.tar.xz";
+    md5name = "1f98b5e3d06a344fe667d7e8210094ced458791499839bddde98c167ce6a7c79-harfbuzz-8.0.0.tar.xz";
   }
   {
     name = "hsqldb_1_8_0.zip";
@@ -329,18 +329,18 @@
     md5name = "5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
   }
   {
-    name = "icu4c-72_1-src.tgz";
-    url = "https://dev-www.libreoffice.org/src/icu4c-72_1-src.tgz";
-    sha256 = "a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68";
+    name = "icu4c-73_2-src.tgz";
+    url = "https://dev-www.libreoffice.org/src/icu4c-73_2-src.tgz";
+    sha256 = "818a80712ed3caacd9b652305e01afc7fa167e6f2e94996da44b90c2ab604ce1";
     md5 = "";
-    md5name = "a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68-icu4c-72_1-src.tgz";
+    md5name = "818a80712ed3caacd9b652305e01afc7fa167e6f2e94996da44b90c2ab604ce1-icu4c-73_2-src.tgz";
   }
   {
-    name = "icu4c-72_1-data.zip";
-    url = "https://dev-www.libreoffice.org/src/icu4c-72_1-data.zip";
-    sha256 = "ee19f876507d6c23d9e0a2b631096f6b0eaa6fa61728c33a89efdb55e3385dea";
+    name = "icu4c-73_2-data.zip";
+    url = "https://dev-www.libreoffice.org/src/icu4c-73_2-data.zip";
+    sha256 = "ca1ee076163b438461e484421a7679fc33a64cd0a54f9d4b401893fa1eb42701";
     md5 = "";
-    md5name = "ee19f876507d6c23d9e0a2b631096f6b0eaa6fa61728c33a89efdb55e3385dea-icu4c-72_1-data.zip";
+    md5name = "ca1ee076163b438461e484421a7679fc33a64cd0a54f9d4b401893fa1eb42701-icu4c-73_2-data.zip";
   }
   {
     name = "flow-engine-0.9.4.zip";
@@ -427,11 +427,11 @@
     md5name = "2fdc3feb6e9deb17adec9bafa3321419aa19f8f4e5dea7bf8486844ca22207bf-libjpeg-turbo-2.1.5.1.tar.gz";
   }
   {
-    name = "language-subtag-registry-2022-08-08.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/language-subtag-registry-2022-08-08.tar.bz2";
-    sha256 = "e2d9224e0e50fc8ad12a3cf47396bbcadf45b2515839d4770432653a88972c00";
+    name = "language-subtag-registry-2023-05-11.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/language-subtag-registry-2023-05-11.tar.bz2";
+    sha256 = "9042b64cd473bf36073513b474046f13778107b57c2ac47fb2633104120d69da";
     md5 = "";
-    md5name = "e2d9224e0e50fc8ad12a3cf47396bbcadf45b2515839d4770432653a88972c00-language-subtag-registry-2022-08-08.tar.bz2";
+    md5name = "9042b64cd473bf36073513b474046f13778107b57c2ac47fb2633104120d69da-language-subtag-registry-2023-05-11.tar.bz2";
   }
   {
     name = "lcms2-2.12.tar.gz";
@@ -441,11 +441,11 @@
     md5name = "18663985e864100455ac3e507625c438c3710354d85e5cbb7cd4043e11fe10f5-lcms2-2.12.tar.gz";
   }
   {
-    name = "libassuan-2.5.5.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/libassuan-2.5.5.tar.bz2";
-    sha256 = "8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4";
+    name = "libassuan-2.5.6.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/libassuan-2.5.6.tar.bz2";
+    sha256 = "e9fd27218d5394904e4e39788f9b1742711c3e6b41689a31aa3380bd5aa4f426";
     md5 = "";
-    md5name = "8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4-libassuan-2.5.5.tar.bz2";
+    md5name = "e9fd27218d5394904e4e39788f9b1742711c3e6b41689a31aa3380bd5aa4f426-libassuan-2.5.6.tar.bz2";
   }
   {
     name = "libatomic_ops-7.6.8.tar.gz";
@@ -497,18 +497,18 @@
     md5name = "5dcb4db3b2340f81f601ce86d8d76b69e34d70f84f804192c901e4b7f84d5fb0-libnumbertext-1.0.11.tar.xz";
   }
   {
-    name = "ltm-1.0.zip";
-    url = "https://dev-www.libreoffice.org/src/ltm-1.0.zip";
-    sha256 = "083daa92d8ee6f4af96a6143b12d7fc8fe1a547e14f862304f7281f8f7347483";
+    name = "ltm-1.2.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/ltm-1.2.0.tar.xz";
+    sha256 = "b7c75eecf680219484055fcedd686064409254ae44bc31a96c5032843c0e18b1";
     md5 = "";
-    md5name = "083daa92d8ee6f4af96a6143b12d7fc8fe1a547e14f862304f7281f8f7347483-ltm-1.0.zip";
+    md5name = "b7c75eecf680219484055fcedd686064409254ae44bc31a96c5032843c0e18b1-ltm-1.2.0.tar.xz";
   }
   {
-    name = "libwebp-1.3.0.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/libwebp-1.3.0.tar.gz";
-    sha256 = "64ac4614db292ae8c5aa26de0295bf1623dbb3985054cb656c55e67431def17c";
+    name = "libwebp-1.3.2.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libwebp-1.3.2.tar.gz";
+    sha256 = "2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4";
     md5 = "";
-    md5name = "64ac4614db292ae8c5aa26de0295bf1623dbb3985054cb656c55e67431def17c-libwebp-1.3.0.tar.gz";
+    md5name = "2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4-libwebp-1.3.2.tar.gz";
   }
   {
     name = "xmlsec1-1.2.37.tar.gz";
@@ -518,18 +518,18 @@
     md5name = "5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c-xmlsec1-1.2.37.tar.gz";
   }
   {
-    name = "libxml2-2.10.4.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libxml2-2.10.4.tar.xz";
-    sha256 = "ed0c91c5845008f1936739e4eee2035531c1c94742c6541f44ee66d885948d45";
+    name = "libxml2-2.11.4.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libxml2-2.11.4.tar.xz";
+    sha256 = "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7";
     md5 = "";
-    md5name = "ed0c91c5845008f1936739e4eee2035531c1c94742c6541f44ee66d885948d45-libxml2-2.10.4.tar.xz";
+    md5name = "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7-libxml2-2.11.4.tar.xz";
   }
   {
-    name = "libxslt-1.1.35.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libxslt-1.1.35.tar.xz";
-    sha256 = "8247f33e9a872c6ac859aa45018bc4c4d00b97e2feac9eebc10c93ce1f34dd79";
+    name = "libxslt-1.1.38.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libxslt-1.1.38.tar.xz";
+    sha256 = "1f32450425819a09acaff2ab7a5a7f8a2ec7956e505d7beeb45e843d0e1ecab1";
     md5 = "";
-    md5name = "8247f33e9a872c6ac859aa45018bc4c4d00b97e2feac9eebc10c93ce1f34dd79-libxslt-1.1.35.tar.xz";
+    md5name = "1f32450425819a09acaff2ab7a5a7f8a2ec7956e505d7beeb45e843d0e1ecab1-libxslt-1.1.38.tar.xz";
   }
   {
     name = "lp_solve_5.5.tar.gz";
@@ -553,11 +553,11 @@
     md5name = "431434d3926f4bcce2e5c97240609983f60d7ff50df5a72083934759bb863f7b-mariadb-connector-c-3.1.8-src.tar.gz";
   }
   {
-    name = "mdds-2.0.3.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/mdds-2.0.3.tar.bz2";
-    sha256 = "9771fe42e133443c13ca187253763e17c8bc96a1a02aec9e1e8893367ffa9ce5";
+    name = "mdds-2.1.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/mdds-2.1.1.tar.xz";
+    sha256 = "1483d90cefb8aa4563c4d0a85cb7b243aa95217d235d422e9ca6722fd5b97e56";
     md5 = "";
-    md5name = "9771fe42e133443c13ca187253763e17c8bc96a1a02aec9e1e8893367ffa9ce5-mdds-2.0.3.tar.bz2";
+    md5name = "1483d90cefb8aa4563c4d0a85cb7b243aa95217d235d422e9ca6722fd5b97e56-mdds-2.1.1.tar.xz";
   }
   {
     name = "mDNSResponder-878.200.35.tar.gz";
@@ -588,11 +588,11 @@
     md5name = "19279f70707bbe5ffa619f2dc319f888cec0c4a8d339dc0a21330517bd6f521d-mythes-1.2.5.tar.xz";
   }
   {
-    name = "nss-3.88.1-with-nspr-4.35.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/nss-3.88.1-with-nspr-4.35.tar.gz";
-    sha256 = "fcfa26d2738ec5b0cf72ab4be784eac832a75132cda2e295799c04d62a93607a";
+    name = "nss-3.90-with-nspr-4.35.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/nss-3.90-with-nspr-4.35.tar.gz";
+    sha256 = "f78ab1d911cae8bbc94758fb3bd0f731df4087423a4ff5db271ba65381f6b739";
     md5 = "";
-    md5name = "fcfa26d2738ec5b0cf72ab4be784eac832a75132cda2e295799c04d62a93607a-nss-3.88.1-with-nspr-4.35.tar.gz";
+    md5name = "f78ab1d911cae8bbc94758fb3bd0f731df4087423a4ff5db271ba65381f6b739-nss-3.90-with-nspr-4.35.tar.gz";
   }
   {
     name = "libodfgen-0.1.8.tar.xz";
@@ -616,25 +616,25 @@
     md5name = "8249374c274932a21846fa7629c2aa9b-officeotron-0.7.4-master.jar";
   }
   {
-    name = "openldap-2.4.59.tgz";
-    url = "https://dev-www.libreoffice.org/src/openldap-2.4.59.tgz";
-    sha256 = "99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34";
+    name = "openldap-2.6.6.tgz";
+    url = "https://dev-www.libreoffice.org/src/openldap-2.6.6.tgz";
+    sha256 = "082e998cf542984d43634442dbe11da860759e510907152ea579bdc42fe39ea0";
     md5 = "";
-    md5name = "99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34-openldap-2.4.59.tgz";
+    md5name = "082e998cf542984d43634442dbe11da860759e510907152ea579bdc42fe39ea0-openldap-2.6.6.tgz";
   }
   {
-    name = "openssl-3.0.8.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/openssl-3.0.8.tar.gz";
-    sha256 = "6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e";
+    name = "openssl-3.0.10.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/openssl-3.0.10.tar.gz";
+    sha256 = "1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323";
     md5 = "";
-    md5name = "6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e-openssl-3.0.8.tar.gz";
+    md5name = "1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323-openssl-3.0.10.tar.gz";
   }
   {
-    name = "liborcus-0.17.2.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/liborcus-0.17.2.tar.bz2";
-    sha256 = "2a86c405a5929f749b27637509596421d46805753364ab258b035fd01fbde143";
+    name = "liborcus-0.18.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/liborcus-0.18.1.tar.xz";
+    sha256 = "6006b9f1576315e313df715a7e72a17f3e0b17d7b6bd119cfa8a0b608ce971eb";
     md5 = "";
-    md5name = "2a86c405a5929f749b27637509596421d46805753364ab258b035fd01fbde143-liborcus-0.17.2.tar.bz2";
+    md5name = "6006b9f1576315e313df715a7e72a17f3e0b17d7b6bd119cfa8a0b608ce971eb-liborcus-0.18.1.tar.xz";
   }
   {
     name = "libpagemaker-0.0.4.tar.xz";
@@ -644,11 +644,11 @@
     md5name = "66adacd705a7d19895e08eac46d1e851332adf2e736c566bef1164e7a442519d-libpagemaker-0.0.4.tar.xz";
   }
   {
-    name = "pdfium-5408.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/pdfium-5408.tar.bz2";
-    sha256 = "7db59b1e91f2bc0ab4c5e19d1a4f881e6a47dbb0d3b7e980a7358225b12a0f35";
+    name = "pdfium-5778.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/pdfium-5778.tar.bz2";
+    sha256 = "b1052ff24e9ffb11af017c444bb0f6ad508d64c9a0fb88cacb0e8210245dde06";
     md5 = "";
-    md5name = "7db59b1e91f2bc0ab4c5e19d1a4f881e6a47dbb0d3b7e980a7358225b12a0f35-pdfium-5408.tar.bz2";
+    md5name = "b1052ff24e9ffb11af017c444bb0f6ad508d64c9a0fb88cacb0e8210245dde06-pdfium-5778.tar.bz2";
   }
   {
     name = "pixman-0.42.2.tar.gz";
@@ -658,46 +658,46 @@
     md5name = "ea1480efada2fd948bc75366f7c349e1c96d3297d09a3fe62626e38e234a625e-pixman-0.42.2.tar.gz";
   }
   {
-    name = "libpng-1.6.39.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libpng-1.6.39.tar.xz";
-    sha256 = "1f4696ce70b4ee5f85f1e1623dc1229b210029fa4b7aee573df3e2ba7b036937";
+    name = "libpng-1.6.40.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libpng-1.6.40.tar.xz";
+    sha256 = "535b479b2467ff231a3ec6d92a525906fb8ef27978be4f66dbe05d3f3a01b3a1";
     md5 = "";
-    md5name = "1f4696ce70b4ee5f85f1e1623dc1229b210029fa4b7aee573df3e2ba7b036937-libpng-1.6.39.tar.xz";
+    md5name = "535b479b2467ff231a3ec6d92a525906fb8ef27978be4f66dbe05d3f3a01b3a1-libpng-1.6.40.tar.xz";
   }
   {
-    name = "tiff-4.5.0rc3.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/tiff-4.5.0rc3.tar.xz";
-    sha256 = "dafac979c5e7b6c650025569c5a4e720995ba5f17bc17e6276d1f12427be267c";
+    name = "tiff-4.5.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/tiff-4.5.1.tar.xz";
+    sha256 = "3c080867114c26edab3129644a63b708028a90514b7fe3126e38e11d24f9f88a";
     md5 = "";
-    md5name = "dafac979c5e7b6c650025569c5a4e720995ba5f17bc17e6276d1f12427be267c-tiff-4.5.0rc3.tar.xz";
+    md5name = "3c080867114c26edab3129644a63b708028a90514b7fe3126e38e11d24f9f88a-tiff-4.5.1.tar.xz";
   }
   {
-    name = "poppler-22.12.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/poppler-22.12.0.tar.xz";
-    sha256 = "d9aa9cacdfbd0f8e98fc2b3bb008e645597ed480685757c3e7bc74b4278d15c0";
+    name = "poppler-23.06.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/poppler-23.06.0.tar.xz";
+    sha256 = "d38c6b2f31c8f6f3727fb60a011a0e6c567ebf56ef1ccad36263ca9ed6448a65";
     md5 = "";
-    md5name = "d9aa9cacdfbd0f8e98fc2b3bb008e645597ed480685757c3e7bc74b4278d15c0-poppler-22.12.0.tar.xz";
+    md5name = "d38c6b2f31c8f6f3727fb60a011a0e6c567ebf56ef1ccad36263ca9ed6448a65-poppler-23.06.0.tar.xz";
   }
   {
-    name = "poppler-data-0.4.11.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/poppler-data-0.4.11.tar.gz";
-    sha256 = "2cec05cd1bb03af98a8b06a1e22f6e6e1a65b1e2f3816cb3069bb0874825f08c";
+    name = "poppler-data-0.4.12.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/poppler-data-0.4.12.tar.gz";
+    sha256 = "c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74";
     md5 = "";
-    md5name = "2cec05cd1bb03af98a8b06a1e22f6e6e1a65b1e2f3816cb3069bb0874825f08c-poppler-data-0.4.11.tar.gz";
+    md5name = "c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74-poppler-data-0.4.12.tar.gz";
   }
   {
-    name = "postgresql-13.10.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/postgresql-13.10.tar.bz2";
-    sha256 = "5bbcf5a56d85c44f3a8b058fb46862ff49cbc91834d07e295d02e6de3c216df2";
+    name = "postgresql-13.11.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/postgresql-13.11.tar.bz2";
+    sha256 = "4992ff647203566b670d4e54dc5317499a26856c93576d0ea951bdf6bee50bfb";
     md5 = "";
-    md5name = "5bbcf5a56d85c44f3a8b058fb46862ff49cbc91834d07e295d02e6de3c216df2-postgresql-13.10.tar.bz2";
+    md5name = "4992ff647203566b670d4e54dc5317499a26856c93576d0ea951bdf6bee50bfb-postgresql-13.11.tar.bz2";
   }
   {
-    name = "Python-3.8.16.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/Python-3.8.16.tar.xz";
-    sha256 = "d85dbb3774132473d8081dcb158f34a10ccad7a90b96c7e50ea4bb61f5ce4562";
+    name = "Python-3.8.18.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/Python-3.8.18.tar.xz";
+    sha256 = "3ffb71cd349a326ba7b2fadc7e7df86ba577dd9c4917e52a8401adbda7405e3f";
     md5 = "";
-    md5name = "d85dbb3774132473d8081dcb158f34a10ccad7a90b96c7e50ea4bb61f5ce4562-Python-3.8.16.tar.xz";
+    md5name = "3ffb71cd349a326ba7b2fadc7e7df86ba577dd9c4917e52a8401adbda7405e3f-Python-3.8.18.tar.xz";
   }
   {
     name = "libqxp-0.0.2.tar.xz";
@@ -742,11 +742,11 @@
     md5name = "798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip";
   }
   {
-    name = "skia-m103-b301ff025004c9cd82816c86c547588e6c24b466.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/skia-m103-b301ff025004c9cd82816c86c547588e6c24b466.tar.xz";
-    sha256 = "c094a6247e44104beaaa0d00c825beb6baf1a8e532dc22214747495317a65bd9";
+    name = "skia-m111-a31e897fb3dcbc96b2b40999751611d029bf5404.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/skia-m111-a31e897fb3dcbc96b2b40999751611d029bf5404.tar.xz";
+    sha256 = "0d08a99ed46cde43b5ad2672b5d8770c8eb85d0d26cb8f1f85fd9befe1e9ceb9";
     md5 = "";
-    md5name = "c094a6247e44104beaaa0d00c825beb6baf1a8e532dc22214747495317a65bd9-skia-m103-b301ff025004c9cd82816c86c547588e6c24b466.tar.xz";
+    md5name = "0d08a99ed46cde43b5ad2672b5d8770c8eb85d0d26cb8f1f85fd9befe1e9ceb9-skia-m111-a31e897fb3dcbc96b2b40999751611d029bf5404.tar.xz";
   }
   {
     name = "libstaroffice-0.0.7.tar.xz";
@@ -819,10 +819,10 @@
     md5name = "27051a30cb057fdb5d5de65a1f165c7153dc76e27fe62251cbb86639eb2caf22-libzmf-0.0.2.tar.xz";
   }
   {
-    name = "zxing-cpp-1.4.0.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/zxing-cpp-1.4.0.tar.gz";
-    sha256 = "126767bb56f8a1f25ae84d233db2e9b9be50d71f5776092d0e170ca0f0ed1862";
+    name = "zxing-cpp-2.0.0.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/zxing-cpp-2.0.0.tar.gz";
+    sha256 = "12b76b7005c30d34265fc20356d340da179b0b4d43d2c1b35bcca86776069f76";
     md5 = "";
-    md5name = "126767bb56f8a1f25ae84d233db2e9b9be50d71f5776092d0e170ca0f0ed1862-zxing-cpp-1.4.0.tar.gz";
+    md5name = "12b76b7005c30d34265fc20356d340da179b0b4d43d2c1b35bcca86776069f76-zxing-cpp-2.0.0.tar.gz";
   }
 ]

--- a/pkgs/applications/office/libreoffice/src-fresh/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/primary.nix
@@ -3,12 +3,12 @@
 rec {
   fetchSrc = {name, hash}: fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${name}-${version}.tar.xz";
-    sha256 = hash;
+    inherit hash;
   };
 
   major = "7";
-  minor = "5";
-  patch = "4";
+  minor = "6";
+  patch = "2";
   tweak = "1";
 
   subdir = "${major}.${minor}.${patch}";
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    hash = "sha256-dWE7yXldkiEnsJOxfxyZ9p05eARqexgRRgNV158VVF4=";
+    hash = "sha256-5dJzO9As4kwwIHeVt3ufXitaujoUdzN1+1zCKO0rnKI=";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    hash = "sha256-dv3L8DtdxZcwmeXnqtTtwIpOvwZg3aH3VvJBiiZzbh0=";
+    hash = "sha256-WyOfphJ+h7ALeZCl7e+WsfpSL4DB2W4/h0nZUZD21go=";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    hash = "sha256-2CrGEyK5AQEAo1Qz1ACmvMH7BaOubW5BNLWv3fDEdOY=";
+    hash = "sha256-a9wnAnpgMDF4XWxlB4UHOt2NVYcquBoVBnRZ7hts0Ug=";
   };
 }

--- a/pkgs/applications/office/libreoffice/src-still/download.nix
+++ b/pkgs/applications/office/libreoffice/src-still/download.nix
@@ -7,11 +7,11 @@
     md5name = "e763a9dc21c3d2667402d66e202e3f8ef4db51b34b79ef41f56cacb86dcd6eed-libabw-0.1.3.tar.xz";
   }
   {
-    name = "boost_1_79_0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/boost_1_79_0.tar.xz";
-    sha256 = "2058aa88758a0e1aaac1759b3c4bad2526f899c6ecc6eeea79aa5e8fd3ea95dc";
+    name = "boost_1_80_0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/boost_1_80_0.tar.xz";
+    sha256 = "322e567e98c466c0aa0e380ed8c647552fe4af48998648428f1b5f0c8eff4666";
     md5 = "";
-    md5name = "2058aa88758a0e1aaac1759b3c4bad2526f899c6ecc6eeea79aa5e8fd3ea95dc-boost_1_79_0.tar.xz";
+    md5name = "322e567e98c466c0aa0e380ed8c647552fe4af48998648428f1b5f0c8eff4666-boost_1_80_0.tar.xz";
   }
   {
     name = "box2d-2.4.1.tar.gz";
@@ -98,11 +98,11 @@
     md5name = "89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7-cppunit-1.15.1.tar.gz";
   }
   {
-    name = "curl-8.0.1.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/curl-8.0.1.tar.xz";
-    sha256 = "0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0";
+    name = "curl-8.2.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/curl-8.2.1.tar.xz";
+    sha256 = "dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894";
     md5 = "";
-    md5name = "0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0-curl-8.0.1.tar.xz";
+    md5name = "dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894-curl-8.2.1.tar.xz";
   }
   {
     name = "libe-book-0.1.3.tar.xz";
@@ -210,32 +210,11 @@
     md5name = "e7a384790b13c29113e22e596ade9687-LinLibertineG-20120116.zip";
   }
   {
-    name = "source-code-pro-2.030R-ro-1.050R-it.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/907d6e99f241876695c19ff3db0b8923-source-code-pro-2.030R-ro-1.050R-it.tar.gz";
-    sha256 = "09466dce87653333f189acd8358c60c6736dcd95f042dee0b644bdcf65b6ae2f";
-    md5 = "907d6e99f241876695c19ff3db0b8923";
-    md5name = "907d6e99f241876695c19ff3db0b8923-source-code-pro-2.030R-ro-1.050R-it.tar.gz";
-  }
-  {
     name = "source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
     url = "https://dev-www.libreoffice.org/src/edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
     sha256 = "e7bc9a1fec787a529e49f5a26b93dcdcf41506449dfc70f92cdef6d17eb6fb61";
     md5 = "edc4d741888bc0d38e32dbaa17149596";
     md5name = "edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
-  }
-  {
-    name = "source-serif-pro-3.000R.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/source-serif-pro-3.000R.tar.gz";
-    sha256 = "826a2b784d5cdb4c2bbc7830eb62871528360a61a52689c102a101623f1928e3";
-    md5 = "";
-    md5name = "826a2b784d5cdb4c2bbc7830eb62871528360a61a52689c102a101623f1928e3-source-serif-pro-3.000R.tar.gz";
-  }
-  {
-    name = "EmojiOneColor-SVGinOT-1.3.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/EmojiOneColor-SVGinOT-1.3.tar.gz";
-    sha256 = "d1a08f7c10589f22740231017694af0a7a270760c8dec33d8d1c038e2be0a0c7";
-    md5 = "";
-    md5name = "d1a08f7c10589f22740231017694af0a7a270760c8dec33d8d1c038e2be0a0c7-EmojiOneColor-SVGinOT-1.3.tar.gz";
   }
   {
     name = "noto-fonts-20171024.tar.gz";
@@ -266,18 +245,11 @@
     md5name = "b98b67602a2c8880a1770f0b9e37c190f29a7e2ade5616784f0b89fbdb75bf52-alef-1.001.tar.gz";
   }
   {
-    name = "Amiri-0.117.zip";
-    url = "https://dev-www.libreoffice.org/src/Amiri-0.117.zip";
-    sha256 = "9c4e768893e0023a0ad6f488d5c84bd5add6565d3dcadb838ba5b20e75fcc9a7";
+    name = "Amiri-1.000.zip";
+    url = "https://dev-www.libreoffice.org/src/Amiri-1.000.zip";
+    sha256 = "926fe1bd7dfde8e55178281f645258bfced6420c951c6f2fd532fd21691bca30";
     md5 = "";
-    md5name = "9c4e768893e0023a0ad6f488d5c84bd5add6565d3dcadb838ba5b20e75fcc9a7-Amiri-0.117.zip";
-  }
-  {
-    name = "ttf-kacst_2.01+mry.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/ttf-kacst_2.01+mry.tar.gz";
-    sha256 = "dca00f5e655f2f217a766faa73a81f542c5c204aa3a47017c3c2be0b31d00a56";
-    md5 = "";
-    md5name = "dca00f5e655f2f217a766faa73a81f542c5c204aa3a47017c3c2be0b31d00a56-ttf-kacst_2.01+mry.tar.gz";
+    md5name = "926fe1bd7dfde8e55178281f645258bfced6420c951c6f2fd532fd21691bca30-Amiri-1.000.zip";
   }
   {
     name = "ReemKufi-1.2.zip";
@@ -301,11 +273,11 @@
     md5name = "0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac-libfreehand-0.1.2.tar.xz";
   }
   {
-    name = "freetype-2.12.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/freetype-2.12.0.tar.xz";
-    sha256 = "ef5c336aacc1a079ff9262d6308d6c2a066dd4d2a905301c4adda9b354399033";
+    name = "freetype-2.13.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/freetype-2.13.0.tar.xz";
+    sha256 = "5ee23abd047636c24b2d43c6625dcafc66661d1aca64dec9e0d05df29592624c";
     md5 = "";
-    md5name = "ef5c336aacc1a079ff9262d6308d6c2a066dd4d2a905301c4adda9b354399033-freetype-2.12.0.tar.xz";
+    md5name = "5ee23abd047636c24b2d43c6625dcafc66661d1aca64dec9e0d05df29592624c-freetype-2.13.0.tar.xz";
   }
   {
     name = "glm-0.9.9.8.zip";
@@ -343,11 +315,11 @@
     md5name = "17410483b5b5f267aa18b7e00b65e6e0-hsqldb_1_8_0.zip";
   }
   {
-    name = "hunspell-1.7.0.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/hunspell-1.7.0.tar.gz";
-    sha256 = "57be4e03ae9dd62c3471f667a0d81a14513e314d4d92081292b90435944ff951";
+    name = "hunspell-1.7.2.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/hunspell-1.7.2.tar.gz";
+    sha256 = "11ddfa39afe28c28539fe65fc4f1592d410c1e9b6dd7d8a91ca25d85e9ec65b8";
     md5 = "";
-    md5name = "57be4e03ae9dd62c3471f667a0d81a14513e314d4d92081292b90435944ff951-hunspell-1.7.0.tar.gz";
+    md5name = "11ddfa39afe28c28539fe65fc4f1592d410c1e9b6dd7d8a91ca25d85e9ec65b8-hunspell-1.7.2.tar.gz";
   }
   {
     name = "hyphen-2.8.8.tar.gz";
@@ -357,18 +329,18 @@
     md5name = "5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
   }
   {
-    name = "icu4c-71_1-src.tgz";
-    url = "https://dev-www.libreoffice.org/src/icu4c-71_1-src.tgz";
-    sha256 = "67a7e6e51f61faf1306b6935333e13b2c48abd8da6d2f46ce6adca24b1e21ebf";
+    name = "icu4c-72_1-src.tgz";
+    url = "https://dev-www.libreoffice.org/src/icu4c-72_1-src.tgz";
+    sha256 = "a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68";
     md5 = "";
-    md5name = "67a7e6e51f61faf1306b6935333e13b2c48abd8da6d2f46ce6adca24b1e21ebf-icu4c-71_1-src.tgz";
+    md5name = "a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68-icu4c-72_1-src.tgz";
   }
   {
-    name = "icu4c-71_1-data.zip";
-    url = "https://dev-www.libreoffice.org/src/icu4c-71_1-data.zip";
-    sha256 = "e3882b4fece6e5e039f22c3189b7ba224180fd26fdbfa9db284617455b93e804";
+    name = "icu4c-72_1-data.zip";
+    url = "https://dev-www.libreoffice.org/src/icu4c-72_1-data.zip";
+    sha256 = "ee19f876507d6c23d9e0a2b631096f6b0eaa6fa61728c33a89efdb55e3385dea";
     md5 = "";
-    md5name = "e3882b4fece6e5e039f22c3189b7ba224180fd26fdbfa9db284617455b93e804-icu4c-71_1-data.zip";
+    md5name = "ee19f876507d6c23d9e0a2b631096f6b0eaa6fa61728c33a89efdb55e3385dea-icu4c-72_1-data.zip";
   }
   {
     name = "flow-engine-0.9.4.zip";
@@ -448,18 +420,18 @@
     md5name = "39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip";
   }
   {
-    name = "libjpeg-turbo-2.1.2.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/libjpeg-turbo-2.1.2.tar.gz";
-    sha256 = "09b96cb8cbff9ea556a9c2d173485fd19488844d55276ed4f42240e1e2073ce5";
+    name = "libjpeg-turbo-2.1.5.1.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libjpeg-turbo-2.1.5.1.tar.gz";
+    sha256 = "2fdc3feb6e9deb17adec9bafa3321419aa19f8f4e5dea7bf8486844ca22207bf";
     md5 = "";
-    md5name = "09b96cb8cbff9ea556a9c2d173485fd19488844d55276ed4f42240e1e2073ce5-libjpeg-turbo-2.1.2.tar.gz";
+    md5name = "2fdc3feb6e9deb17adec9bafa3321419aa19f8f4e5dea7bf8486844ca22207bf-libjpeg-turbo-2.1.5.1.tar.gz";
   }
   {
-    name = "language-subtag-registry-2022-08-08.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/language-subtag-registry-2022-08-08.tar.bz2";
-    sha256 = "e2d9224e0e50fc8ad12a3cf47396bbcadf45b2515839d4770432653a88972c00";
+    name = "language-subtag-registry-2023-05-11.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/language-subtag-registry-2023-05-11.tar.bz2";
+    sha256 = "9042b64cd473bf36073513b474046f13778107b57c2ac47fb2633104120d69da";
     md5 = "";
-    md5name = "e2d9224e0e50fc8ad12a3cf47396bbcadf45b2515839d4770432653a88972c00-language-subtag-registry-2022-08-08.tar.bz2";
+    md5name = "9042b64cd473bf36073513b474046f13778107b57c2ac47fb2633104120d69da-language-subtag-registry-2023-05-11.tar.bz2";
   }
   {
     name = "lcms2-2.12.tar.gz";
@@ -532,25 +504,25 @@
     md5name = "083daa92d8ee6f4af96a6143b12d7fc8fe1a547e14f862304f7281f8f7347483-ltm-1.0.zip";
   }
   {
-    name = "libwebp-1.2.4.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/libwebp-1.2.4.tar.gz";
-    sha256 = "7bf5a8a28cc69bcfa8cb214f2c3095703c6b73ac5fba4d5480c205331d9494df";
+    name = "libwebp-1.3.2.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libwebp-1.3.2.tar.gz";
+    sha256 = "2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4";
     md5 = "";
-    md5name = "7bf5a8a28cc69bcfa8cb214f2c3095703c6b73ac5fba4d5480c205331d9494df-libwebp-1.2.4.tar.gz";
+    md5name = "2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4-libwebp-1.3.2.tar.gz";
   }
   {
-    name = "xmlsec1-1.2.34.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/xmlsec1-1.2.34.tar.gz";
-    sha256 = "52ced4943f35bd7d0818a38298c1528ca4ac8a54440fd71134a07d2d1370a262";
+    name = "xmlsec1-1.2.37.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/xmlsec1-1.2.37.tar.gz";
+    sha256 = "5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c";
     md5 = "";
-    md5name = "52ced4943f35bd7d0818a38298c1528ca4ac8a54440fd71134a07d2d1370a262-xmlsec1-1.2.34.tar.gz";
+    md5name = "5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c-xmlsec1-1.2.37.tar.gz";
   }
   {
-    name = "libxml2-2.10.4.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libxml2-2.10.4.tar.xz";
-    sha256 = "ed0c91c5845008f1936739e4eee2035531c1c94742c6541f44ee66d885948d45";
+    name = "libxml2-2.11.4.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libxml2-2.11.4.tar.xz";
+    sha256 = "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7";
     md5 = "";
-    md5name = "ed0c91c5845008f1936739e4eee2035531c1c94742c6541f44ee66d885948d45-libxml2-2.10.4.tar.xz";
+    md5name = "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7-libxml2-2.11.4.tar.xz";
   }
   {
     name = "libxslt-1.1.35.tar.xz";
@@ -609,18 +581,18 @@
     md5name = "e8750123a78d61b943cef78b7736c8a7f20bb0a649aa112402124fba794fc21c-libmwaw-0.3.21.tar.xz";
   }
   {
-    name = "mythes-1.2.4.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
-    sha256 = "1e81f395d8c851c3e4e75b568e20fa2fa549354e75ab397f9de4b0e0790a305f";
-    md5 = "a8c2c5b8f09e7ede322d5c602ff6a4b6";
-    md5name = "a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
+    name = "mythes-1.2.5.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/mythes-1.2.5.tar.xz";
+    sha256 = "19279f70707bbe5ffa619f2dc319f888cec0c4a8d339dc0a21330517bd6f521d";
+    md5 = "";
+    md5name = "19279f70707bbe5ffa619f2dc319f888cec0c4a8d339dc0a21330517bd6f521d-mythes-1.2.5.tar.xz";
   }
   {
-    name = "nss-3.88.1-with-nspr-4.35.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/nss-3.88.1-with-nspr-4.35.tar.gz";
-    sha256 = "fcfa26d2738ec5b0cf72ab4be784eac832a75132cda2e295799c04d62a93607a";
+    name = "nss-3.90-with-nspr-4.35.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/nss-3.90-with-nspr-4.35.tar.gz";
+    sha256 = "f78ab1d911cae8bbc94758fb3bd0f731df4087423a4ff5db271ba65381f6b739";
     md5 = "";
-    md5name = "fcfa26d2738ec5b0cf72ab4be784eac832a75132cda2e295799c04d62a93607a-nss-3.88.1-with-nspr-4.35.tar.gz";
+    md5name = "f78ab1d911cae8bbc94758fb3bd0f731df4087423a4ff5db271ba65381f6b739-nss-3.90-with-nspr-4.35.tar.gz";
   }
   {
     name = "libodfgen-0.1.8.tar.xz";
@@ -651,11 +623,11 @@
     md5name = "99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34-openldap-2.4.59.tgz";
   }
   {
-    name = "openssl-1.1.1t.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/openssl-1.1.1t.tar.gz";
-    sha256 = "8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b";
+    name = "openssl-3.0.10.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/openssl-3.0.10.tar.gz";
+    sha256 = "1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323";
     md5 = "";
-    md5name = "8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b-openssl-1.1.1t.tar.gz";
+    md5name = "1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323-openssl-3.0.10.tar.gz";
   }
   {
     name = "liborcus-0.17.2.tar.bz2";
@@ -672,11 +644,11 @@
     md5name = "66adacd705a7d19895e08eac46d1e851332adf2e736c566bef1164e7a442519d-libpagemaker-0.0.4.tar.xz";
   }
   {
-    name = "pdfium-5058.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/pdfium-5058.tar.bz2";
-    sha256 = "eaf4ce9fad32b5d951c524139df23119b66c67720057defb97acab2dfb2582ac";
+    name = "pdfium-5778.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/pdfium-5778.tar.bz2";
+    sha256 = "b1052ff24e9ffb11af017c444bb0f6ad508d64c9a0fb88cacb0e8210245dde06";
     md5 = "";
-    md5name = "eaf4ce9fad32b5d951c524139df23119b66c67720057defb97acab2dfb2582ac-pdfium-5058.tar.bz2";
+    md5name = "b1052ff24e9ffb11af017c444bb0f6ad508d64c9a0fb88cacb0e8210245dde06-pdfium-5778.tar.bz2";
   }
   {
     name = "pixman-0.42.2.tar.gz";
@@ -693,11 +665,11 @@
     md5name = "1f4696ce70b4ee5f85f1e1623dc1229b210029fa4b7aee573df3e2ba7b036937-libpng-1.6.39.tar.xz";
   }
   {
-    name = "tiff-4.5.0rc3.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/tiff-4.5.0rc3.tar.xz";
-    sha256 = "dafac979c5e7b6c650025569c5a4e720995ba5f17bc17e6276d1f12427be267c";
+    name = "tiff-4.5.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/tiff-4.5.1.tar.xz";
+    sha256 = "3c080867114c26edab3129644a63b708028a90514b7fe3126e38e11d24f9f88a";
     md5 = "";
-    md5name = "dafac979c5e7b6c650025569c5a4e720995ba5f17bc17e6276d1f12427be267c-tiff-4.5.0rc3.tar.xz";
+    md5name = "3c080867114c26edab3129644a63b708028a90514b7fe3126e38e11d24f9f88a-tiff-4.5.1.tar.xz";
   }
   {
     name = "poppler-22.12.0.tar.xz";
@@ -721,11 +693,11 @@
     md5name = "5bbcf5a56d85c44f3a8b058fb46862ff49cbc91834d07e295d02e6de3c216df2-postgresql-13.10.tar.bz2";
   }
   {
-    name = "Python-3.8.16.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/Python-3.8.16.tar.xz";
-    sha256 = "d85dbb3774132473d8081dcb158f34a10ccad7a90b96c7e50ea4bb61f5ce4562";
+    name = "Python-3.8.18.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/Python-3.8.18.tar.xz";
+    sha256 = "3ffb71cd349a326ba7b2fadc7e7df86ba577dd9c4917e52a8401adbda7405e3f";
     md5 = "";
-    md5name = "d85dbb3774132473d8081dcb158f34a10ccad7a90b96c7e50ea4bb61f5ce4562-Python-3.8.16.tar.xz";
+    md5name = "3ffb71cd349a326ba7b2fadc7e7df86ba577dd9c4917e52a8401adbda7405e3f-Python-3.8.18.tar.xz";
   }
   {
     name = "libqxp-0.0.2.tar.xz";
@@ -798,13 +770,6 @@
     md5name = "82c818be771f242388457aa8c807e4b52aa84dc22b21c6c56184a6b4cbb085e6-twaindsm_2.4.1.orig.tar.gz";
   }
   {
-    name = "ucpp-1.3.2.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz";
-    sha256 = "983941d31ee8d366085cadf28db75eb1f5cb03ba1e5853b98f12f7f51c63b776";
-    md5 = "0168229624cfac409e766913506961a8";
-    md5name = "0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz";
-  }
-  {
     name = "libvisio-0.1.7.tar.xz";
     url = "https://dev-www.libreoffice.org/src/libvisio-0.1.7.tar.xz";
     sha256 = "8faf8df870cb27b09a787a1959d6c646faa44d0d8ab151883df408b7166bea4c";
@@ -819,11 +784,11 @@
     md5name = "2465b0b662fdc5d4e3bebcdc9a79027713fb629ca2bff04a3c9251fdec42dd09-libwpd-0.10.3.tar.xz";
   }
   {
-    name = "libwpg-0.3.3.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libwpg-0.3.3.tar.xz";
-    sha256 = "99b3f7f8832385748582ab8130fbb9e5607bd5179bebf9751ac1d51a53099d1c";
+    name = "libwpg-0.3.4.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libwpg-0.3.4.tar.xz";
+    sha256 = "b55fda9440d1e070630eb2487d8b8697cf412c214a27caee9df69cec7c004de3";
     md5 = "";
-    md5name = "99b3f7f8832385748582ab8130fbb9e5607bd5179bebf9751ac1d51a53099d1c-libwpg-0.3.3.tar.xz";
+    md5name = "b55fda9440d1e070630eb2487d8b8697cf412c214a27caee9df69cec7c004de3-libwpg-0.3.4.tar.xz";
   }
   {
     name = "libwps-0.4.12.tar.xz";
@@ -854,10 +819,10 @@
     md5name = "27051a30cb057fdb5d5de65a1f165c7153dc76e27fe62251cbb86639eb2caf22-libzmf-0.0.2.tar.xz";
   }
   {
-    name = "zxing-cpp-1.2.0.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/zxing-cpp-1.2.0.tar.gz";
-    sha256 = "653d9e44195d86cf64a36af9ff3a1978ec5599df3882439fefa56e7064f55e8a";
+    name = "zxing-cpp-1.4.0.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/zxing-cpp-1.4.0.tar.gz";
+    sha256 = "126767bb56f8a1f25ae84d233db2e9b9be50d71f5776092d0e170ca0f0ed1862";
     md5 = "";
-    md5name = "653d9e44195d86cf64a36af9ff3a1978ec5599df3882439fefa56e7064f55e8a-zxing-cpp-1.2.0.tar.gz";
+    md5name = "126767bb56f8a1f25ae84d233db2e9b9be50d71f5776092d0e170ca0f0ed1862-zxing-cpp-1.4.0.tar.gz";
   }
 ]

--- a/pkgs/applications/office/libreoffice/src-still/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-still/primary.nix
@@ -7,9 +7,9 @@ rec {
   };
 
   major = "7";
-  minor = "4";
+  minor = "5";
   patch = "7";
-  tweak = "2";
+  tweak = "1";
 
   subdir = "${major}.${minor}.${patch}";
 
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    hash = "sha256-dD2R8qE4png4D6eo7LWyQB2ZSwZ7MwdQ8DrY9SOi+yA=";
+    hash = "sha256-ZZMvlHHYBnu2bE5UQRnRbmPkrsvhJF+xD4anUdLRKxA=";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    hash = "sha256-7wea0EClmvwcPvgQDGagkOF7eBVvYTZScCEEpirdXnE=";
+    hash = "sha256-hMG+f57fUat1inRAwlg1dgr1qU5hPM/C8jRTrZG1sP8=";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    hash = "sha256-vcQWE3mBZx2sBQ9KzTh6zM7277mK9twfvyESTzTiII8=";
+    hash = "sha256-Yz0pCiUY5Tk2NNXlYKM0jWvOwFfNplXogrvjATBn71I=";
   };
 }


### PR DESCRIPTION
## Description of changes
Closes https://github.com/NixOS/nixpkgs/issues/257657

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).