### PR TITLE
or-tools: fix string_view compilation issue

### DIFF
--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -45,6 +45,9 @@ stdenv.mkDerivation rec {
       url = "https://github.com/google/or-tools/commit/edd1544375bd55f79168db315151a48faa548fa0.patch";
       hash = "sha256-S//1YM3IoRCp3Ghg8zMF0XXgIpVmaw4gH8cVb9eUbqM=";
     })
+    # Don't use non-existent member of string_view. Partial patch from commit
+    # https://github.com/google/or-tools/commit/c5a2fa1eb673bf652cb9ad4f5049d054b8166e17.patch
+    ./fix-stringview-compile.patch
   ];
 
   # or-tools normally attempts to build Protobuf for the build platform when

--- a/pkgs/development/libraries/science/math/or-tools/fix-stringview-compile.patch
+++ b/pkgs/development/libraries/science/math/or-tools/fix-stringview-compile.patch
@@ -1,0 +1,36 @@
+diff --git a/ortools/lp_data/lp_parser.cc b/ortools/lp_data/lp_parser.cc
+index 58286306e5..bd26c019ab 100644
+--- a/ortools/lp_data/lp_parser.cc
++++ b/ortools/lp_data/lp_parser.cc
+@@ -185,7 +185,7 @@ bool LPParser::ParseIntegerVariablesList(StringPiece line) {
+ 
+ bool LPParser::ParseConstraint(StringPiece constraint) {
+   const StatusOr<ParsedConstraint> parsed_constraint_or_status =
+-      ::operations_research::glop::ParseConstraint(constraint.as_string());
++      ::operations_research::glop::ParseConstraint(constraint);
+   if (!parsed_constraint_or_status.ok()) return false;
+   const ParsedConstraint& parsed_constraint =
+       parsed_constraint_or_status.value();
+@@ -342,10 +342,9 @@ TokenType LPParser::ConsumeToken(StringPiece* sp) {
+ 
+ }  // namespace
+ 
+-StatusOr<ParsedConstraint> ParseConstraint(absl::string_view constraint_view) {
++StatusOr<ParsedConstraint> ParseConstraint(absl::string_view constraint) {
+   ParsedConstraint parsed_constraint;
+   // Get the name, if present.
+-  StringPiece constraint{constraint_view};
+   StringPiece constraint_copy{constraint};
+   std::string consumed_name;
+   Fractional consumed_coeff;
+@@ -413,8 +412,8 @@ StatusOr<ParsedConstraint> ParseConstraint(absl::string_view constraint_view) {
+     right_bound = consumed_coeff;
+     if (ConsumeToken(&constraint, &consumed_name, &consumed_coeff) !=
+         TokenType::END) {
+-      return absl::InvalidArgumentError(absl::StrCat(
+-          "End of input was expected, found: ", constraint.as_string()));
++      return absl::InvalidArgumentError(
++          absl::StrCat("End of input was expected, found: ", constraint));
+     }
+   }
+ 


### PR DESCRIPTION
Don't use non-existent member function on string_view. (StringPiece and string_view are almost the same looks like they are typedef'd to the same string_view. StringPiece used to have a as_string() member)

or-tools did not compile anymore with nixpkgs head; this makes them compile again.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
