### PR TITLE
jetbrains: avoid LD_LIBRARY_PATH leaks

### DIFF
--- a/pkgs/applications/editors/jetbrains/linux.nix
+++ b/pkgs/applications/editors/jetbrains/linux.nix
@@ -107,9 +107,7 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
     wrapProgram  "$out/$pname/bin/${loName}.sh" \
       --prefix PATH : "$out/libexec/${pname}:${lib.makeBinPath [ jdk coreutils gnugrep which git python3 ]}" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath ([
-        # Some internals want libstdc++.so.6
-        stdenv.cc.cc.lib libsecret e2fsprogs
-        libnotify
+        libsecret e2fsprogs libnotify
         # Required for Help -> Collect Logs
         # in at least rider and goland
         udev

--- a/pkgs/applications/editors/jetbrains/linux.nix
+++ b/pkgs/applications/editors/jetbrains/linux.nix
@@ -89,6 +89,21 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
     if [ -d "plugins/remote-dev-server" ]; then
       patch -p1 < ${./JetbrainsRemoteDev.patch}
     fi
+
+    vmopts_file=bin/linux/${vmoptsName}
+    if [[ ! -f $vmopts_file ]]; then
+      vmopts_file=bin/${vmoptsName}
+      if [[ ! -f $vmopts_file ]]; then
+        echo "ERROR: $vmopts_file not found"
+        exit 1
+      fi
+    fi
+    echo -Djna.library.path=${lib.makeLibraryPath ([
+      libsecret e2fsprogs libnotify
+      # Required for Help -> Collect Logs
+      # in at least rider and goland
+      udev
+    ])} >> $vmopts_file
   '';
 
   installPhase = ''
@@ -106,12 +121,7 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
 
     wrapProgram  "$out/$pname/bin/${loName}.sh" \
       --prefix PATH : "$out/libexec/${pname}:${lib.makeBinPath [ jdk coreutils gnugrep which git python3 ]}" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath ([
-        libsecret e2fsprogs libnotify
-        # Required for Help -> Collect Logs
-        # in at least rider and goland
-        udev
-      ] ++ extraLdPath)}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath extraLdPath}" \
       ${lib.concatStringsSep " " extraWrapperArgs} \
       --set-default JDK_HOME "$jdk" \
       --set-default ANDROID_JAVA_HOME "$jdk" \


### PR DESCRIPTION
## Description of changes

See the ~~two~~ three commit messages. I also fixed Rider to properly patch binaries instead of relying on LD_LIBRARY_PATH.

Fixes #141593

I have tested this with CLion, I would appreciate help with testing other IDEs as well to be sure. Expectation is that everything should work as before, but now Nix can be properly used within the IDE terminal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - [x] CLion
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [x] CLion
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
