### PR TITLE
duckstation: unstable-2023-04-14 -> unstable-2023-09-30

### DIFF
--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -23,7 +23,7 @@
 , libbacktrace
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "duckstation";
   version = "unstable-2023-09-30";
 
@@ -33,15 +33,6 @@ stdenv.mkDerivation rec {
     rev = "d5608bf12df7a7e03750cb94a08a3d7999034ae2";
     hash = "sha256-ktfZgacjkN6GQb1vLmyTZMr8QmmH12qAvFSIBTjgRSs=";
   };
-
-  # hack to fix missing version numbers in build (help->about and titlebar).
-  # src/scmversion/gen_scmversion.sh script expects to be in a git repo to generate these values.
-  # sh src/scmversion/gen_scmversion.sh in duckstation git repo manually on the rev commit and edit this.
-
-  git_hash = "${src.rev}";
-  git_branch = "master";
-  git_tag = "0.1-5889-gd5608bf1";
-  git_date = "2023-09-30T23:20:09+10:00";
 
   nativeBuildInputs = [
     cmake
@@ -80,12 +71,6 @@ stdenv.mkDerivation rec {
   postPatch = ''
       substituteInPlace src/CMakeLists.txt \
       --replace 'add_subdirectory(common-tests EXCLUDE_FROM_ALL)' 'add_subdirectory(common-tests)'
-
-      substituteInPlace src/scmversion/gen_scmversion.sh \
-      --replace "HASH=\$(git rev-parse HEAD)" "HASH=${git_hash}" \
-      --replace "BRANCH=\$(git rev-parse --abbrev-ref HEAD | tr -d '\r\n')" "BRANCH=${git_branch}" \
-      --replace "TAG=\$(git describe --tags --dirty --exclude latest --exclude preview --exclude legacy --exclude previous-latest | tr -d '\r\n')" "TAG=${git_tag}" \
-      --replace "DATE=\$(git log -1 --date=iso8601-strict --format=%cd)" "DATE=${git_date}"
   '';
 
   desktopItems = [

--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -92,7 +92,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  doCheck = true;
+  #common-tests not found as of 2023-09-30
+  doCheck = false;
   checkPhase = ''
     runHook preCheck
     bin/common-tests

--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation {
     pkg-config
     qttools
     wrapQtAppsHook
-    libbacktrace
   ]
   ++ lib.optionals enableWayland [
     extra-cmake-modules

--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -20,6 +20,7 @@
 , wayland
 , wrapQtAppsHook
 , enableWayland ? true
+, libbacktrace
 }:
 
 stdenv.mkDerivation {
@@ -40,6 +41,7 @@ stdenv.mkDerivation {
     pkg-config
     qttools
     wrapQtAppsHook
+    libbacktrace
   ]
   ++ lib.optionals enableWayland [
     extra-cmake-modules
@@ -53,6 +55,7 @@ stdenv.mkDerivation {
     qtbase
     qtsvg
     vulkan-loader
+    libbacktrace
   ]
   ++ lib.optionals enableWayland [
     qtwayland

--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation {
   pname = "duckstation";
-  version = "unstable-2023-04-14";
+  version = "unstable-2023-09-30";
 
   src = fetchFromGitHub {
     owner = "stenzek";
     repo = "duckstation";
-    rev = "5fee6f5abee7f3aad65da5523e57896e10e2a53a";
-    sha256 = "sha256-sRs/b4GVXhF3zrOef8DSBKJJGYECUER/nNWZAqv7suA=";
+    rev = "d5608bf12df7a7e03750cb94a08a3d7999034ae2";
+    hash = "sha256-ktfZgacjkN6GQb1vLmyTZMr8QmmH12qAvFSIBTjgRSs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -64,10 +64,9 @@ stdenv.mkDerivation {
   ++ cubeb.passthru.backendLibs;
 
   cmakeFlags = [
-    "-DUSE_DRMKMS=ON"
     "-DBUILD_TESTS=ON"
   ]
-  ++ lib.optionals enableWayland [ "-DUSE_WAYLAND=ON" ];
+  ++ lib.optionals enableWayland [ "-DENABLE_WAYLAND=ON" ];
 
   postPatch = ''
       substituteInPlace src/CMakeLists.txt \

--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -62,8 +62,14 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     "-DUSE_DRMKMS=ON"
+    "-DBUILD_TESTS=ON"
   ]
   ++ lib.optionals enableWayland [ "-DUSE_WAYLAND=ON" ];
+
+  postPatch = ''
+      substituteInPlace src/CMakeLists.txt \
+      --replace 'add_subdirectory(common-tests EXCLUDE_FROM_ALL)' 'add_subdirectory(common-tests)'
+  '';
 
   desktopItems = [
     (makeDesktopItem {
@@ -92,8 +98,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  #common-tests not found as of 2023-09-30
-  doCheck = false;
+  doCheck = true;
   checkPhase = ''
     runHook preCheck
     bin/common-tests

--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -23,7 +23,7 @@
 , libbacktrace
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "duckstation";
   version = "unstable-2023-09-30";
 
@@ -33,6 +33,15 @@ stdenv.mkDerivation {
     rev = "d5608bf12df7a7e03750cb94a08a3d7999034ae2";
     hash = "sha256-ktfZgacjkN6GQb1vLmyTZMr8QmmH12qAvFSIBTjgRSs=";
   };
+
+  # hack to fix missing version numbers in build (help->about and titlebar).
+  # src/scmversion/gen_scmversion.sh script expects to be in a git repo to generate these values.
+  # sh src/scmversion/gen_scmversion.sh in duckstation git repo manually on the rev commit and edit this.
+
+  git_hash = "${src.rev}";
+  git_branch = "master";
+  git_tag = "0.1-5889-gd5608bf1";
+  git_date = "2023-09-30T23:20:09+10:00";
 
   nativeBuildInputs = [
     cmake
@@ -71,6 +80,12 @@ stdenv.mkDerivation {
   postPatch = ''
       substituteInPlace src/CMakeLists.txt \
       --replace 'add_subdirectory(common-tests EXCLUDE_FROM_ALL)' 'add_subdirectory(common-tests)'
+
+      substituteInPlace src/scmversion/gen_scmversion.sh \
+      --replace "HASH=\$(git rev-parse HEAD)" "HASH=${git_hash}" \
+      --replace "BRANCH=\$(git rev-parse --abbrev-ref HEAD | tr -d '\r\n')" "BRANCH=${git_branch}" \
+      --replace "TAG=\$(git describe --tags --dirty --exclude latest --exclude preview --exclude legacy --exclude previous-latest | tr -d '\r\n')" "TAG=${git_tag}" \
+      --replace "DATE=\$(git log -1 --date=iso8601-strict --format=%cd)" "DATE=${git_date}"
   '';
 
   desktopItems = [


### PR DESCRIPTION
## Description of changes

Update to the latest commit which actually compiles now under gcc.

bin/common-tests is built again when BUILD_TESTS=ON 

cmake said libbacktrace is an option for crashes so I added that but not sure if needed in buildInputs.

ENABLE_WAYLAND cmake flag is defaulted on in upstream so it can probably be removed. USE_DRMKMS was removed.

The last commit is a hack to fix the version number not showing in the build. Ideas are welcome, it should probably be a different PR. We can probably just assign the git tag variable to our package's version or rev and call it a day. This and the branch are the only ones in the titlebar, the date and hash seem to be used for autoupdating which isn't a feature here.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
