### PR TITLE
qtile: add iwlib as dependency for wlan widget

### DIFF
--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -60,31 +60,31 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    setuptools-scm
     setuptools
+    setuptools-scm
   ];
 
   propagatedBuildInputs = [
-    xcffib
     (cairocffi.override { withXcffib = true; })
-    python-dateutil
-    dbus-python
     dbus-next
+    dbus-python
     mpd2
     psutil
     pulsectl-asyncio
-    pyxdg
     pygobject3
+    python-dateutil
     pywayland
     pywlroots
+    pyxdg
+    xcffib
     xkbcommon
   ];
 
   buildInputs = [
     libinput
+    libxkbcommon
     wayland
     wlroots
-    libxkbcommon
     xcbutilwm
   ];
 

--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -5,6 +5,7 @@
 , dbus-next
 , dbus-python
 , glib
+, iwlib
 , libdrm
 , libinput
 , libxkbcommon
@@ -68,6 +69,7 @@ buildPythonPackage rec {
     (cairocffi.override { withXcffib = true; })
     dbus-next
     dbus-python
+    iwlib
     mpd2
     psutil
     pulsectl-asyncio


### PR DESCRIPTION
## Description of changes

`iwlib` is required for the built-in wlan widget, so added it as a build input to satisfy that.

Additionally, I sorted the built inputs in the derivation, as they were in a random order while the inputs at the top were sorted.
I can remove that commit if wanted, but I personally feel like it would be good to keep.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
