### PR TITLE
teams: remove (linux)

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -24,11 +24,9 @@
 let
   pname = "teams";
   versions = {
-    linux = "1.5.00.23861";
     darwin = "1.6.00.4464";
   };
   hashes = {
-    linux = "sha256-h0YnCeJX//l4TegJVZtavV3HrxjYUF2Fa5KmaYmZW8E=";
     darwin = "sha256-DvXMrXotKWUqFCb7rZj8wU7mmZJKuTLGyx8qOB/aQtg=";
   };
   meta = with lib; {
@@ -38,110 +36,8 @@ let
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ liff tricktron ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
     mainProgram = "teams";
-  };
-
-  linux = stdenv.mkDerivation rec {
-    inherit pname meta;
-    version = versions.linux;
-
-    src = fetchurl {
-      urls = [
-        "https://packages.microsoft.com/repos/ms-teams/pool/main/t/teams/teams_${versions.linux}_amd64.deb"
-        # NOTE: the archive.org timestamp must also be updated if the version changes.
-        "https://web.archive.org/web/20221130115842if_/https://packages.microsoft.com/repos/ms-teams/pool/main/t/teams/teams_${versions.linux}_amd64.deb"
-      ];
-      hash = hashes.linux;
-    };
-
-    nativeBuildInputs = [ dpkg autoPatchelfHook wrapGAppsHook asar ];
-
-    unpackCmd = "dpkg -x $curSrc .";
-
-    buildInputs = atomEnv.packages ++ [
-      libuuid
-      at-spi2-atk
-    ];
-
-    runtimeDependencies = [
-      (lib.getLib systemd)
-      pulseaudio
-      libappindicator-gtk3
-    ];
-
-    preFixup = ''
-      gappsWrapperArgs+=(
-        --prefix PATH : "${coreutils}/bin:${gawk}/bin"
-
-        # fix for https://docs.microsoft.com/en-us/answers/questions/298724/open-teams-meeting-link-on-linux-doens39t-work.html?childToView=309406#comment-309406
-        --append-flags '--disable-namespace-sandbox --disable-setuid-sandbox'
-      )
-    '';
-
-
-    buildPhase = ''
-      runHook preBuild
-
-      asar extract share/teams/resources/app.asar "$TMP/work"
-      substituteInPlace $TMP/work/main.bundle.js \
-          --replace "/usr/share/pixmaps/" "$out/share/pixmaps" \
-          --replace "/usr/bin/xdg-mime" "${xdg-utils}/bin/xdg-mime" \
-          --replace "Exec=/usr/bin/" "Exec=" # Remove usage of absolute path in autostart.
-      asar pack --unpack='{*.node,*.ftz,rect-overlay}' "$TMP/work" share/teams/resources/app.asar
-
-      runHook postBuild
-    '';
-
-    preferLocalBuild = true;
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/{opt,bin}
-
-      mv share/teams $out/opt/
-      mv share $out/share
-
-      mkdir -p $out/share/icons/hicolor/512x512/apps
-      mv $out/share/pixmaps/teams.png $out/share/icons/hicolor/512x512/apps
-      rmdir $out/share/pixmaps
-
-      substituteInPlace $out/share/applications/teams.desktop \
-        --replace /usr/bin/ ""
-
-      ln -s $out/opt/teams/teams $out/bin/
-
-      ${lib.optionalString (!enableRectOverlay) ''
-      # Work-around screen sharing bug
-      # https://docs.microsoft.com/en-us/answers/questions/42095/sharing-screen-not-working-anymore-bug.html
-      rm $out/opt/teams/resources/app.asar.unpacked/node_modules/slimcore/bin/rect-overlay
-      ''}
-
-      runHook postInstall
-    '';
-
-    dontAutoPatchelf = true;
-
-    # Includes runtimeDependencies in the RPATH of the included Node modules
-    # so that dynamic loading works. We cannot use directly runtimeDependencies
-    # here, since the libraries from runtimeDependencies are not propagated
-    # to the dynamically loadable node modules because of a condition in
-    # autoPatchElfHook since *.node modules have Type: DYN (Shared object file)
-    # instead of EXEC or INTERP it expects.
-    # Fixes: https://github.com/NixOS/nixpkgs/issues/85449
-    postFixup = ''
-      autoPatchelf "$out"
-
-      runtime_rpath="${lib.makeLibraryPath runtimeDependencies}"
-
-      for mod in $(find "$out/opt/teams" -name '*.node'); do
-        mod_rpath="$(patchelf --print-rpath "$mod")"
-
-        echo "Adding runtime dependencies to RPATH of Node module $mod"
-        patchelf --set-rpath "$runtime_rpath:$mod_rpath" "$mod"
-      done;
-    '';
   };
 
   appName = "Teams.app";
@@ -178,4 +74,4 @@ let
 in
 if stdenv.isDarwin
 then darwin
-else linux
+else throw "Teams app for Linux has been removed as it is unmaintained by upstream. (2023-09-29)"


### PR DESCRIPTION
The linux flavour of the app is abandoned by upstream and likely affected by multiple vulnerabilities.

We have the (inofficial) teams-for-linux packaged as an alternative.

## Description of changes


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
