### PR TITLE
edir: 2.16 -> 2.22

### DIFF
--- a/pkgs/tools/misc/edir/default.nix
+++ b/pkgs/tools/misc/edir/default.nix
@@ -2,12 +2,21 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "edir";
-  version = "2.16";
+  version = "2.22";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ro1GZkJ6xDZcMRaWTAW/a2qhFbZAxsduvGO3C4sOI+A=";
+    sha256 = "sha256-Z4p16v0J7mgl1Av8tdUZ6vSILgbOpLHs3rWx2P7AH+E=";
   };
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    platformdirs
+  ];
 
   meta = with lib; {
     description = "Program to rename and remove files and directories using your editor";


### PR DESCRIPTION


## Description of changes

There have been some  smaller changes since the last update to 2.16. Sadly, edir's developer doesn't have a nice changelog to link to, or at least I haven't found one. The release tags have some information:

 - https://github.com/bulletmark/edir/releases/tag/2.22
 - https://github.com/bulletmark/edir/releases/tag/2.21
 - https://github.com/bulletmark/edir/releases/tag/2.20
 - https://github.com/bulletmark/edir/releases/tag/2.19
 - https://github.com/bulletmark/edir/releases/tag/2.18
 - https://github.com/bulletmark/edir/releases/tag/2.17

The project moved from `setup.py` to `pyproject.toml`, so I had to adapt accordingly. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
