### PR TITLE
gnome.gnome-session: fix session crash with gnome-boxes

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-session/default.nix
@@ -1,4 +1,5 @@
 { fetchurl
+, fetchpatch
 , lib
 , stdenv
 , substituteAll
@@ -46,6 +47,12 @@ stdenv.mkDerivation rec {
       gsettings = "${glib.bin}/bin/gsettings";
       dbusLaunch = "${dbus.lib}/bin/dbus-launch";
       bash = "${bash}/bin/bash";
+    })
+    # See #226355. Can be removed on update to v45.
+    (fetchpatch {
+      name = "fix-gnome-boxes-crash.patch";
+      url = "https://gitlab.gnome.org/GNOME/gnome-session/commit/fab1a3b91677035d541de2c141f8073c4057342c.patch";
+      hash = "sha256-2xeoNgV8UDexkufXDqimAplX0GC99tUWUqjw3kfN+5Q=";
     })
   ];
 


### PR DESCRIPTION
## Description of changes

Users keep stumbling over a rather annoying bug that shoots down the complete Gnome session. This bug is triggered by trying to install a VM in gnome-boxes. Upstream has recently [fixed](https://gitlab.gnome.org/GNOME/gnome-session/-/merge_requests/97) this issue. This PR backports the fix to gnome-session 44.

I'm currently running this and can confirm that this fixes #226355. I've also tested this on NixOS 23.05 (my daily driver).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
