### PR TITLE
ocamlPackages.containers: 3.11 → 3.12

### DIFF
--- a/pkgs/development/ocaml-modules/containers/data.nix
+++ b/pkgs/development/ocaml-modules/containers/data.nix
@@ -1,6 +1,7 @@
 { buildDunePackage, containers
 , dune-configurator
 , gen, iter, qcheck-core
+, mdx
 }:
 
 buildDunePackage {
@@ -8,9 +9,8 @@ buildDunePackage {
 
   inherit (containers) src version doCheck;
 
-  duneVersion = "3";
-
   buildInputs = [ dune-configurator ];
+  nativeCheckInputs = [ mdx.bin ];
   checkInputs = [ gen iter qcheck-core ];
 
   propagatedBuildInputs = [ containers ];

--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -5,16 +5,14 @@
 }:
 
 buildDunePackage rec {
-  version = "3.11";
+  version = "3.12";
   pname = "containers";
-
-  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "ocaml-containers";
     rev = "v${version}";
-    hash = "sha256-tGAsg98/T6VKvG95I4qioabWM3TEKrDKlsrfUJqxCyM=";
+    hash = "sha256-15Wd6k/NvjAvTmxlPlZPClODBtFXM6FG3VxniC66u88=";
   };
 
   buildInputs = [ dune-configurator ];


### PR DESCRIPTION
## Description of changes

https://github.com/c-cube/ocaml-containers/blob/v3.12/CHANGELOG.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
