### PR TITLE
[23.05] golden-cheetah-bin: mark insecure due to CVE-2023-4863

### DIFF
--- a/pkgs/applications/misc/golden-cheetah-bin/default.nix
+++ b/pkgs/applications/misc/golden-cheetah-bin/default.nix
@@ -31,5 +31,6 @@ appimageTools.wrapType2 {
     maintainers = with maintainers; [ gador ];
     license = licenses.gpl2Plus;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    knownVulnerabilities = [ "Vendors libwebp vulnerable to CVE-2023-4863" ];
   };
 }


### PR DESCRIPTION
(cherry picked from commit c0e3985db89e2a7c0ee1c61d64e7223bb0375f46)

Backport of PR #255339  &ndash; my git auto-resolved the trivial conflict.
_The usual checklist does not apply here._