### PR TITLE
python3Packages.dtaidistance: init at 2.3.10

### DIFF
--- a/pkgs/development/python-modules/dtaidistance/default.nix
+++ b/pkgs/development/python-modules/dtaidistance/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, llvmPackages
+, pytestCheckHook
+, cython
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "dtaidistance";
+  version = "2.3.10";
+
+  src = fetchFromGitHub {
+    owner = "wannesm";
+    repo = "dtaidistance";
+    rev = "v${version}";
+    hash = "sha256-JP/EljFemywgRgspxFzIoHeTtI8gK1SbKgBcGTmzmqw=";
+  };
+
+  nativeBuildInputs = [ cython numpy ];
+
+  buildInputs = [ llvmPackages.openmp ];
+
+  propagatedBuildInputs = [ numpy ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [
+    "$src/tests"
+  ];
+
+  preCheck = ''
+    cd $out
+  '';
+
+  meta = with lib; {
+    homepage = "https://dtaidistance.readthedocs.io";
+    description = "Time series distances: Dynamic Time Warping (fast DTW implementation in C)";
+    changelog = "https://github.com/wannesm/dtaidistance/releases/tag/${src.rev}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ wietsedv ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3272,6 +3272,8 @@ self: super: with self; {
 
   dsnap = callPackage ../development/python-modules/dsnap { };
 
+  dtaidistance = callPackage ../development/python-modules/dtaidistance { };
+
   dtlssocket = callPackage ../development/python-modules/dtlssocket { };
 
   dtschema = callPackage ../development/python-modules/dtschema { };


### PR DESCRIPTION
## Description of changes

DTAIDistance is a library for dynamic time warping in Python.

I have set `doCheck` to `false` because the included tests are expensive long-running benchmark tests.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
