### PR TITLE
release.nix: generate bootstrap tools for musl

### DIFF
--- a/maintainers/scripts/all-tarballs.nix
+++ b/maintainers/scripts/all-tarballs.nix
@@ -12,5 +12,5 @@ import ../../pkgs/top-level/release.nix
     scrubJobs = false;
     # No need to evaluate on i686.
     supportedSystems = [ "x86_64-linux" ];
-    limitedSupportedSystems = [];
+    bootstrapConfigs = [];
   }

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -211,7 +211,7 @@ in rec {
   };
 
   bootstrapTools = derivation {
-    inherit (localSystem) system;
+    inherit (stdenv.hostPlatform) system;
 
     name = "bootstrap-tools";
     builder = "${bootstrapFiles.tools}/bin/bash";

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -16,9 +16,11 @@
 , bootstrapConfigs ? [
     "aarch64-apple-darwin"
     "aarch64-unknown-linux-gnu"
+    "aarch64-unknown-linux-musl"
     "i686-unknown-linux-gnu"
     "x86_64-apple-darwin"
     "x86_64-unknown-linux-gnu"
+    "x86_64-unknown-linux-musl"
   ]
   # Strip most of attributes when evaluating to spare memory usage
 , scrubJobs ? true

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -10,9 +10,16 @@
 */
 { nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; revision = "0000000000000000000000000000000000000000"; }
 , officialRelease ? false
-  # The platforms for which we build Nixpkgs.
+  # The platform doubles for which we build Nixpkgs.
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
-, limitedSupportedSystems ? [ "i686-linux" ]
+  # The platform triples for which we build bootstrap tools.
+, bootstrapConfigs ? [
+    "aarch64-apple-darwin"
+    "aarch64-unknown-linux-gnu"
+    "i686-unknown-linux-gnu"
+    "x86_64-apple-darwin"
+    "x86_64-unknown-linux-gnu"
+  ]
   # Strip most of attributes when evaluating to spare memory usage
 , scrubJobs ? true
   # Attributes passed to nixpkgs. Don't build packages marked as unfree.
@@ -35,12 +42,10 @@ with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs; 
 
 let
 
-  systemsWithAnySupport = supportedSystems ++ limitedSupportedSystems;
-
   supportDarwin = lib.genAttrs [
     "x86_64"
     "aarch64"
-  ] (arch: builtins.elem "${arch}-darwin" systemsWithAnySupport);
+  ] (arch: builtins.elem "${arch}-darwin" supportedSystems);
 
   nonPackageJobs =
     { tarball = import ./make-tarball.nix { inherit pkgs nixpkgs officialRelease supportedSystems; };
@@ -177,21 +182,21 @@ let
         };
 
       stdenvBootstrapTools = with lib;
-        genAttrs systemsWithAnySupport (system:
-          if hasSuffix "-linux" system then
+        genAttrs bootstrapConfigs (config:
+          if hasInfix "-linux-" config then
             let
               bootstrap = import ../stdenv/linux/make-bootstrap-tools.nix {
                 pkgs = import ../.. {
-                  localSystem = { inherit system; };
+                  localSystem = { inherit config; };
                 };
               };
             in {
               inherit (bootstrap) dist test;
             }
-          else if hasSuffix "-darwin" system then
+          else if hasSuffix "-darwin" config then
             let
               bootstrap = import ../stdenv/darwin/make-bootstrap-tools.nix {
-                localSystem = { inherit system; };
+                localSystem = { inherit config; };
               };
             in {
               # Lightweight distribution and test
@@ -201,7 +206,7 @@ let
               #inherit (bootstrap.test-pkgs) stdenv;
             }
           else
-            abort "No bootstrap implementation for system: ${system}"
+            abort "No bootstrap implementation for system: ${config}"
         );
     };
 


### PR DESCRIPTION
## Description of changes

This is a fresh attempt at https://github.com/NixOS/nixpkgs/pull/169793, done in a way that should make @Ericson2314 happier — i.e., all `bootstrapTools` jobs are switched to use config triples.

This will allow us to regenerate our woefully out-of-date aarch64-unknown-linux-gnu musl bootstrap tools, which can't compile lots of modern code.

We could technically also do i686-unknown-linux-musl bootstrap tools, but I don't know if there's demand for that, so it's best to wait and see if somebody asks for it before we commit Hydra to it.

I've tested the switch to triples by running

    nix-eval-jobs --force-recurse pkgs/top-level/release.nix

both before and after this change, and diffing the results to verify that no new errors are introduced, the derivations for all bootstrap tools are the same, and that the only changes aside from the bootstrap tool jobs being renamed are to derivations that include the Nixpkgs source tree.

Closes #169793.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
