### PR TITLE
auto-cpufreq: 1.9.9 -> 2.2.0

### DIFF
--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, python3Packages, fetchFromGitHub, substituteAll }:
+{ lib, python3Packages, fetchFromGitHub, substituteAll, wrapGAppsHook, gobject-introspection, gtk3 }:
 
 python3Packages.buildPythonPackage rec {
   pname = "auto-cpufreq";
@@ -11,7 +11,7 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-164Gi1Oo9Tfd58aDq/3UjsWeS4rAZ39xCEhBgqv+GtI=";
   };
 
-  nativeBuildInputs = with pkgs; [ wrapGAppsHook gobject-introspection ];
+  nativeBuildInputs = [ wrapGAppsHook gobject-introspection ];
 
   buildInputs = with pkgs; [ gtk3 ];
 

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -1,21 +1,24 @@
 { lib, python3Packages, fetchFromGitHub, substituteAll, wrapGAppsHook, gobject-introspection, gtk3 }:
 
 python3Packages.buildPythonPackage rec {
+  # use pyproject.toml instead of setup.py
+  format = "pyproject";
+
   pname = "auto-cpufreq";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "AdnanHodzic";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-164Gi1Oo9Tfd58aDq/3UjsWeS4rAZ39xCEhBgqv+GtI=";
+    hash = "sha256-cALWWcmT1fVOof4Kgsbs+TMKB2dBpUF5VpFU3JM20Uc=";
   };
 
   nativeBuildInputs = [ wrapGAppsHook gobject-introspection ];
 
-  buildInputs = with pkgs; [ gtk3 ];
+  buildInputs = [ gtk3 python3Packages.poetry-core ];
 
-  propagatedBuildInputs = with python3Packages; [ setuptools-git-versioning click distro psutil pygobject3 ];
+  propagatedBuildInputs = with python3Packages; [ setuptools click distro psutil pygobject3 poetry-dynamic-versioning];
 
   doCheck = false;
   pythonImportsCheck = [ "auto_cpufreq" ];

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -1,6 +1,6 @@
-{ lib, pkgs, python310Packages, fetchFromGitHub, substituteAll }:
+{ lib, pkgs, python3Packages, fetchFromGitHub, substituteAll }:
 
-python310Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "auto-cpufreq";
   version = "2.0.0";
 
@@ -15,7 +15,7 @@ python310Packages.buildPythonPackage rec {
 
   buildInputs = with pkgs; [ gtk3 ];
 
-  propagatedBuildInputs = with python310Packages; [ setuptools-git-versioning click distro psutil pygobject3 ];
+  propagatedBuildInputs = with python3Packages; [ setuptools-git-versioning click distro psutil pygobject3 ];
 
   doCheck = false;
   pythonImportsCheck = [ "auto_cpufreq" ];

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -37,11 +37,20 @@ python310Packages.buildPythonPackage rec {
   postPatch = ''
     substituteInPlace auto_cpufreq/core.py --replace '/opt/auto-cpufreq/override.pickle' /var/run/override.pickle
     substituteInPlace scripts/org.auto-cpufreq.pkexec.policy --replace "/opt/auto-cpufreq/venv/bin/auto-cpufreq" $out/bin/auto-cpufreq
+
+    substituteInPlace auto_cpufreq/gui/app.py auto_cpufreq/gui/objects.py --replace "/usr/local/share/auto-cpufreq/images/icon.png" $out/share/pixmaps/auto-cpufreq.png
+    substituteInPlace auto_cpufreq/gui/app.py --replace "/usr/local/share/auto-cpufreq/scripts/style.css" $out/share/auto-cpufreq/scripts/style.css
+
     '';
 
   postInstall = ''
     # copy script manually
     cp ${src}/scripts/cpufreqctl.sh $out/bin/cpufreqctl.auto-cpufreq
+
+    # copy css file
+    mkdir -p $out/share/auto-cpufreq/scripts
+    cp scripts/style.css $out/share/auto-cpufreq/scripts/style.css
+
 
     # systemd service
     mkdir -p $out/lib/systemd/system

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -1,4 +1,11 @@
-{ lib, python3Packages, fetchFromGitHub, substituteAll, wrapGAppsHook, gobject-introspection, gtk3 }:
+{ lib
+, python3Packages
+, fetchFromGitHub
+, substituteAll
+, wrapGAppsHook
+, gobject-introspection
+, gtk3
+}:
 
 python3Packages.buildPythonPackage rec {
   # use pyproject.toml instead of setup.py
@@ -14,11 +21,24 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-cALWWcmT1fVOof4Kgsbs+TMKB2dBpUF5VpFU3JM20Uc=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook gobject-introspection ];
+  nativeBuildInputs = [ 
+    gobject-introspection
+    wrapGAppsHook
+  ];
 
-  buildInputs = [ gtk3 python3Packages.poetry-core ];
+  buildInputs = [ 
+    gtk3 
+    python3Packages.poetry-core
+  ];
 
-  propagatedBuildInputs = with python3Packages; [ setuptools click distro psutil pygobject3 poetry-dynamic-versioning];
+  propagatedBuildInputs = with python3Packages; [ 
+    click 
+    distro 
+    psutil 
+    pygobject3 
+    poetry-dynamic-versioning
+    setuptools 
+  ];
 
   doCheck = false;
   pythonImportsCheck = [ "auto_cpufreq" ];
@@ -41,8 +61,10 @@ python3Packages.buildPythonPackage rec {
     substituteInPlace auto_cpufreq/core.py --replace '/opt/auto-cpufreq/override.pickle' /var/run/override.pickle
     substituteInPlace scripts/org.auto-cpufreq.pkexec.policy --replace "/opt/auto-cpufreq/venv/bin/auto-cpufreq" $out/bin/auto-cpufreq
 
-    substituteInPlace auto_cpufreq/gui/app.py auto_cpufreq/gui/objects.py --replace "/usr/local/share/auto-cpufreq/images/icon.png" $out/share/pixmaps/auto-cpufreq.png
-    substituteInPlace auto_cpufreq/gui/app.py --replace "/usr/local/share/auto-cpufreq/scripts/style.css" $out/share/auto-cpufreq/scripts/style.css
+    substituteInPlace auto_cpufreq/gui/app.py auto_cpufreq/gui/objects.py \
+      --replace-fail "/usr/local/share/auto-cpufreq/images/icon.png" $out/share/pixmaps/auto-cpufreq.png
+    substituteInPlace auto_cpufreq/gui/app.py \
+      --replace-fail "/usr/local/share/auto-cpufreq/scripts/style.css" $out/share/auto-cpufreq/scripts/style.css
 
     '';
 

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -21,23 +21,23 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-lwimP4+qRFNQN+uHSFJHdkXYREWGwtoEc7U+bN5TDcc=";
   };
 
-  nativeBuildInputs = [ 
+  nativeBuildInputs = [
     gobject-introspection
     wrapGAppsHook
   ];
 
-  buildInputs = [ 
-    gtk3 
+  buildInputs = [
+    gtk3
     python3Packages.poetry-core
   ];
 
-  propagatedBuildInputs = with python3Packages; [ 
-    click 
-    distro 
-    psutil 
-    pygobject3 
+  propagatedBuildInputs = with python3Packages; [
+    click
+    distro
+    psutil
+    pygobject3
     poetry-dynamic-versioning
-    setuptools 
+    setuptools
   ];
 
   doCheck = false;

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -50,11 +50,10 @@ python3Packages.buildPythonPackage rec {
       inherit version;
     })
 
-     # patch to prevent update
-    ./prevent-update.patch
-
     # patch to prevent script copying and to disable install
     ./prevent-install-and-copy.patch
+     # patch to prevent update
+    ./prevent-update.patch
  ];
 
   postPatch = ''

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -16,7 +16,7 @@ python3Packages.buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "AdnanHodzic";
-    repo = pname;
+    repo = "auto-cpufreq";
     rev = "v${version}";
     hash = "sha256-lwimP4+qRFNQN+uHSFJHdkXYREWGwtoEc7U+bN5TDcc=";
   };

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -12,13 +12,13 @@ python3Packages.buildPythonPackage rec {
   format = "pyproject";
 
   pname = "auto-cpufreq";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "AdnanHodzic";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-cALWWcmT1fVOof4Kgsbs+TMKB2dBpUF5VpFU3JM20Uc=";
+    hash = "sha256-lwimP4+qRFNQN+uHSFJHdkXYREWGwtoEc7U+bN5TDcc=";
   };
 
   nativeBuildInputs = [ 
@@ -52,7 +52,7 @@ python3Packages.buildPythonPackage rec {
 
     # patch to prevent script copying and to disable install
     ./prevent-install-and-copy.patch
-     # patch to prevent update
+    # patch to prevent update
     ./prevent-update.patch
  ];
 
@@ -61,9 +61,9 @@ python3Packages.buildPythonPackage rec {
     substituteInPlace scripts/org.auto-cpufreq.pkexec.policy --replace "/opt/auto-cpufreq/venv/bin/auto-cpufreq" $out/bin/auto-cpufreq
 
     substituteInPlace auto_cpufreq/gui/app.py auto_cpufreq/gui/objects.py \
-      --replace-fail "/usr/local/share/auto-cpufreq/images/icon.png" $out/share/pixmaps/auto-cpufreq.png
+      --replace "/usr/local/share/auto-cpufreq/images/icon.png" $out/share/pixmaps/auto-cpufreq.png
     substituteInPlace auto_cpufreq/gui/app.py \
-      --replace-fail "/usr/local/share/auto-cpufreq/scripts/style.css" $out/share/auto-cpufreq/scripts/style.css
+      --replace "/usr/local/share/auto-cpufreq/scripts/style.css" $out/share/auto-cpufreq/scripts/style.css
 
     '';
 

--- a/pkgs/tools/system/auto-cpufreq/fix-version-output.patch
+++ b/pkgs/tools/system/auto-cpufreq/fix-version-output.patch
@@ -1,19 +1,17 @@
 diff --git a/auto_cpufreq/core.py b/auto_cpufreq/core.py
-index 99397a9..f3ef28f 100755
+index 0ef4315..66fd9e2 100755
 --- a/auto_cpufreq/core.py
 +++ b/auto_cpufreq/core.py
-@@ -144,26 +144,10 @@ except PermissionError:
+@@ -145,26 +145,8 @@ except PermissionError:
  
  # display running version of auto-cpufreq
  def app_version():
-+    print("auto-cpufreq version: @version@")
-+    print("Git commit: v@version@")
- 
+-
 -    print("auto-cpufreq version: ", end="")
- 
+-
 -    # snap package
 -    if os.getenv("PKG_MARKER") == "SNAP":
--        print(getoutput("echo \(Snap\) $SNAP_VERSION"))
+-        print(getoutput(r"echo \(Snap\) $SNAP_VERSION"))
 -    # aur package
 -    elif dist_name in ["arch", "manjaro", "garuda"]:
 -        aur_pkg_check = call("pacman -Qs auto-cpufreq > /dev/null", shell=True)
@@ -28,6 +26,8 @@ index 99397a9..f3ef28f 100755
 -        except Exception as e:
 -            print(repr(e))
 -            pass
- def verify_update():
-     # Specify the repository and package name
-     # IT IS IMPORTANT TO  THAT IF THE REPOSITORY STRUCTURE IS CHANGED, THE FOLLOWING FUNCTION NEEDS TO BE UPDATED ACCORDINGLY
++   print("auto-cpufreq version: @version@")
++   print("Git commit: v@version@")
+ 
+ def check_for_update():
+     # returns True if a new release is available from the GitHub repo

--- a/pkgs/tools/system/auto-cpufreq/prevent-install-and-copy.patch
+++ b/pkgs/tools/system/auto-cpufreq/prevent-install-and-copy.patch
@@ -113,11 +113,11 @@ index 99397a9..48a377a 100755
  
  def gov_check():
 
-diff --git a/bin/auto-cpufreq b/bin/auto-cpufreq
-index b89d925..b73974c 100755
---- a/bin/auto-cpufreq
-+++ b/bin/auto-cpufreq
-@@ -189,41 +189,9 @@
+diff --git a/auto_cpufreq/bin/auto_cpufreq.py b/auto_cpufreq/bin/auto_cpufreq.py
+index db2b84d..9c3caf3 100755
+--- a/auto_cpufreq/bin/auto_cpufreq.py
++++ b/auto_cpufreq/bin/auto_cpufreq.py
+@@ -189,41 +189,9 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
              print("https://github.com/AdnanHodzic/auto-cpufreq/#donate")
              footer()
          elif install:
@@ -160,4 +160,5 @@ index b89d925..b73974c 100755
 +            print("remove is disabled in the nix package")
          elif update:
              root_check()
-             if os.getenv("PKG_MARKER") == "SNAP":
+             custom_dir = "/opt/auto-cpufreq/source"
+

--- a/pkgs/tools/system/auto-cpufreq/prevent-update.patch
+++ b/pkgs/tools/system/auto-cpufreq/prevent-update.patch
@@ -1,21 +1,8 @@
-diff --git a/requirements.txt b/requirements.txt
-index f492cac..1cbad0d 100755
---- a/requirements.txt
-+++ b/requirements.txt
-@@ -2,5 +2,4 @@ setuptools
- psutil
- click
- distro
--requests
--PyGObject
-\ No newline at end of file
-+PyGObject
-
 diff --git a/auto_cpufreq/core.py b/auto_cpufreq/core.py
-index 99397a9..697fb68 100755
+index 0ef4315..fe9dc25 100755
 --- a/auto_cpufreq/core.py
 +++ b/auto_cpufreq/core.py
-@@ -18,7 +18,6 @@ from math import isclose
+@@ -19,7 +19,6 @@ from math import isclose
  from pathlib import Path
  from shutil import which
  from subprocess import getoutput, call, run, check_output, DEVNULL
@@ -24,11 +11,12 @@ index 99397a9..697fb68 100755
  
  # execution timestamp used in countdown func
 
-diff --git a/bin/auto-cpufreq b/bin/auto-cpufreq
-index 4e94e55..ee164b2 100755
---- a/bin/auto-cpufreq
-+++ b/bin/auto-cpufreq
-@@ -225,45 +225,7 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
+
+diff --git a/auto_cpufreq/bin/auto_cpufreq.py b/auto_cpufreq/bin/auto_cpufreq.py
+index db2b84d..0425338 100755
+--- a/auto_cpufreq/bin/auto_cpufreq.py
++++ b/auto_cpufreq/bin/auto_cpufreq.py
+@@ -225,47 +225,7 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
                  remove_daemon()
                  remove_complete_msg()
          elif update:
@@ -55,7 +43,9 @@ index 4e94e55..ee164b2 100755
 -            elif subprocess.run(["bash", "-c", "command -v pacman >/dev/null 2>&1"]).returncode == 0 and subprocess.run(["bash", "-c", "pacman -Q auto-cpufreq >/dev/null 2>&1"]).returncode == 0:
 -                print("Arch-based distribution with AUR support detected. Please refresh auto-cpufreq using your AUR helper.")
 -            else:
--                verify_update()
+-                is_new_update = check_for_update()
+-                if not is_new_update:
+-                    return
 -                ans = input("Do you want to update auto-cpufreq to the latest release? [Y/n]: ").strip().lower()
 -                if not os.path.exists(custom_dir):
 -                    os.makedirs(custom_dir)
@@ -71,7 +61,7 @@ index 4e94e55..ee164b2 100755
 -                    run(["auto-cpufreq", "--version"])
 -                else:
 -                    print("Aborted")
-+            print("Update is disabled in the Nix package")
++             print("Update is disabled in the Nix package")
  
- if __name__ == "__main__":
-     main()
+         elif completions:
+             if completions == "bash":

--- a/pkgs/tools/system/auto-cpufreq/prevent-update.patch
+++ b/pkgs/tools/system/auto-cpufreq/prevent-update.patch
@@ -1,12 +1,15 @@
 diff --git a/requirements.txt b/requirements.txt
-index f492cac..e61d1a4 100755
+index f492cac..1cbad0d 100755
 --- a/requirements.txt
 +++ b/requirements.txt
-@@ -2,4 +2,3 @@
+@@ -2,5 +2,4 @@ setuptools
  psutil
  click
  distro
 -requests
+-PyGObject
+\ No newline at end of file
++PyGObject
 
 diff --git a/auto_cpufreq/core.py b/auto_cpufreq/core.py
 index 99397a9..697fb68 100755
@@ -22,39 +25,53 @@ index 99397a9..697fb68 100755
  # execution timestamp used in countdown func
 
 diff --git a/bin/auto-cpufreq b/bin/auto-cpufreq
-index b89d925..b73974c 100755
+index 4e94e55..ee164b2 100755
 --- a/bin/auto-cpufreq
 +++ b/bin/auto-cpufreq
-@@ -193,31 +193,7 @@
-         elif remove:
-             print("remove is disabled in the nix package")
+@@ -225,45 +225,7 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
+                 remove_daemon()
+                 remove_complete_msg()
          elif update:
 -            root_check()
+-            custom_dir = "/opt/auto-cpufreq/source"
+-            for arg in sys.argv:
+-                if arg.startswith("--update="):
+-                    custom_dir = arg.split("=")[1]
+-                    sys.argv.remove(arg)
+-                    
+-            if "--update" in sys.argv:
+-                update = True
+-                sys.argv.remove("--update")
+-                if len(sys.argv) == 2:
+-                    custom_dir = sys.argv[1] 
+-                    
 -            if os.getenv("PKG_MARKER") == "SNAP":
 -                print("Detected auto-cpufreq was installed using snap")
 -                # refresh snap directly using this command
+-                # path wont work in this case
 -
 -                print("Please update using snap package manager, i.e: `sudo snap refresh auto-cpufreq`.")
 -                #check for AUR 
--            elif subprocess.run(["bash", "-c", "command -v yay >/dev/null 2>&1"]).returncode == 0 or subprocess.run(["bash", "-c", "command -v pacman >/dev/null 2>&1"]).returncode == 0:
+-            elif subprocess.run(["bash", "-c", "command -v pacman >/dev/null 2>&1"]).returncode == 0 and subprocess.run(["bash", "-c", "pacman -Q auto-cpufreq >/dev/null 2>&1"]).returncode == 0:
 -                print("Arch-based distribution with AUR support detected. Please refresh auto-cpufreq using your AUR helper.")
 -            else:
 -                verify_update()
--                ans = input ("Do you want to update auto-cpufreq to the latest release? [y/n]: ")
--                valid_options = ['y', 'Y', 'yes', 'YES', 'Yes']
--                if ans.lower() in valid_options:
+-                ans = input("Do you want to update auto-cpufreq to the latest release? [Y/n]: ").strip().lower()
+-                if not os.path.exists(custom_dir):
+-                    os.makedirs(custom_dir)
+-                if os.path.exists(os.path.join(custom_dir, "auto-cpufreq")):
+-                    shutil.rmtree(os.path.join(custom_dir, "auto-cpufreq"))
+-                if ans in ['', 'y', 'yes']:
 -                    remove_daemon()
 -                    remove_complete_msg()
--                    new_update()
+-                    new_update(custom_dir)
+-                    print("enabling daemon")
+-                    run(["auto-cpufreq", "--install"])
+-                    print("auto-cpufreq is installed with the latest version")
+-                    run(["auto-cpufreq", "--version"])
 -                else:
--                    print("incorrect input\n")
 -                    print("Aborted")
--                print("enabling daemon")
--                run(["auto-cpufreq", "--install"])
--                print("auto-cpufreq is installed with the latest version")
--                app_version()
--            
-+            print("update is disabled in the nix package")            
-
-
++            print("Update is disabled in the Nix package")
+ 
  if __name__ == "__main__":
+     main()

--- a/pkgs/tools/system/auto-cpufreq/prevent-update.patch
+++ b/pkgs/tools/system/auto-cpufreq/prevent-update.patch
@@ -65,3 +65,49 @@ index db2b84d..0425338 100755
  
          elif completions:
              if completions == "bash":
+diff --git a/auto_cpufreq/core.py b/auto_cpufreq/core.py
+index e355ff3..a0e9c48 100755
+--- a/auto_cpufreq/core.py
++++ b/auto_cpufreq/core.py
+@@ -167,40 +167,8 @@ def app_version():
+             pass
+ 
+ def check_for_update():
+-    # returns True if a new release is available from the GitHub repo
++    pass
+ 
+-    # Specify the repository and package name
+-    # IT IS IMPORTANT TO  THAT IF THE REPOSITORY STRUCTURE IS CHANGED, THE FOLLOWING FUNCTION NEEDS TO BE UPDATED ACCORDINGLY
+-    # Fetch the latest release information from GitHub API
+-    latest_release_url = f"https://api.github.com/repos/AdnanHodzic/auto-cpufreq/releases/latest"
+-    try:
+-        latest_release = requests.get(latest_release_url).json()
+-    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout,
+-            requests.exceptions.RequestException, requests.exceptions.HTTPError) as err:
+-        print ("Error Connecting to server!")
+-        return False
+-
+-    latest_version =  latest_release["tag_name"]
+-
+-    # Get the current version of auto-cpufreq
+-    # Extract version number from the output string
+-    output = check_output(['auto-cpufreq', '--version']).decode('utf-8')
+-    try:
+-        version_line = next((re.search(r'\d+\.\d+\.\d+', line).group() for line in output.split('\n') if line.startswith('auto-cpufreq version')), None)
+-    except AttributeError:
+-        print("Error Retrieving Current Version!")
+-        exit(1)
+-    installed_version = "v" + version_line
+-    #Check whether the same is installed or not
+-    # Compare the latest version with the installed version and perform update if necessary
+-    if latest_version == installed_version:
+-        print("auto-cpufreq is up to date")
+-        return False
+-    else:
+-        print(f"Updates are available,\nCurrent version: {installed_version}\nLatest version: {latest_version}")
+-        print("Note that your previous custom settings might be erased with the following update")
+-        return True
+-    
+ def new_update(custom_dir):
+     os.chdir(custom_dir)
+     print(f"Cloning the latest release to {custom_dir}")


### PR DESCRIPTION
## Description of changes
Closes #258208 
[Changelog](https://github.com/AdnanHodzic/auto-cpufreq/releases/tag/v2.0.0)
This update introduces a GTK gui, so several new build inputs were added to make this work, as well as copying the desktop entry file and polkit policy to the Nix store
Also adds small subtituteInPlace patches and fixed the `prevent-update.patch` file to work with this new update.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
