### PR TITLE
nixos/gnome/xkb-settings: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -459,6 +459,7 @@
   ./services/desktops/gnome/sushi.nix
   ./services/desktops/gnome/tracker-miners.nix
   ./services/desktops/gnome/tracker.nix
+  ./services/desktops/gnome/xkb-settings.nix
   ./services/desktops/gsignond.nix
   ./services/desktops/gvfs.nix
   ./services/desktops/malcontent.nix

--- a/nixos/modules/services/desktops/gnome/xkb-settings.nix
+++ b/nixos/modules/services/desktops/gnome/xkb-settings.nix
@@ -1,0 +1,92 @@
+# GNOME Settings Daemon
+
+{ config, lib, ... }:
+
+let
+  xcfg = config.services.xserver;
+
+  splitToParts = str: if str == "" then [] else builtins.filter builtins.isString (builtins.split ",\s*" str);
+
+  layouts = splitToParts xcfg.layout;
+  variantsUnpadded = splitToParts xcfg.xkbVariant;
+  variants =
+    let
+      padding = lib.max 0 (builtins.length layouts - builtins.length variantsUnpadded);
+    in
+    variantsUnpadded ++ lib.replicate padding "";
+in
+
+{
+
+  meta = {
+    maintainers = lib.teams.gnome.members;
+  };
+
+  options = {
+    services.gnome.useXkbConfig = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        If enabled, configure the keyboard layout in GNOME Settings Daemon to match [xserver keyboard settings](#opt-services.xserver.layout).
+      '';
+    };
+  };
+
+  config = lib.mkIf config.services.gnome.useXkbConfig {
+    assertions = [
+      {
+        /*
+        X appears to ignore the variant option when it is not the same type (string/list) as layout, compare:
+
+            xkbvalidate pc104 us,cz,pl qwerty ""
+            xkbvalidate pc104 us qwerty, ""
+
+        and
+
+            xkbvalidate pc104 us,cz,pl qwerty, ""
+        */
+        assertion = variantsUnpadded != [] -> (builtins.length layouts == 1) == (builtins.length variantsUnpadded == 1);
+        message = "services.xserver.layout and services.xserver.xkbVariant should have the same number of comma-separated items.";
+      }
+    ];
+
+    programs = {
+      dconf = {
+        profiles = {
+          user = {
+            databases = [
+              {
+                # Disallow changing the input settings in Control Center since unlike with NixOS options,
+                # there is no merging between databases and user-db would just replace this.
+                lockAll = true;
+
+                settings = {
+                  "org/gnome/desktop/input-sources" = {
+                    sources =
+                      if variants != [] then
+                        lib.zipListsWith
+                          (layout: variant: lib.gvariant.mkTuple [
+                            "xkb"
+                            "${layout}${lib.optionalString (variant != "") "+" + variant}"
+                          ])
+                          layouts
+                          variants
+                      else
+                        builtins.map
+                          (layout: lib.gvariant.mkTuple [
+                            "xkb"
+                            layout
+                          ])
+                          layouts
+                      ;
+                    xkb-options = splitToParts xcfg.xkbOptions;
+                  };
+                };
+              }
+            ];
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Description of changes

`services.xserver.xkbLayout` does not really work in GNOME, which is a common source of confusion for newcomers ([latest instance](https://discourse.nixos.org/t/strange-xkboptions-behavior-gnome/33535)).
Let’s add an option inspired by `console.useXkbConfig` reflecting the X server options in GNOME settings.

cc @linsui, @bobby285271

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
