### PR TITLE
opentelemetry-collector-builder: init at 0.101.0

### DIFF
--- a/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
+++ b/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "ocb";
+  version = "0.101.0";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-collector";
+    rev = "cmd/builder/v${version}";
+    hash = "sha256-Ucp00OjyPtHA6so/NOzTLtPSuhXwz6A2708w2WIZb/E=";
+  };
+
+  sourceRoot = "${src.name}/cmd/builder";
+  vendorHash = "sha256-MTwD9xkrq3EudppLSoONgcPCBWlbSmaODLH9NtYgVOk=";
+
+  GOFLAGS = [ "-trimpath" ];
+  CGO_ENABLED = 0;
+  ldflags = [
+    "-s"
+    "-w"
+    "-X go.opentelemetry.io/collector/cmd/builder/internal.version=${version}"
+  ];
+
+  # The TestGenerateAndCompile tests download new dependencies for a modified go.mod. Nix doesn't allow network access so skipping.
+  checkFlags = [ "-skip TestGenerateAndCompile" ];
+
+  # Rename the to ocb (it's generated as "builder")
+  postInstall = ''
+    mv $out/bin/builder $out/bin/ocb
+  '';
+
+  meta = {
+    description = "OpenTelemetry Collector";
+    homepage = "https://github.com/open-telemetry/opentelemetry-collector.git";
+    changelog = "https://github.com/open-telemetry/opentelemetry-collector/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ DavSanchez ];
+    mainProgram = "ocb";
+  };
+}

--- a/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
+++ b/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
@@ -17,7 +17,6 @@ buildGoModule rec {
   sourceRoot = "${src.name}/cmd/builder";
   vendorHash = "sha256-MTwD9xkrq3EudppLSoONgcPCBWlbSmaODLH9NtYgVOk=";
 
-  GOFLAGS = [ "-trimpath" ];
   CGO_ENABLED = 0;
   ldflags = [
     "-s"

--- a/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
+++ b/pkgs/by-name/op/opentelemetry-collector-builder/package.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
     homepage = "https://github.com/open-telemetry/opentelemetry-collector.git";
     changelog = "https://github.com/open-telemetry/opentelemetry-collector/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ DavSanchez ];
+    maintainers = with lib.maintainers; [ davsanchez ];
     mainProgram = "ocb";
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
