### PR TITLE
slweb: 0.6.9 → 0.6.11

### DIFF
--- a/pkgs/applications/misc/slweb/default.nix
+++ b/pkgs/applications/misc/slweb/default.nix
@@ -2,28 +2,34 @@
 , stdenv
 , fetchFromSourcehut
 , redo-apenwarr
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "slweb";
-  version = "0.6.9";
+  version = "0.6.11";
 
   src = fetchFromSourcehut {
     owner = "~strahinja";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-YSHJJ+96Xj2zaDtPi8jftPWIyeIG9LwQ/eYT/oh2Y2c=";
+    repo = "slweb";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-+bKapK/s1pmo1NRRslf7V4ogWTtchFNWpzi+S8YG6+4=";
   };
 
   nativeBuildInputs = [ redo-apenwarr ];
 
   installPhase = ''
     runHook preInstall
+    export FALLBACKVER=${finalAttrs.version}
     PREFIX=$out redo install
     runHook postInstall
   '';
 
   enableParallelBuilding = true;
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
 
   meta = with lib; {
     description = "A static website generator which aims at being simplistic";
@@ -32,4 +38,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ GaetanLepage ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes
[Changelog](https://git.sr.ht/~strahinja/slweb/log)

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
