### PR TITLE
u-boot: 2023.07.02 -> 2023.10

### DIFF
--- a/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
+++ b/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
@@ -1,17 +1,17 @@
-From 3d0ce353cf62efea11aa88f814aa23bf8c04acc9 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Milan=20P=C3=A4ssler?= <milan@petabyte.dev>
-Date: Mon, 11 Jan 2021 15:13:10 +0100
+From 05769cd401f443f29547dbacd1b722e9a099b66b Mon Sep 17 00:00:00 2001
+From: Jared Baur <jaredbaur@fastmail.com>
+Date: Mon, 2 Oct 2023 18:32:34 -0700
 Subject: [PATCH] configs/rpi: allow for bigger kernels
 
 ---
- include/configs/rpi.h | 16 ++++++++--------
+ board/raspberrypi/rpi/rpi.env | 16 ++++++++--------
  1 file changed, 8 insertions(+), 8 deletions(-)
 
-diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 834f1cd..10ab1e7 100644
---- a/include/configs/rpi.h
-+++ b/include/configs/rpi.h
-@@ -153,20 +153,20 @@
+diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
+index 30228285ed..0327ef74fa 100644
+--- a/board/raspberrypi/rpi/rpi.env
++++ b/board/raspberrypi/rpi/rpi.env
+@@ -55,11 +55,11 @@ dfu_alt_info+=zImage fat 0 1
   * more than ~700M away from the start of the kernel image but this number can
   * be larger OR smaller depending on e.g. the 'vmalloc=xxxM' command line
   * parameter given to the kernel. So reserving memory from low to high
@@ -25,21 +25,22 @@ index 834f1cd..10ab1e7 100644
 + * only 64M, the remaining 8M starting at 0x04800000 should allow reasonably
 + * sized initrds before they start colliding with U-Boot.
   */
- #define ENV_MEM_LAYOUT_SETTINGS \
- 	"fdt_high=" FDT_HIGH "\0" \
- 	"initrd_high=" INITRD_HIGH "\0" \
- 	"kernel_addr_r=0x00080000\0" \
--	"scriptaddr=0x02400000\0" \
--	"pxefile_addr_r=0x02500000\0" \
--	"fdt_addr_r=0x02600000\0" \
--	"ramdisk_addr_r=0x02700000\0"
-+	"scriptaddr=0x04500000\0" \
-+	"pxefile_addr_r=0x04600000\0" \
-+	"fdt_addr_r=0x04700000\0" \
-+	"ramdisk_addr_r=0x04800000\0"
+ #ifdef CONFIG_ARM64
+ fdt_high=ffffffffffffffff
+@@ -69,9 +69,9 @@ fdt_high=ffffffff
+ initrd_high=ffffffff
+ #endif
+ kernel_addr_r=0x00080000
+-scriptaddr=0x02400000
+-pxefile_addr_r=0x02500000
+-fdt_addr_r=0x02600000
+-ramdisk_addr_r=0x02700000
++scriptaddr=0x04500000
++pxefile_addr_r=0x04600000
++fdt_addr_r=0x04700000
++ramdisk_addr_r=0x04800000
  
- #if CONFIG_IS_ENABLED(CMD_MMC)
- 	#define BOOT_TARGET_MMC(func) \
+ boot_targets=mmc usb pxe dhcp
 -- 
-2.29.2
+2.42.0
 

--- a/pkgs/misc/uboot/0001-rpi.env-allow-for-bigger-kernels.patch
+++ b/pkgs/misc/uboot/0001-rpi.env-allow-for-bigger-kernels.patch
@@ -1,7 +1,7 @@
-From 05769cd401f443f29547dbacd1b722e9a099b66b Mon Sep 17 00:00:00 2001
+From 30c64236cca889cc54e9100d050cef2715692c72 Mon Sep 17 00:00:00 2001
 From: Jared Baur <jaredbaur@fastmail.com>
-Date: Mon, 2 Oct 2023 18:32:34 -0700
-Subject: [PATCH] configs/rpi: allow for bigger kernels
+Date: Fri, 6 Oct 2023 23:34:57 -0700
+Subject: [PATCH 1/2] rpi.env: allow for bigger kernels
 
 ---
  board/raspberrypi/rpi/rpi.env | 16 ++++++++--------

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -57,6 +57,8 @@ let
 
     nativeBuildInputs = [
       ncurses # tools/kwboot
+      libuuid # tools/mkeficapsule
+      gnutls # tools/mkeficapsule
       bc
       bison
       flex
@@ -71,11 +73,7 @@ let
     ];
     depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-    buildInputs = [
-      ncurses # tools/kwboot
-      libuuid # tools/mkeficapsule
-      gnutls # tools/mkeficapsule
-    ];
+    strictDeps = true;
 
     hardeningDisable = [ "all" ];
 
@@ -130,6 +128,13 @@ in {
     extraMakeFlags = [ "HOST_TOOLS_ALL=y" "CROSS_BUILD_TOOLS=1" "NO_SDL=1" "tools" ];
 
     outputs = [ "out" "man" ];
+
+    buildInputs = [
+      ncurses # tools/kwboot
+      libuuid # tools/mkeficapsule
+      gnutls # tools/mkeficapsule
+      openssl # tools/mkimage
+    ];
 
     postInstall = ''
       installManPage doc/*.1

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -184,7 +184,7 @@ in {
   ubootClearfog = buildUBoot {
     defconfig = "clearfog_defconfig";
     extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-spl.kwb"];
+    filesToInstall = ["u-boot-with-spl.kwb"];
   };
 
   ubootCubieboard2 = buildUBoot {

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -2,7 +2,6 @@
 , lib
 , bc
 , bison
-, dtc
 , fetchFromGitHub
 , fetchpatch
 , fetchurl
@@ -25,10 +24,10 @@
 }:
 
 let
-  defaultVersion = "2023.07.02";
+  defaultVersion = "2023.10";
   defaultSrc = fetchurl {
     url = "https://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
-    hash = "sha256-a2pIWBwUq7D5W9h8GvTXQJIkBte4AQAqn5Ryf93gIdU=";
+    hash = "sha256-4A5sbwFOBGEBc50I0G8yiBHOvPWuEBNI9AnLvVXOaQA=";
   };
   buildUBoot = lib.makeOverridable ({
     version ? null
@@ -60,12 +59,10 @@ let
       ncurses # tools/kwboot
       bc
       bison
-      dtc
       flex
       installShellFiles
       openssl
       (buildPackages.python3.withPackages (p: [
-        p.libfdt
         p.setuptools # for pkg_resources
         p.pyelftools
       ]))
@@ -84,10 +81,7 @@ let
 
     enableParallelBuilding = true;
 
-    makeFlags = [
-      "DTC=dtc"
-      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-    ] ++ extraMakeFlags;
+    makeFlags = [ "CROSS_COMPILE=${stdenv.cc.targetPrefix}" ] ++ extraMakeFlags;
 
     passAsFile = [ "extraConfig" ];
 

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -21,6 +21,7 @@
 , armTrustedFirmwareRK3399
 , armTrustedFirmwareS905
 , buildPackages
+, fetchpatch2
 }:
 
 let
@@ -47,7 +48,11 @@ let
     src = if src == null then defaultSrc else src;
 
     patches = [
-      ./0001-configs-rpi-allow-for-bigger-kernels.patch
+      ./0001-rpi.env-allow-for-bigger-kernels.patch
+      (fetchpatch2 {
+        url = "https://patchwork.ozlabs.org/project/uboot/patch/20230923205017.1754340-1-sjg@chromium.org/raw/";
+        hash = "sha256-GJHmfYDmJjqHBY+fgkyHrqyJYMzgvJksHXSZz8sK1A8=";
+      })
     ] ++ extraPatches;
 
     postPatch = ''


### PR DESCRIPTION
## Description of changes

Among other changes, this release moves more boards to use the new environment format where a simple text file is used under ./board rather than using CFG_EXTRA_ENV_SETTINGS. This includes the default environment for the raspberry pi, hence the change of patch.

Something I haven't been able to track down is the need for removing the DTC make flag. U-boot has a version of this (along with libfdt) in their tree that builds just fine, so I propose we use that instead.

I've tested these changes building various boards defined in nixpkgs (cross compiling from x86_64-linux) with good success. I'm not sure of the expectation that every u-boot board defined in nixpkgs build successfully, (as I saw one with an incorrect `filesToInstall`), so I have not tested all boards. Please test if these changes break your board!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
