### PR TITLE
libvirt: add mdevctl to path

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -95,6 +95,7 @@ let
     openssh
     pmutils
     systemd
+    mdevctl
   ] ++ lib.optionals enableIscsi [
     libiscsi
     openiscsi

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -56,6 +56,7 @@
 , parted ? null
 , systemd ? null
 , util-linux ? null
+, mdevctl ? null
 
   # Darwin
 , gmp


### PR DESCRIPTION
Added mdevctl to path of libvirt.

without it you get:

```
❯ virsh nodedev-define vgpu-test.xml
error: Failed to define node device from 'vgpu-test.xml'
error: Cannot find 'mdevctl' in path: No such file or directory
```

On my system this works when adding:
`systemd.services.libvirtd.path = [ pkgs.mdevctl ];`

Not sure if this is the way to fix it, but i'ts a starting point for discussion.