### PR TITLE
Fix broken genJqSecretsReplacementSnippet for jq 1.7

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -177,6 +177,7 @@ rec {
   genJqSecretsReplacementSnippet' = attr: set: output:
     let
       secrets = recursiveGetAttrWithJqPrefix set attr;
+      stringOrDefault = str: def: if str == "" then def else str;
     in ''
       if [[ -h '${output}' ]]; then
         rm '${output}'
@@ -195,10 +196,12 @@ rec {
                (attrNames secrets))
     + "\n"
     + "${pkgs.jq}/bin/jq >'${output}' "
-    + lib.escapeShellArg (concatStringsSep
-      " | "
-      (imap1 (index: name: ''${name} = $ENV.secret${toString index}'')
-             (attrNames secrets)))
+    + lib.escapeShellArg (stringOrDefault
+          (concatStringsSep
+            " | "
+            (imap1 (index: name: ''${name} = $ENV.secret${toString index}'')
+                   (attrNames secrets)))
+          ".")
     + ''
        <<'EOF'
       ${builtins.toJSON set}


### PR DESCRIPTION
jq 1.7 updated it's behaviour and now throws an error if the first argument is an empty string. It now needs "." to pass the input through.

## Description of changes

The jq update to 1.7 broke this utility function because passing an empty argument in the case
of no defined secrets does not work anymore.
jq 1.6, when given the "" command, just returns its input.
jq 1.7, when given the "" command, returns an error suggesting using ".".

I tested this with my local gitlab installation, which was broken because i had the default gitlab-workhorse configuration.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).