### PR TITLE
bluemail: 1.136.21-1884 -> 1.140.8-1922 and add desktop item

### DIFF
--- a/pkgs/applications/networking/mailreaders/bluemail/default.nix
+++ b/pkgs/applications/networking/mailreaders/bluemail/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , dpkg
 , autoPatchelfHook
+, copyDesktopItems
 , pango
 , gtk3
 , alsa-lib
@@ -11,6 +12,7 @@
 , libdrm
 , mesa
 , libxshmfence
+, makeDesktopItem
 , makeWrapper
 , wrapGAppsHook
 , gcc-unwrapped
@@ -19,18 +21,32 @@
 
 stdenv.mkDerivation rec {
   pname = "bluemail";
-  version = "1.136.21-1884";
+  version = "1.140.8-1922";
 
   # Taking a snapshot of the DEB release because there are no tagged version releases.
   # For new versions, download the upstream release, extract it and check for the version string.
   # In case there's a new version, create a snapshot of it on https://archive.org before updating it here.
   src = fetchurl {
-    url = "https://archive.org/download/blue-mail-1.136.21-1884/BlueMail.deb";
-    hash = "sha256-L9mCUjsEcalVxzl80P3QzVclCKa75So2sBG7KjjBVIc=";
+    url = "https://web.archive.org/web/20240208120704/https://download.bluemail.me/BlueMail/deb/BlueMail.deb";
+    hash = "sha256-dnYOb3Q/9vSDssHGS2ywC/Q24Oq96/mvKF+eqd/4dVw=";
   };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "bluemail";
+      icon = "bluemail";
+      exec = "bluemail";
+      desktopName = "BlueMail";
+      comment = meta.description;
+      genericName = "Email Reader";
+      mimeTypes = [ "x-scheme-handler/me.blueone.linux" "x-scheme-handler/mailto" ];
+      categories = [ "Office" ];
+    })
+  ];
 
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     makeWrapper
     dpkg
     wrapGAppsHook
@@ -55,9 +71,16 @@ stdenv.mkDerivation rec {
   dontWrapGApps = true;
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     mv opt/BlueMail/* $out
     ln -s $out/bluemail $out/bin/bluemail
+
+    mkdir -p $out/share/icons
+    mv usr/share/icons/hicolor $out/share/icons/
+
+    runHook postInstall
   '';
 
   makeWrapperArgs = [


### PR DESCRIPTION
## Description of changes

Simple update and desktop item for existing package.

Fixes #252443
cc @Lordraven19

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`): the desktop item works, and the binary also works if you pass `--disable-gpu-sandbox`
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).