### PR TITLE
nixos/nginx: add systemd-tmpfiles exclusion of temporary directories

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1340,6 +1340,11 @@ in
       nginx.gid = config.ids.gids.nginx;
     };
 
+    # do not delete the default temp directories created upon nginx startup
+    systemd.tmpfiles.rules = [
+      "X /tmp/systemd-private-%b-nginx.service-*/tmp/nginx_*"
+    ];
+
     services.logrotate.settings.nginx = mapAttrs (_: mkDefault) {
       files = "/var/log/nginx/*.log";
       frequency = "weekly";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -554,6 +554,7 @@ in {
   nginx-sandbox = handleTestOn ["x86_64-linux"] ./nginx-sandbox.nix {};
   nginx-sso = handleTest ./nginx-sso.nix {};
   nginx-status-page = handleTest ./nginx-status-page.nix {};
+  nginx-tmpdir = handleTest ./nginx-tmpdir.nix {};
   nginx-variants = handleTest ./nginx-variants.nix {};
   nifi = handleTestOn ["x86_64-linux"] ./web-apps/nifi.nix {};
   nitter = handleTest ./nitter.nix {};

--- a/nixos/tests/nginx-tmpdir.nix
+++ b/nixos/tests/nginx-tmpdir.nix
@@ -1,0 +1,60 @@
+let
+  dst-dir = "/run/nginx-test-tmpdir-uploads";
+in
+  import ./make-test-python.nix {
+    name = "nginx-tmpdir";
+
+    nodes.machine = { pkgs, ... }: {
+      environment.etc."tmpfiles.d/nginx-uploads.conf".text = "d ${dst-dir} 0755 nginx nginx 1d";
+
+      # overwrite the tmp.conf with a short age, there will be a duplicate line info from systemd-tmpfiles in the log
+      systemd.tmpfiles.rules = [
+        "q /tmp 1777 root root 1min"
+      ];
+
+      services.nginx.enable = true;
+      # simple upload service using the nginx client body temp path
+      services.nginx.virtualHosts = {
+        localhost = {
+          locations."~ ^/upload/([0-9a-zA-Z-.]*)$" = {
+            extraConfig = ''
+              alias ${dst-dir}/$1;
+              client_body_in_file_only clean;
+              dav_methods PUT;
+              create_full_put_path on;
+              dav_access group:rw all:r;
+            '';
+          };
+        };
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("nginx")
+      machine.wait_for_open_port(80)
+
+      with subtest("Needed prerequisite --http-client-body-temp-path=/tmp/nginx_client_body and private temp"):
+        machine.succeed("touch /tmp/systemd-private-*-nginx.service-*/tmp/nginx_client_body")
+
+      with subtest("Working upload of test setup"):
+        machine.succeed("curl -X PUT http://localhost/upload/test1 --fail --data-raw 'Raw data 1'")
+        machine.succeed('test "$(cat ${dst-dir}/test1)" = "Raw data 1"')
+
+      # let the tmpfiles clean service do its job
+      machine.succeed("touch /tmp/touched")
+      machine.wait_until_succeeds(
+        "sleep 15 && systemctl start systemd-tmpfiles-clean.service && [ ! -f /tmp/touched ]",
+        timeout=150
+      )
+
+      with subtest("Working upload after cleaning"):
+        machine.succeed("curl -X PUT http://localhost/upload/test2 --fail --data-raw 'Raw data 2'")
+        machine.succeed('test "$(cat ${dst-dir}/test2)" = "Raw data 2"')
+
+      # manually remove the nginx temp dir
+      machine.succeed("rm -r --interactive=never /tmp/systemd-private-*-nginx.service-*/tmp/nginx_client_body")
+
+      with subtest("Broken upload after manual temp dir removal"):
+        machine.fail("curl -X PUT http://localhost/upload/test3 --fail --data-raw 'Raw data 3'")
+    '';
+  }


### PR DESCRIPTION
Directories used by nginx in the tmp path are only created upon startup and must not be deleted while nginx is running.

cc @dasJ @ajs124 @SuperSandro2000

## Description of changes

Added a systemd-tmpfiles rule to prevent deletion directories created in tmp by nginx. The content of the paths is not excluded from cleaning.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
