### PR TITLE
gnuradio: general improvements

### DIFF
--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -221,19 +221,11 @@ let
   inherit (shared.passthru) hasFeature; # function
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: (shared // {
   inherit pname version;
-  inherit (shared)
-    src
-    nativeBuildInputs
-    buildInputs
-    disallowedReferences
-    stripDebugList
-    doCheck
-    dontWrapPythonPrograms
-    dontWrapQtApps
-    meta
-  ;
+  # Will still evaluate correctly if not used here. It only helps nix-update
+  # find the right file in which version is defined.
+  inherit (shared) src;
   patches = [
     # Not accepted upstream, see https://github.com/gnuradio/gnuradio/pull/5227
     ./modtool-newmod-permissions.3_8.patch
@@ -286,4 +278,4 @@ stdenv.mkDerivation {
       ${removeReferencesTo}/bin/remove-references-to -t ${python} $out/lib/cmake/gnuradio/GnuradioConfig.cmake
     ''
   ;
-}
+}))

--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -40,11 +40,7 @@
 # If one wishes to use a different src or name for a very custom build
 , overrideSrc ? {}
 , pname ? "gnuradio"
-, versionAttr ? {
-  major = "3.8";
-  minor = "5";
-  patch = "0";
-}
+, version ? "3.8.5.0"
 }:
 
 let
@@ -214,7 +210,7 @@ let
       removeReferencesTo
       featuresInfo
       features
-      versionAttr
+      version
       sourceSha256
       overrideSrc
       fetchFromGitHub
@@ -222,13 +218,12 @@ let
     qt = qt5;
     gtk = gtk3;
   });
-  inherit (shared) hasFeature; # function
+  inherit (shared.passthru) hasFeature; # function
 in
 
 stdenv.mkDerivation {
-  inherit pname;
+  inherit pname version;
   inherit (shared)
-    version
     src
     nativeBuildInputs
     buildInputs

--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -200,6 +200,11 @@ let
     gr-zeromq = {
       runtime = [ cppzmq ];
       cmakeEnableFlag = "GR_ZEROMQ";
+      pythonRuntime = [
+        # Will compile without this, but it is required by tests, and by some
+        # gr blocks.
+        python.pkgs.pyzmq
+      ];
     };
   };
   shared = (import ./shared.nix {
@@ -226,6 +231,20 @@ stdenv.mkDerivation (finalAttrs: (shared // {
   # Will still evaluate correctly if not used here. It only helps nix-update
   # find the right file in which version is defined.
   inherit (shared) src;
+  # Remove failing tests
+  preConfigure = (shared.preConfigure or "") + ''
+    # https://github.com/gnuradio/gnuradio/issues/3801
+    rm gr-blocks/python/blocks/qa_cpp_py_binding.py
+    rm gr-blocks/python/blocks/qa_cpp_py_binding_set.py
+    rm gr-blocks/python/blocks/qa_ctrlport_probes.py
+    # Tests that fail due to numpy deprecations upstream hasn't accomodated to yet.
+    rm gr-fec/python/fec/qa_polar_decoder_sc.py
+    rm gr-fec/python/fec/qa_polar_decoder_sc_list.py
+    rm gr-fec/python/fec/qa_polar_decoder_sc_systematic.py
+    rm gr-fec/python/fec/qa_polar_encoder.py
+    rm gr-fec/python/fec/qa_polar_encoder_systematic.py
+    rm gr-filter/python/filter/qa_freq_xlating_fft_filter.py
+  '';
   patches = [
     # Not accepted upstream, see https://github.com/gnuradio/gnuradio/pull/5227
     ./modtool-newmod-permissions.3_8.patch

--- a/pkgs/applications/radio/gnuradio/3.9.nix
+++ b/pkgs/applications/radio/gnuradio/3.9.nix
@@ -42,11 +42,7 @@
 # If one wishes to use a different src or name for a very custom build
 , overrideSrc ? {}
 , pname ? "gnuradio"
-, versionAttr ? {
-  major = "3.9";
-  minor = "8";
-  patch = "0";
-}
+, version ? "3.9.8.0"
 }:
 
 let
@@ -250,7 +246,7 @@ let
       removeReferencesTo
       featuresInfo
       features
-      versionAttr
+      version
       sourceSha256
       overrideSrc
       fetchFromGitHub
@@ -258,13 +254,12 @@ let
     qt = qt5;
     gtk = gtk3;
   });
-  inherit (shared) hasFeature; # function
+  inherit (shared.passthru) hasFeature; # function
 in
 
 stdenv.mkDerivation {
-  inherit pname;
+  inherit pname version;
   inherit (shared)
-    version
     src
     nativeBuildInputs
     buildInputs

--- a/pkgs/applications/radio/gnuradio/3.9.nix
+++ b/pkgs/applications/radio/gnuradio/3.9.nix
@@ -257,20 +257,11 @@ let
   inherit (shared.passthru) hasFeature; # function
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: (shared // {
   inherit pname version;
-  inherit (shared)
-    src
-    nativeBuildInputs
-    buildInputs
-    cmakeFlags
-    disallowedReferences
-    stripDebugList
-    doCheck
-    dontWrapPythonPrograms
-    dontWrapQtApps
-    meta
-  ;
+  # Will still evaluate correctly if not used here. It only helps nix-update
+  # find the right file in which version is defined.
+  inherit (shared) src;
   patches = [
     # Not accepted upstream, see https://github.com/gnuradio/gnuradio/pull/5227
     ./modtool-newmod-permissions.patch
@@ -298,4 +289,4 @@ stdenv.mkDerivation {
       ${removeReferencesTo}/bin/remove-references-to -t ${python.pkgs.pybind11} $out/lib/cmake/gnuradio/gnuradio-runtimeTargets.cmake
     ''
   ;
-}
+}))

--- a/pkgs/applications/radio/gnuradio/3.9.nix
+++ b/pkgs/applications/radio/gnuradio/3.9.nix
@@ -227,6 +227,11 @@ let
     gr-zeromq = {
       runtime = [ cppzmq ];
       cmakeEnableFlag = "GR_ZEROMQ";
+      pythonRuntime = [
+        # Will compile without this, but it is required by tests, and by some
+        # gr blocks.
+        python.pkgs.pyzmq
+      ];
     };
     gr-network = {
       cmakeEnableFlag = "GR_NETWORK";
@@ -262,6 +267,13 @@ stdenv.mkDerivation (finalAttrs: (shared // {
   # Will still evaluate correctly if not used here. It only helps nix-update
   # find the right file in which version is defined.
   inherit (shared) src;
+  # Remove failing tests
+  preConfigure = (shared.preConfigure or "") + ''
+    # https://github.com/gnuradio/gnuradio/issues/3801
+    rm gr-blocks/python/blocks/qa_cpp_py_binding.py
+    rm gr-blocks/python/blocks/qa_cpp_py_binding_set.py
+    rm gr-blocks/python/blocks/qa_ctrlport_probes.py
+  '';
   patches = [
     # Not accepted upstream, see https://github.com/gnuradio/gnuradio/pull/5227
     ./modtool-newmod-permissions.patch

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -278,20 +278,11 @@ let
   inherit (shared.passthru) hasFeature; # function
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: (shared // {
   inherit pname version;
-  inherit (shared)
-    src
-    nativeBuildInputs
-    buildInputs
-    cmakeFlags
-    disallowedReferences
-    stripDebugList
-    doCheck
-    dontWrapPythonPrograms
-    dontWrapQtApps
-    meta
-  ;
+  # Will still evaluate correctly if not used here. It only helps nix-update
+  # find the right file in which version is defined.
+  inherit (shared) src;
   patches = [
     # Not accepted upstream, see https://github.com/gnuradio/gnuradio/pull/5227
     ./modtool-newmod-permissions.patch
@@ -327,4 +318,4 @@ stdenv.mkDerivation {
       ${removeReferencesTo}/bin/remove-references-to -t ${python.pkgs.pybind11} $out/lib/cmake/gnuradio/gnuradio-runtimeTargets.cmake
     ''
   ;
-}
+}))

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -45,11 +45,7 @@
 # If one wishes to use a different src or name for a very custom build
 , overrideSrc ? {}
 , pname ? "gnuradio"
-, versionAttr ? {
-  major = "3.10";
-  minor = "7";
-  patch = "0";
-}
+, version ? "3.10.7.0"
 }:
 
 let
@@ -271,7 +267,7 @@ let
       removeReferencesTo
       featuresInfo
       features
-      versionAttr
+      version
       sourceSha256
       overrideSrc
       fetchFromGitHub
@@ -279,13 +275,12 @@ let
     qt = qt5;
     gtk = gtk3;
   });
-  inherit (shared) hasFeature; # function
+  inherit (shared.passthru) hasFeature; # function
 in
 
 stdenv.mkDerivation {
-  inherit pname;
+  inherit pname version;
   inherit (shared)
-    version
     src
     nativeBuildInputs
     buildInputs

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -248,6 +248,11 @@ let
     gr-zeromq = {
       runtime = [ cppzmq ];
       cmakeEnableFlag = "GR_ZEROMQ";
+      pythonRuntime = [
+        # Will compile without this, but it is required by tests, and by some
+        # gr blocks.
+        python.pkgs.pyzmq
+      ];
     };
     gr-network = {
       cmakeEnableFlag = "GR_NETWORK";

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -5,7 +5,7 @@
 , removeReferencesTo
 , featuresInfo
 , features
-, versionAttr
+, version
 , sourceSha256
 # If overridden. No need to set default values, as they are given defaults in
 # the main expressions
@@ -13,10 +13,21 @@
 , fetchFromGitHub
 }:
 
-rec {
-  version = builtins.concatStringsSep "." (
-    lib.attrVals [ "major" "minor" "patch" ] versionAttr
+let
+  # Check if a feature is enabled, while defaulting to true if feat is not
+  # specified.
+  hasFeature = feat: (
+    if builtins.hasAttr feat features then
+      features.${feat}
+    else
+      true
   );
+  versionAttr = {
+    major = builtins.concatStringsSep "." (lib.take 2 (lib.splitVersion version));
+    minor = builtins.elemAt (lib.splitVersion version) 2;
+    patch = builtins.elemAt (lib.splitVersion version) 3;
+  };
+in {
   src = if overrideSrc != {} then
     overrideSrc
   else
@@ -27,14 +38,6 @@ rec {
       sha256 = sourceSha256;
     }
   ;
-  # Check if a feature is enabled, while defaulting to true if feat is not
-  # specified.
-  hasFeature = feat: (
-    if builtins.hasAttr feat features then
-      features.${feat}
-    else
-      true
-  );
   nativeBuildInputs = lib.flatten (lib.mapAttrsToList (
     feat: info: (
       lib.optionals (hasFeature feat) (

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -112,9 +112,14 @@ in {
   # Wrapping is done with an external wrapper
   dontWrapPythonPrograms = true;
   dontWrapQtApps = true;
-  # Tests should succeed, but it's hard to get LD_LIBRARY_PATH right in order
-  # for it to happen.
-  doCheck = false;
+  # On darwin, it requires playing with DYLD_FALLBACK_LIBRARY_PATH to make if
+  # find libgnuradio-runtim.3.*.dylib .
+  doCheck = !stdenv.isDarwin;
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    export QT_QPA_PLATFORM=offscreen
+    export QT_PLUGIN_PATH="${qt.qtbase.bin}/${qt.qtbase.qtPluginPrefix}"
+  '';
 
   meta = with lib; {
     description = "Software Defined Radio (SDR) software";

--- a/pkgs/top-level/gnuradio-packages.nix
+++ b/pkgs/top-level/gnuradio-packages.nix
@@ -20,8 +20,10 @@ let
       boost
       volk
       logLib
+      python
     ;
     inherit mkDerivationWith mkDerivation;
+    inherit gnuradio;
   } // lib.optionalAttrs (gnuradio.hasFeature "gr-uhd") {
     inherit (gnuradio) uhd;
   });
@@ -30,9 +32,6 @@ in {
   inherit callPackage mkDerivation mkDerivationWith;
 
   ### Packages
-
-  inherit gnuradio;
-  inherit (gnuradio) python;
 
   osmosdr = callPackage ../development/gnuradio-modules/osmosdr/default.nix { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
