### PR TITLE
docs: clarify maintainer name format

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19,7 +19,7 @@
     where
 
     - `handle` is the handle you are going to use in nixpkgs expressions,
-    - `name` is your, preferably real, name,
+    - `name` is a name that people would know and recognize you by,
     - `email` is your maintainer email address,
     - `matrix` is your Matrix user ID,
     - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),


### PR DESCRIPTION
## Description of changes

Asking for a "real name" doesn't make much sense; different people from different backgrounds have very different interpretations of what that means, and the "real name" phrasing is likely to lead to conflict down the line, when those interpretations come into conflict (eg. people interpreting it as "government-registered name" vs. people not using that name for their own safety).

Instead, this changes the text so that it asks for what I *think* was the original intent behind the text; a name that people are known and recognized by in the community, so that it is easy to associate contributors to nixpkgs with their presence in other NixOS venues, and ensure that name confusion doesn't interfere with collaboration.

## Things done

n/a