### PR TITLE
beetsPackages.filetote: init at 1.0.1

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -73,6 +73,7 @@ lib.makeExtensible (
     alternatives = callPackage ./plugins/alternatives.nix { beets = self.beets-minimal; };
     audible = callPackage ./plugins/audible.nix { beets = self.beets-minimal; };
     copyartifacts = callPackage ./plugins/copyartifacts.nix { beets = self.beets-minimal; };
+    filetote = callPackage ./plugins/filetote.nix { beets = self.beets-minimal; };
   }
   // lib.optionalAttrs config.allowAliases {
     extrafiles = throw "extrafiles is unmaintained since 2020 and broken since beets 2.0.0";

--- a/pkgs/tools/audio/beets/plugins/filetote.nix
+++ b/pkgs/tools/audio/beets/plugins/filetote.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  beets,
+  beetsPackages,
+  writableTmpDirAsHomeHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "beets-filetote";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gtronset";
+    repo = "beets-filetote";
+    tag = "v${version}";
+    hash = "sha256-LTJwZI/kQc+Iv0y8jAi5Xdh4wLEwbTA9hV76ndQsQzU=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail "poetry-core<2.0.0" "poetry-core"
+  '';
+
+  build-system = [ python3Packages.poetry-core ];
+
+  dependencies =
+    [ beets ]
+    ++ (with python3Packages; [
+      mediafile
+      reflink
+      toml
+      typeguard
+    ]);
+
+  optional-dependencies = {
+    lint = with python3Packages; [
+      black
+      check-manifest
+      flake8
+      flake8-bugbear
+      flake8-bugbear-pyi
+      isort
+      mypy
+      pylint
+      typing_extensions
+    ];
+
+    test = with python3Packages; [
+      beetsPackages.audible
+      mediafile
+      pytest
+      reflink
+      toml
+      typeguard
+    ];
+
+    dev = optional-dependencies.lint ++ optional-dependencies.test ++ [ python3Packages.tox ];
+
+  };
+
+  pytestFlagsArray = [ "-r fEs" ];
+
+  disabledTestPaths = [
+    "tests/test_cli_operation.py"
+    "tests/test_pruning.py"
+    "tests/test_version.py"
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    writableTmpDirAsHomeHook
+  ] ++ optional-dependencies.test;
+
+  meta = with lib; {
+    description = "Beets plugin to move non-music files during the import process";
+    homepage = "https://github.com/gtronset/beets-filetote";
+    changelog = "https://github.com/gtronset/beets-filetote/blob/${src.rev}/CHANGELOG.md";
+    maintainers = with maintainers; [ dansbandit ];
+    license = licenses.mit;
+    inherit (beets.meta) platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add alternative to beetsPackages.extrafiles and beetsPackages.copyartifacts as they are rarely updated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
