### PR TITLE
unsilence: init at 1.0.9

### DIFF
--- a/pkgs/by-name/un/unsilence/package.nix
+++ b/pkgs/by-name/un/unsilence/package.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, ffmpeg
+,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "unsilence";
+  version = "1.0.9";
+
+  src = fetchFromGitHub {
+    owner = "lagmoellertim";
+    repo = "unsilence";
+    rev = version;
+    sha256 = "sha256-M4Ek1JZwtr7vIg14aTa8h4otIZnPQfKNH4pZE4GpiBQ=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    rich
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    python3Packages.rich
+    python3Packages.setuptools # imports pkg_resources.parse_version
+  ];
+
+  makeWrapperArgs = [
+    "--suffix PATH : ${lib.makeBinPath [ ffmpeg ]}"
+  ];
+
+  doCheck = false;
+  pythonImportsCheck = [ "unsilence" ];
+
+  pythonRelaxDeps = [ "rich" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/lagmoellertim/unsilence";
+    description = "Console Interface and Library to remove silent parts of a media file";
+    license = licenses.mit;
+    maintainers = with maintainers; [ esau79p ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Unsilence is an open-source tool that removes silence from a media clip of your choice (audio, video).

You can use it to speed up videos without changing the audible speed, so you can understand everything, but get through a video faster.
- Homepage URL: https://github.com/lagmoellertim/unsilence
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).