### PR TITLE
python310Packages.k-diffusion: 0.0.16 -> 0.1.0; python310Packages.dctorch: init at 0.1.2; python310Packages.rotary-embedded-torch: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/dctorch/default.nix
+++ b/pkgs/development/python-modules/dctorch/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, poetry-core
+, numpy
+, scipy
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "dctorch";
+  version = "0.1.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-TmfLAkiofrQNWYBhIlY4zafbZPgFftISCGloO/rlEG4=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    torch
+  ];
+
+  pythonImportsCheck = [
+    "dctorch"
+  ];
+
+  doCheck = false; # no tests
+
+  meta = with lib; {
+    description = "Fast discrete cosine transforms for pytorch";
+    homepage = "https://pypi.org/project/dctorch/";
+    license = licenses.mit;
+    maintainers = teams.tts.members;
+  };
+}

--- a/pkgs/development/python-modules/k-diffusion/default.nix
+++ b/pkgs/development/python-modules/k-diffusion/default.nix
@@ -3,13 +3,15 @@
 , buildPythonPackage
 , clean-fid
 , clip-anytorch
+, dctorch
 , einops
 , fetchFromGitHub
 , jsonmerge
 , kornia
 , pillow
 , pythonOlder
-, resize-right
+, rotary-embedding-torch
+, safetensors
 , scikit-image
 , scipy
 , torch
@@ -22,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "k-diffusion";
-  version = "0.0.16";
+  version = "0.1.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -31,20 +33,22 @@ buildPythonPackage rec {
     owner = "crowsonkb";
     repo = "k-diffusion";
     rev = "refs/tags/v${version}";
-    hash = "sha256-tOWDFt0/hGZF5HENiHPb9a2pBlXdSvDvCNTsCMZljC4=";
+    hash = "sha256-jcIA0HfEnVHk9XDXPevGBw81GsXlm1Ztp8ceNirShEA=";
   };
 
   propagatedBuildInputs = [
     accelerate
     clean-fid
     clip-anytorch
+    dctorch
     einops
     jsonmerge
     kornia
     pillow
-    resize-right
+    rotary-embedding-torch
     scikit-image
     scipy
+    safetensors
     torch
     torchdiffeq
     torchsde

--- a/pkgs/development/python-modules/rotary-embedding-torch/default.nix
+++ b/pkgs/development/python-modules/rotary-embedding-torch/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# build-system
+, setuptools
+, wheel
+
+# dependencies
+, einops
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "rotary-embedding-torch";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lucidrains";
+    repo = "rotary-embedding-torch";
+    rev = version;
+    hash = "sha256-fGyBBPfvVq1iZ2m2NNjmHSK+iy76N/09Pt11YDyOyN4=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    einops
+    torch
+  ];
+
+  pythonImportsCheck = [
+    "rotary_embedding_torch"
+  ];
+
+  doCheck = false; # no tests
+
+  meta = with lib; {
+    description = "Implementation of Rotary Embeddings, from the Roformer paper, in Pytorch";
+    homepage = "https://github.com/lucidrains/rotary-embedding-torch";
+    license = licenses.mit;
+    maintainers = teams.tts.members;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2607,6 +2607,8 @@ self: super: with self; {
 
   dcmstack = callPackage ../development/python-modules/dcmstack { };
 
+  dctorch = callPackage ../development/python-modules/dctorch { };
+
   ddt = callPackage ../development/python-modules/ddt { };
 
   deal = callPackage ../development/python-modules/deal { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11509,6 +11509,8 @@ self: super: with self; {
 
   ropper = callPackage ../development/python-modules/ropper { };
 
+  rotary-embedding-torch = callPackage ../development/python-modules/rotary-embedding-torch { };
+
   rouge-score = callPackage ../development/python-modules/rouge-score { };
 
   routeros-api = callPackage ../development/python-modules/routeros-api { };


### PR DESCRIPTION
Updates k-diffusion to 0.1.0 and packages two new dependencies.

 https://github.com/crowsonkb/k-diffusion/compare/refs/tags/v0.1.0...v0.1.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
