### PR TITLE
python310Packages.pytest-postgresql: init at 5.0.0

### DIFF
--- a/pkgs/development/python-modules/mirakuru/default.nix
+++ b/pkgs/development/python-modules/mirakuru/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, setuptools
+, psutil
+, netcat
+, ps
+, python-daemon
+}:
+
+buildPythonPackage rec {
+  pname = "mirakuru";
+  version = "2.5.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "ClearcodeHQ";
+    repo = "mirakuru";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-jBsSvIy2FaAYlDZLjJXl9hyCiK+nk/cM5j128f24dRc=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [ psutil ];
+
+  nativeCheckInputs = [
+    netcat.nc
+    ps
+    python-daemon
+    pytestCheckHook
+  ];
+  pythonImportsCheck = [ "mirakuru" ];
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/mirakuru";
+    description = "Process orchestration tool designed for functional and integration tests";
+    changelog = "https://github.com/ClearcodeHQ/mirakuru/blob/v${version}/CHANGES.rst";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/port-for/default.nix
+++ b/pkgs/development/python-modules/port-for/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "port-for";
+  version = "0.7.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "kmike";
+    repo = "port-for";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/45TQ2crmTupRgL9hgZGw5IvFKywezSIHqHFbeAkMoo=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+  pythonImportsCheck = [ "port_for" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kmike/port-for";
+    description = "Command-line utility and library that helps with TCP port managment";
+    changelog = "https://github.com/kmike/port-for/blob/v${version}/CHANGES.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-postgresql/default.nix
+++ b/pkgs/development/python-modules/pytest-postgresql/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, setuptools
+, mirakuru
+, port-for
+, psycopg
+, pytest
+, postgresql
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-postgresql";
+  version = "5.0.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "ClearcodeHQ";
+    repo = "pytest-postgresql";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-uWKp9yxTdlswoDPMlhx+2mF1cdhFzhGYKGHdXPGlz+w=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml  \
+      --replace "--cov" ""  \
+      --replace "--max-worker-restart=0" ""
+    sed -i 's#/usr/lib/postgresql/.*/bin/pg_ctl#${postgresql}/bin/pg_ctl#' pytest_postgresql/plugin.py
+  '';
+
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [
+    mirakuru
+    port-for
+    psycopg
+    setuptools  # requires 'pkg_resources' at runtime
+  ];
+
+  nativeCheckInputs = [
+    postgresql
+    pytestCheckHook
+  ];
+  pytestFlagsArray = [
+    "-p"
+    "no:postgresql"
+  ];
+  disabledTestPaths = [ "tests/docker/test_noproc_docker.py" ];  # requires Docker
+  disabledTests = [
+    # permissions issue running pg as Nixbld user
+    "test_executor_init_with_password"
+    # "ValueError: Pytest terminal summary report not found"
+    "test_postgres_options_config_in_cli"
+    "test_postgres_options_config_in_ini"
+  ];
+  pythonImportsCheck = [
+    "pytest_postgresql"
+    "pytest_postgresql.executor"
+  ];
+
+
+  meta = with lib; {
+    homepage = "https://pypi.python.org/pypi/pytest-postgresql";
+    description = "Pytest plugin that enables you to test code on a temporary PostgreSQL database";
+    changelog = "https://github.com/ClearcodeHQ/pytest-postgresql/blob/v${version}/CHANGES.rst";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10349,6 +10349,8 @@ self: super: with self; {
 
   pytest-plt = callPackage ../development/python-modules/pytest-plt { };
 
+  pytest-postgresql = callPackage ../development/python-modules/pytest-postgresql { };
+
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
   pytest-pytestrail = callPackage ../development/python-modules/pytest-pytestrail { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8602,6 +8602,8 @@ self: super: with self; {
 
   portend = callPackage ../development/python-modules/portend { };
 
+  port-for = callPackage ../development/python-modules/port-for { };
+
   portpicker = callPackage ../development/python-modules/portpicker { };
 
   posix_ipc = callPackage ../development/python-modules/posix_ipc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6732,6 +6732,8 @@ self: super: with self; {
 
   mir_eval = callPackage ../development/python-modules/mir_eval { };
 
+  mirakuru = callPackage ../development/python-modules/mirakuru { };
+
   misaka = callPackage ../development/python-modules/misaka { };
 
   misoc = callPackage ../development/python-modules/misoc { };


### PR DESCRIPTION
python310Packages.port-for: init at 0.7.1
python310Packages.mirakuru: init at 2.5.1

## Description of changes

Add a package and its dependencies.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).