### PR TITLE
direwolf: make various buildInputs optional

### DIFF
--- a/pkgs/applications/radio/direwolf/default.nix
+++ b/pkgs/applications/radio/direwolf/default.nix
@@ -1,7 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, cmake, alsa-lib, espeak, gpsd
-, hamlib, perl, python3, udev }:
-
-with lib;
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, alsa-lib
+, gpsd
+, hamlib
+, perl
+, python3
+, espeak
+, udev
+}:
 
 stdenv.mkDerivation rec {
   pname = "direwolf";
@@ -19,8 +27,12 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   buildInputs = [
-    espeak gpsd hamlib perl python3
-  ] ++ (optionals stdenv.isLinux [alsa-lib udev]);
+    espeak
+    gpsd
+    hamlib
+    perl
+    python3
+  ] ++ (lib.optionals stdenv.isLinux [ alsa-lib udev ]);
 
   postPatch = ''
     substituteInPlace conf/CMakeLists.txt \
@@ -41,7 +53,7 @@ stdenv.mkDerivation rec {
       --replace 'GPSD_API_MAJOR_VERSION > 11' 'GPSD_API_MAJOR_VERSION > 14'
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A Soundcard Packet TNC, APRS Digipeater, IGate, APRStt gateway";
     homepage = "https://github.com/wb2osz/direwolf/";
     license = licenses.gpl2;

--- a/pkgs/applications/radio/direwolf/default.nix
+++ b/pkgs/applications/radio/direwolf/default.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/wb2osz/direwolf/";
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ lasandell ];
+    maintainers = with maintainers; [ lasandell sarcasticadmin ];
   };
 }


### PR DESCRIPTION

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

direwolf only depends on a `cmake, alsa-lib, udev`(https://github.com/wb2osz/direwolf/tree/1.6#linux---using-git-clone-recommended) and should have each of its additional dependencies marked as options (`gpsd`, `hamlib`).

Adding `extraScripts` option to exclude [various scripts](https://github.com/wb2osz/direwolf/tree/1.6/scripts) that are more of examples of direwolf capabilities vs required for using the tool.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
