### PR TITLE
indilib: fix udev rules

### DIFF
--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -1,9 +1,11 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, bash
 , cmake
 , cfitsio
 , libusb1
+, kmod
 , zlib
 , boost
 , libev
@@ -57,6 +59,15 @@ stdenv.mkDerivation rec {
 
   # Socket address collisions between tests
   enableParallelChecking = false;
+
+  postFixup = lib.optionalString stdenv.isLinux ''
+    for f in $out/lib/udev/rules.d/*.rules
+    do
+      substituteInPlace $f --replace "/bin/sh" "${bash}/bin/sh" \
+                           --replace "/sbin/modprobe" "${kmod}/sbin/modprobe"
+    done
+  '';
+
 
   meta = with lib; {
     homepage = "https://www.indilib.org/";

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-firmware.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-firmware.nix
@@ -1,7 +1,9 @@
 { stdenv
 , lib
+, bash
 , cmake
 , cfitsio
+, coreutils
 , libusb1
 , zlib
 , boost
@@ -21,7 +23,9 @@
 , src
 , autoPatchelfHook
 }:
-
+let
+  libusb-with-fxload = libusb1.override { withExamples = true;};
+in
 stdenv.mkDerivation rec {
   pname = "indi-firmware";
 
@@ -39,7 +43,8 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DUDEVRULES_INSTALL_DIR=lib/udev/rules.d"
     "-DRULES_INSTALL_DIR=lib/udev/rules.d"
-    "-DFIRMWARE_INSTALL_DIR=\${CMAKE_INSTALL_PREFIX}/lib/firmware"
+    "-DFIRMWARE_INSTALL_DIR=lib/firmware"
+    "-DQHY_FIRMWARE_INSTALL_DIR=\${CMAKE_INSTALL_PREFIX}/lib/firmware/qhy"
     "-DCONF_DIR=etc"
     "-DBUILD_LIBS=1"
     "-DWITH_PENTAX=off"
@@ -52,8 +57,17 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  postFixup = ''
-    rm $out/lib/udev/rules.d/99-fli.rules
+  postFixup = lib.optionalString stdenv.isLinux ''
+    for f in $out/lib/udev/rules.d/*.rules
+    do
+      substituteInPlace "$f" --replace "/sbin/fxload" "${libusb-with-fxload}/sbin/fxload" \
+                             --replace "/bin/sleep" "${coreutils}/bin/sleep" \
+                             --replace "/bin/cat" "${coreutils}/bin/cat" \
+                             --replace "/bin/echo" "${coreutils}/bin/echo" \
+                             --replace "/bin/sh" "${bash}/bin/sh" \
+                             --replace "/lib/firmware/" "$out/lib/firmware/"
+      sed -e 's|-D $env{DEVNAME}|-p $env{BUSNUM},$env{DEVNUM}|' -i "$f"
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
This fixes the udev rules so that the indi packages can be added to nixos services.udev.packages option. It also fixes the loading of firmware for devices which need fxload.

## Description of changes

fixes the paths in the provided udev rules so the indi packages can be added to services.udev.packages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
