### PR TITLE
nixos/network-interfaces-systemd: support and require defaultGateway.interface

### DIFF
--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -43,19 +43,6 @@ let
     }
   ));
 
-  genericNetwork = override:
-    let gateway = optional (cfg.defaultGateway != null && (cfg.defaultGateway.address or "") != "" && cfg.defaultGateway.interface == null) cfg.defaultGateway.address
-      ++ optional (cfg.defaultGateway6 != null && (cfg.defaultGateway6.address or "") != "" && cfg.defaultGateway6.interface == null) cfg.defaultGateway6.address;
-        makeGateway = gateway: {
-          routeConfig = {
-            Gateway = gateway;
-            GatewayOnLink = false;
-          };
-        };
-    in optionalAttrs (gateway != [ ]) {
-      routes = override (map makeGateway gateway);
-    };
-
   genericDhcpNetworks = initrd: mkIf cfg.useDHCP {
     networks."99-ethernet-default-dhcp" = {
       # We want to match physical ethernet interfaces as commonly
@@ -101,7 +88,7 @@ let
         };
       };
     });
-    networks."40-${i.name}" = mkMerge [ (genericNetwork id) {
+    networks."40-${i.name}" = {
       name = mkDefault i.name;
       DHCP = mkForce (dhcpStr
         (if i.useDHCP != null then i.useDHCP else false));
@@ -173,7 +160,7 @@ let
       } // optionalAttrs (i.mtu != null) {
         MTUBytes = toString i.mtu;
       };
-    }];
+    };
   }));
 
   bridgeNetworks = mkMerge (flip mapAttrsToList cfg.bridges (name: bridge: {
@@ -184,10 +171,10 @@ let
       };
     };
     networks = listToAttrs (forEach bridge.interfaces (bi:
-      nameValuePair "40-${bi}" (mkMerge [ (genericNetwork (mkOverride 999)) {
+      nameValuePair "40-${bi}" {
         DHCP = mkOverride 0 (dhcpStr false);
         networkConfig.Bridge = name;
-      } ])));
+      }));
   }));
 
   vlanNetworks = mkMerge (flip mapAttrsToList cfg.vlans (name: vlan: {
@@ -198,9 +185,9 @@ let
       };
       vlanConfig.Id = vlan.id;
     };
-    networks."40-${vlan.interface}" = (mkMerge [ (genericNetwork (mkOverride 999)) {
+    networks."40-${vlan.interface}" = {
       vlan = [ name ];
-    } ]);
+    };
   }));
 
 in
@@ -229,6 +216,12 @@ in
     assertions = [ {
       assertion = cfg.defaultGatewayWindowSize == null;
       message = "networking.defaultGatewayWindowSize is not supported by networkd.";
+    } {
+      assertion = cfg.defaultGateway != null -> cfg.defaultGateway.interface != null;
+      message = "networking.defaultGateway.interface is not optional when using networkd.";
+    } {
+      assertion = cfg.defaultGateway6 != null -> cfg.defaultGateway6.interface != null;
+      message = "networking.defaultGateway6.interface is not optional when using networkd.";
     } ] ++ flip mapAttrsToList cfg.bridges (n: { rstp, ... }: {
       assertion = !rstp;
       message = "networking.bridges.${n}.rstp is not supported by networkd.";
@@ -313,10 +306,10 @@ in
         };
 
         networks = listToAttrs (forEach bond.interfaces (bi:
-          nameValuePair "40-${bi}" (mkMerge [ (genericNetwork (mkOverride 999)) {
+          nameValuePair "40-${bi}" {
             DHCP = mkOverride 0 (dhcpStr false);
             networkConfig.Bond = name;
-          } ])));
+          }));
       })))
       (mkMerge (flip mapAttrsToList cfg.macvlans (name: macvlan: {
         netdevs."40-${name}" = {
@@ -326,9 +319,9 @@ in
           };
           macvlanConfig = optionalAttrs (macvlan.mode != null) { Mode = macvlan.mode; };
         };
-        networks."40-${macvlan.interface}" = (mkMerge [ (genericNetwork (mkOverride 999)) {
+        networks."40-${macvlan.interface}" = {
           macvlan = [ name ];
-        } ]);
+        };
       })))
       (mkMerge (flip mapAttrsToList cfg.fooOverUDP (name: fou: {
         netdevs."40-${name}" = {
@@ -373,9 +366,9 @@ in
               })));
         };
         networks = mkIf (sit.dev != null) {
-          "40-${sit.dev}" = (mkMerge [ (genericNetwork (mkOverride 999)) {
+          "40-${sit.dev}" = {
             tunnel = [ name ];
-          } ]);
+          };
         };
       })))
       (mkMerge (flip mapAttrsToList cfg.greTunnels (name: gre: {
@@ -394,9 +387,9 @@ in
             });
         };
         networks = mkIf (gre.dev != null) {
-          "40-${gre.dev}" = (mkMerge [ (genericNetwork (mkOverride 999)) {
+          "40-${gre.dev}" = {
             tunnel = [ name ];
-          } ]);
+          };
         };
       })))
       vlanNetworks

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -128,7 +128,7 @@ in
     boot.consoleLogLevel = 7;
 
     # Prevent tests from accessing the Internet.
-    networking.defaultGateway = mkOverride 150 "";
+    networking.defaultGateway = mkOverride 150 null;
     networking.nameservers = mkOverride 150 [ ];
 
     system.requiredKernelConfig = with config.lib.kernelConfig; [

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -113,8 +113,8 @@ let
         networking = {
           useNetworkd = networkd;
           useDHCP = false;
-          defaultGateway = "192.168.1.1";
-          defaultGateway6 = "fd00:1234:5678:1::1";
+          defaultGateway = { address = "192.168.1.1"; interface = "enp1s0"; };
+          defaultGateway6 = { address = "fd00:1234:5678:1::1"; interface = "enp1s0"; };
           interfaces.enp1s0.ipv4.addresses = [
             { address = "192.168.1.2"; prefixLength = 24; }
             { address = "192.168.1.3"; prefixLength = 32; }


### PR DESCRIPTION
## Description of changes

### Support `defaultGateway.interface`

When `interface` and `address` are both specified, we can set `Gateway=` on the named interface. The existing logic assumes `interface` is not set (since it's guarded by assertion) so we now disable it when `interface` has a value.

As a bonus, we now support the `defaultGateway.metric` option when `interface` is set.

### Require `defaultGateway.interface`

The logic for configuring a gateway without an interface specified adds a route with `Gateway=` to *every interface* configured by NixOS for networkd. This leads to nonsensical configurations like the following:

```ini
[Network]
DHCP=no
Address=192.168.0.1/24

[Route]
Gateway=10.0.0.1
GatewayOnLink=false
```

We remove this logic and make `defaultGateway.interface` required to configure a default gateway when using networkd.

We can ignore the removal of `GatewayOnLink` because systemd defaults it to "no" anyway.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - [x] `nixosTests.networking.networkd.*`
    - [x] `nixosTests.networking.scripted.static`
    - [x] `nixosTests.networkingProxy`
    - [x] `nixosTests.systemd-networkd`
    - [x] `nixosTests.systemd-networkd-vrf`
    - [x] `nixosTests.systemd-networkd-ipv6-prefix-delegation`
    - [x] `nixosTests.systemd-networkd-dhcpserver`
    - [x] `nixosTests.systemd-networkd-dhcpserver-static-leases`
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
