### PR TITLE
nixos/locate: rip out dbfile overrides

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -230,9 +230,9 @@ in
         plocate = (mkIf isPLocate (mkMerge [ common plocate ]));
       };
 
-    environment.systemPackages = [ (cfg.locate.override { dbfile = cfg.output; }) ];
+    environment.systemPackages = [ cfg.locate ];
 
-    environment.variables = mkIf (!isMorPLocate) { LOCATE_PATH = cfg.output; };
+    environment.variables.LOCATE_PATH = cfg.output;
 
     environment.etc = {
       # write /etc/updatedb.conf for manual calls to `updatedb`

--- a/pkgs/tools/misc/mlocate/default.nix
+++ b/pkgs/tools/misc/mlocate/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, config, dbfile ? config.locate.dbfile or "/var/cache/locatedb" }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "mlocate";
@@ -8,9 +8,6 @@ stdenv.mkDerivation rec {
     url = "https://releases.pagure.org/mlocate/${pname}-${version}.tar.xz";
     sha256 = "0gi6y52gkakhhlnzy0p6izc36nqhyfx5830qirhvk3qrzrwxyqrh";
   };
-
-  buildInputs = [ ];
-  makeFlags = [ "dbfile=${dbfile}" ];
 
   meta = with lib; {
     description = "Merging locate is an utility to index and quickly search for files";

--- a/pkgs/tools/misc/plocate/default.nix
+++ b/pkgs/tools/misc/plocate/default.nix
@@ -1,5 +1,4 @@
-{ config
-, stdenv
+{ stdenv
 , lib
 , fetchgit
 , pkg-config
@@ -8,7 +7,6 @@
 , systemd
 , liburing
 , zstd
-, dbfile ? config.locate.dbfile or "/var/cache/locatedb"
 }:
 stdenv.mkDerivation rec {
   pname = "plocate";
@@ -31,8 +29,6 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dsystemunitdir=${placeholder "out"}/etc/systemd/system"
-    "-Dsharedstatedir=${builtins.dirOf dbfile}"
-    "-Ddbpath=${builtins.baseNameOf dbfile}"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
All the locate versions we have support LOCATE_PATH, so just use that instead of adding indirections all over the place AND forcing people to rebuild their locate implementation if they want the path changed.

Follow-up #257458.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
