### PR TITLE
ligo: 0.72.0 -> 1.0.0

### DIFF
--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -15,31 +15,28 @@
 
 ocamlPackages.buildDunePackage rec {
   pname = "ligo";
-  version = "0.72.0";
+  version = "1.0.0";
   src = fetchFromGitLab {
     owner = "ligolang";
     repo = "ligo";
     rev = version;
-    sha256 = "sha256-DQ3TxxLxi8/W1+uBX7NEBIsVXBKnJBa6YNRBFleNrEA=";
+    sha256 = "sha256-tHIIA1JE7mzDIf2v9IEZt1pjVQEA89zjTsmqhzTn3Wc=";
     fetchSubmodules = true;
   };
 
   postPatch = ''
-    substituteInPlace "vendors/tezos-ligo/src/lib_hacl/hacl.ml" \
+    substituteInPlace "vendors/tezos-ligo/dune-project" \
       --replace \
-        "Hacl.NaCl.Noalloc.Easy.secretbox ~pt:msg ~n:nonce ~key ~ct:cmsg" \
-        "Hacl.NaCl.Noalloc.Easy.secretbox ~pt:msg ~n:nonce ~key ~ct:cmsg ()" \
+        "(using ctypes 0.1)" \
+        "(using ctypes 0.3)" \
       --replace \
-        "Hacl.NaCl.Noalloc.Easy.box_afternm ~pt:msg ~n:nonce ~ck:k ~ct:cmsg" \
-        "Hacl.NaCl.Noalloc.Easy.box_afternm ~pt:msg ~n:nonce ~ck:k ~ct:cmsg ()"
+        "(lang dune 3.0)" \
+        "(lang dune 3.7)"
 
-    substituteInPlace "vendors/tezos-ligo/src/lib_crypto/crypto_box.ml" \
+    substituteInPlace "src/coq/dune" \
       --replace \
-        "secretbox_open ~key ~nonce ~cmsg ~msg" \
-        "secretbox_open ~key ~nonce ~cmsg ~msg ()" \
-      --replace \
-        "Box.box_open ~k ~nonce ~cmsg ~msg" \
-        "Box.box_open ~k ~nonce ~cmsg ~msg ()"
+        "(name ligo_coq)" \
+        "(name ligo_coq)(mode vo)"
   '';
 
   # The build picks this up for ligo --version
@@ -47,8 +44,6 @@ ocamlPackages.buildDunePackage rec {
 
   # This is a hack to work around the hack used in the dune files
   OPAM_SWITCH_PREFIX = "${tezos-rust-libs}";
-
-  duneVersion = "3";
 
   strictDeps = true;
 
@@ -93,6 +88,8 @@ ocamlPackages.buildDunePackage rec {
     parse-argv
     hacl-star
     prometheus
+    lwt_ppx
+    msgpck
     # lsp
     linol
     linol-lwt

--- a/pkgs/development/ocaml-modules/msgpck/default.nix
+++ b/pkgs/development/ocaml-modules/msgpck/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, ocplib-endian
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "msgpck";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "vbmithr";
+    repo = "ocaml-msgpck";
+    rev = "${version}";
+    hash = "sha256-gBHIiicmk/5KBkKzRKyV0ymEH8dGCZG8vfE0mtpcDCM=";
+  };
+
+  propagatedBuildInputs = [ ocplib-endian ];
+
+  checkInputs = [ alcotest ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Fast MessagePack (http://msgpack.org) library ";
+    license = lib.licenses.isc;
+    homepage = "https://github.com/vbmithr/ocaml-msgpck";
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9880,9 +9880,13 @@ with pkgs;
 
   ldc = callPackage ../development/compilers/ldc { };
 
-  ligo = callPackage ../development/compilers/ligo {
-    coq = coq_8_14;
-    ocamlPackages = ocaml-ng.ocamlPackages_4_14_janeStreet_0_15;
+  ligo =
+    let ocaml_p = ocaml-ng.ocamlPackages_4_14_janeStreet_0_15; in
+    callPackage ../development/compilers/ligo {
+    coq = coq_8_13.override {
+      customOCamlPackages = ocaml_p;
+    };
+    ocamlPackages = ocaml_p;
   };
 
   lego = callPackage ../tools/admin/lego { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1158,6 +1158,8 @@ let
 
     mparser-pcre =  callPackage ../development/ocaml-modules/mparser/pcre.nix { };
 
+    msgpck = callPackage ../development/ocaml-modules/msgpck { };
+
     mrmime = callPackage ../development/ocaml-modules/mrmime { };
 
     mtime_1 =  callPackage ../development/ocaml-modules/mtime/1_x.nix { };


### PR DESCRIPTION
###### Description of changes 

Update ligo version to latest one 

###### Things done 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
