### PR TITLE
photoqt: 3.1 -> 3.3

### DIFF
--- a/pkgs/applications/graphics/photoqt/default.nix
+++ b/pkgs/applications/graphics/photoqt/default.nix
@@ -1,28 +1,70 @@
-{ mkDerivation, lib, fetchurl, cmake, exiv2, graphicsmagick, libraw
-, qtbase, qtdeclarative, qtmultimedia, qtquickcontrols2, qttools, qtgraphicaleffects
-, extra-cmake-modules, poppler, kimageformats, libarchive, pugixml, wrapQtAppsHook}:
+{ lib
+, stdenv
+, fetchurl
+, cmake
+, extra-cmake-modules
+, qttools
+, wrapQtAppsHook
+, exiv2
+, graphicsmagick
+, kimageformats
+, libarchive
+, libraw
+, mpv
+, poppler
+, pugixml
+, qtbase
+, qtdeclarative
+, qtgraphicaleffects
+, qtmultimedia
+, qtquickcontrols
+, qtquickcontrols2
+}:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "photoqt";
-  version = "3.1";
+  version = "3.3";
 
   src = fetchurl {
-    url = "https://${pname}.org/pkgs/${pname}-${version}.tar.gz";
-    hash = "sha256-hihfqE7XIlSAxPg3Kzld3LrYS97wDH//GGqpBpBwFm0=";
+    url = "https://photoqt.org/pkgs/photoqt-${version}.tar.gz";
+    hash = "sha256-AD+Uww/tmXRiAkmeuHBBollE6Y9L7c+fB882ALVtSXQ=";
   };
 
-  nativeBuildInputs = [ cmake extra-cmake-modules qttools wrapQtAppsHook ];
+  # error: no member named 'setlocale' in namespace 'std'; did you mean simply 'setlocale'?
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace cplusplus/main.cpp \
+      --replace "std::setlocale" "setlocale"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    qttools
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
-    qtbase qtquickcontrols2 exiv2 graphicsmagick poppler
-    qtmultimedia qtdeclarative libraw qtgraphicaleffects
-    kimageformats libarchive pugixml
+    exiv2
+    graphicsmagick
+    kimageformats
+    libarchive
+    libraw
+    mpv
+    poppler
+    pugixml
+    qtbase
+    qtdeclarative
+    qtgraphicaleffects
+    qtmultimedia
+    qtquickcontrols
+    qtquickcontrols2
   ];
 
   cmakeFlags = [
-    "-DFREEIMAGE=OFF"
     "-DDEVIL=OFF"
     "-DCHROMECAST=OFF"
+    "-DFREEIMAGE=OFF"
+    "-DIMAGEMAGICK=OFF"
   ];
 
   preConfigure = ''
@@ -30,9 +72,11 @@ mkDerivation rec {
   '';
 
   meta = {
-    homepage = "https://photoqt.org/";
     description = "Simple, yet powerful and good looking image viewer";
+    homepage = "https://photoqt.org/";
     license = lib.licenses.gpl2Plus;
+    mainProgram = "photoqt";
+    maintainers = with lib.maintainers; [ wegank ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

https://gitlab.com/lspies/photoqt/-/blob/master/CHANGELOG?ref_type=heads

Also refactored and added myself as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
