### PR TITLE
kubectl-neat: init at 2.0.3

### DIFF
--- a/pkgs/by-name/ku/kubectl-neat/package.nix
+++ b/pkgs/by-name/ku/kubectl-neat/package.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub, bash }:
+
+buildGoModule rec {
+  pname = "kubectl-neat";
+  version = "2.0.3";
+
+  src = fetchFromGitHub {
+    owner = "itaysk";
+    repo = "kubectl-neat";
+    rev = "v${version}";
+    hash = "sha256-j8v0zJDBqHzmLamIZPW9UvMe9bv/m3JUQKY+wsgMTFk=";
+  };
+
+  vendorHash = "sha256-vGXoYR0DT9V1BD/FN/4szOal0clsLlqReTFkAd2beMw=";
+
+  postBuild = ''
+    # Replace path to bash in a script
+    # Without this change, there's a problem when running tests
+    sed 's,#!/bin/bash,#!${bash}/bin/bash,' -i test/kubectl-stub
+  '';
+
+  meta = with lib; {
+    description = "Clean up Kubernetes yaml and json output to make it readable";
+    homepage = "https://github.com/itaysk/kubectl-neat";
+    changelog = "https://github.com/itaysk/kubectl-neat/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = [ maintainers.koralowiec ];
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/itaysk/kubectl-neat - Kubectl plugin. Clean up Kubernetes yaml and json output to make it readable

This PR should resolve #257424 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
