### PR TITLE
mml: init at 1.0.0

### DIFF
--- a/pkgs/by-name/mm/mml/package.nix
+++ b/pkgs/by-name/mm/mml/package.nix
@@ -1,0 +1,60 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, installShellFiles
+, installShellCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
+, installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
+, gnupg
+, gpgme
+, enableCompiler ? true
+, enableInterpreter ? true
+, enablePgpCommands ? false
+, enablePgpGpg ? false
+, enablePgpNative ? false
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mml";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "soywod";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-8CFLtmN7CfcXcImRcqIaohT3vWWVfWzEwXIXvmL8MsQ=";
+  };
+
+  cargoSha256 = "35VEYViJJjD5rvaCPRJJSm/8bOO4BZKLOnynH6AQf+o=";
+
+  nativeBuildInputs = lib.optional (installManPages || installShellCompletions) installShellFiles;
+
+  buildInputs = lib.optionals enablePgpGpg [ gnupg gpgme ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ ]
+    ++ lib.optional enableCompiler "compiler"
+    ++ lib.optional enableInterpreter "interpreter"
+    ++ lib.optional enablePgpCommands "pgp-commands"
+    ++ lib.optional enablePgpGpg "pgp-gpg"
+    ++ lib.optional enablePgpNative "pgp-native";
+
+  postInstall = lib.optionalString installManPages ''
+    mkdir -p $out/man
+    $out/bin/mml man $out/man
+    installManPage $out/man/*
+  '' + lib.optionalString installShellCompletions ''
+    installShellCompletion --cmd mml \
+      --bash <($out/bin/mml completion bash) \
+      --fish <($out/bin/mml completion fish) \
+      --zsh <($out/bin/mml completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "CLI to compile MML messages to MIME messages and interpret MIME messages as MML messages";
+    homepage = "https://pimalaya.org/mml/";
+    changelog = "https://github.com/soywod/mml/blob/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ soywod ];
+  };
+}


### PR DESCRIPTION
## Description of changes

CLI to compile [MML] messages to [MIME] messages and interpret [MIME] messages as [MML] messages, based on [mml-lib].

[MML]: https://www.gnu.org/software/emacs/manual/html_node/emacs-mime/MML-Definition.html
[MIME]: https://www.rfc-editor.org/rfc/rfc2045
[mml-lib]: https://sr.ht/~soywod/pimalaya/

Sources: https://github.com/soywod/mml
Doc: https://pimalaya.org/mml/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
