### PR TITLE
wavebox: 10.114.26-2 -> 10.118.5-2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wavebox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wavebox/default.nix
@@ -79,6 +79,8 @@ stdenv.mkDerivation {
     --prefix PATH : ${xdg-utils}/bin
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "Wavebox messaging application";
     homepage = "https://wavebox.io";

--- a/pkgs/applications/networking/instant-messengers/wavebox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wavebox/default.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "10.117.18-2";
+  version = "10.117.21-2";
   desktopItem = makeDesktopItem rec {
     name = "Wavebox";
     exec = "wavebox";
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = "https://download.wavebox.app/stable/linux/tar/${tarball}";
-    hash = "sha256-2t59VmCR3TWeLDozR6EVlqd62zHCdXHDXW4gIFaGLlg=";
+    sha256 = "1g2mf3xmcaz3y6vwa65r4ccw71ddqj1cn12p0k1f1xawfl74kc5c";
   };
 
   # don't remove runtime deps

--- a/pkgs/applications/networking/instant-messengers/wavebox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wavebox/default.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "10.114.26-2";
+  version = "10.117.18-2";
   desktopItem = makeDesktopItem rec {
     name = "Wavebox";
     exec = "wavebox";
@@ -36,11 +36,13 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = "https://download.wavebox.app/stable/linux/tar/${tarball}";
-    sha256 = "1yk664zgahjg6n98n3kc9avcay0nqwcyq8wq231p7kvd79zazk0r";
+    hash = "sha256-2t59VmCR3TWeLDozR6EVlqd62zHCdXHDXW4gIFaGLlg=";
   };
 
   # don't remove runtime deps
   dontPatchELF = true;
+  # ignore optional Qt 6 shim
+  autoPatchelfIgnoreMissingDeps = [ "libQt6Widgets.so.6" "libQt6Gui.so.6" "libQt6Core.so.6" ];
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper qt5.wrapQtAppsHook ];
 

--- a/pkgs/applications/networking/instant-messengers/wavebox/update.sh
+++ b/pkgs/applications/networking/instant-messengers/wavebox/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p coreutils curl gnugrep
+#!nix-shell -i bash -p coreutils curl jq
 set -euo pipefail
 
 cd $(dirname "${BASH_SOURCE[0]}")
@@ -8,7 +8,7 @@ setKV () {
     sed -i "s|$2 = \".*\"|$2 = \"${3:-}\"|" $1
 }
 
-version=$(curl -LIs --show-error -o /dev/null -w %{url_effective} 'https://download.wavebox.app/latest/stable/linux/tar' | grep -oP 'Wavebox_\K(.+)(?=.tar.gz)')
+version=$(curl "https://download.wavebox.app/stable/linux/latest.json" | jq --raw-output '.["urls"]["tar"] | match("https://download.wavebox.app/stable/linux/tar/Wavebox_(.+).tar.gz").captures[0]["string"]')
 
 sha256_linux64=$(nix-prefetch-url --quiet https://download.wavebox.app/stable/linux/tar/Wavebox_${version}.tar.gz)
 setKV ./default.nix version $version

--- a/pkgs/applications/networking/instant-messengers/wavebox/update.sh
+++ b/pkgs/applications/networking/instant-messengers/wavebox/update.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p coreutils curl jq
-set -euo pipefail
-
-cd $(dirname "${BASH_SOURCE[0]}")
-
-setKV () {
-    sed -i "s|$2 = \".*\"|$2 = \"${3:-}\"|" $1
-}
+#!nix-shell -i bash -p nix-update curl jq
 
 version=$(curl "https://download.wavebox.app/stable/linux/latest.json" | jq --raw-output '.["urls"]["tar"] | match("https://download.wavebox.app/stable/linux/tar/Wavebox_(.+).tar.gz").captures[0]["string"]')
-
-sha256_linux64=$(nix-prefetch-url --quiet https://download.wavebox.app/stable/linux/tar/Wavebox_${version}.tar.gz)
-setKV ./default.nix version $version
-setKV ./default.nix sha256 "$sha256_linux64"
+nix-update wavebox --version "$version"

--- a/pkgs/applications/networking/instant-messengers/wavebox/update.sh
+++ b/pkgs/applications/networking/instant-messengers/wavebox/update.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl gnugrep
+set -euo pipefail
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+setKV () {
+    sed -i "s|$2 = \".*\"|$2 = \"${3:-}\"|" $1
+}
+
+version=$(curl -LIs --show-error -o /dev/null -w %{url_effective} 'https://download.wavebox.app/latest/stable/linux/tar' | grep -oP 'Wavebox_\K(.+)(?=.tar.gz)')
+
+sha256_linux64=$(nix-prefetch-url --quiet https://download.wavebox.app/stable/linux/tar/Wavebox_${version}.tar.gz)
+setKV ./default.nix version $version
+setKV ./default.nix sha256 "$sha256_linux64"


### PR DESCRIPTION
## Description of changes

Update to latest version. It seems there is now an optional dependency on Qt 6 (Qt 5 is still required).

Fixes #254908

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).