### PR TITLE
nixos/gonic: allow gonic to perform non-local DNS resolution

### DIFF
--- a/nixos/modules/services/audio/gonic.nix
+++ b/nixos/modules/services/audio/gonic.nix
@@ -57,6 +57,7 @@ in
         ReadWritePaths = "";
         BindReadOnlyPaths = [
           # gonic can access scrobbling services
+          "-/etc/resolv.conf"
           "-/etc/ssl/certs/ca-certificates.crt"
           builtins.storeDir
           cfg.settings.podcast-path


### PR DESCRIPTION
Gonic accesses external services (e.g. Listenbrainz or last.FM) for scrobbling, but it was previously not allowed to read `/etc/resolv.conf`.

This had the effect that, unless a local resolver was configured on the system, any connection attempt would fail due to DNS resolution being unavailable.

Tested [in my configuration](https://cl.tvl.fyi/c/depot/+/9502).