### PR TITLE
python312Packages.cffi: 1.15.1 -> 1.16.0

### DIFF
--- a/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
+++ b/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
@@ -1,6 +1,6 @@
 diff -r bac92fcfe4d7 c/_cffi_backend.c
---- a/c/_cffi_backend.c	Mon Jul 18 15:58:34 2022 +0200
-+++ b/c/_cffi_backend.c	Sat Aug 20 12:38:31 2022 -0700
+--- a/src/c/_cffi_backend.c	Mon Jul 18 15:58:34 2022 +0200
++++ b/src/c/_cffi_backend.c	Sat Aug 20 12:38:31 2022 -0700
 @@ -96,7 +96,7 @@
  # define CFFI_CHECK_FFI_PREP_CIF_VAR 0
  # define CFFI_CHECK_FFI_PREP_CIF_VAR_MAYBE 0

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -7,6 +7,7 @@
 , pytestCheckHook
 , libffi
 , pkg-config
+, setuptools
 , pycparser
 , pythonAtLeast
 }:
@@ -14,6 +15,7 @@
 if isPyPy then null else buildPythonPackage rec {
   pname = "cffi";
   version = "1.16.0";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -50,7 +52,7 @@ if isPyPy then null else buildPythonPackage rec {
 
   buildInputs = [ libffi ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config setuptools ];
 
   propagatedBuildInputs = [ pycparser ];
 

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -13,11 +13,11 @@
 
 if isPyPy then null else buildPythonPackage rec {
   pname = "cffi";
-  version = "1.15.1";
+  version = "1.16.0";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-1AC/uaN7E1ElPLQCZxzqfom97MKU6AFqcH9tHYrJNPk=";
+    hash = "sha256-vLPvQ+WGZbvaL7GYaY/K5ndkg+DEpjGqVkeAbCXgLMA=";
   };
 
   patches = [
@@ -32,38 +32,12 @@ if isPyPy then null else buildPythonPackage rec {
     # deemed safe to trust in cffi.
     #
     ./darwin-use-libffi-closures.diff
-    (fetchpatch {
-      # Drop py.code usage from tests, no longer depend on the deprecated py package
-      url = "https://foss.heptapod.net/pypy/cffi/-/commit/9c7d865e17ec16a847090a3e0d1498b698b99756.patch";
-      excludes = [
-        "README.md"
-        "requirements.txt"
-      ];
-      hash = "sha256-HSuLLIYXXGGCPccMNLV7o1G3ppn2P0FGCrPjqDv2e7k=";
-    })
-    (fetchpatch {
-      #  Replace py.test usage with pytest
-      url = "https://foss.heptapod.net/pypy/cffi/-/commit/bd02e1b122612baa74a126e428bacebc7889e897.patch";
-      excludes = [
-        "README.md"
-        "requirements.txt"
-      ];
-      hash = "sha256-+2daRTvxtyrCPimOEAmVbiVm1Bso9hxGbaAbd03E+ws=";
-    })
   ] ++ lib.optionals (stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc) "13") [
     # -Wnull-pointer-subtraction is enabled with -Wextra. Suppress it to allow the following tests
     # to run and pass when cffi is built with newer versions of clang:
     # - testing/cffi1/test_verify1.py::test_enum_usage
     # - testing/cffi1/test_verify1.py::test_named_pointer_as_argument
     ./clang-pointer-substraction-warning.diff
-  ] ++  lib.optionals (pythonAtLeast "3.11") [
-    # Fix test that failed because python seems to have changed the exception format in the
-    # final release. This patch should be included in the next version and can be removed when
-    # it is released.
-    (fetchpatch {
-      url = "https://foss.heptapod.net/pypy/cffi/-/commit/8a3c2c816d789639b49d3ae867213393ed7abdff.diff";
-      hash = "sha256-3wpZeBqN4D8IP+47QDGK7qh/9Z0Ag4lAe+H0R5xCb1E=";
-    })
   ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
## Description of changes

Contains fixes for python 3.12

- Removed redundant patches
- Adjusted darwin patch since the package source was moved to `src`.

Release notes:

- Add support for Python 3.12. With the removal of distutils from Python 3.12, projects using CFFI features that depend on distutils at runtime must add a dependency on setuptools to function under Python 3.12+. CFFI does not declare a runtime setuptools requirement to avoid an unnecessary dependency for projects that do not require it.
- Drop support for end-of-life Python versions (2.7, 3.6, 3.7).
- Add support for PEP517 builds; setuptools is now a required build dependency.
- Declare python_requires metadata for Python 3.8+. This allows unsupported Pythons to continue using previously released sdists and wheels.
- Move project source under src/; a more standard layout that also enables CI to more easily catch packaging errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
