### PR TITLE
Add network library with IPv4 conversion functions.

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -48,6 +48,7 @@ let
     asserts = callLibs ./asserts.nix;
     debug = callLibs ./debug.nix;
     misc = callLibs ./deprecated.nix;
+    network = callLibs ./network.nix;
 
     # domain-specific
     fetchers = callLibs ./fetchers.nix;
@@ -163,6 +164,7 @@ let
       mergeAttrsByFuncDefaultsClean mergeAttrBy
       fakeHash fakeSha256 fakeSha512
       nixType imap;
+    inherit (self.network) ipv4;
     inherit (self.versions)
       splitVersion;
   });

--- a/lib/network.nix
+++ b/lib/network.nix
@@ -1,0 +1,317 @@
+{lib}: let
+  /*
+  Converts an IP address from a list of ints to a string.
+
+  Type: prettyIp :: [ Int ] -> String
+
+  Examples:
+    prettyIp [ 192 168 70 9 ]
+    => "192.168.70.9"
+  */
+  prettyIp = addr:
+    lib.concatStringsSep "." (builtins.map builtins.toString addr);
+
+  /*
+  Given a bit mask, return the associated subnet mask.
+
+  Type: bitMaskToSubnetMask :: Int -> [ Int ]
+
+  Examples:
+    bitMaskToSubnetMask 15
+    => [ 255 254 0 0 ]
+    bitMaskToSubnetMask 24
+    => [ 255 255 255 0 ]
+  */
+  bitMaskToSubnetMask = bitMask: let
+    numOctets = 4;
+    octetBits = 8;
+    octetMin = 0;
+    octetMax = 255;
+    # How many initial parts of the mask are full (=255)
+    fullParts = bitMask / octetBits;
+  in
+    lib.genList (
+      idx:
+      # Fill up initial full parts
+        if idx < fullParts
+        then octetMax
+        # If we're above the first non-full part, fill with 0
+        else if fullParts < idx
+        then octetMin
+        # First non-full part generation
+        else _genPartialMask (lib.mod bitMask octetBits)
+    )
+    numOctets;
+
+  /*
+  Generate a the partial portion of a subnet mask.
+
+  Type: _genPartialMask :: Int -> Int
+
+  Examples:
+    _genPartialMask 0
+    => 0
+    _genPartialMask 1
+    => 128
+    _genPartialMask 2
+    => 192
+    _genPartialMask 3
+    => 224
+    _genPartialMask 4
+    => 240
+    _genPartialMask 5
+    => 248
+    _genPartialMask 6
+    => 252
+    _genPartialMask 7
+    => 254
+  */
+  _genPartialMask = n:
+    if n == 0
+    then 0
+    else _genPartialMask (n - 1) / 2 + 128;
+
+  /*
+  Given a subnet mask, return the associated bit mask.
+
+  Type: subnetMaskToBitMask :: [ Int ] -> Int
+
+  Examples:
+    subnetMaskToBitMask [ 255 254 0 0 ]
+    => 15
+    subnetMaskToBitMask [ 255 255 255 0 ]
+    => 24
+  */
+  subnetMaskToBitMask = subnetMask: let
+    partialBits = octet:
+      if octet == 0
+      then 0
+      else (lib.mod octet 2) + partialBits (octet / 2);
+  in
+    builtins.foldl'
+    (x: y: x + y)
+    0
+    (builtins.map partialBits subnetMask);
+
+  /*
+  Given a CIDR, return the IP Address.
+
+  Type: cidrToIpAddress :: String -> [ Int ]
+
+  Examples:
+    cidrToIpAddress "192.168.70.9/15"
+    => [ 192 168 70 9 ]
+  */
+  cidrToIpAddress = cidr: let
+    splitParts = lib.splitString "/" cidr;
+    addr = lib.elemAt splitParts 0;
+    parsed =
+      builtins.map
+      lib.toInt
+      (builtins.match "([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)" addr);
+    checkBounds = octet:
+      (octet >= 0) && (octet <= 255);
+  in
+    if (builtins.all checkBounds parsed)
+    then parsed
+    else builtins.throw "IP ${prettyIp addr} has out of bounds octet(s)";
+
+  /*
+  Given a CIDR, return the bitmask.
+
+  Type: cidrToBitMask :: String -> Int
+
+  Examples:
+    cidrToBitMask "192.168.70.9/15"
+    => 15
+  */
+  cidrToBitMask = cidr: let
+    splitParts = lib.splitString "/" cidr;
+    mask = lib.toInt (lib.elemAt splitParts 1);
+    checkBounds = mask:
+      (mask >= 0) && (mask <= 32);
+  in
+    if (checkBounds mask)
+    then mask
+    else builtins.throw "Bitmask ${builtins.toString mask} is invalid.";
+
+  /*
+  Given a CIDR, return the associated subnet mask.
+
+  Type: cidrToSubnetMask :: String -> [ Int ]
+
+  Examples:
+    cidrToSubnetMask "192.168.70.9/15"
+    => [ 255 254 0 0 ]
+  */
+  cidrToSubnetMask = cidr:
+    bitMaskToSubnetMask (cidrToBitMask cidr);
+
+  /*
+  Given a CIDR, return the associated network ID.
+
+  Type: cidrToNetworkId :: String -> [ Int ]
+
+  Examples:
+    cidrToNetworkId "192.168.70.9/15"
+    => [ 192 168 0 0 ]
+  */
+  cidrToNetworkId = cidr: let
+    ip = cidrToIpAddress cidr;
+    subnetMask = cidrToSubnetMask cidr;
+  in
+    lib.zipListsWith lib.bitAnd ip subnetMask;
+
+  /*
+  Given a CIDR, return the associated first usable IP address.
+
+  Type: cidrToFirstUsableIp :: String -> [ Int ]
+
+  Examples:
+    cidrToFirstUsableIp "192.168.70.9/15"
+    => [ 192 168 0 1 ]
+  */
+  cidrToFirstUsableIp = cidr: let
+    networkId = cidrToNetworkId cidr;
+  in
+    incrementIp networkId 1;
+
+  /*
+  Given a CIDR, return the associated broadcast address.
+
+  Type: cidrToBroadcastAddress :: String -> [ Int ]
+
+  Examples:
+    cidrToBroadcastAddress "192.168.70.9/15"
+    => [ 192 169 255 255 ]
+  */
+  cidrToBroadcastAddress = cidr: let
+    subnetMask = cidrToSubnetMask cidr;
+    networkId = cidrToNetworkId cidr;
+  in
+    getBroadcastAddress networkId subnetMask;
+
+  /*
+  Given a network ID and subnet mask, return the associated broadcast address.
+
+  Type: getBroadcastAddress :: [ Int ] -> [ Int ] -> [ Int ]
+
+  Examples:
+    getBroadcastAddress [ 192 168 0 0 ] [ 255 254 0 0 ]
+    => [ 192 169 255 255 ]
+  */
+  getBroadcastAddress = networkId: subnetMask:
+    lib.zipListsWith (nid: mask: 255 - mask + nid) networkId subnetMask;
+
+  /*
+  Given a CIDR, return the associated last usable IP address.
+
+  Type: cidrToLastUsableIp :: String -> [ Int ]
+
+  Examples:
+    cidrToLastUsableIp "192.168.70.9/15"
+    => [ 192 169 255 254 ]
+  */
+  cidrToLastUsableIp = cidr: let
+    broadcast = cidrToBroadcastAddress cidr;
+  in
+    incrementIp broadcast (-1);
+
+  /*
+  Increment the last octet of a given IP address.
+
+  Type: incrementIp :: [ Int ] -> Int -> [ Int ]
+
+  Examples:
+    incrementIp [ 192 168 70 9 ] 3
+    => [ 192 168 70 12 ]
+    incrementIp [ 192 168 70 9 ] (-2)
+    => [ 192 168 70 7 ]
+  */
+  incrementIp = addr: offset: let
+    lastOctet = lib.last addr;
+    firstThree = lib.init addr;
+  in
+    firstThree ++ [(lastOctet + offset)];
+
+  /*
+  Given an IP address and bit mask, return the associated CIDR.
+
+  Type: ipAndBitMaskToCidr :: [ Int ] -> Int -> String
+
+  Examples:
+    ipAndBitMaskToCidr [ 192 168 70 9 ] 15
+    => "192.168.70.9/15"
+  */
+  ipAndBitMaskToCidr = addr: bitMask:
+    lib.concatStringsSep "/"
+    [
+      (prettyIp addr)
+      (builtins.toString bitMask)
+    ];
+
+  /*
+  Given an IP address and subnet mask, return the associated CIDR.
+
+  Type: ipAndSubnetMaskToCidr :: [ Int ] -> Int -> String
+
+  Examples:
+    ipAndSubnetMaskToCidr [ 192 168 70 9 ] [ 255 254 0 0 ]
+    => "192.168.70.9/15"
+  */
+  ipAndSubnetMaskToCidr = addr: subnetMask:
+    ipAndBitMaskToCidr addr (subnetMaskToBitMask subnetMask);
+
+  /*
+  Given a CIDR, return an attribute set of:
+    the IP Address,
+    the bit mask,
+    the first usable IP address,
+    the last usable IP address,
+    the network ID,
+    the subnet mask,
+    the broadcast address.
+
+  Type: getNetworkProperties :: str -> attrset
+
+  Examples:
+    getNetworkProperties "192.168.70.9/15"
+    => {
+      bitMask = 15;
+      broadcast = "192.169.255.255";
+      firstUsableIp = "192.168.0.1";
+      ipAddress = "192.168.70.9";
+      lastUsableIp = "192.169.255.254";
+      networkId = "192.168.0.0";
+      subnetMask = "255.254.0.0";
+    }
+  */
+  getNetworkProperties = cidr: let
+    ipAddress = prettyIp (cidrToIpAddress cidr);
+    bitMask = cidrToBitMask cidr;
+    firstUsableIp = prettyIp (cidrToFirstUsableIp cidr);
+    lastUsableIp = prettyIp (cidrToLastUsableIp cidr);
+    networkId = prettyIp (cidrToNetworkId cidr);
+    subnetMask = prettyIp (cidrToSubnetMask cidr);
+    broadcast = prettyIp (cidrToBroadcastAddress cidr);
+  in {inherit ipAddress bitMask firstUsableIp lastUsableIp networkId subnetMask broadcast;};
+in {
+  ipv4 = {
+    inherit
+      prettyIp
+      incrementIp
+      bitMaskToSubnetMask
+      subnetMaskToBitMask
+      ipAndBitMaskToCidr
+      ipAndSubnetMaskToCidr
+      cidrToIpAddress
+      cidrToBitMask
+      cidrToFirstUsableIp
+      cidrToLastUsableIp
+      cidrToNetworkId
+      cidrToSubnetMask
+      cidrToBroadcastAddress
+      getNetworkProperties
+      ;
+  };
+}

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1870,4 +1870,147 @@ runTests {
     expr = (with types; either int (listOf (either bool str))).description;
     expected = "signed integer or list of (boolean or string)";
   };
+
+# NETWORK
+
+  testPrettyIp = {
+    expr = network.ipv4.prettyIp [192 168 70 9];
+    expected = "192.168.70.9";
+  };
+  testBitMaskToSubnetMask1 = {
+    expr = network.ipv4.bitMaskToSubnetMask 15;
+    expected = [255 254 0 0];
+  };
+  testBitMaskToSubnetMask2 = {
+    expr = network.ipv4.bitMaskToSubnetMask 24;
+    expected = [255 255 255 0];
+  };
+  testSubnetMaskToBitMask1 = {
+    expr = network.ipv4.subnetMaskToBitMask [0 0 0 0];
+    expected = 0;
+  };
+  testSubnetMaskToBitMask2 = {
+    expr = network.ipv4.subnetMaskToBitMask [255 254 0 0];
+    expected = 15;
+  };
+  testSubnetMaskToBitMask3 = {
+    expr = network.ipv4.subnetMaskToBitMask [255 255 1 0];
+    expected = 17;
+  };
+  testSubnetMaskToBitMask4 = {
+    expr = network.ipv4.subnetMaskToBitMask [255 255 255 0];
+    expected = 24;
+  };
+  testSubnetMaskToBitMask5 = {
+    expr = network.ipv4.subnetMaskToBitMask [255 255 255 255];
+    expected = 32;
+  };
+  testCidrToIpAddress1 = {
+    expr = network.ipv4.cidrToIpAddress "192.168.70.9/15";
+    expected = [192 168 70 9];
+  };
+  testCidrToIpAddress2 = {
+    expr = network.ipv4.cidrToIpAddress "0.0.0.0/0";
+    expected = [0 0 0 0];
+  };
+  testCidrToIpAddress3 = {
+    expr = network.ipv4.cidrToIpAddress "255.255.255.255/32";
+    expected = [255 255 255 255];
+  };
+  testCidrToBitMask1 = {
+    expr = network.ipv4.cidrToBitMask "192.168.70.9/15";
+    expected = 15;
+  };
+  testCidrToBitMask2 = {
+    expr = network.ipv4.cidrToBitMask "0.0.0.0/0";
+    expected = 0;
+  };
+  testCidrToBitMask3 = {
+    expr = network.ipv4.cidrToBitMask "255.255.255.255/32";
+    expected = 32;
+  };
+  testCidrToSubnetMask1 = {
+    expr = network.ipv4.cidrToSubnetMask "192.168.70.9/15";
+    expected = [255 254 0 0];
+  };
+  testCidrToSubnetMask2 = {
+    expr = network.ipv4.cidrToSubnetMask "0.0.0.0/0";
+    expected = [0 0 0 0];
+  };
+  testCidrToSubnetMask3 = {
+    expr = network.ipv4.cidrToSubnetMask "255.255.255.255/32";
+    expected = [255 255 255 255];
+  };
+  testCidrToNetworkId1 = {
+    expr = network.ipv4.cidrToNetworkId "192.168.70.9/15";
+    expected = [192 168 0 0];
+  };
+  testCidrToNetworkId2 = {
+    expr = network.ipv4.cidrToNetworkId "192.168.70.9/17";
+    expected = [192 168 0 0];
+  };
+  testCidrToFirstUsableIp1 = {
+    expr = network.ipv4.cidrToFirstUsableIp "192.168.70.9/15";
+    expected = [192 168 0 1];
+  };
+  testCidrToFirstUsableIp2 = {
+    expr = network.ipv4.cidrToFirstUsableIp "192.168.70.9/17";
+    expected = [192 168 0 1];
+  };
+  testCidrToBroadcastAddress1 = {
+    expr = network.ipv4.cidrToBroadcastAddress "192.168.70.9/15";
+    expected = [192 169 255 255];
+  };
+  testCidrToBroadcastAddress2 = {
+    expr = network.ipv4.cidrToBroadcastAddress "192.168.70.9/17";
+    expected = [192 168 127 255];
+  };
+  testCidrToLastUsableIp1 = {
+    expr = network.ipv4.cidrToLastUsableIp "192.168.70.9/15";
+    expected = [192 169 255 254];
+  };
+  testCidrToLastUsableIp2 = {
+    expr = network.ipv4.cidrToLastUsableIp "192.168.70.9/17";
+    expected = [192 168 127 254];
+  };
+  testIncrementIp1 = {
+    expr = network.ipv4.incrementIp [192 168 70 9] 3;
+    expected = [192 168 70 12];
+  };
+  testIncrementIp2 = {
+    expr = network.ipv4.incrementIp [192 168 70 9] (-2);
+    expected = [192 168 70 7];
+  };
+  testIpAndBitMaskToCidr = {
+    expr = network.ipv4.ipAndBitMaskToCidr [192 168 70 9] 15;
+    expected = "192.168.70.9/15";
+  };
+  testIpAndSubnetMaskToCidr = {
+    expr = network.ipv4.ipAndSubnetMaskToCidr [192 168 70 9] [255 254 0 0];
+    expected = "192.168.70.9/15";
+  };
+  testGetNetworkPropertiesTest1 = {
+    expr = network.ipv4.getNetworkProperties "192.168.70.9/15";
+    expected = {
+      bitMask = 15;
+      ipAddress = "192.168.70.9";
+      subnetMask = "255.254.0.0";
+      networkId = "192.168.0.0";
+      firstUsableIp = "192.168.0.1";
+      lastUsableIp = "192.169.255.254";
+      broadcast = "192.169.255.255";
+    };
+  };
+  testGetNetworkPropertiesTest2 = {
+    expr = network.ipv4.getNetworkProperties "192.168.70.9/17";
+    expected = {
+      bitMask = 17;
+      ipAddress = "192.168.70.9";
+      subnetMask = "255.255.128.0";
+      networkId = "192.168.0.0";
+      firstUsableIp = "192.168.0.1";
+      lastUsableIp = "192.168.127.254";
+      broadcast = "192.168.127.255";
+    };
+  };
 }


### PR DESCRIPTION
## Description of changes

Adds a network library to `lib` with functions for IPv4 conversions. Many core and supplementary modules can benefit from simple Nix functions that do IPv4 cidr/address/mask conversions. Examples include:
 - `dhcpd`
   -  https://github.com/NixOS/nixpkgs/blob/nixos-23.05/nixos/modules/services/networking/dhcpd.nix#L114
 - `networking.interfaces` 
   - https://github.com/NixOS/nixpkgs/blob/nixos-23.05/nixos/modules/tasks/network-interfaces.nix#L199
   - https://github.com/NixOS/nixpkgs/blob/nixos-23.05/nixos/modules/tasks/network-interfaces.nix#L223
 - `flannel`
   - https://github.com/NixOS/nixpkgs/blob/nixos-23.05/nixos/modules/services/networking/flannel.nix#L44
   - https://github.com/NixOS/nixpkgs/blob/nixos-23.05/nixos/modules/services/networking/flannel.nix#L106
   - https://github.com/NixOS/nixpkgs/blob/nixos-23.05/nixos/modules/services/networking/flannel.nix#L116
   - https://github.com/NixOS/nixpkgs/blob/nixos-23.05/nixos/modules/services/networking/flannel.nix#L125
 - `fail2ban`
 - `postgrey`
 - `tinc`

Example of how configuration can be improved using the new network library. This helps minimize the chance for typographical errors.

```nix
# before
services.dhcpd4.extraConfig = ''
  option subnet-mask 255.255.255.0;
  option broadcast-address 192.168.1.255;
  option routers 192.168.1.5;
  subnet 192.168.1.0 netmask 255.255.255.0 {
    range 192.168.1.100 192.168.1.200;
  }
''
```



```nix
# after
services.dhcpd4.extraConfig = let
  props = lib.networking.ipv4.getNetworkProperties "192.168.1.5/24";
in
  ''
    option subnet-mask ${props.subnetMask};
    option broadcast-address ${props.broadcast};
    option routers ${props.ipAddress};
    subnet ${props.networkId} netmask ${props.subnetMask} {
      range ${props.firstUsableIp} ${props.lastUsableIp};
    }
  ''
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
