### PR TITLE
treewide: fix invalid gentoo/distfiles urls

### DIFF
--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.10";
 
   src = fetchurl {
-    url = "mirror://gentoo/distfiles/${pname}-${version}.tar.xz";
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.xz";
     sha256 = "sha256-smJDWlJB6Jv6UcPKvVEzdTlS96e3uT8y4Iy52W9YDWk=";
   };
 

--- a/pkgs/os-specific/linux/pax-utils/default.nix
+++ b/pkgs/os-specific/linux/pax-utils/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchurl
+, fetchgit
 , buildPackages
 , docbook_xml_dtd_44
 , docbook_xsl
@@ -18,9 +18,10 @@ stdenv.mkDerivation rec {
   pname = "pax-utils";
   version = "1.3.7";
 
-  src = fetchurl {
-    url = "mirror://gentoo/distfiles/${pname}-${version}.tar.xz";
-    sha256 = "sha256-EINi0pZo0lz3sMrcY7FaTBz8DbxxrcFRszxf597Ok5o=";
+  src = fetchgit {
+    url = "https://anongit.gentoo.org/git/proj/pax-utils.git";
+    rev = "v${version}";
+    hash = "sha256-WyNng+UtfRz1+Eu4gwXLxUvBAg+m3mdrc8GdEPYRKVE=";
   };
 
   strictDeps = true;

--- a/pkgs/tools/backup/mtx/default.nix
+++ b/pkgs/tools/backup/mtx/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.3.12";
 
   src = fetchurl {
-    url = "mirror://gentoo/distfiles/mtx-${version}.tar.gz";
+    url = "mirror://sourceforge/${pname}/${pname}-stable/${version}/${pname}-${version}.tar.gz";
     sha256 = "0261c5e90b98b6138cd23dadecbc7bc6e2830235145ed2740290e1f35672d843";
   };
 

--- a/pkgs/tools/networking/vlan/default.nix
+++ b/pkgs/tools/networking/vlan/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.9";
 
   src = fetchurl {
-    url = "mirror://gentoo/distfiles/vlan.${version}.tar.gz";
+    url = "https://www.candelatech.com/~greear/${pname}/${pname}.${version}.tar.gz";
     sha256 = "1jjc5f26hj7bk8nkjxsa8znfxcf8pgry2ipnwmj2fr6ky0dhm3rv";
   };
 


### PR DESCRIPTION
## Description of changes

Gentoo recently updated its [distfile mirror directory structure](https://www.gentoo.org/glep/glep-0075.html#status):

> As of 2019-10-18, the Gentoo Infrastructure team has successfully deployed the filename-hash BLAKE2B 8 layout on Gentoo mirrors. The previous flat directory structure has been removed on 2023-09-14.

This set of patches updates the URLs of a few packages.

This change in Gentoo raises some questions wrt. the discoverability of new releases, etc.; those are *not* addressed in the initial version of this PR (the hash prefixes were determined "manually").

## Things done

- Built on platform(s)
  - [x ] x86_64-linux

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
