### PR TITLE
tt-rss-plugin-af-readability: init at unstable-2025-10-16

### DIFF
--- a/pkgs/by-name/tt/tt-rss-plugin-af-readability/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-af-readability/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  tt-rss,
+}:
+
+stdenv.mkDerivation {
+  pname = "tt-rss-plugin-af-readability";
+  version = "unstable-2025-10-16";
+
+  src = fetchFromGitHub {
+    owner = "tt-rss";
+    repo = "tt-rss-plugin-af-readability";
+    rev = "fce528aa69c2a7193fb7eb3a3cd9dd17885d6ab6";
+    hash = "sha256-3rxrICtm6+ujlBHj5Su2sSEq3lgiHhQMJ/OVfzhzYXA=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/af_readability
+
+    cp -a * $out/af_readability/
+  '';
+
+  meta = {
+    description = "Plugin for TT-RSS to inline article content using Readability";
+    license = lib.licenses.gpl3;
+    homepage = "https://github.com/tt-rss/tt-rss-plugin-af-readability/";
+    maintainers = with lib.maintainers; [ gdamjan ];
+    inherit (tt-rss.meta) platforms;
+  };
+}


### PR DESCRIPTION
this was previously included in tt-rss,
but was split in its own separate repo on 2022-12-13
https://github.com/tt-rss/tt-rss/commit/8ea537123d1cef38f25f9fbe92e3a9c0f89de55a


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

