### PR TITLE
rustc: support clang-based stdenv

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -15,6 +15,7 @@
 , potrace
 , openxr-loader
 , embree, gmp, libharu
+, openpgl
 , mesa
 , runCommand
 }:
@@ -58,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: rec {
       potrace
       libharu
       libepoxy
+      openpgl
     ]
     ++ lib.optionals waylandSupport [
       wayland wayland-protocols libffi libdecor libxkbcommon dbus

--- a/pkgs/applications/networking/browsers/librewolf/src.json
+++ b/pkgs/applications/networking/browsers/librewolf/src.json
@@ -1,15 +1,15 @@
 {
-  "packageVersion": "117.0.1-1",
+  "packageVersion": "118.0.1-1",
   "source": {
-    "rev": "117.0.1-1",
-    "sha256": "06j85b6v54vxj99hgrlibpsg6f8w8cqj912vz7gwyfa17pawax9z"
+    "rev": "118.0.1-1",
+    "sha256": "1wdqiif1la97w9b3xsz20xrcg2d1c0j13pdfcj7z23jz8846iqk4"
   },
   "settings": {
     "rev": "9c862f06f970d69e00c1035e0d4774fb44fd84a6",
     "sha256": "0ay58wrhfn0b56748phpn0ahz11ls9y8d2fd1z4zrj6dv398vlmb"
   },
   "firefox": {
-    "version": "117.0.1",
-    "sha512": "1583b0ad3b3b17c59bfbfb3e416074766327d0b926ef4f6c6b1e3b2d7cf6a18dec592b7d17fab9493ba1506f3540a02277096d28616dd29b6e7b9e93905f2071"
+    "version": "118.0.1",
+    "sha512": "b1efa1afea70434dc2a18d335bb8b526883cde200f1503b8c5fd2e7db8285e6a999cfa3aac354ea1c15a91d13a46d68db37023235314240b59eb8f55e01554ad"
   }
 }

--- a/pkgs/by-name/co/colorized-logs/package.nix
+++ b/pkgs/by-name/co/colorized-logs/package.nix
@@ -1,0 +1,30 @@
+{ cmake
+, fetchFromGitHub
+, lib
+, stdenv
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "colorized-logs";
+  version = "2.6";
+
+  src = fetchFromGitHub {
+    owner = "kilobyte";
+    repo = "colorized-logs";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-QiZeIYeIWA3C7wYi2G2EItdW+jLjVrCbIYllur/RtY8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    description = "Tools for logs with ANSI color";
+    homepage = "https://github.com/kilobyte/colorized-logs";
+    changelog = "https://github.com/kilobyte/colorized-logs/blob/v${finalAttrs.version}/ChangeLog";
+    license = with lib.licenses; [ mit ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ CobaltCause ];
+  };
+})

--- a/pkgs/by-name/op/openpgl/package.nix
+++ b/pkgs/by-name/op/openpgl/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, cmake
+, fetchFromGitHub
+, ninja
+, stdenv
+, tbb
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openpgl";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenPathGuidingLibrary";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-dbHmGGiHQkU0KPpQYpY/o0uCWdb3L5namETdOcOREgs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    tbb
+  ];
+
+  cmakeFlags = [
+    "-DOPENPGL_BUILD_STATIC=OFF"
+    "-DTBB_ROOT=${tbb.out}"
+  ];
+
+  meta = {
+    description = "Intel Open Path Guiding Library";
+    homepage = "https://github.com/OpenPathGuidingLibrary/openpgl";
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.amarshall ];
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -66,15 +66,18 @@ in stdenv.mkDerivation rec {
   # We need rust to build rust. If we don't provide it, configure will try to download it.
   # Reference: https://github.com/rust-lang/rust/blob/master/src/bootstrap/configure.py
   configureFlags = let
+    prefixForStdenv = stdenv: "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}";
+    ccPrefixForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang" else "cc"}";
+    cxxPrefixForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang++" else "c++"}";
     setBuild  = "--set=target.${rust.toRustTarget stdenv.buildPlatform}";
     setHost   = "--set=target.${rust.toRustTarget stdenv.hostPlatform}";
     setTarget = "--set=target.${rust.toRustTarget stdenv.targetPlatform}";
-    ccForBuild  = "${pkgsBuildBuild.targetPackages.stdenv.cc}/bin/${pkgsBuildBuild.targetPackages.stdenv.cc.targetPrefix}cc";
-    cxxForBuild = "${pkgsBuildBuild.targetPackages.stdenv.cc}/bin/${pkgsBuildBuild.targetPackages.stdenv.cc.targetPrefix}c++";
-    ccForHost  = "${pkgsBuildHost.targetPackages.stdenv.cc}/bin/${pkgsBuildHost.targetPackages.stdenv.cc.targetPrefix}cc";
-    cxxForHost = "${pkgsBuildHost.targetPackages.stdenv.cc}/bin/${pkgsBuildHost.targetPackages.stdenv.cc.targetPrefix}c++";
-    ccForTarget  = "${pkgsBuildTarget.targetPackages.stdenv.cc}/bin/${pkgsBuildTarget.targetPackages.stdenv.cc.targetPrefix}cc";
-    cxxForTarget = "${pkgsBuildTarget.targetPackages.stdenv.cc}/bin/${pkgsBuildTarget.targetPackages.stdenv.cc.targetPrefix}c++";
+    ccForBuild  = ccPrefixForStdenv pkgsBuildBuild.targetPackages.stdenv;
+    cxxForBuild  = cxxPrefixForStdenv pkgsBuildBuild.targetPackages.stdenv;
+    ccForHost  = ccPrefixForStdenv pkgsBuildHost.targetPackages.stdenv;
+    cxxForHost  = cxxPrefixForStdenv pkgsBuildHost.targetPackages.stdenv;
+    ccForTarget  = ccPrefixForStdenv pkgsBuildTarget.targetPackages.stdenv;
+    cxxForTarget  = cxxPrefixForStdenv pkgsBuildTarget.targetPackages.stdenv;
   in [
     "--release-channel=stable"
     "--set=build.rustc=${rustc}/bin/rustc"

--- a/pkgs/development/interpreters/yabasic/default.nix
+++ b/pkgs/development/interpreters/yabasic/default.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "yabasic";
-  version = "2.90.3";
+  version = "2.90.4";
 
   src = fetchurl {
     url = "http://www.yabasic.de/download/yabasic-${finalAttrs.version}.tar.gz";
-    hash = "sha256-ItmlkraNUE0qlq1RghUJcDq4MHb6HRKNoIRylugjboA=";
+    hash = "sha256-td54SC1LnO3z07m3BsVDpiAsmokzB4xn4dbVdfeYH8M=";
   };
 
   buildInputs = [

--- a/pkgs/development/python-modules/boschshcpy/default.nix
+++ b/pkgs/development/python-modules/boschshcpy/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "boschshcpy";
-  version = "0.2.68";
+  version = "0.2.69";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "tschamm";
     repo = pname;
     rev = version;
-    hash = "sha256-/W9Z1LjHpiAupA+D1tD+B0jmGhNbSo5aSv/nL2WSc8M=";
+    hash = "sha256-NXn92a+dhJhAfh92zvNQyrfNE7ZCCIl2er5569IXff8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/botocore-stubs/default.nix
+++ b/pkgs/development/python-modules/botocore-stubs/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "botocore-stubs";
-  version = "1.31.56";
+  version = "1.31.57";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "botocore_stubs";
     inherit version;
-    hash = "sha256-4VEL02Gs91XsrOQu6YQoGt/qb5ZpXtIqCKTO6r/mb18=";
+    hash = "sha256-4o88p6YnnwHc7EZjmAvoCqk9xOsu/MI5aFnOtkdiO4M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/dvc-data/default.nix
+++ b/pkgs/development/python-modules/dvc-data/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "dvc-data";
-  version = "2.16.4";
+  version = "2.17.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "iterative";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-DvG1SFYDzLXhftfyCVbO9WNSZeRE2tRU1nbkIayJYv4=";
+    hash = "sha256-Mb2dX2PXQVLI5HEOyxpfVh/9vL9BkQ8o8Ly3lYZ2eYI=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/neo4j/default.nix
+++ b/pkgs/development/python-modules/neo4j/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "neo4j";
-  version = "5.12.0";
+  version = "5.13.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "neo4j";
     repo = "neo4j-python-driver";
     rev = "refs/tags/${version}";
-    hash = "sha256-feKKBbULkWxEgUaMROvmQph2YTAgSOVDRz/OnpzG9Ac=";
+    hash = "sha256-ykbKNLMnbAGUavyfRtF3q97FRLaeuKOt0pcWHtJ9mCY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/opower/default.nix
+++ b/pkgs/development/python-modules/opower/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "opower";
-  version = "0.0.34";
+  version = "0.0.35";
   format = "pyproject";
 
   disabled = pythonOlder "3.9";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "tronikos";
     repo = "opower";
     rev = "refs/tags/v${version}";
-    hash = "sha256-VIw0FRFhZpd9R5/j8ejgfy1p8/R2Gv8Wtjc3PDA4bqo=";
+    hash = "sha256-bS9KsPMuzQ+4AXsVzKiCevZujU4iW2hZ+eSJheM4NRI=";
   };
 
   pythonRemoveDeps = [

--- a/pkgs/development/python-modules/oss2/default.nix
+++ b/pkgs/development/python-modules/oss2/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "oss2";
-  version = "2.18.1";
+  version = "2.18.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "aliyun";
     repo = "aliyun-oss-python-sdk";
     rev = "refs/tags/${version}";
-    hash = "sha256-4P2o10FhnLwRkhRYS+LzY+ugWPQgz+Tddn9XYR17018=";
+    hash = "sha256-xbbdzuaUvFnXA5glGr/1/s1Bm28d4XbtuvCKaj8Js68=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/sqlparse/default.nix
+++ b/pkgs/development/python-modules/sqlparse/default.nix
@@ -10,7 +10,7 @@
 , django
 , django_4
 , django-silk
-, pgadmin
+, pgadmin4
 }:
 
 buildPythonPackage rec {
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   '';
 
   passthru.tests = {
-    inherit django django_4 django-silk pgadmin;
+    inherit django django_4 django-silk pgadmin4;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/go-mockery/default.nix
+++ b/pkgs/development/tools/go-mockery/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "go-mockery";
-  version = "2.33.3";
+  version = "2.34.1";
 
   src = fetchFromGitHub {
     owner = "vektra";
     repo = "mockery";
     rev = "v${version}";
-    sha256 = "sha256-ctq4DPlLsV9HCa2Vc+soQJu3DdrTyaHoSN9pZZtk+Mw=";
+    sha256 = "sha256-c1imyCv/eqyTEHz6H18McKY+59swG84PcLG6HI1uQmE=";
   };
 
   preCheck = ''

--- a/pkgs/development/tools/rust/cargo-binstall/default.nix
+++ b/pkgs/development/tools/rust/cargo-binstall/default.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-binstall";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "cargo-bins";
     repo = "cargo-binstall";
     rev = "v${version}";
-    hash = "sha256-viy7C9ZMUJoAdIwOBvogkiTApTrD3X9cEOqPtfksjOA=";
+    hash = "sha256-FO8Kh2mzHyofLX/9RCzIZIbnf3G/vZui0+NSwjmHCOY=";
   };
 
-  cargoHash = "sha256-hH2P2hpQji4n7LidNionkEYHcDpU4qP23ScQLsy92Nw=";
+  cargoHash = "sha256-pOsmgMvYIQMf0vLXqyNdAhOLMFbn7WpFUiA0CfLz8Io=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/games/doom-ports/doomretro/default.nix
+++ b/pkgs/games/doom-ports/doomretro/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "doomretro";
-  version = "4.9.2";
+  version = "5.0.3";
 
   src = fetchFromGitHub {
     owner = "bradharding";
     repo = "doomretro";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-thH18+Og5kSiMdzgPdGyUwBchpjpd9xfFfUlUQMAl1A=";
+    hash = "sha256-jZBgPXg9vQ8HxO/D0GzEiI/78OEW6LgxVIqxdqw63Ko=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/alsa-project/alsa-utils/default.nix
+++ b/pkgs/os-specific/linux/alsa-project/alsa-utils/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "alsa-utils";
-  version = "1.2.9";
+  version = "1.2.10";
 
   src = fetchurl {
     url = "mirror://alsa/utils/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-52I9RSVZX5LhHOJe6al/IEChTG5NzQJ6qW4Gy854F70=";
+    sha256 = "sha256-EEti7H8Cp84WynefSBVhbfHMIZM1A3g6kQe1lE+DBjo=";
   };
 
   nativeBuildInputs = [ gettext makeWrapper ];

--- a/pkgs/tools/security/tlsx/default.nix
+++ b/pkgs/tools/security/tlsx/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "tlsx";
-  version = "1.1.4";
+  version = "1.1.5";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-EMTNd5NOvaFbVxv31j3pBU//mWQQpThswCT8bMNx5Qw=";
+    hash = "sha256-lS/D3p8Q6Zu3/XxwkC77fPS9cXVrUTkDPGd46Y+krbo=";
   };
 
-  vendorHash = "sha256-5fS10G1YxtyhMZcpaqYy9P6eX/xQABYVZj1HX6WxQxo=";
+  vendorHash = "sha256-aEsq9LwU/ZWvuZGGzZ4NEvMWFk1m/Sr9LOXiCA/X388=";
 
   # Tests require network access
   doCheck = false;


### PR DESCRIPTION
Previously, we were passing `cc` and `c++` all the time to rustc bootstrap process.

This was wrong because `cc-rs` relies on the name of the compiler to detect whether this is Clang or a GNU GCC.

Related:

[1]: https://github.com/rust-lang/cc-rs/blob/df2f86ceafbe787698b890a3d6bde9f969d5fa88/src/lib.rs#L3334
[2]: https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Missing.20dynamic.20libraries.20when.20bootstrapping.20Rust/near/377914373

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
