### PR TITLE
luaPackages.middleclass: init at 4.1.1-0

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -89,6 +89,7 @@ lyaml,,,,,,lblasc
 magick,,,,,,donovanglover
 markdown,,,,,,
 mediator_lua,,,,,,
+middleclass,,,,,,
 mpack,,,,,,
 moonscript,https://github.com/leafo/moonscript.git,dev-1,,,,arobyn
 nvim-client,https://github.com/neovim/lua-client.git,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -2501,6 +2501,29 @@ buildLuarocksPackage {
   };
 }) {};
 
+middleclass = callPackage({ luaOlder, buildLuarocksPackage, fetchurl, lua }:
+buildLuarocksPackage {
+  pname = "middleclass";
+  version = "4.1.1-0";
+  knownRockspec = (fetchurl {
+    url    = "mirror://luarocks/middleclass-4.1.1-0.rockspec";
+    sha256 = "10xzs48lr1dy7cx99581r956gl16px0a9gbdlfar41n19r96mhb1";
+  }).outPath;
+  src = fetchurl {
+    url    = "https://github.com/kikito/middleclass/archive/v4.1.1.tar.gz";
+    sha256 = "11ahv0b9wgqfnabv57rb7ilsvn2vcvxb1czq6faqrsqylvr5l7nh";
+  };
+
+  disabled = (luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];
+
+  meta = {
+    homepage = "https://github.com/kikito/middleclass";
+    description = "A simple OOP library for Lua";
+    license.fullName = "MIT";
+  };
+}) {};
+
 moonscript = callPackage({ lpeg, luaOlder, fetchgit, lua, buildLuarocksPackage, argparse, luafilesystem }:
 buildLuarocksPackage {
   pname = "moonscript";


### PR DESCRIPTION
This is my first pr to nixpkgs! Bare with me

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add Lua package https://luarocks.org/modules/kikito/middleclass

## Some things to note

- This is a basic, "pure lua", lib with no deps that appears to have been around awhile (and seems fairly popular).
- This lua module consists of just a single file named `middleclass.lua` which is located in the root of the repo. Hopefully this doesn't cause issues when used with neovim?
- I didn't implement tests/testing (checks?), not sure if this is necessary? I believe the repo does have tests and [uses busted](https://github.com/kikito/middleclass#specs).
- [x] Still need to run update script to generate the nix expressions? But it keeps failing on me with a different error each time. **(edit: nix expression/drv was added manually, see below)**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
