### PR TITLE
{ruby,neovim}: fix build with content-addressed derivations

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, gettext, msgpack-c, libtermkey, libiconv
+{ lib, stdenv, fetchFromGitHub, removeReferencesTo, cmake, gettext, msgpack-c, libtermkey, libiconv
 , libuv, lua, ncurses, pkg-config
 , unibilium, gperf
 , libvterm-neovim
@@ -98,6 +98,7 @@ in
       cmake
       gettext
       pkg-config
+      removeReferencesTo
     ];
 
     # extra programs test via `make functionaltest`
@@ -116,8 +117,11 @@ in
       sed -i src/nvim/po/CMakeLists.txt \
         -e "s|\$<TARGET_FILE:nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
     '';
+    postInstall = ''
+      find "$out" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
+    '';
     # check that the above patching actually works
-    disallowedReferences = [ stdenv.cc ] ++ lib.optional (lua != codegenLua) codegenLua;
+    disallowedRequisites = [ stdenv.cc ] ++ lib.optional (lua != codegenLua) codegenLua;
 
     cmakeFlags = [
       # Don't use downloaded dependencies. At the end of the configurePhase one

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -82,7 +82,7 @@ let
 
         strictDeps = true;
 
-        nativeBuildInputs = [ autoreconfHook bison ]
+        nativeBuildInputs = [ autoreconfHook bison removeReferencesTo ]
           ++ (op docSupport groff)
           ++ (ops (dtraceSupport && stdenv.isLinux) [ systemtap libsystemtap ])
           ++ ops yjitSupport [ rustPlatform.cargoSetupHook cargo rustc ]
@@ -225,10 +225,10 @@ let
           ${
             lib.optionalString (!jitSupport) ''
               # Get rid of the CC runtime dependency
-              ${removeReferencesTo}/bin/remove-references-to \
+              remove-references-to \
                 -t ${stdenv.cc} \
                 $out/lib/libruby*
-              ${removeReferencesTo}/bin/remove-references-to \
+              remove-references-to \
                 -t ${stdenv.cc} \
                 $rbConfig
               sed -i '/CC_VERSION_MESSAGE/d' $rbConfig
@@ -270,7 +270,7 @@ let
           cp ${./rbconfig.rb} $devdoc/lib/ruby/site_ruby/rbconfig.rb
         '' + opString useBaseRuby ''
           # Prevent the baseruby from being included in the closure.
-          ${removeReferencesTo}/bin/remove-references-to \
+          remove-references-to \
             -t ${baseRuby} \
             $rbConfig $out/lib/libruby*
         '';
@@ -290,7 +290,7 @@ let
         '';
         doInstallCheck = true;
 
-        disallowedRequisites = op (!jitSupport) stdenv.cc.cc
+        disallowedRequisites = op (!jitSupport) stdenv.cc
           ++ op useBaseRuby baseRuby;
 
         meta = with lib; {


### PR DESCRIPTION
## Description of changes

This PR fixes some packages that were broken after https://github.com/NixOS/nixpkgs/pull/211783 with `contentAddressedByDefault`. See https://github.com/NixOS/nixpkgs/pull/211783#discussion_r1090028466, https://github.com/NixOS/nixpkgs/pull/211783#issuecomment-1412043477, and https://github.com/NixOS/nixpkgs/pull/214044#issuecomment-1413447043

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
