### PR TITLE
spotify: use `hash` instead of `sha512` in update script

### DIFF
--- a/pkgs/applications/audio/spotify/update.sh
+++ b/pkgs/applications/audio/spotify/update.sh
@@ -39,12 +39,11 @@ snap_info=($(
 # just for human consumption. Revision is just an integer that gets increased
 # by one every (stable or unstable) release.
 revision="${snap_info[0]}"
-sha512="${snap_info[1]}"
+# We need to escape the slashes
+hash="$(nix-hash --to-sri --type sha512 ${snap_info[1]} | sed 's|/|\\/|g')"
 upstream_version="${snap_info[2]}"
 last_updated="${snap_info[3]}"
-
 echo "Latest $channel release is $upstream_version from $last_updated."
-
 #
 # read the current spotify version from the currently *committed* nix expression
 #
@@ -70,7 +69,7 @@ echo "Updating from ${current_nix_version} to ${upstream_version}, released on $
 # search-and-replace revision, hash and version
 sed --regexp-extended \
   -e 's/rev\s*=\s*"[0-9]+"\s*;/rev = "'"${revision}"'";/' \
-  -e 's/sha512\s*=\s*"[^"]*"\s*;/sha512 = "'"${sha512}"'";/' \
+  -e 's/hash\s*=\s*"[^"]*"\s*;/hash = "'"${hash}"'";/' \
   -e 's/version\s*=\s*".*"\s*;/version = "'"${upstream_version}"'";/' \
   -i "$spotify_nix"
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Fixed update script for spotify to use `hash` instead of `sha512`
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
