### PR TITLE
zhixi: init at 2.1.3.1

### DIFF
--- a/pkgs/by-name/zh/zhixi/package.nix
+++ b/pkgs/by-name/zh/zhixi/package.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, makeWrapper
+, electron_25
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zhixi";
+  version = "2.1.3.1";
+
+  src = fetchurl {
+    url = "https://cdn-resource.zhixi.com/application/soft_package/channel/80004201/21C8B557/software/2.1.3.1/jIgnVa/zhixilinux_21C8B557.deb";
+    hash = "sha256-lyrtQcalSs+Z8My2AEf1K6n+Jk++4EqaDEdG33oz61M=";
+  };
+  sourceRoot = ".";
+  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src .";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/${pname} $out/share/applications $out/share/icons/hicolor/512x512
+
+    cp -a opt/zhiximind-desktop/{locales,resources} $out/share/${pname}
+    cp -a usr/share/applications/zhiximind-desktop.desktop $out/share/applications/${pname}.desktop
+    cp -a usr/share/icons/hicolor/512x512/apps $out/share/icons/hicolor/512x512
+
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=/opt/zhiximind-desktop/zhiximind-desktop' 'Exec=zhiximind-desktop'
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${electron_25}/bin/electron $out/bin/zhiximind-desktop \
+      --add-flags $out/share/${pname}/resources/app.asar \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [ stdenv.cc.cc ]
+      }" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.zhixi.com/";
+    description = "A cross-platform mindmap and diagramming tool that is lightweight and easy to use";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ pokon548 ];
+    mainProgram = "zhiximind-desktop";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

zhixi is a full-platform mind mapping and diagramming software that is lightweight and easy to use. Specified for lightweight and collaboration.

~~Please ignore update notice from the app, as it will wrongly download Windows prebuilt binary.~~ Reported to officials and will be fixed soon.

Website: https://www.zhixi.com/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
