### PR TITLE
qt6Packages.qtspell: init at 1.0.1

### DIFF
--- a/pkgs/development/libraries/qtspell/default.nix
+++ b/pkgs/development/libraries/qtspell/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  doxygen,
+  enchant,
+  glib,
+  llvmPackages,
+  pkg-config,
+  qtbase,
+  qttools,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qtspell";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "manisandro";
+    repo = "qtspell";
+    rev = "${version}";
+    hash = "sha256-yaR3eCUbK2KTpvzO2G5sr+NEJ2mDnzJzzzwlU780zqU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    pkg-config
+    qttools
+  ];
+
+  buildInputs =
+    [
+      enchant
+      qtbase
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      glib
+      llvmPackages.clang
+    ];
+
+  cmakeFlags = [ "-DQT_VER=6" ];
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Provides spell-checking to Qt's text widgets, using the enchant spell-checking library";
+    homepage = "https://github.com/manisandro/qtspell";
+    changelog = "https://github.com/manisandro/qtspell/blob/version/NEWS";
+    maintainers = with maintainers; [ dansbandit ];
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -90,6 +90,8 @@ makeScopeWithSplicing' {
 
   qscintilla = callPackage ../development/libraries/qscintilla { };
 
+  qtspell = callPackage ../development/libraries/qtspell { };
+
   qwlroots = callPackage ../development/libraries/qwlroots {
     wlroots = pkgs.wlroots_0_17;
   };


### PR DESCRIPTION
## Description of changes

Add qtspell library so that it is possible to build [gImageReader](https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/applications/misc/gImageReader/default.nix#L14) with qt5.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
