### PR TITLE
Make Quarto available on all platforms

### DIFF
--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -7,12 +7,12 @@
 , dart-sass
 , rWrapper
 , rPackages
-, extraRPackages ? []
+, extraRPackages ? [ ]
 , makeWrapper
 , runCommand
 , python3
 , quarto
-, extraPythonPackages ? ps: with ps; []
+, extraPythonPackages ? ps: with ps; [ ]
 }:
 
 stdenv.mkDerivation (final: {
@@ -51,20 +51,20 @@ stdenv.mkDerivation (final: {
   '';
 
   installPhase = ''
-      runHook preInstall
+    runHook preInstall
 
-      mkdir -p $out/bin $out/share
+    mkdir -p $out/bin $out/share
 
-      rm -r bin/tools
+    rm -r bin/tools
 
-      mv bin/* $out/bin
-      mv share/* $out/share
+    mv bin/* $out/bin
+    mv share/* $out/share
 
-      runHook preInstall
+    runHook preInstall
   '';
 
   passthru.tests = {
-    quarto-check = runCommand "quarto-check" {} ''
+    quarto-check = runCommand "quarto-check" { } ''
       export HOME="$(mktemp -d)"
       ${quarto}/bin/quarto check
       touch $out
@@ -74,14 +74,13 @@ stdenv.mkDerivation (final: {
   meta = with lib; {
     description = "Open-source scientific and technical publishing system built on Pandoc";
     longDescription = ''
-        Quarto is an open-source scientific and technical publishing system built on Pandoc.
-        Quarto documents are authored using markdown, an easy to write plain text format.
+      Quarto is an open-source scientific and technical publishing system built on Pandoc.
+      Quarto documents are authored using markdown, an easy to write plain text format.
     '';
     homepage = "https://quarto.org/";
     changelog = "https://github.com/quarto-dev/quarto-cli/releases/tag/v${version}";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ minijackson mrtarantoga ];
-    platforms = [ "x86_64-linux" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode binaryBytecode ];
   };
 })


### PR DESCRIPTION
## Description of changes

Makes Quarto version 1.3.450 available on any platform.

Even though the linux amd64 tarball gets pulled, it builds successfully on an the platforms listed below.

Fixes #251957

Thanks to work done by @sagikazarmark 

pinging maintainers @MrTarantoga @minijackson

fyi: @jbedo @Kupac @philipp-baumann

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
