### PR TITLE
percona-xtrabackup_8_0: 8.0.29-22 -> 8.0.34-29

### DIFF
--- a/pkgs/tools/backup/percona-xtrabackup/8_0.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/8_0.nix
@@ -1,8 +1,8 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "8.0.29-22";
-  sha256 = "sha256-dGpfU+IesAyr2s1AEjfYggOEkMGQ9JdEesu5PtJHNXA=";
+  version = "8.0.34-29";
+  hash = "sha256-dO5ciIIAnKj2t+fYhrtnY7MvBThoA+SymBzN8H07giM=";
 
   # includes https://github.com/Percona-Lab/libkmip.git
   fetchSubmodules = true;

--- a/pkgs/tools/backup/percona-xtrabackup/generic.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/generic.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, bison, boost, cmake, makeWrapper, pkg-config
 , curl, cyrus_sasl, libaio, libedit, libev, libevent, libgcrypt, libgpg-error, lz4
-, ncurses, numactl, openssl, protobuf, valgrind, xxd, zlib
+, ncurses, numactl, openssl, procps, protobuf, valgrind, xxd, zlib
 , perlPackages
-, version, sha256, fetchSubmodules ? false, extraPatches ? [], extraPostInstall ? "", ...
+, version, hash, fetchSubmodules ? false, extraPatches ? [], extraPostInstall ? "", ...
 }:
 
 stdenv.mkDerivation rec {
@@ -13,14 +13,14 @@ stdenv.mkDerivation rec {
     owner = "percona";
     repo = "percona-xtrabackup";
     rev = "${pname}-${version}";
-    inherit sha256 fetchSubmodules;
+    inherit hash fetchSubmodules;
   };
 
   nativeBuildInputs = [ bison boost cmake makeWrapper pkg-config ];
 
   buildInputs = [
     (curl.override { inherit openssl; }) cyrus_sasl libaio libedit libevent libev libgcrypt libgpg-error lz4
-    ncurses numactl openssl protobuf valgrind xxd zlib
+    ncurses numactl openssl procps protobuf valgrind xxd zlib
   ] ++ (with perlPackages; [ perl DBI DBDmysql ]);
 
   patches = extraPatches;
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.percona.com/software/percona-xtrabackup";
     license = licenses.lgpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ izorkin ];
+    maintainers = teams.flyingcircus.members ++ [ maintainers.izorkin ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11864,7 +11864,6 @@ with pkgs;
   percona-xtrabackup = percona-xtrabackup_8_0;
   percona-xtrabackup_8_0 = callPackage ../tools/backup/percona-xtrabackup/8_0.nix {
     boost = boost177;
-    openssl = openssl_1_1;
   };
 
   pick = callPackage ../tools/misc/pick { };


### PR DESCRIPTION
## Description of changes

Updates xtrabackup to the current version of MySQL. Also drops the openssl_1_1 dependency.

Release notes: [Percona XtraBackup 8.0.34-29](https://docs.percona.com/percona-xtrabackup/8.0/release-notes/8.0/8.0.34-29.0.html)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested backup/restore manually using `bin/xtrabackup`.