### PR TITLE
picom-allusive: init for 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -829,6 +829,12 @@
     githubId = 5892756;
     name = "Alec Snyder";
   };
+  allusive = {
+    email = "jasper@allusive.dev";
+    name = "Allusive";
+    github = "allusive-dev";
+    githubId = 99632976;
+  };
   almac = {
     email = "alma.cemerlic@gmail.com";
     github = "a1mac";

--- a/pkgs/applications/window-managers/picom/picom-allusive.nix
+++ b/pkgs/applications/window-managers/picom/picom-allusive.nix
@@ -1,0 +1,24 @@
+{ picom, lib, fetchFromGitHub }:
+
+picom.overrideAttrs (oldAttrs: rec {
+  pname = "picom-allusive";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "allusive-dev";
+    repo = "picom-allusive";
+    rev = version;
+    hash = "sha256-lk4Ll0mi9h3BAqwgOzFQw4WYKnSW9XTl3PjoK2E4WKg=";
+  };
+
+  postInstall = ''
+    chmod +x $out/bin/picom-trans
+  '' + (lib.optionalString (oldAttrs ? postInstall) oldAttrs.postInstall);
+
+  meta = {
+    description = "A fork of picom featuring improved animations and other features";
+    homepage = "https://github.com/allusive-dev/picom-allusive";
+    license = with lib.licenses; [ mit mpl20 ];
+    maintainers = with lib.maintainers; [ allusive ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36802,6 +36802,8 @@ with pkgs;
 
   picom = callPackage ../applications/window-managers/picom { };
 
+  picom-allusive = callPackage ../applications/window-managers/picom/picom-allusive.nix { };
+
   picom-jonaburg = callPackage ../applications/window-managers/picom/picom-jonaburg.nix { };
 
   picom-next = callPackage ../applications/window-managers/picom/picom-next.nix { };


### PR DESCRIPTION
## Description of changes

Add picom-allusive: https://github.com/allusive-dev/picom-allusive
Add `allusive` to maintainers list

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
