### PR TITLE
fsautocomplete: 0.63.1 -> 0.64.0

### DIFF
--- a/pkgs/development/tools/fsautocomplete/default.nix
+++ b/pkgs/development/tools/fsautocomplete/default.nix
@@ -5,13 +5,13 @@ let
 in
 buildDotnetModule rec {
   pname = "fsautocomplete";
-  version = "0.63.1";
+  version = "0.64.0";
 
   src = fetchFromGitHub {
     owner = "fsharp";
     repo = "FsAutoComplete";
     rev = "v${version}";
-    sha256 = "sha256-+ymdt0FPrhZu5mUjRHhfzMtROX0eBVYsAOiB6g06mn0=";
+    sha256 = "sha256-C01CsGHRy0/FFEofEN8xLM/QgnMI8aq2tr4qkEbxlsQ=";
   };
 
   nugetDeps = ./deps.nix;

--- a/pkgs/development/tools/fsautocomplete/deps.nix
+++ b/pkgs/development/tools/fsautocomplete/deps.nix
@@ -39,7 +39,7 @@
   (fetchNuGet { pname = "Fake.IO.Zip"; version = "5.23.1"; sha256 = "0iac86jlxb5bwgiich3zzvr7bz5aw8xq53ly263mwxhv9lrsd815"; })
   (fetchNuGet { pname = "Fake.Net.Http"; version = "5.23.1"; sha256 = "1g0dpxi5b78qh7myz09pmjxzb0iblj3rqx5mpaammbppbbazvzdk"; })
   (fetchNuGet { pname = "Fake.Tools.Git"; version = "5.23.1"; sha256 = "0cg1sbp7zl1d18cjhbs94ix8580hr6gyaxjw17q246lbaj9bfg8l"; })
-  (fetchNuGet { pname = "fantomas"; version = "6.1.0"; sha256 = "0qk983ybs66infm6q60qsn6sl9i17i6rjavsygcld6w3vfzza9kx"; })
+  (fetchNuGet { pname = "fantomas"; version = "6.2.0"; sha256 = "0jmr63c2a4maf1blcsiyxz9najrc31xk1ignc7j7l2sswis6hx7k"; })
   (fetchNuGet { pname = "Fantomas.Client"; version = "0.9.0"; sha256 = "1zixwk61fyk7y9q6f8266kwxi6byr8fmyp1lf57qhbbvhq2waj9d"; })
   (fetchNuGet { pname = "Fantomas.Core"; version = "6.2.0"; sha256 = "07yl2hr06zk1nl66scm24di3nf1zbrnd6329prwirnv370rz4q92"; })
   (fetchNuGet { pname = "Fantomas.FCS"; version = "6.2.0"; sha256 = "1hhsa7hbxsm2d8ap4sqzwlzjmf4wsgg74i731rprr0nshjvd8ic7"; })


### PR DESCRIPTION
## Description of changes

https://github.com/fsharp/FsAutoComplete/releases/tag/v0.64.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
