### PR TITLE
neovim: heavy refactor

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -14,6 +14,31 @@
 let
   inherit (vimUtils) toVimPlugin;
 
+  /* transform all plugins into an attrset
+   { optional = bool; plugin = package; }
+  */
+  normalizePlugins = plugins:
+      let
+        defaultPlugin = {
+          plugin = null;
+          config = null;
+          optional = false;
+        };
+      in
+        # TODO use (coercedTo package (v: { plugin = v; }) pluginWithConfigType);
+        map (x: defaultPlugin // (if (x ? plugin) then x else { plugin = x; })) plugins;
+
+
+  /* accepts a list of
+  */
+  normalizedPluginsToVimPackage = normalizedPlugins:
+    let
+      pluginsPartitioned = lib.partition (x: x.optional == true) normalizedPlugins;
+    in {
+        start = map (x: x.plugin) pluginsPartitioned.wrong;
+        opt = map (x: x.plugin) pluginsPartitioned.right;
+      };
+
    /* returns everything needed for the caller to wrap its own neovim:
    - the generated content of the future init.vim
    - the arguments to wrap neovim with
@@ -24,103 +49,8 @@ let
    Indeed, note that wrapping with `-u init.vim` has sideeffects like .nvimrc wont be loaded
    anymore, $MYVIMRC wont be set etc
    */
-  makeNeovimConfig =
-    { withPython3 ? true
-    /* the function you would have passed to python3.withPackages */
-    , extraPython3Packages ? (_: [ ])
-    , withNodeJs ? false
-    , withRuby ? true
-    /* the function you would have passed to lua.withPackages */
-    , extraLuaPackages ? (_: [ ])
+  makeNeovimConfig = args: args // { wrapperArgs = []; };
 
-    # expects a list of plugin configuration
-    # expects { plugin=far-vim; config = "let g:far#source='rg'"; optional = false; }
-    , plugins ? []
-    # custom viml config appended after plugin-specific config
-    , customRC ? ""
-
-    # for forward compability, when adding new environments, haskell etc.
-    , ...
-    }@args:
-    let
-      rubyEnv = bundlerEnv {
-        name = "neovim-ruby-env";
-        gemdir = ./ruby_provider;
-        postBuild = ''
-          ln -sf ${ruby}/bin/* $out/bin
-        '';
-      };
-
-      # transform all plugins into an attrset
-      # { optional = bool; plugin = package; }
-      pluginsNormalized = let
-        defaultPlugin = {
-          plugin = null;
-          config = null;
-          optional = false;
-        };
-      in
-        map (x: defaultPlugin // (if (x ? plugin) then x else { plugin = x; })) plugins;
-
-      pluginRC = lib.foldl (acc: p: if p.config != null then acc ++ [p.config] else acc) []  pluginsNormalized;
-
-      pluginsPartitioned = lib.partition (x: x.optional == true) pluginsNormalized;
-      requiredPlugins = vimUtils.requiredPluginsForPackage myVimPackage;
-      getDeps = attrname: map (plugin: plugin.${attrname} or (_: [ ]));
-      myVimPackage = {
-            start = map (x: x.plugin) pluginsPartitioned.wrong;
-            opt = map (x: x.plugin) pluginsPartitioned.right;
-      };
-
-      pluginPython3Packages = getDeps "python3Dependencies" requiredPlugins;
-      python3Env = python3Packages.python.withPackages (ps:
-        [ ps.pynvim ]
-        ++ (extraPython3Packages ps)
-        ++ (lib.concatMap (f: f ps) pluginPython3Packages));
-
-      luaEnv = neovim-unwrapped.lua.withPackages(extraLuaPackages);
-
-      # as expected by packdir
-      packpathDirs.myNeovimPackages = myVimPackage;
-      ## Here we calculate all of the arguments to the 1st call of `makeWrapper`
-      # We start with the executable itself NOTE we call this variable "initial"
-      # because if configure != {} we need to call makeWrapper twice, in order to
-      # avoid double wrapping, see comment near finalMakeWrapperArgs
-      makeWrapperArgs =
-        let
-          binPath = lib.makeBinPath (lib.optionals withRuby [ rubyEnv ] ++ lib.optionals withNodeJs [ nodejs ]);
-        in
-        [
-          "--inherit-argv0"
-        ] ++ lib.optionals withRuby [
-          "--set" "GEM_HOME" "${rubyEnv}/${rubyEnv.ruby.gemPath}"
-        ] ++ lib.optionals (binPath != "") [
-          "--suffix" "PATH" ":" binPath
-        ] ++ lib.optionals (luaEnv != null) [
-          "--prefix" "LUA_PATH" ";" (neovim-unwrapped.lua.pkgs.luaLib.genLuaPathAbsStr luaEnv)
-          "--prefix" "LUA_CPATH" ";" (neovim-unwrapped.lua.pkgs.luaLib.genLuaCPathAbsStr luaEnv)
-        ];
-
-      manifestRc = vimUtils.vimrcContent ({ customRC = ""; }) ;
-      # we call vimrcContent without 'packages' to avoid the init.vim generation
-      neovimRcContent = vimUtils.vimrcContent ({
-        beforePlugins = "";
-        customRC = lib.concatStringsSep "\n" (pluginRC ++ [customRC]);
-        packages = null;
-      });
-    in
-
-    builtins.removeAttrs args ["plugins"] // {
-      wrapperArgs = makeWrapperArgs;
-      inherit packpathDirs;
-      inherit neovimRcContent;
-      inherit manifestRc;
-      inherit python3Env;
-      inherit luaEnv;
-      inherit withNodeJs;
-    } // lib.optionalAttrs withRuby {
-      inherit rubyEnv;
-    };
 
 
   # to keep backwards compatibility for people using neovim.override
@@ -235,6 +165,8 @@ in
   inherit generateProviderRc;
   inherit legacyWrapper;
   inherit grammarToPlugin;
+
+  inherit normalizePlugins normalizedPluginsToVimPackage;
 
   inherit buildNeovimPlugin;
   buildNeovimPluginFrom2Nix = lib.warn "buildNeovimPluginFrom2Nix was renamed to buildNeovimPlugin" buildNeovimPlugin;


### PR DESCRIPTION
## Description of changes

Follow up of https://github.com/NixOS/nixpkgs/pull/237425#issuecomment-1738059902 . 

WIP, creating it ahead of time just to have a reference when cloing other issues


Goal is to simplify the configuration of neovim. Right now we have several mechanisms to configure: override, wrapNeovim, makeNeovimConfig the latter being introduced by me but never documented as it didn't feel right. With the finalAttrs pattern we finally have self-documented parameters: launch a nix repl and explore neovim attributes, you can change them via overrideAttrs and they will automatically be taken into account. 

And we can get rid of makeNeovimConfig: we can expose everything in the wrapper derivation: user customRc, the generatedRc etc. No need to find back the correct setting in the override call to adjust something down the line.
makeNeovimConfig will be kept for 23.11, not sure if it's going to be deprecated, depends how much time I can dedicate to this basically.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
