### PR TITLE
Emscripten docs: reword and remove mention of `nix-env`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -149,6 +149,8 @@
 # C compilers
 /pkgs/development/compilers/gcc @amjoseph-nixpkgs
 /pkgs/development/compilers/llvm @RaitoBezarius
+/pkgs/development/compilers/emscripten @raitobezarius
+/doc/languages-frameworks/emscripten.section.md @raitobezarius
 
 # Audio
 /nixos/modules/services/audio/botamusique.nix @mweinelt

--- a/doc/languages-frameworks/emscripten.section.md
+++ b/doc/languages-frameworks/emscripten.section.md
@@ -13,7 +13,7 @@ A few things to note:
 * `export EMCC_DEBUG=2` is nice for debugging
 * The build artifact cache in `~/.emscripten` sometimes creates issues and needs to be removed from time to time
 
-## Declarative usage {#declarative-usage}
+## Examples {#declarative-usage}
 
 Let's see two different examples from `pkgs/top-level/emscripten-packages.nix`:
 
@@ -27,119 +27,134 @@ This means each Emscripten package requires that a [`checkPhase`](#ssec-check-ph
 * The cache at `~/.emscripten` requires to set `HOME=$TMPDIR` in individual phases.
   This makes compilation slower but also more deterministic.
 
+::: {.example #usage-1-pkgs.zlib.override}
 
-See the `zlib` example:
+# Using `pkgs.zlib.override {}`
 
-    zlib = (pkgs.zlib.override {
-      stdenv = pkgs.emscriptenStdenv;
-    }).overrideAttrs
-    (old: rec {
-      buildInputs = old.buildInputs ++ [ pkg-config ];
-      # we need to reset this setting!
-      env = (old.env or { }) // { NIX_CFLAGS_COMPILE = ""; };
-      configurePhase = ''
-        # FIXME: Some tests require writing at $HOME
-        HOME=$TMPDIR
-        runHook preConfigure
+This example uses `zlib` from Nixpkgs, but instead of compiling **C** to **ELF** it compiles **C** to **JavaScript** since we were using `pkgs.zlib.override` and changed `stdenv` to `pkgs.emscriptenStdenv`.
 
-        #export EMCC_DEBUG=2
-        emconfigure ./configure --prefix=$out --shared
+A few adaptions and hacks were put in place to make it work.
+One advantage is that when `pkgs.zlib` is updated, it will automatically update this package as well.
 
-        runHook postConfigure
-      '';
-      dontStrip = true;
-      outputs = [ "out" ];
-      buildPhase = ''
-        emmake make
-      '';
-      installPhase = ''
-        emmake make install
-      '';
-      checkPhase = ''
-        echo "================= testing zlib using node ================="
 
-        echo "Compiling a custom test"
-        set -x
-        emcc -O2 -s EMULATE_FUNCTION_POINTER_CASTS=1 test/example.c -DZ_SOLO \
-        libz.so.${old.version} -I . -o example.js
+```nix
+(pkgs.zlib.override {
+  stdenv = pkgs.emscriptenStdenv;
+}).overrideAttrs
+(old: rec {
+  buildInputs = old.buildInputs ++ [ pkg-config ];
+  # we need to reset this setting!
+  env = (old.env or { }) // { NIX_CFLAGS_COMPILE = ""; };
+  configurePhase = ''
+    # FIXME: Some tests require writing at $HOME
+    HOME=$TMPDIR
+    runHook preConfigure
 
-        echo "Using node to execute the test"
-        ${pkgs.nodejs}/bin/node ./example.js
+    #export EMCC_DEBUG=2
+    emconfigure ./configure --prefix=$out --shared
 
-        set +x
-        if [ $? -ne 0 ]; then
-          echo "test failed for some reason"
-          exit 1;
-        else
-          echo "it seems to work! very good."
-        fi
-        echo "================= /testing zlib using node ================="
-      '';
+    runHook postConfigure
+  '';
+  dontStrip = true;
+  outputs = [ "out" ];
+  buildPhase = ''
+    emmake make
+  '';
+  installPhase = ''
+    emmake make install
+  '';
+  checkPhase = ''
+    echo "================= testing zlib using node ================="
 
-      postPatch = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
-        substituteInPlace configure \
-          --replace '/usr/bin/libtool' 'ar' \
-          --replace 'AR="libtool"' 'AR="ar"' \
-          --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
-      '';
-    });
+    echo "Compiling a custom test"
+    set -x
+    emcc -O2 -s EMULATE_FUNCTION_POINTER_CASTS=1 test/example.c -DZ_SOLO \
+    libz.so.${old.version} -I . -o example.js
 
-### Usage 2: pkgs.buildEmscriptenPackage {#usage-2-pkgs.buildemscriptenpackage}
+    echo "Using node to execute the test"
+    ${pkgs.nodejs}/bin/node ./example.js
 
-This `xmlmirror` example features a emscriptenPackage which is defined completely from this context and no `pkgs.zlib.override` is used.
+    set +x
+    if [ $? -ne 0 ]; then
+      echo "test failed for some reason"
+      exit 1;
+    else
+      echo "it seems to work! very good."
+    fi
+    echo "================= /testing zlib using node ================="
+  '';
 
-    xmlmirror = pkgs.buildEmscriptenPackage rec {
-      name = "xmlmirror";
+  postPatch = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+    substituteInPlace configure \
+      --replace '/usr/bin/libtool' 'ar' \
+      --replace 'AR="libtool"' 'AR="ar"' \
+      --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
+  '';
+})
+```
 
-      buildInputs = [ pkg-config autoconf automake libtool gnumake libxml2 nodejs openjdk json_c ];
-      nativeBuildInputs = [ pkg-config zlib ];
+:::{.example #usage-2-pkgs.buildemscriptenpackage}
 
-      src = pkgs.fetchgit {
-        url = "https://gitlab.com/odfplugfest/xmlmirror.git";
-        rev = "4fd7e86f7c9526b8f4c1733e5c8b45175860a8fd";
-        hash = "sha256-i+QgY+5PYVg5pwhzcDnkfXAznBg3e8sWH2jZtixuWsk=";
-      };
+# Using `pkgs.buildEmscriptenPackage {}`
 
-      configurePhase = ''
-        rm -f fastXmlLint.js*
-        # a fix for ERROR:root:For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was 234217728
-        # https://gitlab.com/odfplugfest/xmlmirror/issues/8
-        sed -e "s/TOTAL_MEMORY=234217728/TOTAL_MEMORY=268435456/g" -i Makefile.emEnv
-        # https://github.com/kripken/emscripten/issues/6344
-        # https://gitlab.com/odfplugfest/xmlmirror/issues/9
-        sed -e "s/\$(JSONC_LDFLAGS) \$(ZLIB_LDFLAGS) \$(LIBXML20_LDFLAGS)/\$(JSONC_LDFLAGS) \$(LIBXML20_LDFLAGS) \$(ZLIB_LDFLAGS) /g" -i Makefile.emEnv
-        # https://gitlab.com/odfplugfest/xmlmirror/issues/11
-        sed -e "s/-o fastXmlLint.js/-s EXTRA_EXPORTED_RUNTIME_METHODS='[\"ccall\", \"cwrap\"]' -o fastXmlLint.js/g" -i Makefile.emEnv
-      '';
+This `xmlmirror` example features an Emscripten package that is defined completely from this context and no `pkgs.zlib.override` is used.
 
-      buildPhase = ''
-        HOME=$TMPDIR
-        make -f Makefile.emEnv
-      '';
+```nix
+pkgs.buildEmscriptenPackage rec {
+  name = "xmlmirror";
 
-      outputs = [ "out" "doc" ];
+  buildInputs = [ pkg-config autoconf automake libtool gnumake libxml2 nodejs openjdk json_c ];
+  nativeBuildInputs = [ pkg-config zlib ];
 
-      installPhase = ''
-        mkdir -p $out/share
-        mkdir -p $doc/share/${name}
+  src = pkgs.fetchgit {
+    url = "https://gitlab.com/odfplugfest/xmlmirror.git";
+    rev = "4fd7e86f7c9526b8f4c1733e5c8b45175860a8fd";
+    hash = "sha256-i+QgY+5PYVg5pwhzcDnkfXAznBg3e8sWH2jZtixuWsk=";
+  };
 
-        cp Demo* $out/share
-        cp -R codemirror-5.12 $out/share
-        cp fastXmlLint.js* $out/share
-        cp *.xsd $out/share
-        cp *.js $out/share
-        cp *.xhtml $out/share
-        cp *.html $out/share
-        cp *.json $out/share
-        cp *.rng $out/share
-        cp README.md $doc/share/${name}
-      '';
-      checkPhase = ''
+  configurePhase = ''
+    rm -f fastXmlLint.js*
+    # a fix for ERROR:root:For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was 234217728
+    # https://gitlab.com/odfplugfest/xmlmirror/issues/8
+    sed -e "s/TOTAL_MEMORY=234217728/TOTAL_MEMORY=268435456/g" -i Makefile.emEnv
+    # https://github.com/kripken/emscripten/issues/6344
+    # https://gitlab.com/odfplugfest/xmlmirror/issues/9
+    sed -e "s/\$(JSONC_LDFLAGS) \$(ZLIB_LDFLAGS) \$(LIBXML20_LDFLAGS)/\$(JSONC_LDFLAGS) \$(LIBXML20_LDFLAGS) \$(ZLIB_LDFLAGS) /g" -i Makefile.emEnv
+    # https://gitlab.com/odfplugfest/xmlmirror/issues/11
+    sed -e "s/-o fastXmlLint.js/-s EXTRA_EXPORTED_RUNTIME_METHODS='[\"ccall\", \"cwrap\"]' -o fastXmlLint.js/g" -i Makefile.emEnv
+  '';
 
-      '';
-    };
+  buildPhase = ''
+    HOME=$TMPDIR
+    make -f Makefile.emEnv
+  '';
 
-### Declarative debugging {#declarative-debugging}
+  outputs = [ "out" "doc" ];
+
+  installPhase = ''
+    mkdir -p $out/share
+    mkdir -p $doc/share/${name}
+
+    cp Demo* $out/share
+    cp -R codemirror-5.12 $out/share
+    cp fastXmlLint.js* $out/share
+    cp *.xsd $out/share
+    cp *.js $out/share
+    cp *.xhtml $out/share
+    cp *.html $out/share
+    cp *.json $out/share
+    cp *.rng $out/share
+    cp README.md $doc/share/${name}
+  '';
+  checkPhase = ''
+
+  '';
+}
+```
+
+:::
+
+## Debugging {#declarative-debugging}
 
 Use `nix-shell -I nixpkgs=/some/dir/nixpkgs -A emscriptenPackages.libz` and from there you can go trough the individual steps. This makes it easy to build a good `unit test` or list the files of the project.
 

--- a/doc/languages-frameworks/emscripten.section.md
+++ b/doc/languages-frameworks/emscripten.section.md
@@ -2,37 +2,16 @@
 
 [Emscripten](https://github.com/kripken/emscripten): An LLVM-to-JavaScript Compiler
 
-This section of the manual covers how to use `emscripten` in nixpkgs.
+If you want to work with `emcc`, `emconfigure` and `emmake` as you are used to from Ubuntu and similar distributions,
 
-Minimal requirements:
-
-* nix
-* nixpkgs
-
-Modes of use of `emscripten`:
-
-* **Imperative usage** (on the command line):
-
-   If you want to work with `emcc`, `emconfigure` and `emmake` as you are used to from Ubuntu and similar distributions you can use these commands:
-
-    * `nix-env -f "<nixpkgs>" -iA emscripten`
-    * `nix-shell -p emscripten`
-
-* **Declarative usage**:
-
-    This mode is far more power full since this makes use of `nix` for dependency management of emscripten libraries and targets by using the `mkDerivation` which is implemented by `pkgs.emscriptenStdenv` and `pkgs.buildEmscriptenPackage`. The source for the packages is in `pkgs/top-level/emscripten-packages.nix` and the abstraction behind it in `pkgs/development/em-modules/generic/default.nix`. From the root of the nixpkgs repository:
-    * build and install all packages:
-        * `nix-env -iA emscriptenPackages`
-
-    * dev-shell for zlib implementation hacking:
-        * `nix-shell -A emscriptenPackages.zlib`
-
-## Imperative usage {#imperative-usage}
+```console
+nix-shell -p emscripten
+```
 
 A few things to note:
 
 * `export EMCC_DEBUG=2` is nice for debugging
-* `~/.emscripten`, the build artifact cache sometimes creates issues and needs to be removed from time to time
+* The build artifact cache in `~/.emscripten` sometimes creates issues and needs to be removed from time to time
 
 ## Declarative usage {#declarative-usage}
 
@@ -41,16 +20,13 @@ Let's see two different examples from `pkgs/top-level/emscripten-packages.nix`:
 * `pkgs.zlib.override`
 * `pkgs.buildEmscriptenPackage`
 
-Both are interesting concepts.
+A special requirement of the `pkgs.buildEmscriptenPackage` is the `doCheck = true`.
+This means each Emscripten package requires that a [`checkPhase`](#ssec-check-phase) is implemented.
 
-A special requirement of the `pkgs.buildEmscriptenPackage` is the `doCheck = true` is a default meaning that each emscriptenPackage requires a `checkPhase` implemented.
+* Use `export EMCC_DEBUG=2` from within a phase to get more detailed debug output what is going wrong.
+* The cache at `~/.emscripten` requires to set `HOME=$TMPDIR` in individual phases.
+  This makes compilation slower but also more deterministic.
 
-* Use `export EMCC_DEBUG=2` from within a emscriptenPackage's `phase` to get more detailed debug output what is going wrong.
-* ~/.emscripten cache is requiring us to set `HOME=$TMPDIR` in individual phases. This makes compilation slower but also makes it more deterministic.
-
-### Usage 1: pkgs.zlib.override {#usage-1-pkgs.zlib.override}
-
-This example uses `zlib` from nixpkgs but instead of compiling **C** to **ELF** it compiles **C** to **JS** since we were using `pkgs.zlib.override` and changed stdenv to `pkgs.emscriptenStdenv`. A few adaptions and hacks were set in place to make it working. One advantage is that when `pkgs.zlib` is updated, it will automatically update this package as well. However, this can also be the downside...
 
 See the `zlib` example:
 
@@ -174,9 +150,3 @@ Use `nix-shell -I nixpkgs=/some/dir/nixpkgs -A emscriptenPackages.libz` and from
 5. `configurePhase`
 6. `buildPhase`
 7. ... happy hacking...
-
-## Summary {#summary}
-
-Using this toolchain makes it easy to leverage `nix` from NixOS, MacOSX or even Windows (WSL+ubuntu+nix). This toolchain is reproducible, behaves like the rest of the packages from nixpkgs and contains a set of well working examples to learn and adapt from.
-
-If in trouble, ask the maintainers.


### PR DESCRIPTION
Adding @raitobezarius and @matthewbauer to CODEOWNERS to keep track of changes.

really this stuff should move into the source and out of the manual, an effort recently started by @infinisil. but that would require a much larger change touching code, and we didn't want to get into that right now.