### PR TITLE
mlx42: init at 2.3.2

### DIFF
--- a/pkgs/by-name/ml/mlx42/mlx42.pc
+++ b/pkgs/by-name/ml/mlx42/mlx42.pc
@@ -1,0 +1,10 @@
+prefix=@out@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: mlx42
+Description: A simple cross-platform graphics library that uses GLFW and OpenGL
+Version: @version@
+Libs: -L${libdir} -lmlx42
+Cflags: -I${includedir}

--- a/pkgs/by-name/ml/mlx42/package.nix
+++ b/pkgs/by-name/ml/mlx42/package.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, glfw
+, darwin
+, enableShared ? !stdenv.hostPlatform.isStatic
+, enableDebug ? false
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mlx42";
+  version = "2.3.2";
+
+  src = fetchFromGitHub {
+    owner = "codam-coding-college";
+    repo = "MLX42";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-JCBV8NWibSugqXkbgP0v3gDfaaMNFYztWpBRfHJUG8E=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "add-cmake-install.patch";
+      url = "https://github.com/codam-coding-college/MLX42/commit/a51ca8e0ec3fb793fa96d710696dcee8a4fe57d6.patch";
+      hash = "sha256-i+0yHZVvfTG19BGVrz7GuEuBw3B7lylCPEvx07il23M=";
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs ./tools
+  ''
+  + lib.optionalString enableShared ''
+    substituteInPlace CMakeLists.txt \
+        --replace "mlx42 STATIC" "mlx42 SHARED"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ glfw ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ OpenGL Cocoa IOKit ]);
+
+  cmakeFlags = [ "-DDEBUG=${toString enableDebug}" ];
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+    substituteAll ${./mlx42.pc} $out/lib/pkgconfig/mlx42.pc
+
+    # This file was removed after 2.3.2, so the used patch doesn't copy this file
+    # This line can be removed after the next release
+    cp $src/include/MLX42/MLX42_Input.h $out/include/MLX42
+  '';
+
+  meta = {
+    description = "A simple cross-platform graphics library that uses GLFW and OpenGL";
+    homepage = "https://github.com/codam-coding-college/MLX42";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/256400

This PR adds 1 package: `mlx42`

The build process originally created a static library, however I made it so that it can generate shared library files instead.

When using the dynamic version, you can use `-lmlx42` to link
When using the static version, you can use `-lmlx42 -lglfw` to link

I also added `pkg-config` support, if you wanted to, you could use that also.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
