### PR TITLE
lib.fileset: Don't use non-reproducible ulimit for stack overflow testing

### DIFF
--- a/lib/fileset/tests.sh
+++ b/lib/fileset/tests.sh
@@ -467,12 +467,13 @@ for i in $(seq 1000); do
     tree[$i/a]=1
     tree[$i/b]=0
 done
-(
-    # Locally limit the maximum stack size to 100 * 1024 bytes
-    # If unions was implemented recursively, this would stack overflow
-    ulimit -s 100
-    checkFileset 'unions (mapAttrsToList (name: _: ./. + "/${name}/a") (builtins.readDir ./.))'
-)
+# This is actually really hard to test:
+# A lot of files would be needed to cause a stack overflow.
+# And while we could limit the maximum stack size using `ulimit -s`,
+# that turns out to not be very deterministic: https://github.com/NixOS/nixpkgs/pull/256417#discussion_r1339396686.
+# Meanwhile, the test infra here is not the fastest, creating 10000 would be too slow.
+# So, just using 1000 files for now.
+checkFileset 'unions (mapAttrsToList (name: _: ./. + "/${name}/a") (builtins.readDir ./.))'
 
 # TODO: Once we have combinators and a property testing library, derive property tests from https://en.wikipedia.org/wiki/Algebra_of_sets
 


### PR DESCRIPTION
## Description of changes

In https://github.com/NixOS/nixpkgs/pull/255025 I introduced a `lib` test that uses `ulimit -s 100` to artificially limit the stack size to test that the stack wouldn't grow arbitrarily large. However in https://github.com/NixOS/nixpkgs/pull/256417#pullrequestreview-1646573935 (where another test that uses `ulimit -s 100` was introduced) @fricklerhandwerk reported a failure relating to this.

While the number could be increased to say 200 to make it work, it's probably better to not use this after all. It would be hard to come up with a reliable number.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

## Things done
- [x] Ran the tests successfully on x86_64-linux