### PR TITLE
python310Packages.clevercsv: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/development/python-modules/clevercsv/default.nix
+++ b/pkgs/development/python-modules/clevercsv/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "clevercsv";
-  version = "0.8.1";
+  version = "0.8.2";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "alan-turing-institute";
     repo = "CleverCSV";
     rev = "refs/tags/v${version}";
-    hash = "sha256-kCkMZnHbFUuBBvlQ5rn0tNeL7uTAq0aodpj2JvPo968=";
+    hash = "sha256-yyPUNFDq9W5OW1muHtQ10QgAHhXI8w7CY77fsWhIy0k=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
https://github.com/alan-turing-institute/CleverCSV/blob/refs/tags/v0.8.2/CHANGELOG.md

<details>
  <summary>8 packages failed to build:</summary>
  <ul>
    <li>python310Packages.qcodes</li>
    <li>python310Packages.qcodes-contrib-drivers</li>
    <li>python310Packages.qcodes-contrib-drivers.dist</li>
    <li>python310Packages.qcodes-loop</li>
    <li>python310Packages.qcodes-loop.dist</li>
    <li>python310Packages.qcodes.dist</li>
    <li>python311Packages.qcodes-contrib-drivers</li>
    <li>python311Packages.qcodes-contrib-drivers.dist</li>
  </ul>
</details>
<details>
  <summary>80 packages built:</summary>
  <ul>
    <li>ansible (python310Packages.ansible-core)</li>
    <li>ansible-later</li>
    <li>ansible-later.dist</li>
    <li>ansible-lint</li>
    <li>ansible-lint.dist</li>
    <li>ansible.dist (python310Packages.ansible-core.dist)</li>
    <li>ansible_2_13</li>
    <li>ansible_2_13.dist</li>
    <li>ansible_2_14</li>
    <li>ansible_2_14.dist</li>
    <li>appdaemon</li>
    <li>appdaemon.dist</li>
    <li>clevercsv (python310Packages.clevercsv)</li>
    <li>clevercsv.dist (python310Packages.clevercsv.dist)</li>
    <li>deepdiff (python310Packages.deepdiff)</li>
    <li>deepdiff.dist (python310Packages.deepdiff.dist)</li>
    <li>home-assistant-component-tests.apple_tv</li>
    <li>home-assistant-component-tests.litterrobot</li>
    <li>kargo</li>
    <li>kargo.dist</li>
    <li>molecule (python310Packages.molecule)</li>
    <li>molecule.dist (python310Packages.molecule.dist)</li>
    <li>python310Packages.ansible</li>
    <li>python310Packages.ansible-compat</li>
    <li>python310Packages.ansible-compat.dist</li>
    <li>python310Packages.ansible-kernel</li>
    <li>python310Packages.ansible-kernel.dist</li>
    <li>python310Packages.ansible-runner</li>
    <li>python310Packages.ansible-runner.dist</li>
    <li>python310Packages.ansible-vault-rw</li>
    <li>python310Packages.ansible-vault-rw.dist</li>
    <li>python310Packages.ansible.dist</li>
    <li>python310Packages.atsim_potentials</li>
    <li>python310Packages.atsim_potentials.dist</li>
    <li>python310Packages.pyatv</li>
    <li>python310Packages.pyatv.dist</li>
    <li>python310Packages.pylitterbot</li>
    <li>python310Packages.pylitterbot.dist</li>
    <li>python310Packages.pytest-ansible</li>
    <li>python310Packages.pytest-ansible.dist</li>
    <li>python310Packages.pytest-testinfra</li>
    <li>python310Packages.pytest-testinfra.dist</li>
    <li>ttp (python310Packages.ttp)</li>
    <li>ttp.dist (python310Packages.ttp.dist)</li>
    <li>python311Packages.ansible</li>
    <li>python311Packages.ansible-compat</li>
    <li>python311Packages.ansible-compat.dist</li>
    <li>python311Packages.ansible-core</li>
    <li>python311Packages.ansible-core.dist</li>
    <li>python311Packages.ansible-kernel</li>
    <li>python311Packages.ansible-kernel.dist</li>
    <li>python311Packages.ansible-runner</li>
    <li>python311Packages.ansible-runner.dist</li>
    <li>python311Packages.ansible-vault-rw</li>
    <li>python311Packages.ansible-vault-rw.dist</li>
    <li>python311Packages.ansible.dist</li>
    <li>python311Packages.atsim_potentials</li>
    <li>python311Packages.atsim_potentials.dist</li>
    <li>python311Packages.clevercsv</li>
    <li>python311Packages.clevercsv.dist</li>
    <li>python311Packages.deepdiff</li>
    <li>python311Packages.deepdiff.dist</li>
    <li>python311Packages.molecule</li>
    <li>python311Packages.molecule.dist</li>
    <li>python311Packages.pyatv</li>
    <li>python311Packages.pyatv.dist</li>
    <li>python311Packages.pylitterbot</li>
    <li>python311Packages.pylitterbot.dist</li>
    <li>python311Packages.pytest-ansible</li>
    <li>python311Packages.pytest-ansible.dist</li>
    <li>python311Packages.pytest-testinfra</li>
    <li>python311Packages.pytest-testinfra.dist</li>
    <li>python311Packages.qcodes</li>
    <li>python311Packages.qcodes-loop</li>
    <li>python311Packages.qcodes-loop.dist</li>
    <li>python311Packages.qcodes.dist</li>
    <li>python311Packages.ttp</li>
    <li>python311Packages.ttp.dist</li>
    <li>sublime-music</li>
    <li>sublime-music.dist</li>
  </ul>
</details>

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
