### PR TITLE
nixos/virtualisation: add hostname option to oci-containers.

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -203,6 +203,13 @@ let
           '';
         };
 
+        hostname = mkOption {
+          type = with types; nullOr str;
+          default = null;
+          description = lib.mdDoc "The hostname of the container.";
+          example = "hello-world";
+        };
+
         extraOptions = mkOption {
           type = with types; listOf str;
           default = [];
@@ -266,6 +273,8 @@ let
       "--log-driver=${container.log-driver}"
     ] ++ optional (container.entrypoint != null)
       "--entrypoint=${escapeShellArg container.entrypoint}"
+      ++ optional (container.hostname != null)
+      "--hostname=${escapeShellArg container.hostname}"
       ++ lib.optionals (cfg.backend == "podman") [
         "--cidfile=/run/podman-${escapedName}.ctr-id"
         "--cgroups=no-conmon"


### PR DESCRIPTION
## Description of changes

Adds the `hostname` option to the `virtualisation.oci-containers.<name>` set. This maps to the `--hostname` argument for podman and docker. While they can be set using `extraOptions` it's nicer to not. Being able to set the hostname also allows for dynamic container lookup using `dnsmasq` or `systemd-resolved` with the podman dns resolver.

##### Reviewed points

- [x] changes are backward compatible
  - `hostname` is optional.
- [ ] removed options are declared with `mkRemovedOptionModule`
- [ ] changes that are not backward compatible are documented in release notes
- [X] module tests succeed on ARCHITECTURE
- [X] options types are appropriate
- [X] options description is set
- [X] options example is provided
- [X] documentation affected by the changes is updated
  - option documentation added.

##### Possible improvements

##### Comments

Testing with the following set:
```nix
virtualisation.oci-containers.containers = {
    "hello-world" = {
      image = "docker.io/library/hello-world:latest";
      autoStart = true;
      hostname = "not-hello-world.podman";
    };
  };
```

```bash
$ sudo podman inspect hello-world | jq .[].Config.Hostname
"not-hello-world.podman"
```

```bash
$ cat /nix/store/qz4z7mnadd69p7qhi637sgng6mf75gzg-unit-script-podman-hello-world-start/bin/podman-hello-world-start
set -e
exec podman run \
  --rm \
  --name='hello-world' \
  --log-driver=journald \
  --hostname='not-hello-world.podman' \
  --cidfile=/run/podman-'hello-world'.ctr-id \
  --cgroups=no-conmon \
  --sdnotify=conmon \
  -d \
  --replace \
  docker.io/library/hello-world:latest
```