### PR TITLE
platformio: 6.1.6 -> 6.1.11

### DIFF
--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -8,14 +8,14 @@
 with python3.pkgs; buildPythonApplication rec {
   pname = "platformio";
 
-  version = "6.1.6";
+  version = "6.1.11";
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
   src = fetchFromGitHub {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    sha256 = "sha256-BEeMfdmAWqFbQUu8YKKrookQVgmhfZBqXnzeb2gfhms=";
+    sha256 = "sha256-NR4UyAt8q5sUGtz1Sy6E8Of7y9WrH9xpcAWzLBeDQmo=";
   };
 
   outputs = [ "out" "udev" ];

--- a/pkgs/development/embedded/platformio/use-local-spdx-license-list.patch
+++ b/pkgs/development/embedded/platformio/use-local-spdx-license-list.patch
@@ -6,16 +6,16 @@ index 1e5f935a..26d1ac6a 100644
      @staticmethod
      @memoized(expire="1h")
      def load_spdx_licenses():
--        version = "3.19"
+-        version = "3.21"
 -        spdx_data_url = (
 -            "https://raw.githubusercontent.com/spdx/license-list-data/"
--            "v%s/json/licenses.json" % version
+-            f"v{version}/json/licenses.json"
 -        )
 -        return json.loads(fetch_remote_content(spdx_data_url))
-+        # version = "3.19"
++        # version = "3.21"
 +        # spdx_data_url = (
 +            # "https://raw.githubusercontent.com/spdx/license-list-data/"
-+            # "v%s/json/licenses.json" % version
++            # f"v{version}/json/licenses.json"
 +        # )
 +        # return json.loads(fetch_remote_content(spdx_data_url))
 +        with open("@SPDX_LICENSE_LIST_DATA@/json/licenses.json") as f:


### PR DESCRIPTION
## Description of changes

Simple bugfix updates, I believe.
https://github.com/platformio/platformio-core/releases/tag/v6.1.11
https://github.com/platformio/platformio-core/releases/tag/v6.1.10
https://github.com/platformio/platformio-core/releases/tag/v6.1.9
https://github.com/platformio/platformio-core/releases/tag/v6.1.8
https://github.com/platformio/platformio-core/releases/tag/v6.1.7

Fixes #255476

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
```
3 packages updated:
esphome platformio platformio-core (6.1.6 → 6.1.11)
6 packages built:
esphome esphome.dist platformio platformio-core platformio-core.dist platformio-core.udev
```
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).