### PR TITLE
python310Packages.pytest-spec: init at unstable-2023-06-04

### DIFF
--- a/pkgs/development/python-modules/pytest-spec/default.nix
+++ b/pkgs/development/python-modules/pytest-spec/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytest
+, pytestCheckHook
+, pytest-describe
+, pytest-cov
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-spec";
+  version = "unstable-2023-06-04";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pchomik";
+    repo = "pytest-spec";
+    rev = "e16e0550dd6bc557411e4312b7b42d53b26e69ef";
+    hash = "sha256-dyDUdZJU4E4y1yCzunAX2c48Qv6ogu0b60U/5YbJvIU=";
+  };
+
+  postPatch = ''
+    sed -i '/addopts/d' setup.cfg
+    # TODO: upstream
+    substituteInPlace pyproject.toml \
+        --replace "poetry>=0.12" "poetry-core" \
+        --replace "poetry.masonry.api" "poetry.core.masonry.api"
+  '';
+
+  nativeBuildInputs = [ poetry-core ];
+
+  buildInputs = [ pytest ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-describe
+  ];
+
+  pytestFlagsArray = [ "--spec" ];
+
+  pythonImportsCheck = [ "pytest_spec" ];
+
+  meta = {
+    description = "A pytest plugin to display test execution output like a SPECIFICATION";
+    homepage = "https://github.com/pchomik/pytest-spec";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10417,6 +10417,8 @@ self: super: with self; {
 
   pytest-shutil = callPackage ../development/python-modules/pytest-shutil { };
 
+  pytest-spec = callPackage ../development/python-modules/pytest-spec { };
+
   python-status = callPackage ../development/python-modules/python-status { };
 
   python-string-utils = callPackage ../development/python-modules/python-string-utils { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/252217

The self-tests seem to run correctly, but I have not checked out the package being used by another package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
