### PR TITLE
python3Packages.hyperscan: init at 0.6.0

### DIFF
--- a/pkgs/development/libraries/hyperscan/default.nix
+++ b/pkgs/development/libraries/hyperscan/default.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DFAT_RUNTIME=ON"
     "-DBUILD_AVX512=ON"
   ]
+  ++ lib.optional (!stdenv.isDarwin) "-DFAT_RUNTIME=ON"
   ++ lib.optional (withStatic) "-DBUILD_STATIC_AND_SHARED=ON"
   ++ lib.optional (!withStatic) "-DBUILD_SHARED_LIBS=ON";
 
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     homepage = "https://www.hyperscan.io/";
     maintainers = with maintainers; [ avnik ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     license = licenses.bsd3;
   };
 })

--- a/pkgs/development/python-modules/hyperscan/default.nix
+++ b/pkgs/development/python-modules/hyperscan/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, pkgs
+, buildPythonPackage
+, fetchFromGitHub
+, pdm-backend
+, setuptools
+, wheel
+, pcre
+, pkg-config
+, pytestCheckHook
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "hyperscan";
+  version = "0.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "darvid";
+    repo = "python-hyperscan";
+    rev = "v${version}";
+    hash = "sha256-6PoV9rY9CkXkAMWN2QCnfU4S0OJD/6bzkqFgvEVqNjo=";
+  };
+
+  buildInputs = [
+    (pkgs.hyperscan.override { withStatic = true; })
+    # we need static pcre to be built, by default only shared library is built
+    (pcre.overrideAttrs { dontDisableStatic = 0; })
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    pdm-backend
+    setuptools
+    wheel
+  ];
+
+  pythonImportsCheck = [ "hyperscan" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  meta = with lib; {
+    description = "A CPython extension for the Hyperscan regular expression matching library";
+    homepage = "https://github.com/darvid/python-hyperscan";
+    changelog = "https://github.com/darvid/python-hyperscan/blob/${src.rev}/CHANGELOG.md";
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ mbalatsko ];
+  };
+}

--- a/pkgs/tools/security/secretscanner/default.nix
+++ b/pkgs/tools/security/secretscanner/default.nix
@@ -50,6 +50,7 @@ buildGoModule rec {
     description = "Tool to find secrets and passwords in container images and file systems";
     homepage = "https://github.com/deepfence/SecretScanner";
     changelog = "https://github.com/deepfence/SecretScanner/releases/tag/v${version}";
+    platforms = [ "x86_64-linux" ];
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5110,6 +5110,8 @@ self: super: with self; {
 
   hyperframe = callPackage ../development/python-modules/hyperframe { };
 
+  hyperscan = callPackage ../development/python-modules/hyperscan { };
+
   hyperion-py = callPackage ../development/python-modules/hyperion-py { };
 
   hyperlink = callPackage ../development/python-modules/hyperlink { };


### PR DESCRIPTION
## Description of changes

- added package with Python bindings of `hyperscan`
- `hyperscan`: build  on `x86_64-darwin`
- `hyperscan`: build `chimera`
- `secretscanner `: restricted platforms to `x86_64-linux`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
