### PR TITLE
dia: unstable-2022-12-14 -> unstable-2023-09-28

### DIFF
--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -2,12 +2,11 @@
 , stdenv
 , fetchFromGitLab
 , appstream-glib
-, cmake
 , dblatex
 , desktop-file-utils
 , graphene
-, gtk2
-, gtk-mac-integration-gtk2
+, gtk3
+, gtk-mac-integration-gtk3
 , intltool
 , libxml2
 , libxslt
@@ -16,23 +15,21 @@
 , pkg-config
 , poppler
 , python3
-  # Building with docs are failing in unstable-2022-12-14
+  # Building with docs are still failing in unstable-2023-09-28
 , withDocs ? false
 }:
 
 stdenv.mkDerivation {
   pname = "dia";
-  version = "unstable-2022-12-14";
+  version = "unstable-2023-09-28";
 
   src = fetchFromGitLab {
     owner = "GNOME";
     repo = "dia";
     domain = "gitlab.gnome.org";
-    rev = "4a619ec7cc93be5ddfbcc48d9e1572d04943bcad";
-    hash = "sha256-xi45Ak4rlDQjs/FNkdkm145mx76GNHjE6Nrs1dc94ww=";
+    rev = "bd551bb2558dcc89bc0bf7b4dd85b38cd85ad322";
+    hash = "sha256-U+8TUE1ULt6MNxnvw9kFjCAVBecUy2Sarof6H9+kR7Q=";
   };
-
-  patches = [ ./poppler-22_09-build-fix.patch ];
 
   # Required for the PDF plugin when building with clang.
   CXXFLAGS = "-std=c++17";
@@ -43,7 +40,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     graphene
-    gtk2
+    gtk3
     libxml2
     python3
     poppler
@@ -52,7 +49,7 @@ stdenv.mkDerivation {
     libxslt
   ] ++
   lib.optionals stdenv.isDarwin [
-    gtk-mac-integration-gtk2
+    gtk-mac-integration-gtk3
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

updating due to https://gitlab.gnome.org/GNOME/dia/-/merge_requests/85 ( gtk3 port )

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
