### PR TITLE
guile-goblins: init at 0.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6610,6 +6610,11 @@
     githubId = 11212268;
     name = "gruve-p";
   };
+  grxnola = {
+    github = "grxnola";
+    githubId = 49906709;
+    name = "grxnola";
+  };
   gschwartz = {
     email = "gsch@pennmedicine.upenn.edu";
     github = "GregorySchwartz";

--- a/pkgs/by-name/gu/guile-goblins/package.nix
+++ b/pkgs/by-name/gu/guile-goblins/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchurl
+, guile
+, guile-fibers
+, guile-gcrypt
+, texinfo
+, pkg-config
+}:
+stdenv.mkDerivation rec {
+  pname = "guile-goblins";
+  version = "0.11.0";
+
+  src = fetchurl {
+    url = "https://spritely.institute/files/releases/guile-goblins/guile-goblins-${version}.tar.gz";
+    hash = "sha256-1FD35xvayqC04oPdgts08DJl6PVnhc9K/Dr+NYtxhMU=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ guile pkg-config texinfo ];
+  buildInputs = [ guile guile-fibers guile-gcrypt ];
+  makeFlags = [ "GUILE_AUTO_COMPILE=0" ];
+
+  # tests hang on darwin, and fail randomly on aarch64-linux on ofborg
+  doCheck = !stdenv.isDarwin && !stdenv.isAarch64;
+
+  meta = with lib; {
+    description = "Spritely Goblins for Guile";
+    homepage = "https://spritely.institute/goblins/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ grxnola ];
+    platforms = guile.meta.platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes #257361

Goblins is a distributed object programming environment that features a quasi-functional object system, secure networked communication, transactional updates, "time travel", asynchronous programming with promises, communicating event loops, and object capability security. 

For more information visit the homepage: https://spritely.institute/goblins/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
