### PR TITLE
unison-fsmonitor: init at 0.3.3

### DIFF
--- a/pkgs/by-name/un/unison-fsmonitor/package.nix
+++ b/pkgs/by-name/un/unison-fsmonitor/package.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "unison-fsmonitor";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "autozimu";
+    repo = "unison-fsmonitor";
+    rev = "v${version}";
+    hash = "sha256-JA0WcHHDNuQOal/Zy3yDb+O3acZN3rVX1hh0rOtRR+8=";
+  };
+  cargoHash = "sha256-aqAa0F1NSJI1nckTjG5C7VLxaLjJgD+9yK/IpclSMqs=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.CoreServices
+  ];
+
+  checkFlags = [
+    # accesses /usr/bin/env
+    "--skip=test_follow_link"
+  ];
+
+  meta = {
+    homepage = "https://github.com/autozimu/unison-fsmonitor";
+    description = "fsmonitor implementation for darwin";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nevivurn ];
+    platforms = lib.platforms.darwin;
+    mainProgram = "unison-fsmonitor";
+  };
+}


### PR DESCRIPTION
## Description of changes

- https://github.com/autozimu/unison-fsmonitor
- [unison](https://github.com/NixOS/nixpkgs/blob/f357bb31e80356b5f8b48f4cd38bbeb417e4dce6/pkgs/applications/networking/sync/unison/default.nix) does not ship a `unison-fsmonitor` binary for darwin.
- This is a separate project for implementing unison-fsmonitor functionality on darwin.
- It might be possible to get this working on Linux, but there's no point, as unison already ships `unison-fsmonitor`.
- Tested working with `unison -repeat watch`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
