### PR TITLE
kicad: 7.0.7 -> 7.0.9

### DIFF
--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"7.0.7";
+      version =			"7.0.8";
       src = {
-        rev =			"dc7665e950aa0d42de36e928af48be3b060ba5d1";
-        sha256 =		"1xbzf29rhqh6kl0vggdn2dblgp927096fc1lr3y4yw63b8n0qq50";
+        rev =			"589f970445f049f6475b3ebf8a21ce84a1de1415";
+        sha256 =		"1gaj833hm3avyb7gyjnl4jk9cckcmj8084y6q45ysjvh283rxsy4";
       };
     };
     libVersion = {
-      version =			"7.0.7";
+      version =			"7.0.8";
       libSources = {
-        symbols.rev =		"c7df225d1c79b3ea842c77d928ce1f9bc1a63c5b";
-        symbols.sha256 =	"1wr754m4ykidds3i14gqhvyrj3mbkchp2hkfnr0rjsdaqf4zmqdf";
-        templates.rev =		"1561dd81d116a661a17147c3b941a3e96335eecc";
-        templates.sha256 =	"1qi20mrsfn4fxmr1fyphmil2i9p2nzmwk5rlfchc5aq2194nj3lq";
-        footprints.rev =	"ecb85886616b7a6bb957699037f6fb680ce01d30";
-        footprints.sha256 =	"0xnnivlqgcyaz9qay73p43jnvmvshp2b3fbh3569j7rmgi5pn8x0";
-        packages3d.rev =	"4fb0672db1d405b661d0cde8edb5d54ac0a95fc7";
-        packages3d.sha256 =	"141r5wd8s1bgyf77kvb9q14cpsiwwv4zmfzwbgcd42rflsk2lcbc";
+        symbols.rev =		"df7fc7805470766c0663fc074e8e75345aad33f8";
+        symbols.sha256 =	"176zb7df25vz3wbhs94plmpabcgzxsnzbqmpdyssqr7m2wb2424a";
+        templates.rev =		"5397f6f1b9669d236fbbe33beeb3ae66f351c004";
+        templates.sha256 =	"11582ldnv7hkljmhaym83962kixq1hjbfmdrn5laq7l4jk3l19vh";
+        footprints.rev =	"ff0eb7942c7a5b43d4dda878cf8f55860566b3dc";
+        footprints.sha256 =	"1560m5mwwq0jrjhr8zdh2xrm1w7pgr250p81xzhdc4wj7zsb0rrp";
+        packages3d.rev =	"f4b5e8043bf07e1c042d8c408c1f6faac737c839";
+        packages3d.sha256 =	"1ypy2nzs1x8i98jr5kmlxfd6y592qs22aq73yl8nq0s6640fc4kk";
       };
     };
   };

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"7.0.8";
+      version =			"7.0.9";
       src = {
-        rev =			"589f970445f049f6475b3ebf8a21ce84a1de1415";
-        sha256 =		"1gaj833hm3avyb7gyjnl4jk9cckcmj8084y6q45ysjvh283rxsy4";
+        rev =			"1c81053cc40579ecd5febef1aeb1164008039deb";
+        sha256 =		"1hq9rba1gcks14zwbr8nbicpsil4imslgfch6ll33fhizbks3fq4";
       };
     };
     libVersion = {
-      version =			"7.0.8";
+      version =			"7.0.9";
       libSources = {
-        symbols.rev =		"df7fc7805470766c0663fc074e8e75345aad33f8";
-        symbols.sha256 =	"176zb7df25vz3wbhs94plmpabcgzxsnzbqmpdyssqr7m2wb2424a";
-        templates.rev =		"5397f6f1b9669d236fbbe33beeb3ae66f351c004";
+        symbols.rev =		"1ed4ed6c0696e50165b8e3d7978136a05db2d7c3";
+        symbols.sha256 =	"0ynsnjq3z126cjkgm1fjbjvdvpc0walnr42ya9dv46l27kxy2j77";
+        templates.rev =		"856bacc6782ea8c9bcb5a49a2d438a4689e0579b";
         templates.sha256 =	"11582ldnv7hkljmhaym83962kixq1hjbfmdrn5laq7l4jk3l19vh";
-        footprints.rev =	"ff0eb7942c7a5b43d4dda878cf8f55860566b3dc";
-        footprints.sha256 =	"1560m5mwwq0jrjhr8zdh2xrm1w7pgr250p81xzhdc4wj7zsb0rrp";
-        packages3d.rev =	"f4b5e8043bf07e1c042d8c408c1f6faac737c839";
-        packages3d.sha256 =	"1ypy2nzs1x8i98jr5kmlxfd6y592qs22aq73yl8nq0s6640fc4kk";
+        footprints.rev =	"fe7b9aec7635caabbaa85fa8a15b85038394099b";
+        footprints.sha256 =	"16a4c2xs4i8wbm01a901yxabxk0qdsjkzlccfawddv82bkh4b87h";
+        packages3d.rev =	"5bc66f3c0f6dabf09df6c5188b8d955968500eab";
+        packages3d.sha256 =	"1cly28vc07i54v487zbb8d1h70nrd3naxvq146b0xnbrjwnd2q28";
       };
     };
   };


### PR DESCRIPTION
## Description of changes

[7.0.8 release blog post with changelog](https://www.kicad.org/blog/2023/09/KiCad-7.0.8-Release/)
[7.0.9 release blog post](https://www.kicad.org/blog/2023/11/KiCad-7.0.9-Release/)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).