### PR TITLE
bitwig-studio3: 3.3.7 -> 3.3.11

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bitwig-studio";
-  version = "3.3.7";
+  version = "3.3.11";
 
   src = fetchurl {
     url = "https://downloads.bitwig.com/stable/${version}/${pname}-${version}.deb";
-    sha256 = "13jr45kzv0xjhhqk30qpq793349qyx8jpas4kl6i6bk3xfrd3fbz";
+    sha256 = "sha256-cF8gVPjM0KUcKOW09uFccp4/lzbUmZcBkVOwr/A/8Yw=";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook ];
@@ -36,11 +36,8 @@ stdenv.mkDerivation rec {
     cp -r opt/bitwig-studio $out/libexec
     ln -s $out/libexec/bitwig-studio $out/bin/bitwig-studio
     cp -r usr/share $out/share
-    substitute usr/share/applications/bitwig-studio.desktop \
-      $out/share/applications/bitwig-studio.desktop \
-      --replace /usr/bin/bitwig-studio $out/bin/bitwig-studio
 
-      runHook postInstall
+    runHook postInstall
   '';
 
   postFixup = ''
@@ -60,7 +57,6 @@ stdenv.mkDerivation rec {
         --prefix PATH : "${lib.makeBinPath [ ffmpeg ]}" \
         --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}"
     done
-
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Changelog can be found here](https://downloads.bitwig.com/stable/3.3.11/Release-Notes-3.3.11.html)

This commit includes these specific changes:

Changes in Bitwig Studio 3.3.11 [released 25 June 2021]
Improvements

    Additional safety checks added to ensure users aren't inadvertently sent into demo mode

Fixes

    When launching in demo mode, a misleading error message about invalid activation might get shown in certain cases
    Reordering automation lanes stops the updating of the knob on the app side (but playback is correct) [25545]
    macOS: Incorrect names were sometimes shown for certain files loaded from the OS (e.g Korean file names composed of Hangul Jamo characters) [25890]
    Linux: Audio input was not possible using ALSA from Flatpak installation
    Controller API: Was possible to crash the application by calling some methods in certain cases [26165]
    Cursor in the password field was misplaced [26202]

Changes in Bitwig Studio 3.3.10 [released 27 May 2021]
Fixes

    Changing tempo would incorrectly change audio event after certain edits [25728]
    Computer keyboard mappings would repeat the mapping when keys are held down (not only when the physical key is pressed)
    Linux: Icons of Grid modules weren't displayed when installing via Flatpak [25923]
    Linux: Application icon wasn't appearing on Ubuntu (regression since 3.3.8)

Changes in Bitwig Studio 3.3.9 [released 12 May 2021]
Fixes

    ADSR modulator: Amount parameter did not have any effect [25768]
    Windows: App would not start for users whose Windows username included certain characters (e.g., Chinese) [25777]

Changes in Bitwig Studio 3.3.8 [released 06 May 2021]
Improvements

    VST plug-ins: Added support for VST_PATH, VST3_PATH, and LXVST_PATH environment variables
    VST3 plug-ins: IAudioPresentationLatency support, better aligning plug-in GUI painting and audio changes
    Linux: updates to package metadata

Fixes

    Clips were ignoring sustain pedal data when previewed in the browser [25460]
    It was possible to create a feedback loop by moving a track to a return track [25678]
    Projects that contain invalid feedback routings are now fixed automatically [25678]
    The audio engine could get stuck into an infinite loop under certain conditions [25704]
    Fixed a crash in the step sequencer API [25564]
    Sampler device/Grid module: Application of loop range changes now happen immediately [25577]
    Drum devices (E-Clap, E-Cowbell, E-Hat, E-Kick, E-Snare, and E-Tom): Possible clicks with choke settings in the Drum Machine [22853]
    Peak Limiter device: Delay compensation is now handled appropriately for sample rates other than 44.1 kHz [25420]
    ADSR modulator: Always behaved as if in Single Trigger mode [24122]
    S/H LFO modulator: Could crash the audio engine when Smoothing was at zero [25635]
    Pluck (Envelope) Grid/Polymer module: Would break with Attack at zero [25160]
    Wavetable Grid/Polymer module: Graphics would stay colorful when disabled [25459]
    Selected notes were sometimes not painted correctly while hovering or scrolling the editor [25534, 25707]
    Active and Enable labels were missing from the Inspector on multiselection of devices [25731]
    Hovering over Mixer view toggles didn't show names in the window footer [25521]
    DSP graph window was only showing half of the load when using the 2048 buffer size [23613]
    D16 VST plug-ins: Avoid unnecessary audio restarts




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I loaded up a project and did some basic smoke testing, everything I tested worked as expected.

This update also did fix the application icon for me in rofi drun (on sway), so I expect it will fix the icon in gnome as well.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
