### PR TITLE
nixos-option: add withFlakeCompat flag

### DIFF
--- a/pkgs/tools/nix/nixos-option/wrapper.nix
+++ b/pkgs/tools/nix/nixos-option/wrapper.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, installShellFiles
+, makeWrapper
+, nixos-option
+, runCommand
+  # Set this to true to allow compatibility with Flakes. This is a hack until
+  # nixos-option gain support to Flakes natively.
+  # See: https://github.com/NixOS/nixpkgs/issues/97855
+, withFlakeCompat ? false
+  # Used when `withFlakeCompat = true`. Default value works fine if your NixOS
+  # configuration is stored in `/etc/nixos`, however you may want to set this
+  # to another location.
+  # It is also possible to set this to `self` reference in your Flake, allowing
+  # it to work regardless where you configuration is located.
+, optionSrc ? "/etc/nixos"
+}:
+
+let
+  flake-compat = fetchFromGitHub {
+    owner = "edolstra";
+    repo = "flake-compat";
+    rev = "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9";
+    hash = "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=";
+  };
+  prefix = ''(import ${flake-compat} { src = ${optionSrc}; }).defaultNix.nixosConfigurations.\$(hostname)'';
+in
+if withFlakeCompat then
+  (runCommand "nixos-option"
+  {
+    buildInputs = [ makeWrapper installShellFiles ];
+
+    passthru.unwrapped = nixos-option;
+  } ''
+    makeWrapper ${nixos-option}/bin/nixos-option $out/bin/nixos-option \
+      --add-flags --config_expr \
+      --add-flags "\"${prefix}.config\"" \
+      --add-flags --options_expr \
+      --add-flags "\"${prefix}.options\""
+
+    installManPage ${./nixos-option.8}
+  '')
+else nixos-option

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40907,8 +40907,10 @@ with pkgs;
 
   nix-melt = callPackage ../tools/nix/nix-melt { };
 
-  nixos-option = callPackage ../tools/nix/nixos-option {
-    nix = nixVersions.nix_2_15;
+  nixos-option = callPackage ../tools/nix/nixos-option/wrapper.nix {
+    nixos-option = callPackage ../tools/nix/nixos-option {
+      nix = nixVersions.nix_2_15;
+    };
   };
 
   nix-pin = callPackage ../tools/package-management/nix-pin { };


### PR DESCRIPTION
## Description of changes

This PR introduces a wrapped version of `nixos-option`, that allow it to work with Flake-based NixOS configurations by using flake-compat. To avoid backwards incompatibilites, this is turned off by default, that will result in the same nixos-option as it currently exists (e.g.: without a wrapper).

Workaround for issue: https://github.com/NixOS/nixpkgs/issues/97855

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
