### PR TITLE
linuxHeaders: revert accidental `struct sockaddr_ll` size change

### DIFF
--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -119,7 +119,10 @@ in {
         hash = "sha256-eldLvCCALqdrUsp/rwcmf3IEXoYbGJFcUnKpjCer+IQ=";
       };
       patches = [
-         ./no-relocs.patch # for building x86 kernel headers on non-ELF platforms
+        ./no-relocs.patch # for building x86 kernel headers on non-ELF platforms
+
+        # Fix regression turning `struct sockaddr_ll` flexible size.
+        ./revert-af_packet-flex.patch
       ];
     };
 }

--- a/pkgs/os-specific/linux/kernel-headers/revert-af_packet-flex.patch
+++ b/pkgs/os-specific/linux/kernel-headers/revert-af_packet-flex.patch
@@ -1,0 +1,31 @@
+Revert commit https://github.com/torvalds/linux/commit/a0ade8404c3bc2bf2631cb0f20d372eed22d9d96
+
+The change caused API regression by turning fixed size struct to
+flexible size struct. It was an unintentional change, broke `udp2raw`:
+    https://github.com/NixOS/nixpkgs/pull/252587#issuecomment-1744427473
+--- a/include/uapi/linux/if_packet.h
++++ b/include/uapi/linux/if_packet.h
+@@ -18,11 +18,7 @@ struct sockaddr_ll {
+ 	unsigned short	sll_hatype;
+ 	unsigned char	sll_pkttype;
+ 	unsigned char	sll_halen;
+-	union {
+-		unsigned char	sll_addr[8];
+-		/* Actual length is in sll_halen. */
+-		__DECLARE_FLEX_ARRAY(unsigned char, sll_addr_flex);
+-	};
++	unsigned char	sll_addr[8];
+ };
+ 
+ /* Packet types */
+--- a/net/packet/af_packet.c
++++ b/net/packet/af_packet.c
+@@ -3607,7 +3607,7 @@ static int packet_getname(struct socket *sock, struct sockaddr *uaddr,
+ 	if (dev) {
+ 		sll->sll_hatype = dev->type;
+ 		sll->sll_halen = dev->addr_len;
+-		memcpy(sll->sll_addr_flex, dev->dev_addr, dev->addr_len);
++		memcpy(sll->sll_addr, dev->dev_addr, dev->addr_len);
+ 	} else {
+ 		sll->sll_hatype = 0;	/* Bad: we have no ARPHRD_UNSPEC */
+ 		sll->sll_halen = 0;


### PR DESCRIPTION
`linux-6.5` introduced regression in it's headers by breaking `udp2raw`. `udp2raw` relied on the fixed size of `struct sockaddr_ll`:

    https://github.com/NixOS/nixpkgs/pull/252587#issuecomment-1744427473

Let's revert the API change until it's fixed upstream.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
