### PR TITLE
openjdk21, openjfx21: init at 21

### DIFF
--- a/pkgs/development/compilers/openjdk/21.nix
+++ b/pkgs/development/compilers/openjdk/21.nix
@@ -1,0 +1,188 @@
+{ stdenv, lib, fetchurl, fetchpatch, fetchFromGitHub, bash, pkg-config, autoconf, cpio
+, file, which, unzip, zip, perl, cups, freetype, alsa-lib, libjpeg, giflib
+, libpng, zlib, lcms2, libX11, libICE, libXrender, libXext, libXt, libXtst
+, libXi, libXinerama, libXcursor, libXrandr, fontconfig, openjdk21-bootstrap
+, ensureNewerSourcesForZipFilesHook
+, setJavaClassPath
+# TODO(@sternenseemann): gtk3 fails to evaluate in pkgsCross.ghcjs.buildPackages
+# which should be fixable, this is a no-rebuild workaround for GHC.
+, headless ? stdenv.targetPlatform.isGhcjs
+, enableJavaFX ? false, openjfx
+, enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
+}:
+
+let
+  version = {
+    feature = "21";
+    interim = "";
+    build = "35";
+  };
+
+  # when building a headless jdk, also bootstrap it with a headless jdk
+  openjdk-bootstrap = openjdk21-bootstrap.override { gtkSupport = !headless; };
+
+  openjdk = stdenv.mkDerivation {
+    pname = "openjdk" + lib.optionalString headless "-headless";
+    version = "${version.feature}${version.interim}+${version.build}";
+
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jdk${version.feature}u";
+      rev = "jdk-${version.feature}${version.interim}+${version.build}";
+      hash = "sha256-fA8nRWBuTL87S8mwapmNfCPPQoI2aKHjbHJ6PDN3khs=";
+    };
+
+    nativeBuildInputs = [ pkg-config autoconf unzip ensureNewerSourcesForZipFilesHook ];
+    buildInputs = [
+      cpio file which zip perl zlib cups freetype alsa-lib libjpeg giflib
+      libpng zlib lcms2 libX11 libICE libXrender libXext libXtst libXt libXtst
+      libXi libXinerama libXcursor libXrandr fontconfig openjdk-bootstrap
+    ] ++ lib.optionals (!headless && enableGnome2) [
+      gtk3 gnome_vfs GConf glib
+    ];
+
+    patches = [
+      ./fix-java-home-jdk21.patch
+      ./read-truststore-from-env-jdk10.patch
+      ./currency-date-range-jdk10.patch
+      ./increase-javadoc-heap-jdk13.patch
+      ./ignore-LegalNoticeFilePlugin-jdk18.patch
+
+      # -Wformat etc. are stricter in newer gccs, per
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79677
+      # so grab the work-around from
+      # https://src.fedoraproject.org/rpms/java-openjdk/pull-request/24
+      (fetchurl {
+        url = "https://src.fedoraproject.org/rpms/java-openjdk/raw/06c001c7d87f2e9fe4fedeef2d993bcd5d7afa2a/f/rh1673833-remove_removal_of_wformat_during_test_compilation.patch";
+        sha256 = "082lmc30x64x583vqq00c8y0wqih3y4r0mp1c4bqq36l22qv6b6r";
+      })
+
+      # Fix build for gnumake-4.4.1:
+      #   https://github.com/openjdk/jdk/pull/12992
+      (fetchpatch {
+        name = "gnumake-4.4.1";
+        url = "https://github.com/openjdk/jdk/commit/9341d135b855cc208d48e47d30cd90aafa354c36.patch";
+        hash = "sha256-Qcm3ZmGCOYLZcskNjj7DYR85R4v07vYvvavrVOYL8vg=";
+      })
+    ] ++ lib.optionals (!headless && enableGnome2) [
+      ./swing-use-gtk-jdk13.patch
+    ];
+
+    postPatch = ''
+      chmod +x configure
+      patchShebangs --build configure
+    '';
+
+    # JDK's build system attempts to specifically detect
+    # and special-case WSL, and we don't want it to do that,
+    # so pass the correct platform names explicitly
+    configurePlatforms = ["build" "host"];
+
+    configureFlags = [
+      "--with-boot-jdk=${openjdk-bootstrap.home}"
+      "--with-version-build=${version.build}"
+      "--with-version-opt=nixos"
+      "--with-version-pre="
+      "--enable-unlimited-crypto"
+      "--with-native-debug-symbols=internal"
+      "--with-libjpeg=system"
+      "--with-giflib=system"
+      "--with-libpng=system"
+      "--with-zlib=system"
+      "--with-lcms=system"
+      "--with-stdc++lib=dynamic"
+    ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
+      ++ lib.optional headless "--enable-headless-only"
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+
+    separateDebugInfo = true;
+
+    env.NIX_CFLAGS_COMPILE = "-Wno-error";
+
+    NIX_LDFLAGS = toString (lib.optionals (!headless) [
+      "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"
+    ] ++ lib.optionals (!headless && enableGnome2) [
+      "-lgtk-3" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
+    ]);
+
+    # -j flag is explicitly rejected by the build system:
+    #     Error: 'make -jN' is not supported, use 'make JOBS=N'
+    # Note: it does not make build sequential. Build system
+    # still runs in parallel.
+    enableParallelBuilding = false;
+
+    buildFlags = [ "images" ];
+
+    installPhase = ''
+      mkdir -p $out/lib
+
+      mv build/*/images/jdk $out/lib/openjdk
+
+      # Remove some broken manpages.
+      rm -rf $out/lib/openjdk/man/ja*
+
+      # Mirror some stuff in top-level.
+      mkdir -p $out/share
+      ln -s $out/lib/openjdk/include $out/include
+      ln -s $out/lib/openjdk/man $out/share/man
+
+      # IDEs use the provided src.zip to navigate the Java codebase (https://github.com/NixOS/nixpkgs/pull/95081)
+      ln -s $out/lib/openjdk/lib/src.zip $out/lib/src.zip
+
+      # jni.h expects jni_md.h to be in the header search path.
+      ln -s $out/include/linux/*_md.h $out/include/
+
+      # Remove crap from the installation.
+      rm -rf $out/lib/openjdk/demo
+      ${lib.optionalString headless ''
+        rm $out/lib/openjdk/lib/{libjsound,libfontmanager}.so
+      ''}
+
+      ln -s $out/lib/openjdk/bin $out/bin
+    '';
+
+    preFixup = ''
+      # Propagate the setJavaClassPath setup hook so that any package
+      # that depends on the JDK has $CLASSPATH set up properly.
+      mkdir -p $out/nix-support
+      #TODO or printWords?  cf https://github.com/NixOS/nixpkgs/pull/27427#issuecomment-317293040
+      echo -n "${setJavaClassPath}" > $out/nix-support/propagated-build-inputs
+
+      # Set JAVA_HOME automatically.
+      mkdir -p $out/nix-support
+      cat <<EOF > $out/nix-support/setup-hook
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      EOF
+    '';
+
+    postFixup = ''
+      # Build the set of output library directories to rpath against
+      LIBDIRS=""
+      for output in $(getAllOutputNames); do
+        if [ "$output" = debug ]; then continue; fi
+        LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
+      done
+      # Add the local library paths to remove dependencies on the bootstrap
+      for output in $(getAllOutputNames); do
+        if [ "$output" = debug ]; then continue; fi
+        OUTPUTDIR=$(eval echo \$$output)
+        BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
+        echo "$BINLIBS" | while read i; do
+          patchelf --set-rpath "$LIBDIRS:$(patchelf --print-rpath "$i")" "$i" || true
+          patchelf --shrink-rpath "$i" || true
+        done
+      done
+    '';
+
+    disallowedReferences = [ openjdk-bootstrap ];
+
+    pos = builtins.unsafeGetAttrPos "feature" version;
+    meta = import ./meta.nix lib version.feature;
+
+    passthru = {
+      architecture = "";
+      home = "${openjdk}/lib/openjdk";
+      inherit gtk3;
+    };
+  };
+in openjdk

--- a/pkgs/development/compilers/openjdk/darwin/21.nix
+++ b/pkgs/development/compilers/openjdk/darwin/21.nix
@@ -1,0 +1,92 @@
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, setJavaClassPath
+, enableJavaFX ? false
+}:
+let
+  # Details from https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk
+  # Note that the latest build may differ by platform
+  dist = {
+    x86_64-darwin = {
+      arch = "x64";
+      zuluVersion = "21.28.85";
+      jdkVersion = "21.0.0";
+      hash =
+        if enableJavaFX then "sha256-QrgEpLaNGc2aNFF38z2ckUTCpweKnuALYLOWATZFJPA="
+        else "sha256-ljm4fbWG0MifepiSrkf0IeRCxkuXuuvf8xeI++IyZb0=";
+    };
+
+    aarch64-darwin = {
+      arch = "aarch64";
+      zuluVersion = "21.28.85";
+      jdkVersion = "21.0.0";
+      hash =
+        if enableJavaFX then "sha256-PUVB/R1K1dLTi1FsOYIvcI76M6EYYeMG1Bm+oMno//Y="
+        else "sha256-KnqZo+omPb2NMqZ9Hm42O6iyXGRcgm9eFnoCu6+v8fo=";
+    };
+  }."${stdenv.hostPlatform.system}";
+
+  jce-policies = fetchurl {
+    url = "https://web.archive.org/web/20211126120343/http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    hash = "sha256-gCGii4ysQbRPFCH9IQoKCCL8r4jWLS5wo1sv9iioZ1o=";
+  };
+
+  javaPackage = if enableJavaFX then "ca-fx-jdk" else "ca-jdk";
+
+  jdk = stdenv.mkDerivation rec {
+    pname = "zulu${dist.zuluVersion}-${javaPackage}";
+    version = dist.jdkVersion;
+
+    src = fetchurl {
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-${javaPackage}${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      inherit (dist) hash;
+      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
+    };
+
+    nativeBuildInputs = [ unzip ];
+
+    installPhase = ''
+      mkdir -p $out
+      mv * $out
+
+      unzip ${jce-policies}
+      mv -f ZuluJCEPolicies/*.jar $out/lib/security/
+
+      # jni.h expects jni_md.h to be in the header search path.
+      ln -s $out/include/darwin/*_md.h $out/include/
+
+      if [ -f $out/LICENSE ]; then
+        install -D $out/LICENSE $out/share/zulu/LICENSE
+        rm $out/LICENSE
+      fi
+    '';
+
+    preFixup = ''
+      # Propagate the setJavaClassPath setup hook from the JDK so that
+      # any package that depends on the JDK has $CLASSPATH set up
+      # properly.
+      mkdir -p $out/nix-support
+      printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+
+      # Set JAVA_HOME automatically.
+      cat <<EOF >> $out/nix-support/setup-hook
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+      EOF
+    '';
+
+    # fixupPhase is moving the man to share/man which breaks it because it's a
+    # relative symlink.
+    postFixup = ''
+      ln -nsf ../zulu-${lib.versions.major version}.jdk/Contents/Home/man $out/share/man
+    '';
+
+    passthru = {
+      home = jdk;
+    };
+
+    meta = import ./meta.nix lib version;
+  };
+in
+jdk

--- a/pkgs/development/compilers/openjdk/fix-java-home-jdk21.patch
+++ b/pkgs/development/compilers/openjdk/fix-java-home-jdk21.patch
@@ -1,0 +1,14 @@
+--- a/src/hotspot/os/linux/os_linux.cpp	2017-07-04 23:09:02.533972226 -0400
++++ b/src/hotspot/os/linux/os_linux.cpp	2017-07-04 23:07:52.118338845 -0400
+@@ -2270,8 +2270,5 @@
+   assert(ret, "cannot locate libjvm");
+   char *rp = nullptr;
+   if (ret && dli_fname[0] != '\0') {
+-    rp = os::Posix::realpath(dli_fname, buf, buflen);
+-  }
+-  if (rp == nullptr) {
+-    return;
++    snprintf(buf, buflen, "%s", dli_fname);
+   }
+
+   if (Arguments::sun_java_launcher_is_altjvm()) {

--- a/pkgs/development/compilers/openjdk/openjfx/21.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/21.nix
@@ -1,0 +1,113 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch, writeText, openjdk17_headless
+, openjdk19_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
+, libXxf86vm, glib, alsa-lib, ffmpeg_4, python3, ruby, icu68
+, withMedia ? true
+, withWebKit ? false
+}:
+
+let
+  major = "21";
+  update = "";
+  build = "-ga";
+  repover = "${major}${update}${build}";
+  gradle_ = (gradle_7.override {
+    # note: gradle does not yet support running on 19
+    java = openjdk17_headless;
+  });
+
+  makePackage = args: stdenv.mkDerivation ({
+    version = "${major}${update}${build}";
+
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jfx";
+      rev = repover;
+      hash = "sha256-deNAGfnA6gwcAa64l0AWdkX+vJd3ZOfIgAifSl+/m+s=";
+    };
+
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4 icu68 ];
+    nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
+
+    dontUseCmakeConfigure = true;
+
+    config = writeText "gradle.properties" (''
+      CONF = Release
+      JDK_HOME = ${openjdk19_headless.home}
+    '' + args.gradleProperties or "");
+
+    buildPhase = ''
+      runHook preBuild
+
+      export GRADLE_USER_HOME=$(mktemp -d)
+      ln -s $config gradle.properties
+      export NIX_CFLAGS_COMPILE="$(pkg-config --cflags glib-2.0) $NIX_CFLAGS_COMPILE"
+      gradle --no-daemon $gradleFlags sdk
+
+      runHook postBuild
+    '';
+  } // args);
+
+  # Fake build to pre-download deps into fixed-output derivation.
+  # We run nearly full build because I see no other way to download everything that's needed.
+  # Anyone who knows a better way?
+  deps = makePackage {
+    pname = "openjfx-deps";
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME -type f -regex '.*/modules.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+      rm -rf $out/tmp
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    # suspiciously the same as for openjfx 17 ...
+    # could they really not have changed any of their dependencies?
+    # or did we miss changing another upstream hash when copy-pasting?
+    outputHash = "sha256-dV7/U5GpFxhI13smZ587C6cVE4FRNPY0zexZkYK4Yqo=";
+  };
+
+in makePackage {
+  pname = "openjfx-modular-sdk";
+
+  gradleProperties = ''
+    COMPILE_MEDIA = ${lib.boolToString withMedia}
+    COMPILE_WEBKIT = ${lib.boolToString withWebKit}
+  '';
+
+  preBuild = ''
+    swtJar="$(find ${deps} -name org.eclipse.swt\*.jar)"
+    substituteInPlace build.gradle \
+      --replace 'mavenCentral()' 'mavenLocal(); maven { url uri("${deps}") }' \
+      --replace 'name: SWT_FILE_NAME' "files('$swtJar')"
+  '';
+
+  installPhase = ''
+    cp -r build/modular-sdk $out
+  '';
+
+  stripDebugList = [ "." ];
+
+  postFixup = ''
+    # Remove references to bootstrap.
+    export openjdkOutPath='${openjdk19_headless.outPath}'
+    find "$out" -name \*.so | while read lib; do
+      new_refs="$(patchelf --print-rpath "$lib" | perl -pe 's,:?\Q$ENV{openjdkOutPath}\E[^:]*,,')"
+      patchelf --set-rpath "$new_refs" "$lib"
+    done
+  '';
+
+  disallowedReferences = [ openjdk17_headless openjdk19_headless ];
+
+  passthru.deps = deps;
+
+  meta = with lib; {
+    homepage = "https://openjdk.org/projects/openjfx/";
+    license = licenses.gpl2Classpath;
+    description = "The next-generation Java client toolkit";
+    maintainers = with maintainers; [ abbradar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16424,7 +16424,7 @@ with pkgs;
 
   hugs = callPackage ../development/interpreters/hugs { };
 
-  inherit (javaPackages) openjfx11 openjfx15 openjfx17 openjfx19 openjfx20;
+  inherit (javaPackages) openjfx11 openjfx15 openjfx17 openjfx19 openjfx20 openjfx21;
   openjfx = openjfx17;
 
   openjdk8-bootstrap = javaPackages.compiler.openjdk8-bootstrap;
@@ -16458,6 +16458,11 @@ with pkgs;
   openjdk20_headless = javaPackages.compiler.openjdk20.headless;
   jdk20 = openjdk20;
   jdk20_headless = openjdk20_headless;
+
+  openjdk21 = javaPackages.compiler.openjdk21;
+  openjdk21_headless = javaPackages.compiler.openjdk21.headless;
+  jdk21 = openjdk21;
+  jdk21_headless = openjdk21_headless;
 
   /* default JDK */
   jdk = jdk19;

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -8,11 +8,12 @@ let
   openjfx17 = callPackage ../development/compilers/openjdk/openjfx/17.nix { };
   openjfx19 = callPackage ../development/compilers/openjdk/openjfx/19.nix { };
   openjfx20 = callPackage ../development/compilers/openjdk/openjfx/20.nix { };
+  openjfx21 = callPackage ../development/compilers/openjdk/openjfx/21.nix { };
 
   mavenfod = pkgs.maven.buildMavenPackage;
 
 in {
-  inherit mavenfod openjfx11 openjfx15 openjfx17 openjfx19 openjfx20;
+  inherit mavenfod openjfx11 openjfx15 openjfx17 openjfx19 openjfx20 openjfx21;
 
   compiler = let
 
@@ -208,6 +209,14 @@ in {
       {
         openjdk20-bootstrap = temurin-bin.jdk-20;
         openjfx = openjfx20;
+      };
+
+    openjdk21 = mkOpenjdk
+      ../development/compilers/openjdk/21.nix
+      ../development/compilers/openjdk/darwin/21.nix
+      {
+        openjdk21-bootstrap = temurin-bin.jdk-20;
+        openjfx = openjfx21;
       };
 
     temurin-bin = recurseIntoAttrs (callPackage (


### PR DESCRIPTION
## Description of changes

Updates the various Java packages to JDK 21, as per the release: https://openjdk.org/projects/jdk/21/

Temurin has not yet released official binaries for JDK 21 yet, as per [their blog post](https://adoptium.net/blog/2023/09/temurin21-delay/), and as such `generate-sources.py` does not pick up any versions to put in the corresponding JSON file.

Right now I have it setup to bootstrap `openjdk21` using `temurin-bin-20` instead.

I will update the commit, and remove the temporary commit, when Temurin has a release for JDK 21.

Please let me know if there is anything else I need to do.

Also of note, I removed the patches `fix-java-home-jdk10` in Nixpkgs, and `FixNullPtrCast` from Alpine, as they did not apply when building JDK 21. Please let me know if the patch needs to be modified, or if they can just be left out.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
