### PR TITLE
vyxal: init at 3.4.9

### DIFF
--- a/pkgs/by-name/vy/vyxal/package.nix
+++ b/pkgs/by-name/vy/vyxal/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenvNoCC,
+  clangStdenv,
+  fetchFromGitHub,
+  mill,
+  which,
+}:
+
+let
+  # we need to lock the mill version, because an update will change the
+  # fetched internal dependencies, thus breaking the deps FOD
+  lockedMill = mill.overrideAttrs (oldAttrs: {
+    # should ideally match the version listed inside the `.mill-version` file of the source
+    version = "0.11.12";
+    src = oldAttrs.src.overrideAttrs {
+      outputHash = "sha256-k4/oMHvtq5YXY8hRlX4gWN16ClfjXEAn6mRIoEBHNJo=";
+    };
+  });
+in
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "vyxal";
+  version = "3.4.9";
+
+  src = fetchFromGitHub {
+    owner = "Vyxal";
+    repo = "Vyxal";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-8hA4u9zz8jm+tlSZ88z69/PUFNYk7+i3jtgUntgDgPE=";
+  };
+
+  # make sure to resolve all dependencies needed
+  deps = stdenvNoCC.mkDerivation {
+    name = "vyxal-${finalAttrs.version}-deps";
+    inherit (finalAttrs) src;
+
+    nativeBuildInputs = [ lockedMill ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      export JAVA_TOOL_OPTIONS="-Duser.home=$(mktemp -d)"
+      export COURSIER_CACHE=$out/.coursier
+
+      mill native.prepareOffline --all
+
+      runHook postBuild
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-yXKzntb498b8ZLYq7w+s1Brj+pvPN9otdkdY8QGVHPs=";
+  };
+
+  nativeBuildInputs = [
+    lockedMill
+    which
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export JAVA_TOOL_OPTIONS="-Duser.home=$(mktemp -d)"
+    export COURSIER_CACHE=${finalAttrs.deps}/.coursier
+
+    mill native.nativeLink
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 out/native/nativeLink.dest/out $out/bin/vyxal
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/Vyxal/Vyxal/releases/tag/v${finalAttrs.version}";
+    description = "Code-golfing language that has aspects of traditional programming languages";
+    homepage = "https://github.com/Vyxal/Vyxal";
+    license = lib.licenses.mit;
+    mainProgram = "vyxal";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

This PR adds 1 package: `vyxal`

Homepage: https://github.com/Vyxal/Vyxal

The original PR was for Vyxal 2, which was built in python.
Since then Vyxal 3 was released, so I rewrote the derivation completely, as v3 has migrated over to the Scala language from Python.

The dependencies are managed by `mill` (which uses `courier` for caching stuff)
I added a FOD for the dependencies. To ensure that we have a stable hash, I needed to lock the `mill` version: different `mill` versions have different internal version dependencies, which are also fetched at build-time.

With Scala you can compile to JVM, JS or native. 
I originally tried JVM, which worked properly, but native was a lot faster, so I went with that instead.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
