### PR TITLE
gcc: create dummy crtstuff on loongarch64

### DIFF
--- a/pkgs/development/compilers/gcc/common/libgcc-buildstuff.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc-buildstuff.nix
@@ -31,7 +31,22 @@ let
   #
   SHLIB_LC = lib.optionalString stdenv.targetPlatform.isPower "-mnewlib";
 
-in ''
-    echo 'libgcc.a: ${crtstuff-ofiles}' >> libgcc/Makefile.in
-    echo 'SHLIB_LC=${SHLIB_LC}' >> libgcc/Makefile.in
-  ''
+in
+''
+  echo 'libgcc.a: ${crtstuff-ofiles}' >> libgcc/Makefile.in
+  echo 'SHLIB_LC=${SHLIB_LC}' >> libgcc/Makefile.in
+''
+
+  # Meanwhile, crt{i,n}.S are not present on certain platforms
+  # (e.g. LoongArch64), resulting in the following error:
+  #
+  # No rule to make target '../../../gcc-xx.x.x/libgcc/config/loongarch/crti.S', needed by 'crti.o'.  Stop.
+  #
+  # For LoongArch64, a hacky workaround is to simply touch them,
+  # as the platform forces .init_array support.
+  #
+  # https://www.openwall.com/lists/musl/2022/11/09/3
+  #
+  + lib.optionalString stdenv.targetPlatform.isLoongArch64 ''
+  touch libgcc/config/loongarch/crt{i,n}.S
+''


### PR DESCRIPTION
## Description of changes

A hacky workaround to fix #252590.

The workaround can be trivially modified to work for #243614, but the underlying reason is unjustified. I've therefore decided not to generalize this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] loongarch-linux (cross)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
