### PR TITLE
python3Packages.mediafire-dl: init at 2023-09-07

### DIFF
--- a/pkgs/development/python-modules/mediafire-dl/default.nix
+++ b/pkgs/development/python-modules/mediafire-dl/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, requests
+, six
+, tqdm
+}:
+
+buildPythonPackage {
+  pname = "mediafire-dl";
+  version = "unstable-2023-09-07";
+
+  src = fetchFromGitHub {
+    owner = "Juvenal-Yescas";
+    repo = "mediafire-dl";
+    rev = "bf9d461f43c5d5dc2900e08bcd4202a597a07ca0";
+    hash = "sha256-9qACTNMkO/CH/qB6WiggIKwSiFIccgU7CH0UeGUaFb4=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    six
+    tqdm
+  ];
+
+  pythonImportCheck = [
+    "mediafire_dl"
+  ];
+
+  meta = with lib; {
+    description = "Simple command-line script to download files from mediafire based on gdown";
+    homepage = "https://github.com/Juvenal-Yescas/mediafire-dl";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pacien ];
+    mainProgram = "mediafire-dl";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6624,6 +6624,8 @@ self: super: with self; {
 
   mediafile = callPackage ../development/python-modules/mediafile { };
 
+  mediafire-dl = callPackage ../development/python-modules/mediafire-dl { };
+
   mediapy = callPackage ../development/python-modules/mediapy { };
 
   meeko = callPackage ../development/python-modules/meeko { };


### PR DESCRIPTION
## Description of changes

This adds a package for mediafire-dl:
<https://github.com/Juvenal-Yescas/mediafire-dl>


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
