### PR TITLE
fetch-npm-deps: Reduce flaky network issues by limiting parallelism

### DIFF
--- a/pkgs/build-support/node/fetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/fetch-npm-deps/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, bail};
 use rayon::prelude::*;
 use serde_json::{Map, Value};
 use std::{
+    cmp,
     collections::HashMap,
     env, fs,
     path::{Path, PathBuf},
@@ -185,13 +186,16 @@ fn main() -> anyhow::Result<()> {
         process::exit(1);
     }
 
-    if let Ok(jobs) = env::var("NIX_BUILD_CORES") {
-        if !jobs.is_empty() {
+    if let Ok(jobs_str) = env::var("NIX_BUILD_CORES") {
+        if !jobs_str.is_empty() {
+            let jobs = cmp::min(
+                4,
+                jobs_str
+                    .parse()
+                    .expect("NIX_BUILD_CORES must be a whole number"),
+            );
             rayon::ThreadPoolBuilder::new()
-                .num_threads(
-                    jobs.parse()
-                        .expect("NIX_BUILD_CORES must be a whole number"),
-                )
+                .num_threads(jobs)
                 .build_global()
                 .unwrap();
         }


### PR DESCRIPTION
## Description of changes

Sometimes fails flaky with errors like:

> [55] Failed sending data to the peer

that are difficult to reproduce at times, and cause a lot of frustration as the general answer is to just keep retrying.

Testing with `nix-build --check -A bitwarden.npmDeps`, I got these results:

- 2 cores: 20 / 20 runs succeeded in ~35 min total
- 4 cores: 18 / 20 runs succeeded in ~17 min total
- 8 cores: 11 / 20 runs succeeded in ~ 8 min total

This isn’t the ideal solution as it doesn’t fix the problem, but it is at least something to temper the frequent flaky failures without sacrificing too much runtime.

See
https://github.com/NixOS/nixpkgs/issues/256873
https://github.com/NixOS/nixpkgs/issues/257805

## Things done

Have only tested `bitwarden.npmDeps`, assuming given the context of the change that it will not cause problems for other dependents.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
