### PR TITLE
supersonic: init at 0.5.2

### DIFF
--- a/pkgs/by-name/su/supersonic/package.nix
+++ b/pkgs/by-name/su/supersonic/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, pkg-config
+, xorg
+, libglvnd
+, mpv
+, glfw3
+, waylandSupport ? false
+}:
+
+buildGoModule rec {
+  pname = "supersonic" + lib.optionalString waylandSupport "-wayland";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "dweymouth";
+    repo = "supersonic";
+    rev = "v${version}";
+    hash = "sha256-4SLAUqLMoUxTSi4I/QeHqudO62Gmhpm1XbCGf+3rPlc=";
+  };
+
+  vendorHash = "sha256-6Yp5OoybFpoBuIKodbwnyX3crLCl8hJ2r4plzo0plsY=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+  ];
+
+  # go-glfw doesn't support both X11 and Wayland in single build
+  tags = lib.optionals waylandSupport [ "wayland" ];
+
+  buildInputs = [
+    libglvnd
+    mpv
+    xorg.libXxf86vm
+    xorg.libX11
+  ] ++ (glfw3.override { inherit waylandSupport; }).buildInputs;
+
+  postInstall = ''
+    for dimension in 128 256 512;do
+        dimensions=''${dimension}x''${dimension}
+        mkdir -p $out/share/icons/hicolor/$dimensions/apps
+        cp res/appicon-$dimension.png $out/share/icons/hicolor/$dimensions/apps/${meta.mainProgram}.png
+    done
+  '' + lib.optionalString waylandSupport ''
+    mv $out/bin/supersonic $out/bin/${meta.mainProgram}
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = meta.mainProgram;
+      exec = meta.mainProgram;
+      icon = meta.mainProgram;
+      desktopName = "Supersonic" + lib.optionalString waylandSupport " (Wayland)";
+      genericName = "Subsonic Client";
+      comment = meta.description;
+      type = "Application";
+      categories = [ "Audio" "AudioVideo" ];
+    })
+  ];
+
+  meta = with lib; {
+    mainProgram = "supersonic" + lib.optionalString waylandSupport "-wayland";
+    description = "A lightweight cross-platform desktop client for Subsonic music servers";
+    homepage = "https://github.com/dweymouth/supersonic";
+    platforms = platforms.linux;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zane sochotnicky ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35801,6 +35801,10 @@ with pkgs;
 
   sunvox = callPackage ../applications/audio/sunvox { };
 
+  supersonic-wayland = supersonic.override {
+    waylandSupport = true;
+  };
+
   svkbd = callPackage ../applications/accessibility/svkbd { };
 
   swaglyrics = callPackage ../tools/misc/swaglyrics { };


### PR DESCRIPTION
## Description of changes

Add supersonic.

Based off my initial version https://github.com/NixOS/nixpkgs/pull/256466 (which I accidentally force-pushed before re-opening) and review comments on https://github.com/NixOS/nixpkgs/pull/252989, which is unresponsive.

Credit has been kept.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

