### PR TITLE
workflows/check-by-name: Better error when base branch also fails

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -21,6 +21,16 @@ jobs:
         with:
           # pull_request_target checks out the base branch by default
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          # Fetches the merge commit and its parents
+          fetch-depth: 2
+      - name: Determining PR git hashes
+        run: |
+          echo "mergedSha=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+          # For pull_request_target this is the same as $GITHUB_SHA
+          echo "baseSha=$(git rev-parse HEAD^1)" >> "$GITHUB_ENV"
+
+          echo "headSha=$(git rev-parse HEAD^2)" >> "$GITHUB_ENV"
       - uses: cachix/install-nix-action@v23
       - name: Determining channel to use for dependencies
         run: |
@@ -51,4 +61,83 @@ jobs:
           # Passing --max-jobs 0 makes sure that we won't build anything
           nix-build "$nixpkgs" -A tests.nixpkgs-check-by-name --max-jobs 0
       - name: Running nixpkgs-check-by-name
-        run: result/bin/nixpkgs-check-by-name .
+        run: |
+          echo "Checking whether the check succeeds on the base branch $GITHUB_BASE_REF"
+          git checkout -q "$baseSha"
+          if baseOutput=$(result/bin/nixpkgs-check-by-name . 2>&1); then
+            baseSuccess=1
+          else
+            baseSuccess=
+          fi
+          printf "%s\n" "$baseOutput"
+
+          echo "Checking whether the check would succeed after merging this pull request"
+          git checkout -q "$mergedSha"
+          if mergedOutput=$(result/bin/nixpkgs-check-by-name . 2>&1); then
+            mergedSuccess=1
+            exitCode=0
+          else
+            mergedSuccess=
+            exitCode=1
+          fi
+          printf "%s\n" "$mergedOutput"
+
+          resultToEmoji() {
+            if [[ -n "$1" ]]; then
+              echo ":heavy_check_mark:"
+            else
+              echo ":x:"
+            fi
+          }
+
+          # Print a markdown summary in GitHub actions
+          {
+            echo "| Nixpkgs version | Check result |"
+            echo "| --- | --- |"
+            echo "| Latest base commit | $(resultToEmoji "$baseSuccess") |"
+            echo "| After merging this PR | $(resultToEmoji "$mergedSuccess") |"
+            echo ""
+
+            if [[ -n "$baseSuccess" ]]; then
+              if [[ -n "$mergedSuccess" ]]; then
+                echo "The check succeeds on both the base branch and after merging this PR"
+              else
+                echo "The check succeeds on the base branch, but would fail after merging this PR:"
+                echo "\`\`\`"
+                echo "$mergedOutput"
+                echo "\`\`\`"
+                echo ""
+              fi
+            else
+              if [[ -n "$mergedSuccess" ]]; then
+                echo "The check fails on the base branch, but this PR fixes it, nicely done!"
+              else
+                echo "The check fails on both the base branch and after merging this PR, unknown if only this PRs changes would satisfy the check, the base branch needs to be fixed first."
+                echo ""
+                echo "Failure on the base branch:"
+                echo "\`\`\`"
+                echo "$baseOutput"
+                echo "\`\`\`"
+                echo ""
+                echo "Failure after merging this PR:"
+                echo "\`\`\`"
+                echo "$mergedOutput"
+                echo "\`\`\`"
+                echo ""
+              fi
+            fi
+
+            echo "### Details"
+            echo "- nixpkgs-check-by-name tool:"
+            echo "  - Channel: $channel"
+            echo "  - Nixpkgs commit: [$rev](https://github.com/${GITHUB_REPOSITORY}/commit/$rev)"
+            echo "  - Store path: \`$(realpath result)\`"
+            echo "- Tested Nixpkgs:"
+            echo "  - Base branch $GITHUB_BASE_REF"
+            echo "  - Latest base branch commit: [$baseSha](https://github.com/${GITHUB_REPOSITORY}/commit/$baseSha)"
+            echo "  - Latest PR commit: [$headSha](https://github.com/${GITHUB_REPOSITORY}/commit/$headSha)"
+            echo "  - Merge commit: [$mergedSha](https://github.com/${GITHUB_REPOSITORY}/commit/$mergedSha)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$exitCode"
+


### PR DESCRIPTION
## Description of changes

Previously, even if the check also failed on the base branch, it would look like the PR introduced the failure (though I don't think this even happened).

We can have a better error message for such cases by also running the tool on the base branch, which is achievable with little extra effort.

However the main motivation really is that this paves the road towards https://github.com/NixOS/nixpkgs/issues/256788.

Note that due to using [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) instead of [`pull_request`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), this PR itself [does not trigger the new workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#about-workflow-triggers).

## Things done
- [x] Tested all configurations of failing/succeeding base/PR:
  - [x] https://github.com/tweag/nixpkgs/pull/70
  - [x] https://github.com/tweag/nixpkgs/pull/69
  - [x] https://github.com/tweag/nixpkgs/pull/72
  - [x] https://github.com/tweag/nixpkgs/pull/71
- [x] Verified that the CI check is not significantly slower