### PR TITLE
game-music-emu: update build options

### DIFF
--- a/pkgs/development/libraries/audio/game-music-emu/default.nix
+++ b/pkgs/development/libraries/audio/game-music-emu/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     url = "https://bitbucket.org/mpyne/game-music-emu/downloads/${pname}-${version}.tar.xz";
     sha256 = "07857vdkak306d9s5g6fhmjyxk7vijzjhkmqb15s7ihfxx9lx8xb";
   };
-  cmakeFlags = lib.optionals (stdenv.isDarwin || stdenv.hostPlatform.isMusl) [ "-DENABLE_UBSAN=OFF" ];
+  cmakeFlags = [ "-DENABLE_UBSAN=OFF" ];
   nativeBuildInputs = [ cmake removeReferencesTo ];
 
   # It used to reference it, in the past, but thanks to the postFixup hook, now

--- a/pkgs/development/libraries/audio/game-music-emu/default.nix
+++ b/pkgs/development/libraries/audio/game-music-emu/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cmake, removeReferencesTo }:
+{ lib, stdenv, fetchurl, cmake, removeReferencesTo, zlib }:
 
 stdenv.mkDerivation rec {
   version = "0.6.3";
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
   };
   cmakeFlags = [ "-DENABLE_UBSAN=OFF" ];
   nativeBuildInputs = [ cmake removeReferencesTo ];
+  buildInputs = [ zlib ];
 
   # It used to reference it, in the past, but thanks to the postFixup hook, now
   # it doesn't.


### PR DESCRIPTION
## Description of changes

This makes two changes to the build configuration for libgme:
- disables UBSAN unconditionally (rather than only on certain platforms). Some of the loaders have UB in them (int/bool confusion), and while this should be fixed upstream, the console spam this results in when using tools like ffprobe isn't useful to end users.
- enables zlib as a build input. This is necessary to support compressed formats like VGZ; without it, the library still builds but cannot load these files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
